### PR TITLE
chore(deps): bump markdownlint-cli2 to 0.22.1 and remove smol-toml override

### DIFF
--- a/scripts/environment/npm-tools/package-lock.json
+++ b/scripts/environment/npm-tools/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "dependencies": {
         "@datadog/datadog-ci": "5.13.0",
-        "markdownlint-cli2": "0.22.0",
+        "markdownlint-cli2": "0.22.1",
         "prettier": "3.8.1"
       }
     },
@@ -279,9 +279,9 @@
       }
     },
     "node_modules/globby": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-16.1.1.tgz",
-      "integrity": "sha512-dW7vl+yiAJSp6aCekaVnVJxurRv7DCOLyXqEG3RYMYUg7AuJ2jCqPkZTA8ooqC2vtnkaMcV5WfFBMuEnTu1OQg==",
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-16.2.0.tgz",
+      "integrity": "sha512-QrJia2qDf5BB/V6HYlDTs0I0lBahyjLzpGQg3KT7FnCdTonAyPy2RtY802m2k4ALx6Dp752f82WsOczEVr3l6Q==",
       "license": "MIT",
       "dependencies": {
         "@sindresorhus/merge-streams": "^4.0.0",
@@ -486,12 +486,12 @@
       }
     },
     "node_modules/markdownlint-cli2": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/markdownlint-cli2/-/markdownlint-cli2-0.22.0.tgz",
-      "integrity": "sha512-mOC9BY/XGtdX3M9n3AgERd79F0+S7w18yBBTNIQ453sI87etZfp1z4eajqSMV70CYjbxKe5ktKvT2HCpvcWx9w==",
+      "version": "0.22.1",
+      "resolved": "https://registry.npmjs.org/markdownlint-cli2/-/markdownlint-cli2-0.22.1.tgz",
+      "integrity": "sha512-X14ZbytybDCXAViDmtN4DKLt9ZTrRn+oOrxTYlg3a65jS6QcYYbAkGPh/En2L/GDNbFYJ6lKaQSUNrrbN1bPrw==",
       "license": "MIT",
       "dependencies": {
-        "globby": "16.1.1",
+        "globby": "16.2.0",
         "js-yaml": "4.1.1",
         "jsonc-parser": "3.3.1",
         "jsonpointer": "5.0.1",
@@ -499,7 +499,7 @@
         "markdownlint": "0.40.0",
         "markdownlint-cli2-formatter-default": "0.0.6",
         "micromatch": "4.0.8",
-        "smol-toml": "1.6.0"
+        "smol-toml": "1.6.1"
       },
       "bin": {
         "markdownlint-cli2": "markdownlint-cli2-bin.mjs"

--- a/scripts/environment/npm-tools/package.json
+++ b/scripts/environment/npm-tools/package.json
@@ -1,14 +1,9 @@
 {
   "private": true,
   "description": "Pinned npm tools for CI. Run 'npm ci' to install with exact versions from package-lock.json.",
-  "overrides": {
-    "markdownlint-cli2": {
-      "smol-toml": "1.6.1"
-    }
-  },
   "dependencies": {
     "@datadog/datadog-ci": "5.13.0",
-    "markdownlint-cli2": "0.22.0",
+    "markdownlint-cli2": "0.22.1",
     "prettier": "3.8.1"
   }
 }


### PR DESCRIPTION
## Summary

Bumps `markdownlint-cli2` from `0.22.0` to `0.22.1`. The new release ships with `smol-toml` `1.6.1` directly, so the override that was previously added is no longer necessary.

## Vector configuration

NA

## How did you test this PR?

NA

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: #25202