### PR TITLE
feat(prometheus_exporter sink): add SAR auth strategy

### DIFF
--- a/changelog.d/25409_prometheus_exporter_sar_auth.feature.md
+++ b/changelog.d/25409_prometheus_exporter_sar_auth.feature.md
@@ -1,0 +1,8 @@
+The `prometheus_exporter` sink now supports Kubernetes SubjectAccessReview (SAR)
+authentication. Incoming scrape requests are validated by verifying Bearer tokens
+via TokenReview and checking permissions via SubjectAccessReview, using either
+nonResourceURL or resource-based authorization. The full TokenReview identity
+(username, groups, UID, extra) is forwarded to the SAR so webhook authorizers
+receive complete user context.
+
+authors: jcantrill

--- a/lib/k8s-e2e-tests/Cargo.toml
+++ b/lib/k8s-e2e-tests/Cargo.toml
@@ -41,3 +41,7 @@ required-features = ["e2e-tests"]
 [[test]]
 name = "vector"
 required-features = ["e2e-tests"]
+
+[[test]]
+name = "prometheus-exporter-sar"
+required-features = ["e2e-tests"]

--- a/lib/k8s-e2e-tests/tests/prometheus-exporter-sar.rs
+++ b/lib/k8s-e2e-tests/tests/prometheus-exporter-sar.rs
@@ -1,20 +1,56 @@
 #![allow(clippy::await_holding_lock)]
 
-use indoc::{formatdoc, indoc};
+use indoc::formatdoc;
 use k8s_e2e_tests::*;
-use k8s_test_framework::{
-    lock, namespace, vector::Config as VectorConfig, wait_for_resource::WaitFor,
-};
+use k8s_test_framework::{lock, vector::Config as VectorConfig};
 use reqwest::{StatusCode, header};
 use tokio::io::AsyncWriteExt;
 
-const VECTOR_NAMESPACE: &str = "vector-test";
+/// RAII guard for cluster-scoped RBAC resources that ensures cleanup on drop.
+/// This prevents resource leakage when tests fail before reaching explicit cleanup.
+struct ClusterRbacCleanup {
+    kubectl_command: String,
+    resources: Vec<(String, String)>, // (resource_type, name)
+}
+
+impl ClusterRbacCleanup {
+    fn new(kubectl_command: String) -> Self {
+        Self {
+            kubectl_command,
+            resources: Vec::new(),
+        }
+    }
+
+    fn track(&mut self, resource_type: &str, name: String) {
+        self.resources.push((resource_type.to_string(), name));
+    }
+}
+
+impl Drop for ClusterRbacCleanup {
+    fn drop(&mut self) {
+        // Best-effort cleanup - spawn a blocking task to delete resources
+        let kubectl = self.kubectl_command.clone();
+        let resources = self.resources.clone();
+
+        std::thread::spawn(move || {
+            let rt = tokio::runtime::Runtime::new().unwrap();
+            rt.block_on(async move {
+                for (resource_type, name) in resources {
+                    let _ = tokio::process::Command::new(&kubectl)
+                        .args(["delete", &resource_type, &name, "--ignore-not-found=true"])
+                        .output()
+                        .await;
+                }
+            });
+        });
+    }
+}
 
 /// Helper to clean up cluster-scoped resources (ClusterRoles and ClusterRoleBindings)
 /// Silently ignores errors (resources may already be deleted)
