### PR TITLE
chore(vdev): publish to crates.io on tag push

### DIFF
--- a/.github/workflows/vdev_publish.yml
+++ b/.github/workflows/vdev_publish.yml
@@ -59,3 +59,24 @@ jobs:
           files: ${{ env.ASSET }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish:
+    runs-on: ubuntu-24.04
+    needs: build
+    env:
+      DISABLE_MOLD: true
+    steps:
+      - name: Checkout Vector
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: ./.github/actions/setup
+        with:
+          rust: true
+          vdev: false
+          mold: false
+
+      - name: Publish to crates.io
+        working-directory: vdev
+        run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
## Summary

Adds a `publish` job to the vdev publish workflow that runs `cargo publish` to crates.io after the binary build jobs complete. Triggered by the same `vdev-v*.*.*` tag pattern.

Requires a `CARGO_REGISTRY_TOKEN` secret to be set in the repository.

## Vector configuration

NA

## How did you test this PR?

NA

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

NA