### PR TITLE
fix(external docs): warn about log namespace with disk buffers

### DIFF
--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -38,6 +38,9 @@ pub struct Options {
     ///
     /// See the [Log Namespacing guide](/guides/level-up/log_namespace/) for detailed information
     /// about when to use Vector namespace mode and how to migrate from legacy mode.
+    #[configurable(metadata(
+        docs::warnings = "Enabling log namespacing currently does not work when disk buffers are used. Avoid combining `schema.log_namespace = true` with disk buffers until [#18574](https://github.com/vectordotdev/vector/issues/18574) is resolved."
+    ))]
     pub log_namespace: Option<bool>,
 }
 

--- a/website/cue/reference/generated/configuration.cue
+++ b/website/cue/reference/generated/configuration.cue
@@ -442,6 +442,7 @@ generated: configuration: {
 						See the [Log Namespacing guide](/guides/level-up/log_namespace/) for detailed information
 						about when to use Vector namespace mode and how to migrate from legacy mode.
 						"""
+					warnings: ["Enabling log namespacing currently does not work when disk buffers are used. Avoid combining `schema.log_namespace = true` with disk buffers until [#18574](https://github.com/vectordotdev/vector/issues/18574) is resolved."]
 					required: false
 				}
 				validation: {

--- a/website/layouts/partials/data.html
+++ b/website/layouts/partials/data.html
@@ -2034,6 +2034,40 @@
           {{ $v.description | markdownify }}
         </div>
 
+        {{ with $v.warnings }}
+          <div class="mt-3 border-2 rounded-md border-yellow-400 flex flex-col space-y-1.5 py-2 px-3">
+            <span>
+              {{ partial "heading.html" (dict "text" "Warning" "level" 4 "toc_hide" true) }}
+            </span>
+
+            {{ range . }}
+              <div class="flex space-x-5 items-center">
+                <div class="flex-shrink-0">
+                  {{/* Heroicon: outline/exclamation-circle */}}
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    class="text-yellow-500 h-5 w-5"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                  >
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="2"
+                      d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                    />
+                  </svg>
+                </div>
+
+                <div class="prose dark:prose-dark max-w-none leading-snug">
+                  {{ . | markdownify }}
+                </div>
+              </div>
+            {{ end }}
+          </div>
+        {{ end }}
+
         {{ if eq $v.type.string.syntax "template" }}
           <div class="mt-4 text-sm">
             <strong>Note</strong>: This parameter supports Vector's


### PR DESCRIPTION
## Summary

Adds a rendered warning to the `schema.log_namespace` configuration reference explaining that enabling log namespacing currently does not work when disk buffers are used.

## Context

This follows the note from https://github.com/vectordotdev/vector/issues/21360#issuecomment-4418534465 and links readers to https://github.com/vectordotdev/vector/issues/18574.

## Validation

- locally with `make serve`