### PR TITLE
enhancement(opentelemetry sink): warn on invalid json batching

### DIFF
--- a/changelog.d/22054_opentelemetry_sink_json_batching_warning.enhancement.md
+++ b/changelog.d/22054_opentelemetry_sink_json_batching_warning.enhancement.md
@@ -1,0 +1,8 @@
+The `opentelemetry` sink now logs a warning at startup when it is configured
+with `encoding.codec = json` and `batch.max_events` greater than 1. That
+combination produces invalid OTLP request bodies that receivers reject with
+HTTP 400. Use `encoding.codec = otlp` (recommended) or set
+`batch.max_events = 1`. The sink documentation now includes a "Batching
+considerations" section that spells out both paths.
+
+authors: pront

--- a/changelog.d/22054_opentelemetry_sink_json_batching_warning.enhancement.md
+++ b/changelog.d/22054_opentelemetry_sink_json_batching_warning.enhancement.md
@@ -1,8 +1,0 @@
-The `opentelemetry` sink now logs a warning at startup when it is configured
-with `encoding.codec = json` and `batch.max_events` greater than 1. That
-combination produces invalid OTLP request bodies that receivers reject with
-HTTP 400. Use `encoding.codec = otlp` (recommended) or set
-`batch.max_events = 1`. The sink documentation now includes a "Batching
-considerations" section that spells out both paths.
-
-authors: pront

--- a/src/sinks/opentelemetry/mod.rs
+++ b/src/sinks/opentelemetry/mod.rs
@@ -78,7 +78,10 @@ impl GenerateConfig for OpenTelemetryConfig {
 impl SinkConfig for OpenTelemetryConfig {
     async fn build(&self, cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
         match &self.protocol {
-            Protocol::Http(config) => config.build(cx).await,
+            Protocol::Http(config) => {
+                warn_on_invalid_otlp_batching(config);
+                config.build(cx).await
+            }
         }
     }
 
@@ -92,6 +95,21 @@ impl SinkConfig for OpenTelemetryConfig {
         match self.protocol {
             Protocol::Http(ref config) => config.acknowledgements(),
         }
+    }
+}
+
+fn warn_on_invalid_otlp_batching(config: &HttpSinkConfig) {
+    let (_, serializer) = config.encoding.config();
+    let is_json = matches!(serializer, SerializerConfig::Json(_));
+    let batches_more_than_one = !matches!(config.batch.max_events, Some(1));
+    if is_json && batches_more_than_one {
+        tracing::warn!(
+            message = "`opentelemetry` sink is configured with `encoding.codec = json` and \
+                       `batch.max_events` greater than 1. This produces invalid OTLP request \
+                       bodies that receivers reject with HTTP 400. Use `encoding.codec = otlp` \
+                       (recommended) or set `batch.max_events = 1`. See \
+                       https://github.com/vectordotdev/vector/issues/22054.",
+        );
     }
 }
 

--- a/website/cue/reference/components/sinks/opentelemetry.cue
+++ b/website/cue/reference/components/sinks/opentelemetry.cue
@@ -32,7 +32,16 @@ components: sinks: opentelemetry: {
 
 	support: {
 		requirements: ["This sink accepts events conforming to the [OTEL proto format](\(urls.opentelemetry_proto)). You can use [Remap](\(urls.vector_remap_transform)) to prepare events for ingestion."]
-		warnings: []
+		warnings: [
+			"""
+				Batching only works with `encoding.codec: otlp`, which encodes events as protobuf
+				and supports native batching (recommended). The legacy `encoding.codec: json` path
+				produces newline-delimited JSON, which is not a valid OTLP request body, so on
+				that path you must either set `batch.max_events: 1` or merge events into a single
+				envelope upstream with the [`reduce`](\(urls.vector_reduce_transform)) transform.
+				See [#22054](https://github.com/vectordotdev/vector/issues/22054).
+				""",
+		]
 		notices: []
 	}
 


### PR DESCRIPTION
## Summary

Documenting an important limitation of the `opentelemetry` sink: the default `encoding.codec: json` path produces newline-delimited JSON, which is not a valid OTLP request body. OTLP receivers reject batches as soon as `batch.max_events > 1`, which is silent data loss for users on the quickstart config.

This PR surfaces the limitation in two places:

- A startup warning when the sink is built with `codec: json` and `max_events > 1`, pointing users at `encoding.codec: otlp` (recommended) or `batch.max_events: 1`.
- A warning entry on the sink docs page, above the configuration reference.

The check is narrow on purpose: users on `codec: otlp` (which batches natively) are unaffected.

## How did you test this PR?

- `cd website && make serve`

## Change Type

- [x] Non-functional (chore, refactoring, docs)

## Is this a breaking change?

- [x] No

## Does this PR include user facing changes?

- [x] Yes. Changelog fragment added.

## References

- Related: #22054