-async fn cleanup_cluster_resources(resource_names: &[(&str, &str)]) {
+async fn cleanup_cluster_resources(kubectl_command: &str, resource_names: &[(&str, &str)]) {
     for (resource_type, name) in resource_names {
-        let _ = tokio::process::Command::new("kubectl")
+        let _ = tokio::process::Command::new(kubectl_command)
             .args(["delete", resource_type, name, "--ignore-not-found=true"])
             .output()
             .await;
@@ -22,8 +58,11 @@ async fn cleanup_cluster_resources(resource_names: &[(&str, &str)]) {
 }
 
 /// Helper to create a namespace using kubectl
-async fn create_namespace(namespace: &str) -> Result<(), Box<dyn std::error::Error>> {
-    let output = tokio::process::Command::new("kubectl")
+async fn create_namespace(
+    kubectl_command: &str,
+    namespace: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let output = tokio::process::Command::new(kubectl_command)
         .args(["create", "namespace", namespace])
         .output()
         .await?;
@@ -40,10 +79,11 @@ async fn create_namespace(namespace: &str) -> Result<(), Box<dyn std::error::Err
 
 /// Helper to create a ServiceAccount using kubectl
 async fn create_service_account(
+    kubectl_command: &str,
     namespace: &str,
     name: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let output = tokio::process::Command::new("kubectl")
+    let output = tokio::process::Command::new(kubectl_command)
         .args(["create", "serviceaccount", name, "-n", namespace])
         .output()
         .await?;
@@ -59,7 +99,10 @@ async fn create_service_account(
 }
 
 /// Helper to create a ClusterRole for SAR permissions
-async fn create_clusterrole_for_sar(name: &str) -> Result<(), Box<dyn std::error::Error>> {
+async fn create_clusterrole_for_sar(
+    kubectl_command: &str,
+    name: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
     let yaml = formatdoc!(
         r#"
         apiVersion: rbac.authorization.k8s.io/v1
@@ -77,7 +120,7 @@ async fn create_clusterrole_for_sar(name: &str) -> Result<(), Box<dyn std::error
         name = name
     );
 
-    let mut child = tokio::process::Command::new("kubectl")
+    let mut child = tokio::process::Command::new(kubectl_command)
         .args(["apply", "-f", "-"])
         .stdin(std::process::Stdio::piped())
         .spawn()?;
@@ -101,7 +144,10 @@ async fn create_clusterrole_for_sar(name: &str) -> Result<(), Box<dyn std::error
 }
 
 /// Helper to create a ClusterRole for metrics access
-async fn create_clusterrole_for_metrics(name: &str) -> Result<(), Box<dyn std::error::Error>> {
+async fn create_clusterrole_for_metrics(
+    kubectl_command: &str,
+    name: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
     let yaml = formatdoc!(
         r#"
         apiVersion: rbac.authorization.k8s.io/v1
@@ -115,7 +161,7 @@ async fn create_clusterrole_for_metrics(name: &str) -> Result<(), Box<dyn std::e
         name = name
     );
 
-    let mut child = tokio::process::Command::new("kubectl")
+    let mut child = tokio::process::Command::new(kubectl_command)
         .args(["apply", "-f", "-"])
         .stdin(std::process::Stdio::piped())
         .spawn()?;
@@ -140,12 +186,13 @@ async fn create_clusterrole_for_metrics(name: &str) -> Result<(), Box<dyn std::e
 
 /// Helper to create a ClusterRoleBinding
 async fn create_clusterrolebinding(
+    kubectl_command: &str,
     name: &str,
     role_name: &str,
     sa_name: &str,
     sa_namespace: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let output = tokio::process::Command::new("kubectl")
+    let output = tokio::process::Command::new(kubectl_command)
         .args([
             "create",
             "clusterrolebinding",
@@ -173,13 +220,14 @@ async fn create_clusterrolebinding(
 /// This uses `kubectl create token` which works on Kubernetes 1.24+ where
 /// legacy token Secrets are no longer automatically created.
 async fn get_service_account_token(
+    kubectl_command: &str,
     namespace: &str,
     sa_name: &str,
 ) -> Result<String, Box<dyn std::error::Error>> {
     // Wait a bit for SA to be fully initialized
     tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
 
-    let output = tokio::process::Command::new("kubectl")
+    let output = tokio::process::Command::new(kubectl_command)
         .args([
             "create",
             "token",
@@ -213,37 +261,57 @@ async fn sar_auth_with_valid_token() -> Result<(), Box<dyn std::error::Error>> {
     let framework = make_framework();
     let override_name = get_override_name(&namespace, "vector");
 
+    // Create cleanup guard to ensure RBAC resources are deleted even on test failure
+    let mut cleanup = ClusterRbacCleanup::new(framework.kubectl_command().to_string());
+
     // Create namespace first
     // Namespace creation
-    create_namespace(&namespace).await?;
+    create_namespace(framework.kubectl_command(), &namespace).await?;
 
     // Create ServiceAccount for Vector with SAR permissions
 
-    create_service_account(&namespace, "vector-sa").await?;
+    create_service_account(framework.kubectl_command(), &namespace, "vector-sa").await?;
 
-    create_clusterrole_for_sar(&format!("{}-sar-role", namespace)).await?;
+    create_clusterrole_for_sar(
+        framework.kubectl_command(),
+        &format!("{}-sar-role", namespace),
+    )
+    .await?;
+    cleanup.track("clusterrole", format!("{}-sar-role", namespace));
 
-    let sar_binding = make_clusterrolebinding(
+    create_clusterrolebinding(
+        framework.kubectl_command(),
         &format!("{}-sar-binding", namespace),
         &format!("{}-sar-role", namespace),
         "vector-sa",
         &namespace,
-    );
-    framework.create(sar_binding).await?;
+    )
+    .await?;
+    cleanup.track("clusterrolebinding", format!("{}-sar-binding", namespace));
 
     // Create ServiceAccount for Prometheus scraper with metrics permission
 
-    create_service_account(&namespace, "prometheus-sa").await?;
+    create_service_account(framework.kubectl_command(), &namespace, "prometheus-sa").await?;
 
-    create_clusterrole_for_metrics(&format!("{}-metrics-role", namespace)).await?;
+    create_clusterrole_for_metrics(
+        framework.kubectl_command(),
+        &format!("{}-metrics-role", namespace),
+    )
+    .await?;
+    cleanup.track("clusterrole", format!("{}-metrics-role", namespace));
 
-    let metrics_binding = make_clusterrolebinding(
+    create_clusterrolebinding(
+        framework.kubectl_command(),
         &format!("{}-metrics-binding", namespace),
         &format!("{}-metrics-role", namespace),
         "prometheus-sa",
         &namespace,
+    )
+    .await?;
+    cleanup.track(
+        "clusterrolebinding",
+        format!("{}-metrics-binding", namespace),
     );
-    framework.create(metrics_binding).await?;
 
     // Deploy Vector with SAR auth
     let helm_values = formatdoc!(
@@ -306,7 +374,8 @@ async fn sar_auth_with_valid_token() -> Result<(), Box<dyn std::error::Error>> {
     let local_addr = port_forward.local_addr_ipv4();
 
     // Get Prometheus SA token
-    let token = get_service_account_token(&namespace, "prometheus-sa").await?;
+    let token =
+        get_service_account_token(framework.kubectl_command(), &namespace, "prometheus-sa").await?;
 
     // Make authenticated request with valid token
     let client = reqwest::Client::new();
@@ -330,17 +399,7 @@ async fn sar_auth_with_valid_token() -> Result<(), Box<dyn std::error::Error>> {
 
     drop(vector);
 
-    // Clean up cluster-scoped RBAC resources
-    cleanup_cluster_resources(&[
-        ("clusterrole", &format!("{}-sar-role", namespace)),
-        ("clusterrolebinding", &format!("{}-sar-binding", namespace)),
-        ("clusterrole", &format!("{}-metrics-role", namespace)),
-        (
-            "clusterrolebinding",
-            &format!("{}-metrics-binding", namespace),
-        ),
-    ])
-    .await;
+    // Cleanup guard will automatically delete cluster-scoped resources on drop
 
     Ok(())
 }
@@ -355,23 +414,33 @@ async fn sar_auth_rejects_missing_token() -> Result<(), Box<dyn std::error::Erro
     let framework = make_framework();
     let override_name = get_override_name(&namespace, "vector");
 
+    // Create cleanup guard to ensure RBAC resources are deleted even on test failure
+    let mut cleanup = ClusterRbacCleanup::new(framework.kubectl_command().to_string());
+
     // Create namespace first
     // Namespace creation
-    create_namespace(&namespace).await?;
+    create_namespace(framework.kubectl_command(), &namespace).await?;
 
     // Create ServiceAccount for Vector with SAR permissions
 
-    create_service_account(&namespace, "vector-sa").await?;
+    create_service_account(framework.kubectl_command(), &namespace, "vector-sa").await?;
 
-    create_clusterrole_for_sar(&format!("{}-sar-role", namespace)).await?;
+    create_clusterrole_for_sar(
+        framework.kubectl_command(),
+        &format!("{}-sar-role", namespace),
+    )
+    .await?;
+    cleanup.track("clusterrole", format!("{}-sar-role", namespace));
 
-    let sar_binding = make_clusterrolebinding(
+    create_clusterrolebinding(
+        framework.kubectl_command(),
         &format!("{}-sar-binding", namespace),
         &format!("{}-sar-role", namespace),
         "vector-sa",
         &namespace,
-    );
-    framework.create(sar_binding).await?;
+    )
+    .await?;
+    cleanup.track("clusterrolebinding", format!("{}-sar-binding", namespace));
 
     // Deploy Vector with SAR auth
     let helm_values = formatdoc!(
@@ -449,10 +518,13 @@ async fn sar_auth_rejects_missing_token() -> Result<(), Box<dyn std::error::Erro
     drop(vector);
 
     // Clean up cluster-scoped RBAC resources
-    cleanup_cluster_resources(&[
-        ("clusterrole", &format!("{}-sar-role", namespace)),
-        ("clusterrolebinding", &format!("{}-sar-binding", namespace)),
-    ])
+    cleanup_cluster_resources(
+        framework.kubectl_command(),
+        &[
+            ("clusterrole", &format!("{}-sar-role", namespace)),
+            ("clusterrolebinding", &format!("{}-sar-binding", namespace)),
+        ],
+    )
     .await;
 
     Ok(())
@@ -468,27 +540,37 @@ async fn sar_auth_rejects_unauthorized_token() -> Result<(), Box<dyn std::error:
     let framework = make_framework();
     let override_name = get_override_name(&namespace, "vector");
 
+    // Create cleanup guard to ensure RBAC resources are deleted even on test failure
+    let mut cleanup = ClusterRbacCleanup::new(framework.kubectl_command().to_string());
+
     // Create namespace first
     // Namespace creation
-    create_namespace(&namespace).await?;
+    create_namespace(framework.kubectl_command(), &namespace).await?;
 
     // Create ServiceAccount for Vector with SAR permissions
 
-    create_service_account(&namespace, "vector-sa").await?;
+    create_service_account(framework.kubectl_command(), &namespace, "vector-sa").await?;
 
-    create_clusterrole_for_sar(&format!("{}-sar-role", namespace)).await?;
+    create_clusterrole_for_sar(
+        framework.kubectl_command(),
+        &format!("{}-sar-role", namespace),
+    )
+    .await?;
+    cleanup.track("clusterrole", format!("{}-sar-role", namespace));
 
-    let sar_binding = make_clusterrolebinding(
+    create_clusterrolebinding(
+        framework.kubectl_command(),
         &format!("{}-sar-binding", namespace),
         &format!("{}-sar-role", namespace),
         "vector-sa",
         &namespace,
-    );
-    framework.create(sar_binding).await?;
+    )
+    .await?;
+    cleanup.track("clusterrolebinding", format!("{}-sar-binding", namespace));
 
     // Create ServiceAccount WITHOUT metrics permission
 
-    create_service_account(&namespace, "unprivileged-sa").await?;
+    create_service_account(framework.kubectl_command(), &namespace, "unprivileged-sa").await?;
 
     // Deploy Vector with SAR auth
     let helm_values = formatdoc!(
@@ -551,7 +633,9 @@ async fn sar_auth_rejects_unauthorized_token() -> Result<(), Box<dyn std::error:
     let local_addr = port_forward.local_addr_ipv4();
 
     // Get unprivileged SA token
-    let token = get_service_account_token(&namespace, "unprivileged-sa").await?;
+    let token =
+        get_service_account_token(framework.kubectl_command(), &namespace, "unprivileged-sa")
+            .await?;
 
     // Make request with unauthorized token
     let client = reqwest::Client::new();
@@ -570,10 +654,13 @@ async fn sar_auth_rejects_unauthorized_token() -> Result<(), Box<dyn std::error:
     drop(vector);
 
     // Clean up cluster-scoped RBAC resources
-    cleanup_cluster_resources(&[
-        ("clusterrole", &format!("{}-sar-role", namespace)),
-        ("clusterrolebinding", &format!("{}-sar-binding", namespace)),
-    ])
+    cleanup_cluster_resources(
+        framework.kubectl_command(),
+        &[
+            ("clusterrole", &format!("{}-sar-role", namespace)),
+            ("clusterrolebinding", &format!("{}-sar-binding", namespace)),
+        ],
+    )
     .await;
 
     Ok(())
@@ -589,23 +676,33 @@ async fn sar_auth_short_circuits_non_metrics_routes() -> Result<(), Box<dyn std:
     let framework = make_framework();
     let override_name = get_override_name(&namespace, "vector");
 
+    // Create cleanup guard to ensure RBAC resources are deleted even on test failure
+    let mut cleanup = ClusterRbacCleanup::new(framework.kubectl_command().to_string());
+
     // Create namespace first
     // Namespace creation
-    create_namespace(&namespace).await?;
+    create_namespace(framework.kubectl_command(), &namespace).await?;
 
     // Create ServiceAccount for Vector with SAR permissions
 
-    create_service_account(&namespace, "vector-sa").await?;
+    create_service_account(framework.kubectl_command(), &namespace, "vector-sa").await?;
 
-    create_clusterrole_for_sar(&format!("{}-sar-role", namespace)).await?;
+    create_clusterrole_for_sar(
+        framework.kubectl_command(),
+        &format!("{}-sar-role", namespace),
+    )
+    .await?;
+    cleanup.track("clusterrole", format!("{}-sar-role", namespace));
 
-    let sar_binding = make_clusterrolebinding(
+    create_clusterrolebinding(
+        framework.kubectl_command(),
         &format!("{}-sar-binding", namespace),
         &format!("{}-sar-role", namespace),
         "vector-sa",
         &namespace,
-    );
-    framework.create(sar_binding).await?;
+    )
+    .await?;
+    cleanup.track("clusterrolebinding", format!("{}-sar-binding", namespace));
 
     // Deploy Vector with SAR auth
     let helm_values = formatdoc!(
@@ -690,10 +787,13 @@ async fn sar_auth_short_circuits_non_metrics_routes() -> Result<(), Box<dyn std:
     drop(vector);
 
     // Clean up cluster-scoped RBAC resources
-    cleanup_cluster_resources(&[
-        ("clusterrole", &format!("{}-sar-role", namespace)),
-        ("clusterrolebinding", &format!("{}-sar-binding", namespace)),
-    ])
+    cleanup_cluster_resources(
+        framework.kubectl_command(),
+        &[
+            ("clusterrole", &format!("{}-sar-role", namespace)),
+            ("clusterrolebinding", &format!("{}-sar-binding", namespace)),
+        ],
+    )
     .await;
 
     Ok(())
@@ -709,48 +809,73 @@ async fn sar_auth_allowed_user_filter() -> Result<(), Box<dyn std::error::Error>
     let framework = make_framework();
     let override_name = get_override_name(&namespace, "vector");
 
+    // Create cleanup guard to ensure RBAC resources are deleted even on test failure
+    let mut cleanup = ClusterRbacCleanup::new(framework.kubectl_command().to_string());
+
     // Create namespace first
     // Namespace creation
-    create_namespace(&namespace).await?;
+    create_namespace(framework.kubectl_command(), &namespace).await?;
 
     // Create ServiceAccount for Vector with SAR permissions
 
-    create_service_account(&namespace, "vector-sa").await?;
+    create_service_account(framework.kubectl_command(), &namespace, "vector-sa").await?;
 
-    create_clusterrole_for_sar(&format!("{}-sar-role", namespace)).await?;
+    create_clusterrole_for_sar(
+        framework.kubectl_command(),
+        &format!("{}-sar-role", namespace),
+    )
+    .await?;
+    cleanup.track("clusterrole", format!("{}-sar-role", namespace));
 
-    let sar_binding = make_clusterrolebinding(
+    create_clusterrolebinding(
+        framework.kubectl_command(),
         &format!("{}-sar-binding", namespace),
         &format!("{}-sar-role", namespace),
         "vector-sa",
         &namespace,
-    );
-    framework.create(sar_binding).await?;
+    )
+    .await?;
+    cleanup.track("clusterrolebinding", format!("{}-sar-binding", namespace));
 
     // Create two ServiceAccounts, both with metrics permission
 
-    create_service_account(&namespace, "allowed-sa").await?;
+    create_service_account(framework.kubectl_command(), &namespace, "allowed-sa").await?;
 
-    create_service_account(&namespace, "denied-sa").await?;
+    create_service_account(framework.kubectl_command(), &namespace, "denied-sa").await?;
 
-    create_clusterrole_for_metrics(&format!("{}-metrics-role", namespace)).await?;
+    create_clusterrole_for_metrics(
+        framework.kubectl_command(),
+        &format!("{}-metrics-role", namespace),
+    )
+    .await?;
+    cleanup.track("clusterrole", format!("{}-metrics-role", namespace));
 
     // Both get metrics RBAC permission
-    let allowed_binding = make_clusterrolebinding(
+    create_clusterrolebinding(
+        framework.kubectl_command(),
         &format!("{}-allowed-binding", namespace),
         &format!("{}-metrics-role", namespace),
         "allowed-sa",
         &namespace,
+    )
+    .await?;
+    cleanup.track(
+        "clusterrolebinding",
+        format!("{}-allowed-binding", namespace),
     );
-    framework.create(allowed_binding).await?;
 
-    let denied_binding = make_clusterrolebinding(
+    create_clusterrolebinding(
+        framework.kubectl_command(),
         &format!("{}-denied-binding", namespace),
         &format!("{}-metrics-role", namespace),
         "denied-sa",
         &namespace,
+    )
+    .await?;
+    cleanup.track(
+        "clusterrolebinding",
+        format!("{}-denied-binding", namespace),
     );
-    framework.create(denied_binding).await?;
 
     // Deploy Vector with SAR auth and allowed_user filter
     let allowed_user_identity = format!("system:serviceaccount:{}:allowed-sa", namespace);
@@ -818,7 +943,8 @@ async fn sar_auth_allowed_user_filter() -> Result<(), Box<dyn std::error::Error>
     let client = reqwest::Client::new();
 
     // Test with allowed SA - should succeed
-    let allowed_token = get_service_account_token(&namespace, "allowed-sa").await?;
+    let allowed_token =
+        get_service_account_token(framework.kubectl_command(), &namespace, "allowed-sa").await?;
     let response = client
         .get(format!("http://{}/metrics", local_addr))
         .header(header::AUTHORIZATION, format!("Bearer {}", allowed_token))
@@ -832,7 +958,8 @@ async fn sar_auth_allowed_user_filter() -> Result<(), Box<dyn std::error::Error>
     );
 
     // Test with denied SA - should fail even though it has metrics RBAC
-    let denied_token = get_service_account_token(&namespace, "denied-sa").await?;
+    let denied_token =
+        get_service_account_token(framework.kubectl_command(), &namespace, "denied-sa").await?;
     let response = client
         .get(format!("http://{}/metrics", local_addr))
         .header(header::AUTHORIZATION, format!("Bearer {}", denied_token))
@@ -848,19 +975,22 @@ async fn sar_auth_allowed_user_filter() -> Result<(), Box<dyn std::error::Error>
     drop(vector);
 
     // Clean up cluster-scoped RBAC resources
-    cleanup_cluster_resources(&[
-        ("clusterrole", &format!("{}-sar-role", namespace)),
-        ("clusterrolebinding", &format!("{}-sar-binding", namespace)),
-        ("clusterrole", &format!("{}-metrics-role", namespace)),
-        (
-            "clusterrolebinding",
-            &format!("{}-allowed-binding", namespace),
-        ),
-        (
-            "clusterrolebinding",
-            &format!("{}-denied-binding", namespace),
-        ),
-    ])
+    cleanup_cluster_resources(
+        framework.kubectl_command(),
+        &[
+            ("clusterrole", &format!("{}-sar-role", namespace)),
+            ("clusterrolebinding", &format!("{}-sar-binding", namespace)),
+            ("clusterrole", &format!("{}-metrics-role", namespace)),
+            (
+                "clusterrolebinding",
+                &format!("{}-allowed-binding", namespace),
+            ),
+            (
+                "clusterrolebinding",
+                &format!("{}-denied-binding", namespace),
+            ),
+        ],
+    )
     .await;
 
     Ok(())

--- a/lib/k8s-e2e-tests/tests/prometheus-exporter-sar.rs
+++ b/lib/k8s-e2e-tests/tests/prometheus-exporter-sar.rs
@@ -46,7 +46,7 @@ impl Drop for TestResourceCleanup {
             rt.block_on(async move {
                 // First delete cluster-scoped RBAC resources
                 for (resource_type, name) in resources {
-                    let _ = tokio::process::Command::new(&kubectl)
+                    let _output = tokio::process::Command::new(&kubectl)
                         .args(["delete", &resource_type, &name, "--ignore-not-found=true"])
                         .output()
                         .await;
@@ -54,7 +54,7 @@ impl Drop for TestResourceCleanup {
 
                 // Then delete the namespace (which also deletes ServiceAccounts in it)
                 if let Some(ns) = namespace {
-                    let _ = tokio::process::Command::new(&kubectl)
+                    let _output = tokio::process::Command::new(&kubectl)
                         .args(["delete", "namespace", &ns, "--ignore-not-found=true"])
                         .output()
                         .await;
@@ -63,7 +63,7 @@ impl Drop for TestResourceCleanup {
         });
 
         // Wait for cleanup to complete (ignore errors - best effort)
-        let _ = handle.join();
+        let _result = handle.join();
     }
 }
 
@@ -71,7 +71,7 @@ impl Drop for TestResourceCleanup {
 /// Silently ignores errors (resources may already be deleted)
 async fn cleanup_cluster_resources(kubectl_command: &str, resource_names: &[(&str, &str)]) {
     for (resource_type, name) in resource_names {
-        let _ = tokio::process::Command::new(kubectl_command)
+        let _output = tokio::process::Command::new(kubectl_command)
             .args(["delete", resource_type, name, "--ignore-not-found=true"])
             .output()
             .await;

--- a/lib/k8s-e2e-tests/tests/prometheus-exporter-sar.rs
+++ b/lib/k8s-e2e-tests/tests/prometheus-exporter-sar.rs
@@ -6,19 +6,26 @@ use k8s_test_framework::{lock, vector::Config as VectorConfig};
 use reqwest::{StatusCode, header};
 use tokio::io::AsyncWriteExt;
 
-/// RAII guard for cluster-scoped RBAC resources that ensures cleanup on drop.
+/// RAII guard for test resources that ensures cleanup on drop.
 /// This prevents resource leakage when tests fail before reaching explicit cleanup.
-struct ClusterRbacCleanup {
+/// Tracks both cluster-scoped RBAC resources and the test namespace.
+struct TestResourceCleanup {
     kubectl_command: String,
+    namespace: Option<String>,
     resources: Vec<(String, String)>, // (resource_type, name)
 }
 
-impl ClusterRbacCleanup {
+impl TestResourceCleanup {
     fn new(kubectl_command: String) -> Self {
         Self {
             kubectl_command,
+            namespace: None,
             resources: Vec::new(),
         }
+    }
+
+    fn track_namespace(&mut self, namespace: String) {
+        self.namespace = Some(namespace);
     }
 
     fn track(&mut self, resource_type: &str, name: String) {
@@ -26,23 +33,37 @@ impl ClusterRbacCleanup {
     }
 }
 
-impl Drop for ClusterRbacCleanup {
+impl Drop for TestResourceCleanup {
     fn drop(&mut self) {
-        // Best-effort cleanup - spawn a blocking task to delete resources
+        // Best-effort cleanup - run synchronously to ensure completion before test exit
         let kubectl = self.kubectl_command.clone();
         let resources = self.resources.clone();
+        let namespace = self.namespace.clone();
 
-        std::thread::spawn(move || {
+        // Join the thread to ensure cleanup completes before Drop returns
+        let handle = std::thread::spawn(move || {
             let rt = tokio::runtime::Runtime::new().unwrap();
             rt.block_on(async move {
+                // First delete cluster-scoped RBAC resources
                 for (resource_type, name) in resources {
                     let _ = tokio::process::Command::new(&kubectl)
                         .args(["delete", &resource_type, &name, "--ignore-not-found=true"])
                         .output()
                         .await;
                 }
+
+                // Then delete the namespace (which also deletes ServiceAccounts in it)
+                if let Some(ns) = namespace {
+                    let _ = tokio::process::Command::new(&kubectl)
+                        .args(["delete", "namespace", &ns, "--ignore-not-found=true"])
+                        .output()
+                        .await;
+                }
             });
         });
+
+        // Wait for cleanup to complete (ignore errors - best effort)
+        let _ = handle.join();
     }
 }
 
@@ -262,11 +283,12 @@ async fn sar_auth_with_valid_token() -> Result<(), Box<dyn std::error::Error>> {
     let override_name = get_override_name(&namespace, "vector");
 
     // Create cleanup guard to ensure RBAC resources are deleted even on test failure
-    let mut cleanup = ClusterRbacCleanup::new(framework.kubectl_command().to_string());
+    let mut cleanup = TestResourceCleanup::new(framework.kubectl_command().to_string());
 
     // Create namespace first
     // Namespace creation
     create_namespace(framework.kubectl_command(), &namespace).await?;
+    cleanup.track_namespace(namespace.clone());
 
     // Create ServiceAccount for Vector with SAR permissions
 
@@ -415,11 +437,12 @@ async fn sar_auth_rejects_missing_token() -> Result<(), Box<dyn std::error::Erro
     let override_name = get_override_name(&namespace, "vector");
 
     // Create cleanup guard to ensure RBAC resources are deleted even on test failure
-    let mut cleanup = ClusterRbacCleanup::new(framework.kubectl_command().to_string());
+    let mut cleanup = TestResourceCleanup::new(framework.kubectl_command().to_string());
 
     // Create namespace first
     // Namespace creation
     create_namespace(framework.kubectl_command(), &namespace).await?;
+    cleanup.track_namespace(namespace.clone());
 
     // Create ServiceAccount for Vector with SAR permissions
 
@@ -541,11 +564,12 @@ async fn sar_auth_rejects_unauthorized_token() -> Result<(), Box<dyn std::error:
     let override_name = get_override_name(&namespace, "vector");
 
     // Create cleanup guard to ensure RBAC resources are deleted even on test failure
-    let mut cleanup = ClusterRbacCleanup::new(framework.kubectl_command().to_string());
+    let mut cleanup = TestResourceCleanup::new(framework.kubectl_command().to_string());
 
     // Create namespace first
     // Namespace creation
     create_namespace(framework.kubectl_command(), &namespace).await?;
+    cleanup.track_namespace(namespace.clone());
 
     // Create ServiceAccount for Vector with SAR permissions
 
@@ -677,11 +701,12 @@ async fn sar_auth_short_circuits_non_metrics_routes() -> Result<(), Box<dyn std:
     let override_name = get_override_name(&namespace, "vector");
 
     // Create cleanup guard to ensure RBAC resources are deleted even on test failure
-    let mut cleanup = ClusterRbacCleanup::new(framework.kubectl_command().to_string());
+    let mut cleanup = TestResourceCleanup::new(framework.kubectl_command().to_string());
 
     // Create namespace first
     // Namespace creation
     create_namespace(framework.kubectl_command(), &namespace).await?;
+    cleanup.track_namespace(namespace.clone());
 
     // Create ServiceAccount for Vector with SAR permissions
 
@@ -810,11 +835,12 @@ async fn sar_auth_allowed_user_filter() -> Result<(), Box<dyn std::error::Error>
     let override_name = get_override_name(&namespace, "vector");
 
     // Create cleanup guard to ensure RBAC resources are deleted even on test failure
-    let mut cleanup = ClusterRbacCleanup::new(framework.kubectl_command().to_string());
+    let mut cleanup = TestResourceCleanup::new(framework.kubectl_command().to_string());
 
     // Create namespace first
     // Namespace creation
     create_namespace(framework.kubectl_command(), &namespace).await?;
+    cleanup.track_namespace(namespace.clone());
 
     // Create ServiceAccount for Vector with SAR permissions
 

--- a/lib/k8s-e2e-tests/tests/prometheus-exporter-sar.rs
+++ b/lib/k8s-e2e-tests/tests/prometheus-exporter-sar.rs
@@ -2,140 +2,205 @@
 
 use indoc::{formatdoc, indoc};
 use k8s_e2e_tests::*;
-use k8s_openapi::api::{
-    core::v1::ServiceAccount,
-    rbac::v1::{ClusterRole, ClusterRoleBinding, PolicyRule, RoleRef, Subject},
-};
 use k8s_test_framework::{
-    lock, namespace, test_pod, vector::Config as VectorConfig, wait_for_resource::WaitFor,
+    lock, namespace, vector::Config as VectorConfig, wait_for_resource::WaitFor,
 };
 use reqwest::{StatusCode, header};
+use tokio::io::AsyncWriteExt;
 
 const VECTOR_NAMESPACE: &str = "vector-test";
 
-/// Helper to create a ServiceAccount
-fn make_service_account(namespace: &str, name: &str) -> ServiceAccount {
-    use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
-
-    ServiceAccount {
-        metadata: ObjectMeta {
-            name: Some(name.to_owned()),
-            namespace: Some(namespace.to_owned()),
-            ..ObjectMeta::default()
-        },
-        ..ServiceAccount::default()
+/// Helper to clean up cluster-scoped resources (ClusterRoles and ClusterRoleBindings)
+/// Silently ignores errors (resources may already be deleted)
+async fn cleanup_cluster_resources(resource_names: &[(&str, &str)]) {
+    for (resource_type, name) in resource_names {
+        let _ = tokio::process::Command::new("kubectl")
+            .args(["delete", resource_type, name, "--ignore-not-found=true"])
+            .output()
+            .await;
     }
 }
 
-/// Helper to create a ClusterRole for SAR
-fn make_clusterrole_for_sar(name: &str) -> ClusterRole {
-    use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+/// Helper to create a namespace using kubectl
+async fn create_namespace(namespace: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let output = tokio::process::Command::new("kubectl")
+        .args(["create", "namespace", namespace])
+        .output()
+        .await?;
 
-    ClusterRole {
-        metadata: ObjectMeta {
-            name: Some(name.to_owned()),
-            ..ObjectMeta::default()
-        },
-        rules: Some(vec![
-            PolicyRule {
-                api_groups: Some(vec!["authentication.k8s.io".to_string()]),
-                resources: Some(vec!["tokenreviews".to_string()]),
-                verbs: vec!["create".to_string()],
-                ..PolicyRule::default()
-            },
-            PolicyRule {
-                api_groups: Some(vec!["authorization.k8s.io".to_string()]),
-                resources: Some(vec!["subjectaccessreviews".to_string()]),
-                verbs: vec!["create".to_string()],
-                ..PolicyRule::default()
-            },
-        ]),
-        ..ClusterRole::default()
+    if !output.status.success() {
+        return Err(format!(
+            "Failed to create namespace: {}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+        .into());
     }
+    Ok(())
+}
+
+/// Helper to create a ServiceAccount using kubectl
+async fn create_service_account(
+    namespace: &str,
+    name: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let output = tokio::process::Command::new("kubectl")
+        .args(["create", "serviceaccount", name, "-n", namespace])
+        .output()
+        .await?;
+
+    if !output.status.success() {
+        return Err(format!(
+            "Failed to create ServiceAccount: {}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+        .into());
+    }
+    Ok(())
+}
+
+/// Helper to create a ClusterRole for SAR permissions
+async fn create_clusterrole_for_sar(name: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let yaml = formatdoc!(
+        r#"
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRole
+        metadata:
+          name: {name}
+        rules:
+        - apiGroups: ["authentication.k8s.io"]
+          resources: ["tokenreviews"]
+          verbs: ["create"]
+        - apiGroups: ["authorization.k8s.io"]
+          resources: ["subjectaccessreviews"]
+          verbs: ["create"]
+        "#,
+        name = name
+    );
+
+    let mut child = tokio::process::Command::new("kubectl")
+        .args(["apply", "-f", "-"])
+        .stdin(std::process::Stdio::piped())
+        .spawn()?;
+
+    child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(yaml.as_bytes())
+        .await?;
+    let output = child.wait_with_output().await?;
+
+    if !output.status.success() {
+        return Err(format!(
+            "Failed to create ClusterRole: {}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+        .into());
+    }
+    Ok(())
 }
 
 /// Helper to create a ClusterRole for metrics access
-fn make_clusterrole_for_metrics(name: &str) -> ClusterRole {
-    use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+async fn create_clusterrole_for_metrics(name: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let yaml = formatdoc!(
+        r#"
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRole
+        metadata:
+          name: {name}
+        rules:
+        - nonResourceURLs: ["/metrics"]
+          verbs: ["get"]
+        "#,
+        name = name
+    );
 
-    ClusterRole {
-        metadata: ObjectMeta {
-            name: Some(name.to_owned()),
-            ..ObjectMeta::default()
-        },
-        rules: Some(vec![PolicyRule {
-            non_resource_urls: Some(vec!["/metrics".to_string()]),
-            verbs: vec!["get".to_string()],
-            ..PolicyRule::default()
-        }]),
-        ..ClusterRole::default()
+    let mut child = tokio::process::Command::new("kubectl")
+        .args(["apply", "-f", "-"])
+        .stdin(std::process::Stdio::piped())
+        .spawn()?;
+
+    child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(yaml.as_bytes())
+        .await?;
+    let output = child.wait_with_output().await?;
+
+    if !output.status.success() {
+        return Err(format!(
+            "Failed to create ClusterRole: {}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+        .into());
     }
+    Ok(())
 }
 
 /// Helper to create a ClusterRoleBinding
-fn make_clusterrolebinding(
+async fn create_clusterrolebinding(
     name: &str,
     role_name: &str,
     sa_name: &str,
     sa_namespace: &str,
-) -> ClusterRoleBinding {
-    use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+) -> Result<(), Box<dyn std::error::Error>> {
+    let output = tokio::process::Command::new("kubectl")
+        .args([
+            "create",
+            "clusterrolebinding",
+            name,
+            "--clusterrole",
+            role_name,
+            "--serviceaccount",
+            &format!("{}:{}", sa_namespace, sa_name),
+        ])
+        .output()
+        .await?;
 
-    ClusterRoleBinding {
-        metadata: ObjectMeta {
-            name: Some(name.to_owned()),
-            ..ObjectMeta::default()
-        },
-        role_ref: RoleRef {
-            api_group: "rbac.authorization.k8s.io".to_string(),
-            kind: "ClusterRole".to_string(),
-            name: role_name.to_string(),
-        },
-        subjects: Some(vec![Subject {
-            kind: "ServiceAccount".to_string(),
-            name: sa_name.to_string(),
-            namespace: Some(sa_namespace.to_string()),
-            ..Subject::default()
-        }]),
+    if !output.status.success() {
+        return Err(format!(
+            "Failed to create ClusterRoleBinding: {}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+        .into());
     }
+    Ok(())
 }
 
-/// Helper to get ServiceAccount token from K8s
+/// Helper to get ServiceAccount token using kubectl create token
+///
+/// This uses `kubectl create token` which works on Kubernetes 1.24+ where
+/// legacy token Secrets are no longer automatically created.
 async fn get_service_account_token(
-    framework: &k8s_test_framework::Framework,
     namespace: &str,
     sa_name: &str,
 ) -> Result<String, Box<dyn std::error::Error>> {
-    use k8s_openapi::api::core::v1::Secret;
-    use k8s_test_framework::Interface;
-
-    // Wait a bit for token to be created
+    // Wait a bit for SA to be fully initialized
     tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
 
-    // Get secrets for the service account
-    let secrets: k8s_openapi::List<Secret> = framework
-        .interface
-        .client
-        .list(namespace, &Default::default())
+    let output = tokio::process::Command::new("kubectl")
+        .args([
+            "create",
+            "token",
+            sa_name,
+            "-n",
+            namespace,
+            "--duration=3600s",
+        ])
+        .output()
         .await?;
 
-    // Find the token secret for this SA
-    for secret in secrets.items {
-        if let Some(annotations) = &secret.metadata.annotations {
-            if let Some(sa) = annotations.get("kubernetes.io/service-account.name") {
-                if sa == sa_name {
-                    if let Some(data) = &secret.data {
-                        if let Some(token) = data.get("token") {
-                            let token_str = String::from_utf8(token.0.clone())?;
-                            return Ok(token_str);
-                        }
-                    }
-                }
-            }
-        }
+    if !output.status.success() {
+        return Err(format!(
+            "Failed to create token: {}",
+            String::from_utf8_lossy(&output.stderr)
+        )
+        .into());
     }
 
-    Err("Failed to find ServiceAccount token".into())
+    let token = String::from_utf8(output.stdout)?.trim().to_string();
+    Ok(token)
 }
 
 /// Test basic SAR authentication with valid token
@@ -148,12 +213,15 @@ async fn sar_auth_with_valid_token() -> Result<(), Box<dyn std::error::Error>> {
     let framework = make_framework();
     let override_name = get_override_name(&namespace, "vector");
 
-    // Create ServiceAccount for Vector with SAR permissions
-    let vector_sa = make_service_account(&namespace, "vector-sa");
-    framework.create(vector_sa).await?;
+    // Create namespace first
+    // Namespace creation
+    create_namespace(&namespace).await?;
 
-    let sar_role = make_clusterrole_for_sar(&format!("{}-sar-role", namespace));
-    framework.create(sar_role).await?;
+    // Create ServiceAccount for Vector with SAR permissions
+
+    create_service_account(&namespace, "vector-sa").await?;
+
+    create_clusterrole_for_sar(&format!("{}-sar-role", namespace)).await?;
 
     let sar_binding = make_clusterrolebinding(
         &format!("{}-sar-binding", namespace),
@@ -164,11 +232,10 @@ async fn sar_auth_with_valid_token() -> Result<(), Box<dyn std::error::Error>> {
     framework.create(sar_binding).await?;
 
     // Create ServiceAccount for Prometheus scraper with metrics permission
-    let prom_sa = make_service_account(&namespace, "prometheus-sa");
-    framework.create(prom_sa).await?;
 
-    let metrics_role = make_clusterrole_for_metrics(&format!("{}-metrics-role", namespace));
-    framework.create(metrics_role).await?;
+    create_service_account(&namespace, "prometheus-sa").await?;
+
+    create_clusterrole_for_metrics(&format!("{}-metrics-role", namespace)).await?;
 
     let metrics_binding = make_clusterrolebinding(
         &format!("{}-metrics-binding", namespace),
@@ -181,7 +248,9 @@ async fn sar_auth_with_valid_token() -> Result<(), Box<dyn std::error::Error>> {
     // Deploy Vector with SAR auth
     let helm_values = formatdoc!(
         r#"
+        role: Agent
         serviceAccount:
+          create: false
           name: vector-sa
         customConfig:
           sources:
@@ -259,6 +328,19 @@ async fn sar_auth_with_valid_token() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     drop(vector);
+
+    // Clean up cluster-scoped RBAC resources
+    cleanup_cluster_resources(&[
+        ("clusterrole", &format!("{}-sar-role", namespace)),
+        ("clusterrolebinding", &format!("{}-sar-binding", namespace)),
+        ("clusterrole", &format!("{}-metrics-role", namespace)),
+        (
+            "clusterrolebinding",
+            &format!("{}-metrics-binding", namespace),
+        ),
+    ])
+    .await;
+
     Ok(())
 }
 
@@ -272,12 +354,15 @@ async fn sar_auth_rejects_missing_token() -> Result<(), Box<dyn std::error::Erro
     let framework = make_framework();
     let override_name = get_override_name(&namespace, "vector");
 
-    // Create ServiceAccount for Vector with SAR permissions
-    let vector_sa = make_service_account(&namespace, "vector-sa");
-    framework.create(vector_sa).await?;
+    // Create namespace first
+    // Namespace creation
+    create_namespace(&namespace).await?;
 
-    let sar_role = make_clusterrole_for_sar(&format!("{}-sar-role", namespace));
-    framework.create(sar_role).await?;
+    // Create ServiceAccount for Vector with SAR permissions
+
+    create_service_account(&namespace, "vector-sa").await?;
+
+    create_clusterrole_for_sar(&format!("{}-sar-role", namespace)).await?;
 
     let sar_binding = make_clusterrolebinding(
         &format!("{}-sar-binding", namespace),
@@ -290,7 +375,9 @@ async fn sar_auth_rejects_missing_token() -> Result<(), Box<dyn std::error::Erro
     // Deploy Vector with SAR auth
     let helm_values = formatdoc!(
         r#"
+        role: Agent
         serviceAccount:
+          create: false
           name: vector-sa
         customConfig:
           sources:
@@ -355,6 +442,14 @@ async fn sar_auth_rejects_missing_token() -> Result<(), Box<dyn std::error::Erro
     );
 
     drop(vector);
+
+    // Clean up cluster-scoped RBAC resources
+    cleanup_cluster_resources(&[
+        ("clusterrole", &format!("{}-sar-role", namespace)),
+        ("clusterrolebinding", &format!("{}-sar-binding", namespace)),
+    ])
+    .await;
+
     Ok(())
 }
 
@@ -368,12 +463,15 @@ async fn sar_auth_rejects_unauthorized_token() -> Result<(), Box<dyn std::error:
     let framework = make_framework();
     let override_name = get_override_name(&namespace, "vector");
 
-    // Create ServiceAccount for Vector with SAR permissions
-    let vector_sa = make_service_account(&namespace, "vector-sa");
-    framework.create(vector_sa).await?;
+    // Create namespace first
+    // Namespace creation
+    create_namespace(&namespace).await?;
 
-    let sar_role = make_clusterrole_for_sar(&format!("{}-sar-role", namespace));
-    framework.create(sar_role).await?;
+    // Create ServiceAccount for Vector with SAR permissions
+
+    create_service_account(&namespace, "vector-sa").await?;
+
+    create_clusterrole_for_sar(&format!("{}-sar-role", namespace)).await?;
 
     let sar_binding = make_clusterrolebinding(
         &format!("{}-sar-binding", namespace),
@@ -384,13 +482,15 @@ async fn sar_auth_rejects_unauthorized_token() -> Result<(), Box<dyn std::error:
     framework.create(sar_binding).await?;
 
     // Create ServiceAccount WITHOUT metrics permission
-    let unprivileged_sa = make_service_account(&namespace, "unprivileged-sa");
-    framework.create(unprivileged_sa).await?;
+
+    create_service_account(&namespace, "unprivileged-sa").await?;
 
     // Deploy Vector with SAR auth
     let helm_values = formatdoc!(
         r#"
+        role: Agent
         serviceAccount:
+          create: false
           name: vector-sa
         customConfig:
           sources:
@@ -462,6 +562,14 @@ async fn sar_auth_rejects_unauthorized_token() -> Result<(), Box<dyn std::error:
     );
 
     drop(vector);
+
+    // Clean up cluster-scoped RBAC resources
+    cleanup_cluster_resources(&[
+        ("clusterrole", &format!("{}-sar-role", namespace)),
+        ("clusterrolebinding", &format!("{}-sar-binding", namespace)),
+    ])
+    .await;
+
     Ok(())
 }
 
@@ -475,12 +583,15 @@ async fn sar_auth_short_circuits_non_metrics_routes() -> Result<(), Box<dyn std:
     let framework = make_framework();
     let override_name = get_override_name(&namespace, "vector");
 
-    // Create ServiceAccount for Vector with SAR permissions
-    let vector_sa = make_service_account(&namespace, "vector-sa");
-    framework.create(vector_sa).await?;
+    // Create namespace first
+    // Namespace creation
+    create_namespace(&namespace).await?;
 
-    let sar_role = make_clusterrole_for_sar(&format!("{}-sar-role", namespace));
-    framework.create(sar_role).await?;
+    // Create ServiceAccount for Vector with SAR permissions
+
+    create_service_account(&namespace, "vector-sa").await?;
+
+    create_clusterrole_for_sar(&format!("{}-sar-role", namespace)).await?;
 
     let sar_binding = make_clusterrolebinding(
         &format!("{}-sar-binding", namespace),
@@ -493,7 +604,9 @@ async fn sar_auth_short_circuits_non_metrics_routes() -> Result<(), Box<dyn std:
     // Deploy Vector with SAR auth
     let helm_values = formatdoc!(
         r#"
+        role: Agent
         serviceAccount:
+          create: false
           name: vector-sa
         customConfig:
           sources:
@@ -568,6 +681,14 @@ async fn sar_auth_short_circuits_non_metrics_routes() -> Result<(), Box<dyn std:
     }
 
     drop(vector);
+
+    // Clean up cluster-scoped RBAC resources
+    cleanup_cluster_resources(&[
+        ("clusterrole", &format!("{}-sar-role", namespace)),
+        ("clusterrolebinding", &format!("{}-sar-binding", namespace)),
+    ])
+    .await;
+
     Ok(())
 }
 
@@ -581,12 +702,15 @@ async fn sar_auth_allowed_user_filter() -> Result<(), Box<dyn std::error::Error>
     let framework = make_framework();
     let override_name = get_override_name(&namespace, "vector");
 
-    // Create ServiceAccount for Vector with SAR permissions
-    let vector_sa = make_service_account(&namespace, "vector-sa");
-    framework.create(vector_sa).await?;
+    // Create namespace first
+    // Namespace creation
+    create_namespace(&namespace).await?;
 
-    let sar_role = make_clusterrole_for_sar(&format!("{}-sar-role", namespace));
-    framework.create(sar_role).await?;
+    // Create ServiceAccount for Vector with SAR permissions
+
+    create_service_account(&namespace, "vector-sa").await?;
+
+    create_clusterrole_for_sar(&format!("{}-sar-role", namespace)).await?;
 
     let sar_binding = make_clusterrolebinding(
         &format!("{}-sar-binding", namespace),
@@ -597,14 +721,12 @@ async fn sar_auth_allowed_user_filter() -> Result<(), Box<dyn std::error::Error>
     framework.create(sar_binding).await?;
 
     // Create two ServiceAccounts, both with metrics permission
-    let allowed_sa = make_service_account(&namespace, "allowed-sa");
-    framework.create(allowed_sa).await?;
 
-    let denied_sa = make_service_account(&namespace, "denied-sa");
-    framework.create(denied_sa).await?;
+    create_service_account(&namespace, "allowed-sa").await?;
 
-    let metrics_role = make_clusterrole_for_metrics(&format!("{}-metrics-role", namespace));
-    framework.create(metrics_role).await?;
+    create_service_account(&namespace, "denied-sa").await?;
+
+    create_clusterrole_for_metrics(&format!("{}-metrics-role", namespace)).await?;
 
     // Both get metrics RBAC permission
     let allowed_binding = make_clusterrolebinding(
@@ -627,7 +749,9 @@ async fn sar_auth_allowed_user_filter() -> Result<(), Box<dyn std::error::Error>
     let allowed_user_identity = format!("system:serviceaccount:{}:allowed-sa", namespace);
     let helm_values = formatdoc!(
         r#"
+        role: Agent
         serviceAccount:
+          create: false
           name: vector-sa
         customConfig:
           sources:
@@ -714,5 +838,22 @@ async fn sar_auth_allowed_user_filter() -> Result<(), Box<dyn std::error::Error>
     );
 
     drop(vector);
+
+    // Clean up cluster-scoped RBAC resources
+    cleanup_cluster_resources(&[
+        ("clusterrole", &format!("{}-sar-role", namespace)),
+        ("clusterrolebinding", &format!("{}-sar-binding", namespace)),
+        ("clusterrole", &format!("{}-metrics-role", namespace)),
+        (
+            "clusterrolebinding",
+            &format!("{}-allowed-binding", namespace),
+        ),
+        (
+            "clusterrolebinding",
+            &format!("{}-denied-binding", namespace),
+        ),
+    ])
+    .await;
+
     Ok(())
 }

--- a/lib/k8s-e2e-tests/tests/prometheus-exporter-sar.rs
+++ b/lib/k8s-e2e-tests/tests/prometheus-exporter-sar.rs
@@ -1,0 +1,718 @@
+#![allow(clippy::await_holding_lock)]
+
+use indoc::{formatdoc, indoc};
+use k8s_e2e_tests::*;
+use k8s_openapi::api::{
+    core::v1::ServiceAccount,
+    rbac::v1::{ClusterRole, ClusterRoleBinding, PolicyRule, RoleRef, Subject},
+};
+use k8s_test_framework::{
+    lock, namespace, test_pod, vector::Config as VectorConfig, wait_for_resource::WaitFor,
+};
+use reqwest::{StatusCode, header};
+
+const VECTOR_NAMESPACE: &str = "vector-test";
+
+/// Helper to create a ServiceAccount
+fn make_service_account(namespace: &str, name: &str) -> ServiceAccount {
+    use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+
+    ServiceAccount {
+        metadata: ObjectMeta {
+            name: Some(name.to_owned()),
+            namespace: Some(namespace.to_owned()),
+            ..ObjectMeta::default()
+        },
+        ..ServiceAccount::default()
+    }
+}
+
+/// Helper to create a ClusterRole for SAR
+fn make_clusterrole_for_sar(name: &str) -> ClusterRole {
+    use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+
+    ClusterRole {
+        metadata: ObjectMeta {
+            name: Some(name.to_owned()),
+            ..ObjectMeta::default()
+        },
+        rules: Some(vec![
+            PolicyRule {
+                api_groups: Some(vec!["authentication.k8s.io".to_string()]),
+                resources: Some(vec!["tokenreviews".to_string()]),
+                verbs: vec!["create".to_string()],
+                ..PolicyRule::default()
+            },
+            PolicyRule {
+                api_groups: Some(vec!["authorization.k8s.io".to_string()]),
+                resources: Some(vec!["subjectaccessreviews".to_string()]),
+                verbs: vec!["create".to_string()],
+                ..PolicyRule::default()
+            },
+        ]),
+        ..ClusterRole::default()
+    }
+}
+
+/// Helper to create a ClusterRole for metrics access
+fn make_clusterrole_for_metrics(name: &str) -> ClusterRole {
+    use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+
+    ClusterRole {
+        metadata: ObjectMeta {
+            name: Some(name.to_owned()),
+            ..ObjectMeta::default()
+        },
+        rules: Some(vec![PolicyRule {
+            non_resource_urls: Some(vec!["/metrics".to_string()]),
+            verbs: vec!["get".to_string()],
+            ..PolicyRule::default()
+        }]),
+        ..ClusterRole::default()
+    }
+}
+
+/// Helper to create a ClusterRoleBinding
+fn make_clusterrolebinding(
+    name: &str,
+    role_name: &str,
+    sa_name: &str,
+    sa_namespace: &str,
+) -> ClusterRoleBinding {
+    use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+
+    ClusterRoleBinding {
+        metadata: ObjectMeta {
+            name: Some(name.to_owned()),
+            ..ObjectMeta::default()
+        },
+        role_ref: RoleRef {
+            api_group: "rbac.authorization.k8s.io".to_string(),
+            kind: "ClusterRole".to_string(),
+            name: role_name.to_string(),
+        },
+        subjects: Some(vec![Subject {
+            kind: "ServiceAccount".to_string(),
+            name: sa_name.to_string(),
+            namespace: Some(sa_namespace.to_string()),
+            ..Subject::default()
+        }]),
+    }
+}
+
+/// Helper to get ServiceAccount token from K8s
+async fn get_service_account_token(
+    framework: &k8s_test_framework::Framework,
+    namespace: &str,
+    sa_name: &str,
+) -> Result<String, Box<dyn std::error::Error>> {
+    use k8s_openapi::api::core::v1::Secret;
+    use k8s_test_framework::Interface;
+
+    // Wait a bit for token to be created
+    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+
+    // Get secrets for the service account
+    let secrets: k8s_openapi::List<Secret> = framework
+        .interface
+        .client
+        .list(namespace, &Default::default())
+        .await?;
+
+    // Find the token secret for this SA
+    for secret in secrets.items {
+        if let Some(annotations) = &secret.metadata.annotations {
+            if let Some(sa) = annotations.get("kubernetes.io/service-account.name") {
+                if sa == sa_name {
+                    if let Some(data) = &secret.data {
+                        if let Some(token) = data.get("token") {
+                            let token_str = String::from_utf8(token.0.clone())?;
+                            return Ok(token_str);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Err("Failed to find ServiceAccount token".into())
+}
+
+/// Test basic SAR authentication with valid token
+#[tokio::test]
+async fn sar_auth_with_valid_token() -> Result<(), Box<dyn std::error::Error>> {
+    let _guard = lock();
+    init();
+
+    let namespace = get_namespace();
+    let framework = make_framework();
+    let override_name = get_override_name(&namespace, "vector");
+
+    // Create ServiceAccount for Vector with SAR permissions
+    let vector_sa = make_service_account(&namespace, "vector-sa");
+    framework.create(vector_sa).await?;
+
+    let sar_role = make_clusterrole_for_sar(&format!("{}-sar-role", namespace));
+    framework.create(sar_role).await?;
+
+    let sar_binding = make_clusterrolebinding(
+        &format!("{}-sar-binding", namespace),
+        &format!("{}-sar-role", namespace),
+        "vector-sa",
+        &namespace,
+    );
+    framework.create(sar_binding).await?;
+
+    // Create ServiceAccount for Prometheus scraper with metrics permission
+    let prom_sa = make_service_account(&namespace, "prometheus-sa");
+    framework.create(prom_sa).await?;
+
+    let metrics_role = make_clusterrole_for_metrics(&format!("{}-metrics-role", namespace));
+    framework.create(metrics_role).await?;
+
+    let metrics_binding = make_clusterrolebinding(
+        &format!("{}-metrics-binding", namespace),
+        &format!("{}-metrics-role", namespace),
+        "prometheus-sa",
+        &namespace,
+    );
+    framework.create(metrics_binding).await?;
+
+    // Deploy Vector with SAR auth
+    let helm_values = formatdoc!(
+        r#"
+        serviceAccount:
+          name: vector-sa
+        customConfig:
+          sources:
+            internal_metrics:
+              type: internal_metrics
+          sinks:
+            prometheus:
+              type: prometheus_exporter
+              inputs: [internal_metrics]
+              address: "0.0.0.0:9598"
+              auth:
+                strategy: sar
+                path: "/metrics"
+                verb: "get"
+        service:
+          ports:
+            - name: metrics
+              port: 9598
+              protocol: TCP
+        "#
+    );
+
+    let vector = framework
+        .helm_chart(
+            &namespace,
+            "vector",
+            "vector",
+            &helm_chart_repo(),
+            VectorConfig {
+                custom_helm_values: vec![&config_override_name(&override_name, true), &helm_values],
+                ..Default::default()
+            },
+        )
+        .await?;
+
+    framework
+        .wait_for_rollout(
+            &namespace,
+            &format!("daemonset/{override_name}"),
+            vec!["--timeout=60s"],
+        )
+        .await?;
+
+    // Port forward to Vector's metrics endpoint
+    let mut port_forward = framework.port_forward(
+        &namespace,
+        &format!("daemonset/{override_name}"),
+        9598,
+        9598,
+    )?;
+
+    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+
+    // Get Prometheus SA token
+    let token = get_service_account_token(&framework, &namespace, "prometheus-sa").await?;
+
+    // Make authenticated request with valid token
+    let client = reqwest::Client::new();
+    let response = client
+        .get("http://localhost:9598/metrics")
+        .header(header::AUTHORIZATION, format!("Bearer {}", token))
+        .send()
+        .await?;
+
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "Expected 200 OK with valid Prometheus SA token"
+    );
+
+    let body = response.text().await?;
+    assert!(
+        body.contains("# HELP"),
+        "Response should contain Prometheus metrics"
+    );
+
+    drop(vector);
+    Ok(())
+}
+
+/// Test SAR authentication rejects requests without token
+#[tokio::test]
+async fn sar_auth_rejects_missing_token() -> Result<(), Box<dyn std::error::Error>> {
+    let _guard = lock();
+    init();
+
+    let namespace = get_namespace();
+    let framework = make_framework();
+    let override_name = get_override_name(&namespace, "vector");
+
+    // Create ServiceAccount for Vector with SAR permissions
+    let vector_sa = make_service_account(&namespace, "vector-sa");
+    framework.create(vector_sa).await?;
+
+    let sar_role = make_clusterrole_for_sar(&format!("{}-sar-role", namespace));
+    framework.create(sar_role).await?;
+
+    let sar_binding = make_clusterrolebinding(
+        &format!("{}-sar-binding", namespace),
+        &format!("{}-sar-role", namespace),
+        "vector-sa",
+        &namespace,
+    );
+    framework.create(sar_binding).await?;
+
+    // Deploy Vector with SAR auth
+    let helm_values = formatdoc!(
+        r#"
+        serviceAccount:
+          name: vector-sa
+        customConfig:
+          sources:
+            internal_metrics:
+              type: internal_metrics
+          sinks:
+            prometheus:
+              type: prometheus_exporter
+              inputs: [internal_metrics]
+              address: "0.0.0.0:9598"
+              auth:
+                strategy: sar
+                path: "/metrics"
+                verb: "get"
+        service:
+          ports:
+            - name: metrics
+              port: 9598
+              protocol: TCP
+        "#
+    );
+
+    let vector = framework
+        .helm_chart(
+            &namespace,
+            "vector",
+            "vector",
+            &helm_chart_repo(),
+            VectorConfig {
+                custom_helm_values: vec![&config_override_name(&override_name, true), &helm_values],
+                ..Default::default()
+            },
+        )
+        .await?;
+
+    framework
+        .wait_for_rollout(
+            &namespace,
+            &format!("daemonset/{override_name}"),
+            vec!["--timeout=60s"],
+        )
+        .await?;
+
+    // Port forward to Vector's metrics endpoint
+    let mut port_forward = framework.port_forward(
+        &namespace,
+        &format!("daemonset/{override_name}"),
+        9598,
+        9598,
+    )?;
+
+    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+
+    // Make request without token
+    let client = reqwest::Client::new();
+    let response = client.get("http://localhost:9598/metrics").send().await?;
+
+    assert_eq!(
+        response.status(),
+        StatusCode::UNAUTHORIZED,
+        "Expected 401 Unauthorized without token"
+    );
+
+    drop(vector);
+    Ok(())
+}
+
+/// Test SAR authentication rejects token without permission
+#[tokio::test]
+async fn sar_auth_rejects_unauthorized_token() -> Result<(), Box<dyn std::error::Error>> {
+    let _guard = lock();
+    init();
+
+    let namespace = get_namespace();
+    let framework = make_framework();
+    let override_name = get_override_name(&namespace, "vector");
+
+    // Create ServiceAccount for Vector with SAR permissions
+    let vector_sa = make_service_account(&namespace, "vector-sa");
+    framework.create(vector_sa).await?;
+
+    let sar_role = make_clusterrole_for_sar(&format!("{}-sar-role", namespace));
+    framework.create(sar_role).await?;
+
+    let sar_binding = make_clusterrolebinding(
+        &format!("{}-sar-binding", namespace),
+        &format!("{}-sar-role", namespace),
+        "vector-sa",
+        &namespace,
+    );
+    framework.create(sar_binding).await?;
+
+    // Create ServiceAccount WITHOUT metrics permission
+    let unprivileged_sa = make_service_account(&namespace, "unprivileged-sa");
+    framework.create(unprivileged_sa).await?;
+
+    // Deploy Vector with SAR auth
+    let helm_values = formatdoc!(
+        r#"
+        serviceAccount:
+          name: vector-sa
+        customConfig:
+          sources:
+            internal_metrics:
+              type: internal_metrics
+          sinks:
+            prometheus:
+              type: prometheus_exporter
+              inputs: [internal_metrics]
+              address: "0.0.0.0:9598"
+              auth:
+                strategy: sar
+                path: "/metrics"
+                verb: "get"
+        service:
+          ports:
+            - name: metrics
+              port: 9598
+              protocol: TCP
+        "#
+    );
+
+    let vector = framework
+        .helm_chart(
+            &namespace,
+            "vector",
+            "vector",
+            &helm_chart_repo(),
+            VectorConfig {
+                custom_helm_values: vec![&config_override_name(&override_name, true), &helm_values],
+                ..Default::default()
+            },
+        )
+        .await?;
+
+    framework
+        .wait_for_rollout(
+            &namespace,
+            &format!("daemonset/{override_name}"),
+            vec!["--timeout=60s"],
+        )
+        .await?;
+
+    // Port forward to Vector's metrics endpoint
+    let mut port_forward = framework.port_forward(
+        &namespace,
+        &format!("daemonset/{override_name}"),
+        9598,
+        9598,
+    )?;
+
+    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+
+    // Get unprivileged SA token
+    let token = get_service_account_token(&framework, &namespace, "unprivileged-sa").await?;
+
+    // Make request with unauthorized token
+    let client = reqwest::Client::new();
+    let response = client
+        .get("http://localhost:9598/metrics")
+        .header(header::AUTHORIZATION, format!("Bearer {}", token))
+        .send()
+        .await?;
+
+    assert_eq!(
+        response.status(),
+        StatusCode::UNAUTHORIZED,
+        "Expected 401 Unauthorized with unprivileged token"
+    );
+
+    drop(vector);
+    Ok(())
+}
+
+/// Test that non-/metrics routes return 404 without SAR check (short-circuit)
+#[tokio::test]
+async fn sar_auth_short_circuits_non_metrics_routes() -> Result<(), Box<dyn std::error::Error>> {
+    let _guard = lock();
+    init();
+
+    let namespace = get_namespace();
+    let framework = make_framework();
+    let override_name = get_override_name(&namespace, "vector");
+
+    // Create ServiceAccount for Vector with SAR permissions
+    let vector_sa = make_service_account(&namespace, "vector-sa");
+    framework.create(vector_sa).await?;
+
+    let sar_role = make_clusterrole_for_sar(&format!("{}-sar-role", namespace));
+    framework.create(sar_role).await?;
+
+    let sar_binding = make_clusterrolebinding(
+        &format!("{}-sar-binding", namespace),
+        &format!("{}-sar-role", namespace),
+        "vector-sa",
+        &namespace,
+    );
+    framework.create(sar_binding).await?;
+
+    // Deploy Vector with SAR auth
+    let helm_values = formatdoc!(
+        r#"
+        serviceAccount:
+          name: vector-sa
+        customConfig:
+          sources:
+            internal_metrics:
+              type: internal_metrics
+          sinks:
+            prometheus:
+              type: prometheus_exporter
+              inputs: [internal_metrics]
+              address: "0.0.0.0:9598"
+              auth:
+                strategy: sar
+                path: "/metrics"
+                verb: "get"
+        service:
+          ports:
+            - name: metrics
+              port: 9598
+              protocol: TCP
+        "#
+    );
+
+    let vector = framework
+        .helm_chart(
+            &namespace,
+            "vector",
+            "vector",
+            &helm_chart_repo(),
+            VectorConfig {
+                custom_helm_values: vec![&config_override_name(&override_name, true), &helm_values],
+                ..Default::default()
+            },
+        )
+        .await?;
+
+    framework
+        .wait_for_rollout(
+            &namespace,
+            &format!("daemonset/{override_name}"),
+            vec!["--timeout=60s"],
+        )
+        .await?;
+
+    // Port forward to Vector's metrics endpoint
+    let mut port_forward = framework.port_forward(
+        &namespace,
+        &format!("daemonset/{override_name}"),
+        9598,
+        9598,
+    )?;
+
+    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+
+    let client = reqwest::Client::new();
+
+    // Test various non-/metrics paths - should all return 404 immediately
+    // without triggering SAR (we test this by not providing any token)
+    let invalid_paths = vec!["/", "/health", "/api", "/foo", "/metrics/extra"];
+
+    for path in invalid_paths {
+        let response = client
+            .get(format!("http://localhost:9598{}", path))
+            .send()
+            .await?;
+
+        assert_eq!(
+            response.status(),
+            StatusCode::NOT_FOUND,
+            "Path {} should return 404 without auth check",
+            path
+        );
+    }
+
+    drop(vector);
+    Ok(())
+}
+
+/// Test allowed_user filter restricts access to specific identity
+#[tokio::test]
+async fn sar_auth_allowed_user_filter() -> Result<(), Box<dyn std::error::Error>> {
+    let _guard = lock();
+    init();
+
+    let namespace = get_namespace();
+    let framework = make_framework();
+    let override_name = get_override_name(&namespace, "vector");
+
+    // Create ServiceAccount for Vector with SAR permissions
+    let vector_sa = make_service_account(&namespace, "vector-sa");
+    framework.create(vector_sa).await?;
+
+    let sar_role = make_clusterrole_for_sar(&format!("{}-sar-role", namespace));
+    framework.create(sar_role).await?;
+
+    let sar_binding = make_clusterrolebinding(
+        &format!("{}-sar-binding", namespace),
+        &format!("{}-sar-role", namespace),
+        "vector-sa",
+        &namespace,
+    );
+    framework.create(sar_binding).await?;
+
+    // Create two ServiceAccounts, both with metrics permission
+    let allowed_sa = make_service_account(&namespace, "allowed-sa");
+    framework.create(allowed_sa).await?;
+
+    let denied_sa = make_service_account(&namespace, "denied-sa");
+    framework.create(denied_sa).await?;
+
+    let metrics_role = make_clusterrole_for_metrics(&format!("{}-metrics-role", namespace));
+    framework.create(metrics_role).await?;
+
+    // Both get metrics RBAC permission
+    let allowed_binding = make_clusterrolebinding(
+        &format!("{}-allowed-binding", namespace),
+        &format!("{}-metrics-role", namespace),
+        "allowed-sa",
+        &namespace,
+    );
+    framework.create(allowed_binding).await?;
+
+    let denied_binding = make_clusterrolebinding(
+        &format!("{}-denied-binding", namespace),
+        &format!("{}-metrics-role", namespace),
+        "denied-sa",
+        &namespace,
+    );
+    framework.create(denied_binding).await?;
+
+    // Deploy Vector with SAR auth and allowed_user filter
+    let allowed_user_identity = format!("system:serviceaccount:{}:allowed-sa", namespace);
+    let helm_values = formatdoc!(
+        r#"
+        serviceAccount:
+          name: vector-sa
+        customConfig:
+          sources:
+            internal_metrics:
+              type: internal_metrics
+          sinks:
+            prometheus:
+              type: prometheus_exporter
+              inputs: [internal_metrics]
+              address: "0.0.0.0:9598"
+              auth:
+                strategy: sar
+                path: "/metrics"
+                verb: "get"
+                allowed_user: "{}"
+        service:
+          ports:
+            - name: metrics
+              port: 9598
+              protocol: TCP
+        "#,
+        allowed_user_identity
+    );
+
+    let vector = framework
+        .helm_chart(
+            &namespace,
+            "vector",
+            "vector",
+            &helm_chart_repo(),
+            VectorConfig {
+                custom_helm_values: vec![&config_override_name(&override_name, true), &helm_values],
+                ..Default::default()
+            },
+        )
+        .await?;
+
+    framework
+        .wait_for_rollout(
+            &namespace,
+            &format!("daemonset/{override_name}"),
+            vec!["--timeout=60s"],
+        )
+        .await?;
+
+    // Port forward to Vector's metrics endpoint
+    let mut port_forward = framework.port_forward(
+        &namespace,
+        &format!("daemonset/{override_name}"),
+        9598,
+        9598,
+    )?;
+
+    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+
+    let client = reqwest::Client::new();
+
+    // Test with allowed SA - should succeed
+    let allowed_token = get_service_account_token(&framework, &namespace, "allowed-sa").await?;
+    let response = client
+        .get("http://localhost:9598/metrics")
+        .header(header::AUTHORIZATION, format!("Bearer {}", allowed_token))
+        .send()
+        .await?;
+
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "Allowed user should be granted access"
+    );
+
+    // Test with denied SA - should fail even though it has metrics RBAC
+    let denied_token = get_service_account_token(&framework, &namespace, "denied-sa").await?;
+    let response = client
+        .get("http://localhost:9598/metrics")
+        .header(header::AUTHORIZATION, format!("Bearer {}", denied_token))
+        .send()
+        .await?;
+
+    assert_eq!(
+        response.status(),
+        StatusCode::UNAUTHORIZED,
+        "Denied user should be rejected by allowed_user filter"
+    );
+
+    drop(vector);
+    Ok(())
+}

--- a/lib/k8s-e2e-tests/tests/prometheus-exporter-sar.rs
+++ b/lib/k8s-e2e-tests/tests/prometheus-exporter-sar.rs
@@ -302,15 +302,16 @@ async fn sar_auth_with_valid_token() -> Result<(), Box<dyn std::error::Error>> {
         9598,
     )?;
 
-    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+    port_forward.wait_until_ready().await?;
+    let local_addr = port_forward.local_addr_ipv4();
 
     // Get Prometheus SA token
-    let token = get_service_account_token(&framework, &namespace, "prometheus-sa").await?;
+    let token = get_service_account_token(&namespace, "prometheus-sa").await?;
 
     // Make authenticated request with valid token
     let client = reqwest::Client::new();
     let response = client
-        .get("http://localhost:9598/metrics")
+        .get(format!("http://{}/metrics", local_addr))
         .header(header::AUTHORIZATION, format!("Bearer {}", token))
         .send()
         .await?;
@@ -429,11 +430,15 @@ async fn sar_auth_rejects_missing_token() -> Result<(), Box<dyn std::error::Erro
         9598,
     )?;
 
-    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+    port_forward.wait_until_ready().await?;
+    let local_addr = port_forward.local_addr_ipv4();
 
     // Make request without token
     let client = reqwest::Client::new();
-    let response = client.get("http://localhost:9598/metrics").send().await?;
+    let response = client
+        .get(format!("http://{}/metrics", local_addr))
+        .send()
+        .await?;
 
     assert_eq!(
         response.status(),
@@ -542,15 +547,16 @@ async fn sar_auth_rejects_unauthorized_token() -> Result<(), Box<dyn std::error:
         9598,
     )?;
 
-    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+    port_forward.wait_until_ready().await?;
+    let local_addr = port_forward.local_addr_ipv4();
 
     // Get unprivileged SA token
-    let token = get_service_account_token(&framework, &namespace, "unprivileged-sa").await?;
+    let token = get_service_account_token(&namespace, "unprivileged-sa").await?;
 
     // Make request with unauthorized token
     let client = reqwest::Client::new();
     let response = client
-        .get("http://localhost:9598/metrics")
+        .get(format!("http://{}/metrics", local_addr))
         .header(header::AUTHORIZATION, format!("Bearer {}", token))
         .send()
         .await?;
@@ -658,7 +664,8 @@ async fn sar_auth_short_circuits_non_metrics_routes() -> Result<(), Box<dyn std:
         9598,
     )?;
 
-    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+    port_forward.wait_until_ready().await?;
+    let local_addr = port_forward.local_addr_ipv4();
 
     let client = reqwest::Client::new();
 
@@ -668,7 +675,7 @@ async fn sar_auth_short_circuits_non_metrics_routes() -> Result<(), Box<dyn std:
 
     for path in invalid_paths {
         let response = client
-            .get(format!("http://localhost:9598{}", path))
+            .get(format!("http://{}{}", local_addr, path))
             .send()
             .await?;
 
@@ -805,14 +812,15 @@ async fn sar_auth_allowed_user_filter() -> Result<(), Box<dyn std::error::Error>
         9598,
     )?;
 
-    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+    port_forward.wait_until_ready().await?;
+    let local_addr = port_forward.local_addr_ipv4();
 
     let client = reqwest::Client::new();
 
     // Test with allowed SA - should succeed
-    let allowed_token = get_service_account_token(&framework, &namespace, "allowed-sa").await?;
+    let allowed_token = get_service_account_token(&namespace, "allowed-sa").await?;
     let response = client
-        .get("http://localhost:9598/metrics")
+        .get(format!("http://{}/metrics", local_addr))
         .header(header::AUTHORIZATION, format!("Bearer {}", allowed_token))
         .send()
         .await?;
@@ -824,9 +832,9 @@ async fn sar_auth_allowed_user_filter() -> Result<(), Box<dyn std::error::Error>
     );
 
     // Test with denied SA - should fail even though it has metrics RBAC
-    let denied_token = get_service_account_token(&framework, &namespace, "denied-sa").await?;
+    let denied_token = get_service_account_token(&namespace, "denied-sa").await?;
     let response = client
-        .get("http://localhost:9598/metrics")
+        .get(format!("http://{}/metrics", local_addr))
         .header(header::AUTHORIZATION, format!("Bearer {}", denied_token))
         .send()
         .await?;

--- a/lib/k8s-test-framework/src/framework.rs
+++ b/lib/k8s-test-framework/src/framework.rs
@@ -19,6 +19,11 @@ impl Framework {
         Self { interface }
     }
 
+    /// Get the kubectl command configured for this framework.
+    pub fn kubectl_command(&self) -> &str {
+        &self.interface.kubectl_command
+    }
+
     /// Deploy a Helm chart into a cluster.
     pub async fn helm_chart(
         &self,

--- a/src/sinks/prometheus/exporter.rs
+++ b/src/sinks/prometheus/exporter.rs
@@ -22,7 +22,7 @@ use snafu::Snafu;
 use stream_cancel::{Trigger, Tripwire};
 use tower::ServiceBuilder;
 use tower_http::compression::CompressionLayer;
-use tracing::{Instrument, Span};
+use tracing::{Instrument, Span, error, info, warn};
 use vector_lib::{
     ByteSizeOf, EstimatedJsonEncodedSizeOf,
     configurable::configurable_component,
@@ -32,6 +32,9 @@ use vector_lib::{
     },
 };
 
+#[cfg(feature = "kubernetes")]
+use kube::{Api, Client};
+
 use super::collector::{MetricCollector, StringCollector};
 use crate::{
     config::{AcknowledgementsConfig, GenerateConfig, Input, Resource, SinkConfig, SinkContext},
@@ -39,7 +42,7 @@ use crate::{
         Event, EventStatus, Finalizable,
         metric::{Metric, MetricData, MetricKind, MetricSeries, MetricValue},
     },
-    http::{Auth, build_http_trace_layer},
+    http::build_http_trace_layer,
     internal_events::PrometheusNormalizationError,
     sinks::{
         Healthcheck, VectorSink,
@@ -56,6 +59,159 @@ const LOCK_FAILED: &str = "Prometheus exporter data lock is poisoned";
 enum BuildError {
     #[snafu(display("Flush period for sets must be greater or equal to {} secs", min))]
     FlushPeriodTooShort { min: u64 },
+}
+
+/// Authentication configuration for the Prometheus exporter.
+#[configurable_component]
+#[derive(Clone, Debug)]
+#[serde(tag = "strategy")]
+#[serde(rename_all = "lowercase")]
+#[configurable(metadata(docs::enum_tag_description = "The authentication strategy to use."))]
+pub enum PrometheusExporterAuth {
+    /// Basic authentication.
+    Basic {
+        /// The basic authentication username.
+        #[configurable(metadata(docs::examples = "username"))]
+        user: String,
+
+        /// The basic authentication password.
+        #[configurable(metadata(docs::examples = "password"))]
+        password: vector_lib::sensitive_string::SensitiveString,
+    },
+
+    /// Bearer authentication.
+    Bearer {
+        /// The bearer authentication token.
+        token: vector_lib::sensitive_string::SensitiveString,
+    },
+
+    /// Custom Authorization Header Value.
+    Custom {
+        /// Custom string value of the Authorization header.
+        #[configurable(metadata(docs::examples = "CUSTOM_PREFIX ${TOKEN}"))]
+        value: String,
+    },
+
+    #[cfg(feature = "kubernetes")]
+    /// Kubernetes SubjectAccessReview authentication.
+    ///
+    /// Validates Bearer tokens using Kubernetes TokenReview and SubjectAccessReview APIs.
+    /// Supports both resource-based and nonResourceURL-based authorization.
+    ///
+    /// ## Required RBAC Permissions
+    ///
+    /// Vector's ServiceAccount must have permissions to create TokenReview and SubjectAccessReview resources:
+    ///
+    /// ```yaml
+    /// apiVersion: rbac.authorization.k8s.io/v1
+    /// kind: ClusterRole
+    /// metadata:
+    ///   name: vector-token-validator
+    /// rules:
+    /// - apiGroups: ["authentication.k8s.io"]
+    ///   resources: ["tokenreviews"]
+    ///   verbs: ["create"]
+    /// - apiGroups: ["authorization.k8s.io"]
+    ///   resources: ["subjectaccessreviews"]
+    ///   verbs: ["create"]
+    /// ```
+    ///
+    /// ## How it Works
+    ///
+    /// 1. Client (e.g., Prometheus) sends request with `Authorization: Bearer <token>`
+    /// 2. Vector extracts the Bearer token from the request
+    /// 3. Vector uses its own ServiceAccount to authenticate to the Kubernetes API
+    /// 4. Vector calls TokenReview API with the client's token to validate it and get user identity
+    /// 5. Vector calls SubjectAccessReview API to check if that user has the specified permissions
+    /// 6. Vector allows or denies the request based on the SubjectAccessReview response
+    ///
+    /// ## Configuration Examples
+    ///
+    /// NonResourceURL-based (for /metrics, /healthz, etc.):
+    /// ```toml
+    /// [sinks.prometheus.auth]
+    /// strategy = "sar"
+    /// path = "/metrics"
+    /// verb = "get"
+    /// ```
+    ///
+    /// Resource-based (for Kubernetes resources):
+    /// ```toml
+    /// [sinks.prometheus.auth]
+    /// strategy = "sar"
+    /// resource = "pods"
+    /// verb = "get"
+    /// resource_group = ""
+    /// ```
+    ///
+    Sar {
+        /// The URL path to check access for (nonResourceURL).
+        ///
+        /// Use this for API endpoints like /metrics, /healthz, /api.
+        /// Must start with "/" and match the nonResourceURLs in the client's RBAC.
+        ///
+        /// Mutually exclusive with `resource`. Specify either `path` OR `resource`, not both.
+        ///
+        /// Example RBAC rule for nonResourceURL:
+        /// ```yaml
+        /// - nonResourceURLs: ["/metrics"]
+        ///   verbs: ["get"]
+        /// ```
+        #[serde(default)]
+        #[configurable(metadata(docs::examples = "/metrics"))]
+        path: Option<String>,
+
+        /// The resource to check access for (Kubernetes resource).
+        ///
+        /// Use this for Kubernetes resources like pods, services, configmaps.
+        /// Mutually exclusive with `path`. Specify either `path` OR `resource`, not both.
+        ///
+        /// Example RBAC rule for resource:
+        /// ```yaml
+        /// - apiGroups: [""]
+        ///   resources: ["metrics"]
+        ///   verbs: ["get"]
+        /// ```
+        #[serde(default)]
+        #[configurable(metadata(docs::examples = "metrics"))]
+        resource: Option<String>,
+
+        /// The verb to check.
+        ///
+        /// For resources: "get", "list", "watch", "create", "update", "delete"
+        /// For nonResourceURLs: typically "get" or "post"
+        #[configurable(metadata(docs::examples = "get"))]
+        verb: String,
+
+        /// The API group for the resource (only used with `resource`, not `path`).
+        ///
+        /// Leave empty ("") for core Kubernetes resources.
+        /// Use the API group name for custom resources (e.g., "metrics.k8s.io").
+        #[serde(default)]
+        #[configurable(metadata(docs::examples = ""))]
+        resource_group: String,
+
+        /// The namespace to check access in (only used with `resource`, not `path`).
+        ///
+        /// If specified, checks for namespaced resource access.
+        /// If not specified (None), checks for cluster-scoped access.
+        #[serde(default)]
+        namespace: Option<String>,
+
+        /// Override the user to check access for. If not specified, uses the user from the TokenReview.
+        /// Typically left unset to validate the actual token holder's permissions.
+        #[serde(default)]
+        #[configurable(metadata(
+            docs::examples = "system:serviceaccount:my-namespace:myserviceaccount"
+        ))]
+        user: Option<String>,
+
+        /// Override the groups to check access for. If not specified, uses the groups from the TokenReview.
+        /// Typically left unset to validate the actual token holder's permissions.
+        #[serde(default)]
+        #[configurable(metadata(docs::examples = "system:authenticated"))]
+        groups: Option<Vec<String>>,
+    },
 }
 
 /// Configuration for the `prometheus_exporter` sink.
@@ -87,7 +243,7 @@ pub struct PrometheusExporterConfig {
     pub address: SocketAddr,
 
     #[configurable(derived)]
-    pub auth: Option<Auth>,
+    pub auth: Option<PrometheusExporterAuth>,
 
     #[configurable(derived)]
     pub tls: Option<TlsEnableableConfig>,
@@ -308,29 +464,218 @@ impl Hash for MetricRef {
     }
 }
 
-fn authorized<T: HttpBody>(req: &Request<T>, auth: &Option<Auth>) -> bool {
+/// Parameters for SubjectAccessReview authorization check.
+#[cfg(feature = "kubernetes")]
+struct SarAuthParams<'a> {
+    verb: &'a str,
+    path: Option<&'a str>,
+    resource: Option<&'a str>,
+    resource_group: Option<&'a str>,
+    namespace: &'a Option<String>,
+    user: &'a Option<String>,
+    groups: &'a Option<Vec<String>>,
+}
+
+/// Validates a Bearer token using Kubernetes TokenReview and SubjectAccessReview.
+///
+/// This function supports both resource-based and nonResourceURL-based authorization:
+/// - For resource-based: provide `resource`, `resource_group`, and optionally `namespace`
+/// - For nonResourceURL-based: provide `path`
+///
+/// This function:
+/// 1. Uses Vector's own service account to authenticate to the K8s API
+/// 2. Validates the client's token using TokenReview API
+/// 3. Extracts user identity from the TokenReview response
+/// 4. Checks permissions using SubjectAccessReview API (with ResourceAttributes or NonResourceAttributes)
+#[cfg(feature = "kubernetes")]
+async fn validate_token_with_sar(
+    client: &Client,
+    token: &str,
+    params: SarAuthParams<'_>,
+) -> crate::Result<bool> {
+    use k8s_openapi::api::authentication::v1::{TokenReview, TokenReviewSpec};
+    use k8s_openapi::api::authorization::v1::{
+        NonResourceAttributes, ResourceAttributes, SubjectAccessReview, SubjectAccessReviewSpec,
+    };
+
+    debug!(
+        message = "Validating bearer token",
+        path = ?params.path,
+        resource = ?params.resource
+    );
+
+    // Step 1: Validate the client's token using TokenReview
+    let token_review = TokenReview {
+        spec: TokenReviewSpec {
+            token: Some(token.to_string()),
+            audiences: None,
+        },
+        ..Default::default()
+    };
+
+    debug!(message = "Calling TokenReview API");
+    let token_api: Api<TokenReview> = Api::all(client.clone());
+    let token_result = token_api.create(&Default::default(), &token_review).await?;
+
+    // Check if token is valid
+    let token_status = token_result
+        .status
+        .ok_or("TokenReview returned no status")?;
+
+    if !token_status.authenticated.unwrap_or(false) {
+        warn!(message = "Token authentication failed via TokenReview");
+        return Ok(false);
+    }
+
+    // Extract user info from the validated token
+    let user_info = token_status
+        .user
+        .ok_or("TokenReview returned no user info")?;
+
+    // Log the authenticated user
+    debug!(
+        message = "Token authenticated successfully",
+        username = ?user_info.username,
+        uid = ?user_info.uid,
+        groups = ?user_info.groups,
+        extra = ?user_info.extra
+    );
+
+    // Determine the user and groups to check
+    let check_user = params.user.clone().or(user_info.username);
+    let check_groups = params.groups.clone().or(user_info.groups);
+
+    // Step 2: Create SubjectAccessReview with appropriate attributes
+    let sar = match (params.path, params.resource) {
+        (Some(p), None) => {
+            // NonResourceURL-based authorization
+            let non_resource_attrs = NonResourceAttributes {
+                path: Some(p.to_string()),
+                verb: Some(params.verb.to_string()),
+            };
+
+            debug!(
+                message = "Calling SubjectAccessReview API for nonResourceURL",
+                user = ?check_user,
+                groups = ?check_groups,
+                path = %p,
+                verb = %params.verb
+            );
+
+            SubjectAccessReview {
+                spec: SubjectAccessReviewSpec {
+                    non_resource_attributes: Some(non_resource_attrs),
+                    user: check_user.clone(),
+                    groups: check_groups.clone(),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }
+        }
+        (None, Some(r)) => {
+            // Resource-based authorization
+            let resource_attrs = ResourceAttributes {
+                group: Some(params.resource_group.unwrap_or("").to_string()),
+                resource: Some(r.to_string()),
+                verb: Some(params.verb.to_string()),
+                namespace: params.namespace.clone(),
+                ..Default::default()
+            };
+
+            debug!(
+                message = "Calling SubjectAccessReview API for resource",
+                user = ?check_user,
+                groups = ?check_groups,
+                resource = %r,
+                verb = %params.verb,
+                resource_group = %params.resource_group.unwrap_or(""),
+                namespace = ?params.namespace
+            );
+
+            SubjectAccessReview {
+                spec: SubjectAccessReviewSpec {
+                    resource_attributes: Some(resource_attrs),
+                    user: check_user.clone(),
+                    groups: check_groups.clone(),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }
+        }
+        _ => {
+            return Err("Must specify either 'path' or 'resource', not both or neither".into());
+        }
+    };
+
+    // Step 3: Check if the user has the required permissions
+    let sar_api: Api<SubjectAccessReview> = Api::all(client.clone());
+    let sar_result = sar_api.create(&Default::default(), &sar).await?;
+
+    let allowed = sar_result
+        .status
+        .as_ref()
+        .map(|s| s.allowed)
+        .unwrap_or(false);
+
+    // Log the SubjectAccessReview result
+    if allowed {
+        debug!(
+            message = "SubjectAccessReview allowed access",
+            user = ?check_user,
+            path = ?params.path,
+            resource = ?params.resource,
+            verb = %params.verb
+        );
+    } else {
+        warn!(
+            message = "SubjectAccessReview denied access",
+            user = ?check_user,
+            path = ?params.path,
+            resource = ?params.resource,
+            verb = %params.verb,
+            reason = ?sar_result.status.as_ref().and_then(|s| s.reason.as_ref()),
+            evaluation_error = ?sar_result.status.as_ref().and_then(|s| s.evaluation_error.as_ref())
+        );
+    }
+
+    Ok(allowed)
+}
+
+/// Extracts the Bearer token from the Authorization header.
+fn extract_bearer_token<T: HttpBody>(req: &Request<T>) -> Option<String> {
+    req.headers()
+        .get(hyper::header::AUTHORIZATION)?
+        .to_str()
+        .ok()?
+        .strip_prefix("Bearer ")
+        .map(|s| s.to_string())
+}
+
+fn authorized<T: HttpBody>(req: &Request<T>, auth: &Option<PrometheusExporterAuth>) -> bool {
     if let Some(auth) = auth {
         let headers = req.headers();
         if let Some(auth_header) = headers.get(hyper::header::AUTHORIZATION) {
             let encoded_credentials = match auth {
-                Auth::Basic { user, password } => Some(HeaderValue::from_str(
+                PrometheusExporterAuth::Basic { user, password } => Some(HeaderValue::from_str(
                     format!(
                         "Basic {}",
                         BASE64_STANDARD.encode(format!("{}:{}", user, password.inner()))
                     )
                     .as_str(),
                 )),
-                Auth::Bearer { token } => Some(HeaderValue::from_str(
+                PrometheusExporterAuth::Bearer { token } => Some(HeaderValue::from_str(
                     format!("Bearer {}", token.inner()).as_str(),
                 )),
-                Auth::Custom { value } => Some(HeaderValue::from_str(value)),
-                #[cfg(feature = "aws-core")]
-                _ => None,
+                PrometheusExporterAuth::Custom { value } => Some(HeaderValue::from_str(value)),
+                #[cfg(feature = "kubernetes")]
+                PrometheusExporterAuth::Sar { .. } => {
+                    // SubjectAccessReview is handled asynchronously in check_authorization
+                    // This should never be reached
+                    return false;
+                }
             };
 
-            if let Some(Ok(encoded_credentials)) = encoded_credentials
-                && auth_header == encoded_credentials
-            {
+            if matches!(encoded_credentials, Some(Ok(ref creds)) if auth_header == creds) {
                 return true;
             }
         }
@@ -343,23 +688,28 @@ fn authorized<T: HttpBody>(req: &Request<T>, auth: &Option<Auth>) -> bool {
 
 #[derive(Clone)]
 struct Handler {
-    auth: Option<Auth>,
+    auth: Option<PrometheusExporterAuth>,
     default_namespace: Option<String>,
     buckets: Box<[f64]>,
     quantiles: Box<[f64]>,
     bytes_sent: Registered<BytesSent>,
     events_sent: Registered<EventsSent>,
+    #[cfg(feature = "kubernetes")]
+    kube_client: Option<Client>,
 }
 
 impl Handler {
-    fn handle<T: HttpBody>(
+    async fn handle<T: HttpBody>(
         &self,
         req: Request<T>,
         metrics: &RwLock<IndexMap<MetricRef, (Metric, MetricMetadata)>>,
     ) -> Response<Body> {
         let mut response = Response::new(Body::empty());
 
-        match (authorized(&req, &self.auth), req.method(), req.uri().path()) {
+        // Check authorization - SAR takes precedence over basic auth when both token and SAR config present
+        let is_authorized = self.check_authorization(&req).await;
+
+        match (is_authorized, req.method(), req.uri().path()) {
             (false, _, _) => {
                 *response.status_mut() = StatusCode::UNAUTHORIZED;
                 response.headers_mut().insert(
@@ -411,6 +761,75 @@ impl Handler {
 
         response
     }
+
+    async fn check_authorization<T: HttpBody>(&self, req: &Request<T>) -> bool {
+        // Handle SubjectAccessReview authentication
+        #[cfg(feature = "kubernetes")]
+        if let Some(PrometheusExporterAuth::Sar {
+            path,
+            resource,
+            verb,
+            resource_group,
+            namespace,
+            user,
+            groups,
+        }) = &self.auth
+        {
+            // Ensure we have a Kubernetes client
+            let client = match &self.kube_client {
+                Some(c) => c,
+                None => {
+                    error!(
+                        message =
+                            "SubjectAccessReview configured but Kubernetes client not initialized"
+                    );
+                    return false;
+                }
+            };
+
+            // Validate token with SubjectAccessReview
+            if let Some(token) = extract_bearer_token(req) {
+                debug!(message = "Extracted Bearer token from request");
+
+                match validate_token_with_sar(
+                    client,
+                    &token,
+                    SarAuthParams {
+                        verb,
+                        path: path.as_deref(),
+                        resource: resource.as_deref(),
+                        resource_group: Some(resource_group.as_str()),
+                        namespace,
+                        user,
+                        groups,
+                    },
+                )
+                .await
+                {
+                    Ok(allowed) => {
+                        return allowed;
+                    }
+                    Err(e) => {
+                        error!(
+                            message = "Failed to validate token with SubjectAccessReview",
+                            error = %e,
+                            path = ?path,
+                            resource = ?resource
+                        );
+                        return false;
+                    }
+                }
+            } else {
+                warn!(
+                    message = "SubjectAccessReview configured but no Bearer token provided in Authorization header"
+                );
+                return false;
+            }
+        }
+
+        // Fall back to standard auth (Basic, Bearer, Custom)
+        authorized(req, &self.auth)
+    }
 }
 
 impl PrometheusExporter {
@@ -427,6 +846,29 @@ impl PrometheusExporter {
             return Ok(());
         }
 
+        // Create Kubernetes client if SAR authentication is configured
+        #[cfg(feature = "kubernetes")]
+        let kube_client = if matches!(self.config.auth, Some(PrometheusExporterAuth::Sar { .. })) {
+            match Client::try_default().await {
+                Ok(client) => {
+                    info!(
+                        message =
+                            "Kubernetes client initialized for SubjectAccessReview authentication"
+                    );
+                    Some(client)
+                }
+                Err(e) => {
+                    error!(
+                        message = "Failed to initialize Kubernetes client for SubjectAccessReview authentication",
+                        error = %e
+                    );
+                    return Err(Box::new(e));
+                }
+            }
+        } else {
+            None
+        };
+
         let handler = Handler {
             bytes_sent: register!(BytesSent::from(Protocol::HTTP)),
             events_sent: register!(EventsSent::from(Output(None))),
@@ -434,6 +876,8 @@ impl PrometheusExporter {
             buckets: self.config.buckets.clone().into(),
             quantiles: self.config.quantiles.clone().into(),
             auth: self.config.auth.clone(),
+            #[cfg(feature = "kubernetes")]
+            kube_client,
         };
 
         let span = Span::current();
@@ -445,9 +889,13 @@ impl PrometheusExporter {
             let handler = handler.clone();
 
             let inner = service_fn(move |req| {
-                let response = handler.handle(req, &metrics);
+                let handler = handler.clone();
+                let metrics = Arc::clone(&metrics);
 
-                future::ok::<_, Infallible>(response)
+                async move {
+                    let response = handler.handle(req, &metrics).await;
+                    Ok::<_, Infallible>(response)
+                }
             });
 
             let service = ServiceBuilder::new()
@@ -683,7 +1131,7 @@ mod tests {
         let (name2, event2) = tests::create_metric_set(None, vec!["0", "1", "2"]);
         let events = vec![event1, event2];
 
-        let auth_config = Auth::Basic {
+        let auth_config = PrometheusExporterAuth::Basic {
             user: "user".to_string(),
             password: SensitiveString::from("password".to_string()),
         };
@@ -720,7 +1168,7 @@ mod tests {
         let (name2, event2) = tests::create_metric_set(None, vec!["0", "1", "2"]);
         let events = vec![event1, event2];
 
-        let auth_config = Auth::Bearer {
+        let auth_config = PrometheusExporterAuth::Bearer {
             token: SensitiveString::from("token".to_string()),
         };
 
@@ -756,7 +1204,7 @@ mod tests {
         let (_, event2) = tests::create_metric_set(None, vec!["0", "1", "2"]);
         let events = vec![event1, event2];
 
-        let server_auth_config = Auth::Bearer {
+        let server_auth_config = PrometheusExporterAuth::Bearer {
             token: SensitiveString::from("token".to_string()),
         };
 
@@ -773,11 +1221,11 @@ mod tests {
         let (_, event2) = tests::create_metric_set(None, vec!["0", "1", "2"]);
         let events = vec![event1, event2];
 
-        let server_auth_config = Auth::Bearer {
+        let server_auth_config = PrometheusExporterAuth::Bearer {
             token: SensitiveString::from("token".to_string()),
         };
 
-        let client_auth_config = Auth::Basic {
+        let client_auth_config = PrometheusExporterAuth::Basic {
             user: "user".to_string(),
             password: SensitiveString::from("password".to_string()),
         };
@@ -982,8 +1430,8 @@ mod tests {
     }
 
     async fn export_and_fetch_with_auth(
-        server_auth_config: Option<Auth>,
-        client_auth_config: Option<Auth>,
+        server_auth_config: Option<PrometheusExporterAuth>,
+        client_auth_config: Option<PrometheusExporterAuth>,
         mut events: Vec<Event>,
         suppress_timestamp: bool,
     ) -> Result<String, http::status::StatusCode> {
@@ -1027,7 +1475,33 @@ mod tests {
             .expect("Error creating request.");
 
         if let Some(client_auth_config) = client_auth_config {
-            client_auth_config.apply(&mut request);
+            match client_auth_config {
+                PrometheusExporterAuth::Basic { user, password } => {
+                    let credentials = format!("{}:{}", user, password.inner());
+                    let encoded = BASE64_STANDARD.encode(credentials.as_bytes());
+                    request.headers_mut().insert(
+                        hyper::header::AUTHORIZATION,
+                        HeaderValue::from_str(&format!("Basic {}", encoded)).unwrap(),
+                    );
+                }
+                PrometheusExporterAuth::Bearer { token } => {
+                    request.headers_mut().insert(
+                        hyper::header::AUTHORIZATION,
+                        HeaderValue::from_str(&format!("Bearer {}", token.inner())).unwrap(),
+                    );
+                }
+                PrometheusExporterAuth::Custom { value } => {
+                    request.headers_mut().insert(
+                        hyper::header::AUTHORIZATION,
+                        HeaderValue::from_str(&value).unwrap(),
+                    );
+                }
+                #[cfg(feature = "kubernetes")]
+                PrometheusExporterAuth::Sar { .. } => {
+                    // SAR auth is server-side only, not used for client requests in tests
+                    panic!("SAR auth cannot be used for client-side requests in tests");
+                }
+            }
         }
 
         let proxy = ProxyConfig::default();

--- a/src/sinks/prometheus/exporter.rs
+++ b/src/sinks/prometheus/exporter.rs
@@ -625,7 +625,7 @@ async fn validate_token_with_sar(
 
     // Check if user matches allowed_user filter (if configured)
     if let Some(allowed_user) = params.user {
-        if user_info.username.as_deref() != Some(allowed_user) {
+        if user_info.username.as_deref() != Some(allowed_user as &str) {
             warn!(
                 message = "User does not match allowed_user filter",
                 authenticated_user = ?user_info.username,
@@ -2099,6 +2099,7 @@ mod tests {
                     verb: "get".to_string(),
                     resource_group: "".to_string(),
                     namespace: None,
+                    audience: None,
                     allowed_user: None,
                     allowed_groups: None,
                 }),
@@ -2126,6 +2127,7 @@ mod tests {
                     verb: "get".to_string(),
                     resource_group: "".to_string(),
                     namespace: None,
+                    audience: None,
                     allowed_user: None,
                     allowed_groups: None,
                 }),
@@ -2153,6 +2155,7 @@ mod tests {
                     verb: "get".to_string(),
                     resource_group: "".to_string(),
                     namespace: None,
+                    audience: None,
                     allowed_user: None,
                     allowed_groups: None,
                 }),
@@ -2174,6 +2177,7 @@ mod tests {
                     verb: "get".to_string(),
                     resource_group: "".to_string(),
                     namespace: None,
+                    audience: None,
                     allowed_user: None,
                     allowed_groups: None,
                 }),

--- a/src/sinks/prometheus/exporter.rs
+++ b/src/sinks/prometheus/exporter.rs
@@ -1986,6 +1986,169 @@ mod tests {
             .expect("gauge metric should exist");
         assert_eq!(actual_gauge.0.value(), expected_gauge.value());
     }
+
+    #[cfg(feature = "kubernetes")]
+    mod sar_auth_tests {
+        use super::*;
+
+        #[tokio::test]
+        async fn test_sar_config_validation_both_path_and_resource() {
+            let (_guard, address) = next_addr();
+            let config = PrometheusExporterConfig {
+                address,
+                auth: Some(PrometheusExporterAuth::Sar {
+                    path: Some("/metrics".to_string()),
+                    resource: Some("pods".to_string()),
+                    verb: "get".to_string(),
+                    resource_group: "".to_string(),
+                    namespace: None,
+                    allowed_user: None,
+                    allowed_groups: None,
+                }),
+                ..Default::default()
+            };
+
+            let result = config.build(SinkContext::default()).await;
+            assert!(result.is_err());
+            assert!(
+                result
+                    .unwrap_err()
+                    .to_string()
+                    .contains("exactly one of 'path'")
+            );
+        }
+
+        #[tokio::test]
+        async fn test_sar_config_validation_neither_path_nor_resource() {
+            let (_guard, address) = next_addr();
+            let config = PrometheusExporterConfig {
+                address,
+                auth: Some(PrometheusExporterAuth::Sar {
+                    path: None,
+                    resource: None,
+                    verb: "get".to_string(),
+                    resource_group: "".to_string(),
+                    namespace: None,
+                    allowed_user: None,
+                    allowed_groups: None,
+                }),
+                ..Default::default()
+            };
+
+            let result = config.build(SinkContext::default()).await;
+            assert!(result.is_err());
+            assert!(
+                result
+                    .unwrap_err()
+                    .to_string()
+                    .contains("exactly one of 'path'")
+            );
+        }
+
+        #[tokio::test]
+        async fn test_sar_config_validation_path_only_succeeds() {
+            let (_guard, address) = next_addr();
+            let config = PrometheusExporterConfig {
+                address,
+                auth: Some(PrometheusExporterAuth::Sar {
+                    path: Some("/metrics".to_string()),
+                    resource: None,
+                    verb: "get".to_string(),
+                    resource_group: "".to_string(),
+                    namespace: None,
+                    allowed_user: None,
+                    allowed_groups: None,
+                }),
+                ..Default::default()
+            };
+
+            let result = config.build(SinkContext::default()).await;
+            assert!(result.is_ok());
+        }
+
+        #[tokio::test]
+        async fn test_sar_config_validation_resource_only_succeeds() {
+            let (_guard, address) = next_addr();
+            let config = PrometheusExporterConfig {
+                address,
+                auth: Some(PrometheusExporterAuth::Sar {
+                    path: None,
+                    resource: Some("pods".to_string()),
+                    verb: "get".to_string(),
+                    resource_group: "".to_string(),
+                    namespace: None,
+                    allowed_user: None,
+                    allowed_groups: None,
+                }),
+                ..Default::default()
+            };
+
+            let result = config.build(SinkContext::default()).await;
+            assert!(result.is_ok());
+        }
+
+        #[test]
+        fn test_deny_unknown_fields_in_sar_config() {
+            // Test that unknown fields are rejected
+            let config_str = r#"
+                strategy = "sar"
+                path = "/metrics"
+                verb = "get"
+                namesapce = "prod"
+            "#;
+
+            let result: Result<PrometheusExporterAuth, _> = toml::from_str(config_str);
+            assert!(result.is_err());
+            assert!(result.unwrap_err().to_string().contains("unknown field"));
+        }
+
+        #[test]
+        fn test_allowed_user_field_accepts_valid_config() {
+            let config_str = r#"
+                strategy = "sar"
+                path = "/metrics"
+                verb = "get"
+                allowed_user = "system:serviceaccount:monitoring:prometheus"
+            "#;
+
+            let result: Result<PrometheusExporterAuth, _> = toml::from_str(config_str);
+            assert!(result.is_ok());
+
+            if let PrometheusExporterAuth::Sar { allowed_user, .. } = result.unwrap() {
+                assert_eq!(
+                    allowed_user,
+                    Some("system:serviceaccount:monitoring:prometheus".to_string())
+                );
+            } else {
+                panic!("Expected SAR auth variant");
+            }
+        }
+
+        #[test]
+        fn test_allowed_groups_field_accepts_valid_config() {
+            let config_str = r#"
+                strategy = "sar"
+                resource = "pods"
+                verb = "get"
+                allowed_groups = ["system:authenticated", "system:masters"]
+            "#;
+
+            let result: Result<PrometheusExporterAuth, _> = toml::from_str(config_str);
+            assert!(result.is_ok());
+
+            if let PrometheusExporterAuth::Sar { allowed_groups, .. } = result.unwrap() {
+                assert_eq!(
+                    allowed_groups,
+                    Some(vec![
+                        "system:authenticated".to_string(),
+                        "system:masters".to_string()
+                    ])
+                );
+            } else {
+                panic!("Expected SAR auth variant");
+            }
+        }
+    }
 }
 
 #[cfg(all(test, feature = "prometheus-integration-tests"))]

--- a/src/sinks/prometheus/exporter.rs
+++ b/src/sinks/prometheus/exporter.rs
@@ -659,9 +659,11 @@ async fn validate_token_with_sar(
     let sar = match (params.path, params.resource) {
         (Some(p), None) => {
             // NonResourceURL-based authorization
+            // Normalize verb to lowercase to match Kubernetes RBAC conventions
+            let normalized_verb = params.verb.to_lowercase();
             let non_resource_attrs = NonResourceAttributes {
                 path: Some(p.to_string()),
-                verb: Some(params.verb.to_string()),
+                verb: Some(normalized_verb.clone()),
             };
 
             debug!(
@@ -669,7 +671,7 @@ async fn validate_token_with_sar(
                 user = ?check_user,
                 groups = ?check_groups,
                 path = %p,
-                verb = %params.verb
+                verb = %normalized_verb
             );
 
             SubjectAccessReview {
@@ -684,10 +686,12 @@ async fn validate_token_with_sar(
         }
         (None, Some(r)) => {
             // Resource-based authorization
+            // Normalize verb to lowercase to match Kubernetes RBAC conventions
+            let normalized_verb = params.verb.to_lowercase();
             let resource_attrs = ResourceAttributes {
                 group: Some(params.resource_group.unwrap_or("").to_string()),
                 resource: Some(r.to_string()),
-                verb: Some(params.verb.to_string()),
+                verb: Some(normalized_verb.clone()),
                 namespace: params.namespace.clone(),
                 ..Default::default()
             };
@@ -697,7 +701,7 @@ async fn validate_token_with_sar(
                 user = ?check_user,
                 groups = ?check_groups,
                 resource = %r,
-                verb = %params.verb,
+                verb = %normalized_verb,
                 resource_group = %params.resource_group.unwrap_or(""),
                 namespace = ?params.namespace
             );

--- a/src/sinks/prometheus/exporter.rs
+++ b/src/sinks/prometheus/exporter.rs
@@ -22,7 +22,9 @@ use snafu::Snafu;
 use stream_cancel::{Trigger, Tripwire};
 use tower::ServiceBuilder;
 use tower_http::compression::CompressionLayer;
-use tracing::{Instrument, Span, error, info, warn};
+#[cfg(feature = "kubernetes")]
+use tracing::warn;
+use tracing::{Instrument, Span, error, info};
 use vector_lib::{
     ByteSizeOf, EstimatedJsonEncodedSizeOf,
     configurable::configurable_component,
@@ -225,6 +227,26 @@ pub enum PrometheusExporterAuth {
         #[serde(default)]
         #[configurable(metadata(docs::examples = "system:authenticated"))]
         allowed_groups: Option<Vec<String>>,
+
+        /// Required audience for token validation.
+        ///
+        /// The bearer token presented by the client must have been issued for this audience.
+        /// This prevents tokens minted for the Kubernetes API server from being replayed
+        /// to scrape this metrics endpoint.
+        ///
+        /// **Security**: It is strongly recommended to set this to a unique value specific
+        /// to your Vector metrics endpoint (e.g., "https://vector.my-namespace.svc.cluster.local").
+        ///
+        /// If not specified, tokens are validated for the default Kubernetes API server audience,
+        /// which allows API server tokens to be replayed (not recommended for production).
+        ///
+        /// When using projected service account tokens, configure your scraper (e.g., Prometheus)
+        /// to mount a token with this audience.
+        #[serde(default)]
+        #[configurable(metadata(
+            docs::examples = "https://vector-metrics.monitoring.svc.cluster.local"
+        ))]
+        audience: Option<String>,
     },
 }
 
@@ -499,6 +521,7 @@ struct SarAuthParams<'a> {
     namespace: &'a Option<String>,
     user: &'a Option<String>,
     groups: &'a Option<Vec<String>>,
+    audience: &'a Option<String>,
 }
 
 /// Validates a Bearer token using Kubernetes TokenReview and SubjectAccessReview.
@@ -526,19 +549,23 @@ async fn validate_token_with_sar(
     debug!(
         message = "Validating bearer token",
         path = ?params.path,
-        resource = ?params.resource
+        resource = ?params.resource,
+        audience = ?params.audience
     );
 
     // Step 1: Validate the client's token using TokenReview
     let token_review = TokenReview {
         spec: TokenReviewSpec {
             token: Some(token.to_string()),
-            audiences: None,
+            audiences: params.audience.as_ref().map(|aud| vec![aud.clone()]),
         },
         ..Default::default()
     };
 
-    debug!(message = "Calling TokenReview API");
+    debug!(
+        message = "Calling TokenReview API",
+        requested_audience = ?params.audience
+    );
     let token_api: Api<TokenReview> = Api::all(client.clone());
     let token_result = token_api.create(&Default::default(), &token_review).await?;
 
@@ -550,6 +577,36 @@ async fn validate_token_with_sar(
     if !token_status.authenticated.unwrap_or(false) {
         warn!(message = "Token authentication failed via TokenReview");
         return Ok(false);
+    }
+
+    // Validate audience if one was requested
+    if let Some(required_audience) = params.audience {
+        let token_audiences = token_status.audiences.as_ref();
+
+        match token_audiences {
+            Some(auds) if auds.contains(required_audience) => {
+                debug!(
+                    message = "Token audience validated",
+                    required_audience = %required_audience,
+                    token_audiences = ?auds
+                );
+            }
+            Some(auds) => {
+                warn!(
+                    message = "Token audience mismatch",
+                    required_audience = %required_audience,
+                    token_audiences = ?auds
+                );
+                return Ok(false);
+            }
+            None => {
+                warn!(
+                    message = "Token has no audience but one was required",
+                    required_audience = %required_audience
+                );
+                return Ok(false);
+            }
+        }
     }
 
     // Extract user info from the validated token
@@ -695,6 +752,7 @@ async fn validate_token_with_sar(
 }
 
 /// Extracts the Bearer token from the Authorization header.
+#[cfg(feature = "kubernetes")]
 fn extract_bearer_token<T: HttpBody>(req: &Request<T>) -> Option<String> {
     req.headers()
         .get(hyper::header::AUTHORIZATION)?
@@ -831,6 +889,7 @@ impl Handler {
             namespace,
             allowed_user,
             allowed_groups,
+            audience,
         }) = &self.auth
         {
             // Ensure we have a Kubernetes client
@@ -844,6 +903,39 @@ impl Handler {
                     return false;
                 }
             };
+
+            // For path-based (nonResourceURL) SAR, validate that configured path/verb
+            // match the actual request being authorized
+            if let Some(configured_path) = path {
+                let request_path = req.uri().path();
+                let request_method = req.method().as_str().to_lowercase();
+
+                if configured_path != request_path {
+                    error!(
+                        message = "SAR path mismatch: configured path does not match actual request",
+                        configured_path = %configured_path,
+                        request_path = %request_path,
+                        security_note = "This prevents authorizing /metrics based on permission for a different URL"
+                    );
+                    return false;
+                }
+
+                if verb.to_lowercase() != request_method {
+                    error!(
+                        message = "SAR verb mismatch: configured verb does not match actual request",
+                        configured_verb = %verb,
+                        request_method = %request_method,
+                        security_note = "This prevents authorizing GET based on permission for POST"
+                    );
+                    return false;
+                }
+
+                debug!(
+                    message = "SAR request validation passed",
+                    path = %request_path,
+                    method = %request_method
+                );
+            }
 
             // Validate token with SubjectAccessReview
             if let Some(token) = extract_bearer_token(req) {
@@ -860,6 +952,7 @@ impl Handler {
                         namespace,
                         user: allowed_user,
                         groups: allowed_groups,
+                        audience,
                     },
                 )
                 .await

--- a/src/sinks/prometheus/exporter.rs
+++ b/src/sinks/prometheus/exporter.rs
@@ -651,9 +651,11 @@ async fn validate_token_with_sar(
         }
     }
 
-    // Use the actual authenticated user's identity for SAR check
+    // Use the full authenticated user's identity for SAR check
     let check_user = user_info.username;
     let check_groups = user_info.groups;
+    let check_uid = user_info.uid;
+    let check_extra = user_info.extra;
 
     // Step 2: Create SubjectAccessReview with appropriate attributes
     let sar = match (params.path, params.resource) {
@@ -679,6 +681,8 @@ async fn validate_token_with_sar(
                     non_resource_attributes: Some(non_resource_attrs),
                     user: check_user.clone(),
                     groups: check_groups.clone(),
+                    uid: check_uid.clone(),
+                    extra: check_extra.clone(),
                     ..Default::default()
                 },
                 ..Default::default()
@@ -711,6 +715,8 @@ async fn validate_token_with_sar(
                     resource_attributes: Some(resource_attrs),
                     user: check_user.clone(),
                     groups: check_groups.clone(),
+                    uid: check_uid.clone(),
+                    extra: check_extra.clone(),
                     ..Default::default()
                 },
                 ..Default::default()

--- a/src/sinks/prometheus/exporter.rs
+++ b/src/sinks/prometheus/exporter.rs
@@ -70,7 +70,7 @@ enum BuildError {
 /// Authentication configuration for the Prometheus exporter.
 #[configurable_component]
 #[derive(Clone, Debug)]
-#[serde(tag = "strategy")]
+#[serde(tag = "strategy", deny_unknown_fields)]
 #[serde(rename_all = "lowercase")]
 #[configurable(metadata(docs::enum_tag_description = "The authentication strategy to use."))]
 pub enum PrometheusExporterAuth {
@@ -204,19 +204,27 @@ pub enum PrometheusExporterAuth {
         #[serde(default)]
         namespace: Option<String>,
 
-        /// Override the user to check access for. If not specified, uses the user from the TokenReview.
-        /// Typically left unset to validate the actual token holder's permissions.
+        /// Restrict access to a specific user identity.
+        ///
+        /// If specified, the authenticated user from TokenReview must exactly match this value.
+        /// If not specified, any authenticated user's permissions will be checked.
+        ///
+        /// Use this to restrict the endpoint to a specific service account or user.
         #[serde(default)]
         #[configurable(metadata(
             docs::examples = "system:serviceaccount:my-namespace:myserviceaccount"
         ))]
-        user: Option<String>,
+        allowed_user: Option<String>,
 
-        /// Override the groups to check access for. If not specified, uses the groups from the TokenReview.
-        /// Typically left unset to validate the actual token holder's permissions.
+        /// Restrict access to users in specific groups.
+        ///
+        /// If specified, the authenticated user from TokenReview must be a member of at least one
+        /// of these groups. If not specified, any authenticated user's permissions will be checked.
+        ///
+        /// Use this to restrict the endpoint to specific teams or roles.
         #[serde(default)]
         #[configurable(metadata(docs::examples = "system:authenticated"))]
-        groups: Option<Vec<String>>,
+        allowed_groups: Option<Vec<String>>,
     },
 }
 
@@ -558,9 +566,37 @@ async fn validate_token_with_sar(
         extra = ?user_info.extra
     );
 
-    // Determine the user and groups to check
-    let check_user = params.user.clone().or(user_info.username);
-    let check_groups = params.groups.clone().or(user_info.groups);
+    // Check if user matches allowed_user filter (if configured)
+    if let Some(allowed_user) = params.user {
+        if user_info.username.as_deref() != Some(allowed_user) {
+            warn!(
+                message = "User does not match allowed_user filter",
+                authenticated_user = ?user_info.username,
+                allowed_user = %allowed_user
+            );
+            return Ok(false);
+        }
+    }
+
+    // Check if user is in at least one allowed_groups (if configured)
+    if let Some(allowed_groups) = params.groups {
+        let user_groups = user_info.groups.as_deref().unwrap_or(&[]);
+        let has_allowed_group = allowed_groups.iter().any(|ag| user_groups.contains(ag));
+
+        if !has_allowed_group {
+            warn!(
+                message = "User is not in any allowed_groups",
+                authenticated_user = ?user_info.username,
+                user_groups = ?user_groups,
+                allowed_groups = ?allowed_groups
+            );
+            return Ok(false);
+        }
+    }
+
+    // Use the actual authenticated user's identity for SAR check
+    let check_user = user_info.username;
+    let check_groups = user_info.groups;
 
     // Step 2: Create SubjectAccessReview with appropriate attributes
     let sar = match (params.path, params.resource) {
@@ -793,8 +829,8 @@ impl Handler {
             verb,
             resource_group,
             namespace,
-            user,
-            groups,
+            allowed_user,
+            allowed_groups,
         }) = &self.auth
         {
             // Ensure we have a Kubernetes client
@@ -822,8 +858,8 @@ impl Handler {
                         resource: resource.as_deref(),
                         resource_group: Some(resource_group.as_str()),
                         namespace,
-                        user,
-                        groups,
+                        user: allowed_user,
+                        groups: allowed_groups,
                     },
                 )
                 .await

--- a/src/sinks/prometheus/exporter.rs
+++ b/src/sinks/prometheus/exporter.rs
@@ -59,6 +59,12 @@ const LOCK_FAILED: &str = "Prometheus exporter data lock is poisoned";
 enum BuildError {
     #[snafu(display("Flush period for sets must be greater or equal to {} secs", min))]
     FlushPeriodTooShort { min: u64 },
+
+    #[cfg(feature = "kubernetes")]
+    #[snafu(display(
+        "SubjectAccessReview auth must specify exactly one of 'path' (for nonResourceURLs) or 'resource' (for Kubernetes resources), not both or neither"
+    ))]
+    SarInvalidPathResourceConfig,
 }
 
 /// Authentication configuration for the Prometheus exporter.
@@ -355,6 +361,17 @@ impl SinkConfig for PrometheusExporterConfig {
         }
 
         validate_quantiles(&self.quantiles)?;
+
+        // Validate SAR configuration: must specify exactly one of path or resource
+        #[cfg(feature = "kubernetes")]
+        if let Some(PrometheusExporterAuth::Sar { path, resource, .. }) = &self.auth {
+            match (path, resource) {
+                (Some(_), Some(_)) | (None, None) => {
+                    return Err(Box::new(BuildError::SarInvalidPathResourceConfig));
+                }
+                _ => {} // Valid: exactly one is set
+            }
+        }
 
         let sink = PrometheusExporter::new(self.clone());
         let healthcheck = future::ok(()).boxed();
@@ -706,19 +723,23 @@ impl Handler {
     ) -> Response<Body> {
         let mut response = Response::new(Body::empty());
 
-        // Check authorization - SAR takes precedence over basic auth when both token and SAR config present
-        let is_authorized = self.check_authorization(&req).await;
+        // Short-circuit non-metrics routes before authorization checks to prevent
+        // unnecessary Kubernetes API calls for invalid paths, health probes, etc.
+        match (req.method(), req.uri().path()) {
+            (&Method::GET, "/metrics") => {
+                // Only perform authorization for the metrics endpoint
+                let is_authorized = self.check_authorization(&req).await;
 
-        match (is_authorized, req.method(), req.uri().path()) {
-            (false, _, _) => {
-                *response.status_mut() = StatusCode::UNAUTHORIZED;
-                response.headers_mut().insert(
-                    http::header::WWW_AUTHENTICATE,
-                    HeaderValue::from_static("Basic, Bearer"),
-                );
-            }
+                if !is_authorized {
+                    *response.status_mut() = StatusCode::UNAUTHORIZED;
+                    response.headers_mut().insert(
+                        http::header::WWW_AUTHENTICATE,
+                        HeaderValue::from_static("Basic, Bearer"),
+                    );
+                    return response;
+                }
 
-            (true, &Method::GET, "/metrics") => {
+                // Authorization passed, serve metrics
                 let metrics = metrics.read().expect(LOCK_FAILED);
 
                 let count = metrics.len();
@@ -754,7 +775,8 @@ impl Handler {
                 self.bytes_sent.emit(ByteSize(body_size));
             }
 
-            (true, _, _) => {
+            // All other routes return 404 without authorization checks
+            _ => {
                 *response.status_mut() = StatusCode::NOT_FOUND;
             }
         }

--- a/website/cue/reference/components/sinks/generated/aws_s3.cue
+++ b/website/cue/reference/components/sinks/generated/aws_s3.cue
@@ -385,7 +385,7 @@ generated: components: sinks: aws_s3: configuration: {
 			"""
 		required: false
 		type: string: examples: [
-			"gzip",
+			"gzip"
 		]
 	}
 	content_type: {
@@ -862,7 +862,7 @@ generated: components: sinks: aws_s3: configuration: {
 			"""
 		required: false
 		type: string: examples: [
-			"json",
+			"json"
 		]
 	}
 	filename_time_format: {

--- a/website/cue/reference/components/sinks/generated/blackhole.cue
+++ b/website/cue/reference/components/sinks/generated/blackhole.cue
@@ -37,7 +37,7 @@ generated: components: sinks: blackhole: configuration: {
 		type: uint: {
 			default: 0
 			examples: [
-				10,
+				10
 			]
 			unit: "seconds"
 		}
@@ -50,7 +50,7 @@ generated: components: sinks: blackhole: configuration: {
 			"""
 		required: false
 		type: uint: examples: [
-			1000,
+			1000
 		]
 	}
 }

--- a/website/cue/reference/components/sinks/generated/doris.cue
+++ b/website/cue/reference/components/sinks/generated/doris.cue
@@ -848,7 +848,7 @@ generated: components: sinks: doris: configuration: {
 		type: string: {
 			default: "vector"
 			examples: [
-				"vector",
+				"vector"
 			]
 		}
 	}

--- a/website/cue/reference/components/sinks/generated/file.cue
+++ b/website/cue/reference/components/sinks/generated/file.cue
@@ -560,7 +560,7 @@ generated: components: sinks: file: configuration: {
 		type: uint: {
 			default: 30
 			examples: [
-				600,
+				600
 			]
 			unit: "seconds"
 		}

--- a/website/cue/reference/components/sinks/generated/greptimedb.cue
+++ b/website/cue/reference/components/sinks/generated/greptimedb.cue
@@ -75,7 +75,7 @@ generated: components: sinks: greptimedb: configuration: {
 		type: string: {
 			default: "public"
 			examples: [
-				"public",
+				"public"
 			]
 		}
 	}

--- a/website/cue/reference/components/sinks/generated/greptimedb_logs.cue
+++ b/website/cue/reference/components/sinks/generated/greptimedb_logs.cue
@@ -108,7 +108,7 @@ generated: components: sinks: greptimedb_logs: configuration: {
 		type: string: {
 			default: "public"
 			examples: [
-				"public",
+				"public"
 			]
 			syntax: "template"
 		}

--- a/website/cue/reference/components/sinks/generated/greptimedb_metrics.cue
+++ b/website/cue/reference/components/sinks/generated/greptimedb_metrics.cue
@@ -75,7 +75,7 @@ generated: components: sinks: greptimedb_metrics: configuration: {
 		type: string: {
 			default: "public"
 			examples: [
-				"public",
+				"public"
 			]
 		}
 	}

--- a/website/cue/reference/components/sinks/generated/http.cue
+++ b/website/cue/reference/components/sinks/generated/http.cue
@@ -823,7 +823,7 @@ generated: components: sinks: http: configuration: {
 		type: string: {
 			default: ""
 			examples: [
-				"}",
+				"}"
 			]
 		}
 	}

--- a/website/cue/reference/components/sinks/generated/influxdb_logs.cue
+++ b/website/cue/reference/components/sinks/generated/influxdb_logs.cue
@@ -145,7 +145,7 @@ generated: components: sinks: influxdb_logs: configuration: {
 			"""
 		required: false
 		type: string: examples: [
-			"text",
+			"text"
 		]
 	}
 	namespace: {
@@ -380,7 +380,7 @@ generated: components: sinks: influxdb_logs: configuration: {
 			"""
 		required: false
 		type: string: examples: [
-			"source",
+			"source"
 		]
 	}
 	tags: {

--- a/website/cue/reference/components/sinks/generated/logdna.cue
+++ b/website/cue/reference/components/sinks/generated/logdna.cue
@@ -70,7 +70,7 @@ generated: components: sinks: logdna: configuration: {
 		type: string: {
 			default: "vector"
 			examples: [
-				"my-app",
+				"my-app"
 			]
 		}
 	}

--- a/website/cue/reference/components/sinks/generated/mezmo.cue
+++ b/website/cue/reference/components/sinks/generated/mezmo.cue
@@ -70,7 +70,7 @@ generated: components: sinks: mezmo: configuration: {
 		type: string: {
 			default: "vector"
 			examples: [
-				"my-app",
+				"my-app"
 			]
 		}
 	}

--- a/website/cue/reference/components/sinks/generated/nats.cue
+++ b/website/cue/reference/components/sinks/generated/nats.cue
@@ -123,7 +123,7 @@ generated: components: sinks: nats: configuration: {
 		type: string: {
 			default: "vector"
 			examples: [
-				"foo",
+				"foo"
 			]
 		}
 	}

--- a/website/cue/reference/components/sinks/generated/prometheus_exporter.cue
+++ b/website/cue/reference/components/sinks/generated/prometheus_exporter.cue
@@ -40,167 +40,183 @@ generated: components: sinks: prometheus_exporter: configuration: {
 		}
 	}
 	auth: {
-		description: """
-			Configuration of the authentication strategy for HTTP requests.
-
-			HTTP authentication should be used with HTTPS only, as the authentication credentials are passed as an
-			HTTP header without any additional encryption beyond what is provided by the transport itself.
-			"""
-		required: false
+		description: "Authentication configuration for the Prometheus exporter."
+		required:    false
 		type: object: options: {
-			auth: {
-				description:   "The AWS authentication configuration."
-				relevant_when: "strategy = \"aws\""
-				required:      true
-				type: object: options: {
-					access_key_id: {
-						description: "The AWS access key ID."
-						required:    true
-						type: string: examples: ["AKIAIOSFODNN7EXAMPLE"]
-					}
-					assume_role: {
-						description: """
-																The ARN of an [IAM role][iam_role] to assume.
+			allowed_groups: {
+				description: """
+					Restrict access to users in specific groups.
 
-																[iam_role]: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html
-																"""
-						required: true
-						type: string: examples: ["arn:aws:iam::123456789098:role/my_role"]
-					}
-					credentials_file: {
-						description: "Path to the credentials file."
-						required:    true
-						type: string: examples: ["/my/aws/credentials"]
-					}
-					external_id: {
-						description: """
-																The optional unique external ID in conjunction with role to assume.
+					If specified, the authenticated user from TokenReview must be a member of at least one
+					of these groups. If not specified, any authenticated user's permissions will be checked.
 
-																[external_id]: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html
-																"""
-						required: false
-						type: string: examples: ["randomEXAMPLEidString"]
-					}
-					imds: {
-						description: "Configuration for authenticating with AWS through IMDS."
-						required:    false
-						type: object: options: {
-							connect_timeout_seconds: {
-								description: "Connect timeout for IMDS."
-								required:    false
-								type: uint: {
-									default: 1
-									unit:    "seconds"
-								}
-							}
-							max_attempts: {
-								description: "Number of IMDS retries for fetching tokens and metadata."
-								required:    false
-								type: uint: default: 4
-							}
-							read_timeout_seconds: {
-								description: "Read timeout for IMDS."
-								required:    false
-								type: uint: {
-									default: 1
-									unit:    "seconds"
-								}
-							}
-						}
-					}
-					load_timeout_secs: {
-						description: """
-																Timeout for successfully loading any credentials, in seconds.
+					Use this to restrict the endpoint to specific teams or roles.
+					"""
+				relevant_when: "strategy = \"sar\""
+				required:      false
+				type: array: items: type: string: examples: ["system:authenticated"]
+			}
+			allowed_user: {
+				description: """
+					Restrict access to a specific user identity.
 
-																Relevant when the default credentials chain or `assume_role` is used.
-																"""
-						required: false
-						type: uint: {
-							examples: [30]
-							unit: "seconds"
-						}
-					}
-					profile: {
-						description: """
-																The credentials profile to use.
+					If specified, the authenticated user from TokenReview must exactly match this value.
+					If not specified, any authenticated user's permissions will be checked.
 
-																Used to select AWS credentials from a provided credentials file.
-																"""
-						required: false
-						type: string: {
-							default: "default"
-							examples: ["develop"]
-						}
-					}
-					region: {
-						description: """
-																The [AWS region][aws_region] to send STS requests to.
+					Use this to restrict the endpoint to a specific service account or user.
+					"""
+				relevant_when: "strategy = \"sar\""
+				required:      false
+				type: string: examples: ["system:serviceaccount:my-namespace:myserviceaccount"]
+			}
+			audience: {
+				description: """
+					Required audience for token validation.
 
-																If not set, this defaults to the configured region
-																for the service itself.
+					The bearer token presented by the client must have been issued for this audience.
+					This prevents tokens minted for the Kubernetes API server from being replayed
+					to scrape this metrics endpoint.
 
-																[aws_region]: https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints
-																"""
-						required: false
-						type: string: examples: ["us-west-2"]
-					}
-					secret_access_key: {
-						description: "The AWS secret access key."
-						required:    true
-						type: string: examples: ["wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"]
-					}
-					session_name: {
-						description: """
-																The optional [RoleSessionName][role_session_name] is a unique session identifier for your assumed role.
+					**Security**: It is strongly recommended to set this to a unique value specific
+					to your Vector metrics endpoint (e.g., "https://vector.my-namespace.svc.cluster.local").
 
-																Should be unique per principal or reason.
-																If not set, the session name is autogenerated like assume-role-provider-1736428351340
+					If not specified, tokens are validated for the default Kubernetes API server audience,
+					which allows API server tokens to be replayed (not recommended for production).
 
-																[role_session_name]: https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html
-																"""
-						required: false
-						type: string: examples: ["vector-indexer-role"]
-					}
-					session_token: {
-						description: """
-																The AWS session token.
-																See [AWS temporary credentials](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html)
-																"""
-						required: false
-						type: string: examples: ["AQoDYXdz...AQoDYXdz..."]
-					}
-				}
+					When using projected service account tokens, configure your scraper (e.g., Prometheus)
+					to mount a token with this audience.
+					"""
+				relevant_when: "strategy = \"sar\""
+				required:      false
+				type: string: examples: ["https://vector-metrics.monitoring.svc.cluster.local"]
+			}
+			namespace: {
+				description: """
+					The namespace to check access in (only used with `resource`, not `path`).
+
+					If specified, checks for namespaced resource access.
+					If not specified (None), checks for cluster-scoped access.
+					"""
+				relevant_when: "strategy = \"sar\""
+				required:      false
+				type: string: {}
 			}
 			password: {
 				description:   "The basic authentication password."
 				relevant_when: "strategy = \"basic\""
 				required:      true
-				type: string: examples: ["${PASSWORD}", "password"]
+				type: string: examples: ["password"]
 			}
-			service: {
-				description:   "The AWS service name to use for signing."
-				relevant_when: "strategy = \"aws\""
-				required:      true
-				type: string: {}
+			path: {
+				description: """
+					The URL path to check access for (nonResourceURL).
+
+					Use this for API endpoints like /metrics, /healthz, /api.
+					Must start with "/" and match the nonResourceURLs in the client's RBAC.
+
+					Mutually exclusive with `resource`. Specify either `path` OR `resource`, not both.
+
+					Example RBAC rule for nonResourceURL:
+					```yaml
+					- nonResourceURLs: ["/metrics"]
+					  verbs: ["get"]
+					```
+					"""
+				relevant_when: "strategy = \"sar\""
+				required:      false
+				type: string: examples: ["/metrics"]
+			}
+			resource: {
+				description: """
+					The resource to check access for (Kubernetes resource).
+
+					Use this for Kubernetes resources like pods, services, configmaps.
+					Mutually exclusive with `path`. Specify either `path` OR `resource`, not both.
+
+					Example RBAC rule for resource:
+					```yaml
+					- apiGroups: [""]
+					  resources: ["metrics"]
+					  verbs: ["get"]
+					```
+					"""
+				relevant_when: "strategy = \"sar\""
+				required:      false
+				type: string: examples: ["metrics"]
+			}
+			resource_group: {
+				description: """
+					The API group for the resource (only used with `resource`, not `path`).
+
+					Leave empty ("") for core Kubernetes resources.
+					Use the API group name for custom resources (e.g., "metrics.k8s.io").
+					"""
+				relevant_when: "strategy = \"sar\""
+				required:      false
+				type: string: {
+					default: ""
+					examples: [""]
+				}
 			}
 			strategy: {
 				description: "The authentication strategy to use."
 				required:    true
 				type: string: enum: {
-					aws: "AWS authentication."
-					basic: """
-						Basic authentication.
+					basic:  "Basic authentication."
+					bearer: "Bearer authentication."
+					custom: "Custom Authorization Header Value."
+					sar: """
+						Kubernetes SubjectAccessReview authentication.
 
-						The username and password are concatenated and encoded using [base64][base64].
+						Validates Bearer tokens using Kubernetes TokenReview and SubjectAccessReview APIs.
+						Supports both resource-based and nonResourceURL-based authorization.
 
-						[base64]: https://en.wikipedia.org/wiki/Base64
+						## Required RBAC Permissions
+
+						Vector's ServiceAccount must have permissions to create TokenReview and SubjectAccessReview resources:
+
+						```yaml
+						apiVersion: rbac.authorization.k8s.io/v1
+						kind: ClusterRole
+						metadata:
+						  name: vector-token-validator
+						rules:
+						- apiGroups: ["authentication.k8s.io"]
+						  resources: ["tokenreviews"]
+						  verbs: ["create"]
+						- apiGroups: ["authorization.k8s.io"]
+						  resources: ["subjectaccessreviews"]
+						  verbs: ["create"]
+						```
+
+						## How it Works
+
+						1. Client (e.g., Prometheus) sends request with `Authorization: Bearer <token>`
+						2. Vector extracts the Bearer token from the request
+						3. Vector uses its own ServiceAccount to authenticate to the Kubernetes API
+						4. Vector calls TokenReview API with the client's token to validate it and get user identity
+						5. Vector calls SubjectAccessReview API to check if that user has the specified permissions
+						6. Vector allows or denies the request based on the SubjectAccessReview response
+
+						## Configuration Examples
+
+						NonResourceURL-based (for /metrics, /healthz, etc.):
+						```toml
+						[sinks.prometheus.auth]
+						strategy = "sar"
+						path = "/metrics"
+						verb = "get"
+						```
+
+						Resource-based (for Kubernetes resources):
+						```toml
+						[sinks.prometheus.auth]
+						strategy = "sar"
+						resource = "pods"
+						verb = "get"
+						resource_group = ""
+						```
 						"""
-					bearer: """
-						Bearer authentication.
-
-						The bearer token value (OAuth2, JWT, etc.) is passed as-is.
-						"""
-					custom: "Custom Authorization Header Value, will be inserted into the headers as `Authorization: < value >`"
 				}
 			}
 			token: {
@@ -213,13 +229,24 @@ generated: components: sinks: prometheus_exporter: configuration: {
 				description:   "The basic authentication username."
 				relevant_when: "strategy = \"basic\""
 				required:      true
-				type: string: examples: ["${USERNAME}", "username"]
+				type: string: examples: ["username"]
 			}
 			value: {
-				description:   "Custom string value of the Authorization header"
+				description:   "Custom string value of the Authorization header."
 				relevant_when: "strategy = \"custom\""
 				required:      true
-				type: string: examples: ["${AUTH_HEADER_VALUE}", "CUSTOM_PREFIX ${TOKEN}"]
+				type: string: examples: ["CUSTOM_PREFIX ${TOKEN}"]
+			}
+			verb: {
+				description: """
+					The verb to check.
+
+					For resources: "get", "list", "watch", "create", "update", "delete"
+					For nonResourceURLs: typically "get" or "post"
+					"""
+				relevant_when: "strategy = \"sar\""
+				required:      true
+				type: string: examples: ["get"]
 			}
 		}
 	}

--- a/website/cue/reference/components/sinks/generated/socket.cue
+++ b/website/cue/reference/components/sinks/generated/socket.cue
@@ -587,7 +587,7 @@ generated: components: sinks: socket: configuration: {
 		required:      false
 		type: uint: {
 			examples: [
-				65536,
+				65536
 			]
 			unit: "bytes"
 		}

--- a/website/cue/reference/components/sinks/generated/statsd.cue
+++ b/website/cue/reference/components/sinks/generated/statsd.cue
@@ -122,7 +122,7 @@ generated: components: sinks: statsd: configuration: {
 		required: false
 		type: uint: {
 			examples: [
-				65536,
+				65536
 			]
 			unit: "bytes"
 		}

--- a/website/cue/reference/components/sinks/generated/websocket.cue
+++ b/website/cue/reference/components/sinks/generated/websocket.cue
@@ -655,7 +655,7 @@ generated: components: sinks: websocket: configuration: {
 		required: false
 		type: uint: {
 			examples: [
-				30,
+				30
 			]
 			unit: "seconds"
 		}
@@ -671,7 +671,7 @@ generated: components: sinks: websocket: configuration: {
 		required: false
 		type: uint: {
 			examples: [
-				5,
+				5
 			]
 			unit: "seconds"
 		}

--- a/website/cue/reference/components/sources/generated/amqp.cue
+++ b/website/cue/reference/components/sources/generated/amqp.cue
@@ -568,7 +568,7 @@ generated: components: sources: amqp: configuration: {
 			"""
 		required: false
 		type: uint: examples: [
-			100,
+			100
 		]
 	}
 	queue: {

--- a/website/cue/reference/components/sources/generated/file.cue
+++ b/website/cue/reference/components/sources/generated/file.cue
@@ -83,7 +83,7 @@ generated: components: sources: file: configuration: {
 		type: string: {
 			default: "file"
 			examples: [
-				"path",
+				"path"
 			]
 		}
 	}
@@ -197,7 +197,7 @@ generated: components: sources: file: configuration: {
 		required:    false
 		type: uint: {
 			examples: [
-				600,
+				600
 			]
 			unit: "seconds"
 		}
@@ -227,7 +227,7 @@ generated: components: sources: file: configuration: {
 		type: string: {
 			default: "\n"
 			examples: [
-				"\r\n",
+				"\r\n"
 			]
 		}
 	}
@@ -337,7 +337,7 @@ generated: components: sources: file: configuration: {
 			"""
 		required: false
 		type: string: examples: [
-			"offset",
+			"offset"
 		]
 	}
 	oldest_first: {

--- a/website/cue/reference/components/sources/generated/file_descriptor.cue
+++ b/website/cue/reference/components/sources/generated/file_descriptor.cue
@@ -319,7 +319,7 @@ generated: components: sources: file_descriptor: configuration: {
 		description: "The file descriptor number to read from."
 		required:    true
 		type: uint: examples: [
-			10,
+			10
 		]
 	}
 	framing: {

--- a/website/cue/reference/components/sources/generated/fluent.cue
+++ b/website/cue/reference/components/sources/generated/fluent.cue
@@ -84,7 +84,7 @@ generated: components: sources: fluent: configuration: {
 		required:      false
 		type: uint: {
 			examples: [
-				65536,
+				65536
 			]
 			unit: "bytes"
 		}

--- a/website/cue/reference/components/sources/generated/http.cue
+++ b/website/cue/reference/components/sources/generated/http.cue
@@ -703,7 +703,7 @@ generated: components: sources: http: configuration: {
 		type: uint: {
 			default: 200
 			examples: [
-				202,
+				202
 			]
 		}
 	}

--- a/website/cue/reference/components/sources/generated/http_server.cue
+++ b/website/cue/reference/components/sources/generated/http_server.cue
@@ -703,7 +703,7 @@ generated: components: sources: http_server: configuration: {
 		type: uint: {
 			default: 200
 			examples: [
-				202,
+				202
 			]
 		}
 	}

--- a/website/cue/reference/components/sources/generated/kafka.cue
+++ b/website/cue/reference/components/sources/generated/kafka.cue
@@ -653,7 +653,7 @@ generated: components: sources: kafka: configuration: {
 		type: string: {
 			default: "offset"
 			examples: [
-				"offset",
+				"offset"
 			]
 		}
 	}
@@ -843,7 +843,7 @@ generated: components: sources: kafka: configuration: {
 		type: string: {
 			default: "topic"
 			examples: [
-				"topic",
+				"topic"
 			]
 		}
 	}

--- a/website/cue/reference/components/sources/generated/kubernetes_logs.cue
+++ b/website/cue/reference/components/sources/generated/kubernetes_logs.cue
@@ -128,7 +128,7 @@ generated: components: sources: kubernetes_logs: configuration: {
 		required:    false
 		type: uint: {
 			examples: [
-				600,
+				600
 			]
 			unit: "seconds"
 		}
@@ -138,7 +138,7 @@ generated: components: sources: kubernetes_logs: configuration: {
 		required:    false
 		type: array: {
 			default: [
-				"**/*",
+				"**/*"
 			]
 			items: type: string: examples: ["**/include/**"]
 		}

--- a/website/cue/reference/components/sources/generated/logstash.cue
+++ b/website/cue/reference/components/sources/generated/logstash.cue
@@ -56,7 +56,7 @@ generated: components: sources: logstash: configuration: {
 		required:    false
 		type: uint: {
 			examples: [
-				65536,
+				65536
 			]
 			unit: "bytes"
 		}

--- a/website/cue/reference/components/sources/generated/mqtt.cue
+++ b/website/cue/reference/components/sources/generated/mqtt.cue
@@ -652,7 +652,7 @@ generated: components: sources: mqtt: configuration: {
 		type: string: {
 			default: "topic"
 			examples: [
-				"topic",
+				"topic"
 			]
 		}
 	}

--- a/website/cue/reference/components/sources/generated/nats.cue
+++ b/website/cue/reference/components/sources/generated/nats.cue
@@ -95,7 +95,7 @@ generated: components: sources: nats: configuration: {
 			"""
 		required: true
 		type: string: examples: [
-			"vector",
+			"vector"
 		]
 	}
 	decoding: {

--- a/website/cue/reference/components/sources/generated/redis.cue
+++ b/website/cue/reference/components/sources/generated/redis.cue
@@ -520,7 +520,7 @@ generated: components: sources: redis: configuration: {
 		description: "The Redis key to read messages from."
 		required:    true
 		type: string: examples: [
-			"vector",
+			"vector"
 		]
 	}
 	list: {

--- a/website/cue/reference/components/sources/generated/websocket.cue
+++ b/website/cue/reference/components/sources/generated/websocket.cue
@@ -186,7 +186,7 @@ generated: components: sources: websocket: configuration: {
 		type: uint: {
 			default: 30
 			examples: [
-				10,
+				10
 			]
 			unit: "seconds"
 		}
@@ -696,7 +696,7 @@ generated: components: sources: websocket: configuration: {
 		type: uint: {
 			default: 2
 			examples: [
-				5,
+				5
 			]
 			unit: "seconds"
 		}
@@ -715,7 +715,7 @@ generated: components: sources: websocket: configuration: {
 		required: false
 		type: uint: {
 			examples: [
-				30,
+				30
 			]
 			unit: "seconds"
 		}
@@ -739,7 +739,7 @@ generated: components: sources: websocket: configuration: {
 		required: false
 		type: uint: {
 			examples: [
-				5,
+				5
 			]
 			unit: "seconds"
 		}

--- a/website/cue/reference/components/transforms/generated/sample.cue
+++ b/website/cue/reference/components/transforms/generated/sample.cue
@@ -51,7 +51,7 @@ generated: components: transforms: sample: configuration: {
 			"""
 		required: false
 		type: uint: examples: [
-			1500,
+			1500
 		]
 	}
 	rate_field: {
@@ -77,7 +77,7 @@ generated: components: transforms: sample: configuration: {
 			"""
 		required: false
 		type: float: examples: [
-			0.13,
+			0.13
 		]
 	}
 	ratio_field: {


### PR DESCRIPTION
Add Subject Access Review (SAR) authentication strategy to the prometheus_exporter sink. fixes #25409

## Summary
This PR:
* Adds auth.strategy 'sar' (SubjectAccessReview) to the prometheus export sink
* Allows the sink to be protected by a well-known kubernetes pattern

## Vector configuration
```
    [sinks.prometheus_output.auth]
    strategy = "sar"
    path = "/metrics"
    verb = "get"
```

## How did you test this PR?
* Deploy the collector as a pod on an OpenShift cluster
* Bound the pod serviceaccount to the following role
 ```
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
     name: vector-token-validator
rules:
- apiGroups: ["authentication.k8s.io"]
  resources: ["tokenreviews"]
  verbs: ["create"]
  - apiGroups: ["authorization.k8s.io"]
    resources: ["subjectaccessreviews"]
     verbs: ["create"]
```
* Inspect prometheus or create a serviceaccount and bind it to a cluster role that can "get /metrics"

## Change Type

- [ ] Bug fix
- [x ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [ x] No

## Does this PR include user facing changes?
No

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Closes: #25409

## Notes

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details on the [dd-rust-license-tool](https://crates.io/crates/dd-rust-license-tool).
