### PR TITLE
chore(vdev): bump version to 0.3.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12896,7 +12896,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vdev"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "cfg-if",

--- a/vdev/Cargo.toml
+++ b/vdev/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vdev"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2024"
 authors = ["Vector Contributors <vector@datadoghq.com>"]
 license = "MPL-2.0"


### PR DESCRIPTION
## Summary

Bumps vdev to 0.3.3 so a published release exists that contains the native Rust `build component-docs` generator.

vdev 0.3.2 (currently the latest release) defines `build component-docs` as a wrapper around `scripts/generate-component-docs.rb`. PR #24781 replaced the Ruby script with a native Rust generator inside vdev and deleted the Ruby script. Any vdev 0.3.2 binary running against current master fails with `No such file or directory` when invoking `build component-docs`.

This PR is the version bump only. After merge, tag `vdev-v0.3.3` on master to trigger `vdev_publish.yml` and upload the prebuilt binaries.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## How did you test this PR?

- Version bump only; no behavior change.
- Validation happens after release in #25418, which will pick up 0.3.3 via `VDEV_VERSION` in `scripts/environment/prepare.sh`.

## References

- Required by #25418