### PR TITLE
fix(releasing): remove default OS package config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,10 +54,10 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tokio_unstable)'] }
 name = "vector"
 section = "admin"
 maintainer-scripts = "distribution/debian/scripts/"
-conf-files = ["/etc/vector/vector.yaml", "/etc/default/vector"]
+conf-files = ["/etc/default/vector"]
 assets = [
   ["target/release/vector", "/usr/bin/", "755"],
-  ["config/vector.yaml", "/etc/vector/vector.yaml", "644"],
+  ["config/vector.yaml", "/usr/share/vector/examples/vector.yaml", "644"],
   ["config/examples/*", "/etc/vector/examples/", "644"],
   ["distribution/systemd/vector.service", "/lib/systemd/system/vector.service", "644"],
   ["distribution/systemd/vector.default", "/etc/default/vector", "600"],

--- a/changelog.d/15513_remove_default_os_package_config.fix.md
+++ b/changelog.d/15513_remove_default_os_package_config.fix.md
@@ -1,0 +1,7 @@
+The default `/etc/vector/vector.yaml` config file is no longer installed by the Debian, RPM, Alpine, and distroless-static Docker packages. The previous default ran a `demo_logs` source and printed synthesized syslog lines to stdout, which then surfaced in journald or `/var/log/` on hosts running Vector as a service and was a common source of confusion.
+
+New installs will now have no active config on disk. Provide your own configuration at `/etc/vector/vector.yaml` (or pass `--config <path>`) before starting Vector. A reference example is shipped at `/usr/share/vector/examples/vector.yaml`, and more sample configs remain at `/etc/vector/examples/`.
+
+Existing installs are unaffected on upgrade: package managers preserve the on-disk `/etc/vector/vector.yaml` if you already had one.
+
+authors: pront

--- a/distribution/docker/README.md
+++ b/distribution/docker/README.md
@@ -33,9 +33,9 @@ observability data with Vector.
 
 ## Configuring
 
-You can pass a custom
-[Vector configuration file][docs.setup.configuration] to the container via the
-`-c` flag, mounting the file from the host:
+Vector images do not ship a default configuration. You must provide one via the
+`-c` flag, typically by mounting a [Vector configuration file][docs.setup.configuration]
+from the host:
 
 ```bash
 docker run \
@@ -44,9 +44,8 @@ docker run \
   -c /etc/vector/vector.yaml
 ```
 
-You'll want to do this since the
-[default `/etc/vector/vector.yaml` configuration file][urls.default_configuration]
-doesn't do anything.
+A reference [example configuration][urls.example_configuration] is bundled at
+`/usr/share/vector/examples/vector.yaml` inside the image.
 
 ## Deploying
 
@@ -137,7 +136,7 @@ Vector's Docker source files are located
 [docs.transforms]: https://vector.dev/docs/reference/configurationtransforms/
 [pages.index#correctness]: https://vector.dev/#correctness
 [pages.index#performance]: https://vector.dev/#performance
-[urls.default_configuration]: https://github.com/vectordotdev/vector/blob/master/config/vector.yaml
+[urls.example_configuration]: https://github.com/vectordotdev/vector/blob/master/config/vector.yaml
 [urls.docker_alpine]: https://hub.docker.com/_/alpine
 [urls.docker_debian]: https://hub.docker.com/_/debian
 [urls.rust]: https://www.rust-lang.org/

--- a/distribution/docker/alpine/Dockerfile
+++ b/distribution/docker/alpine/Dockerfile
@@ -24,7 +24,7 @@ LABEL org.opencontainers.image.documentation="https://vector.dev/docs"
 RUN apk --no-cache add ca-certificates tzdata
 
 COPY --from=builder /vector/bin/* /usr/local/bin/
-COPY --from=builder /vector/config/vector.yaml /etc/vector/vector.yaml
+COPY --from=builder /vector/config/vector.yaml /usr/share/vector/examples/vector.yaml
 COPY --from=builder /var/lib/vector /var/lib/vector
 
 # Smoke test

--- a/distribution/docker/distroless-static/Dockerfile
+++ b/distribution/docker/distroless-static/Dockerfile
@@ -17,7 +17,7 @@ LABEL org.opencontainers.image.source="https://github.com/vectordotdev/vector"
 LABEL org.opencontainers.image.documentation="https://vector.dev/docs"
 
 COPY --from=builder /vector/bin/* /usr/local/bin/
-COPY --from=builder /vector/config/vector.yaml /etc/vector/vector.yaml
+COPY --from=builder /vector/config/vector.yaml /usr/share/vector/examples/vector.yaml
 COPY --from=builder /var/lib/vector /var/lib/vector
 
 # Smoke test

--- a/distribution/rpm/vector.spec
+++ b/distribution/rpm/vector.spec
@@ -56,7 +56,8 @@ mkdir -p %{buildroot}%{_datadir}/%{_name}
 mkdir -p %{buildroot}%{_unitdir}
 
 cp -a %{_builddir}/bin/vector %{buildroot}%{_bindir}
-cp -a %{_builddir}/config/vector.yaml %{buildroot}%{_sysconfdir}/%{_name}/vector.yaml
+mkdir -p %{buildroot}%{_datadir}/%{_name}/examples
+cp -a %{_builddir}/config/vector.yaml %{buildroot}%{_datadir}/%{_name}/examples/vector.yaml
 cp -a %{_builddir}/config/examples/. %{buildroot}%{_sysconfdir}/%{_name}/examples
 cp -a %{_builddir}/systemd/vector.service %{buildroot}%{_unitdir}/vector.service
 cp -a %{_builddir}/systemd/vector.default %{buildroot}%{_sysconfdir}/default/vector
@@ -79,12 +80,12 @@ rm -rf %{buildroot}
 %defattr(-,root,root,-)
 %{_bindir}/*
 %{_unitdir}/vector.service
-%config(noreplace) %{_sysconfdir}/%{_name}/vector.yaml
 %config(noreplace) %{_sysconfdir}/default/vector
 %config %{_sysconfdir}/%{_name}/examples/*
 %dir %{_sharedstatedir}/%{_name}
 %doc README.md
 %doc %{_datadir}/%{_name}/NOTICE
+%doc %{_datadir}/%{_name}/examples/vector.yaml
 %doc %{_datadir}/%{_name}/licenses/*
 %doc %{_datadir}/%{_name}/LICENSE-3rdparty.csv
 %license LICENSE

--- a/distribution/rpm/vector.spec
+++ b/distribution/rpm/vector.spec
@@ -81,6 +81,10 @@ rm -rf %{buildroot}
 %{_bindir}/*
 %{_unitdir}/vector.service
 %config(noreplace) %{_sysconfdir}/default/vector
+# Older versions installed a demo config at this path; mark it as %ghost so
+# rpm preserves any existing on-disk file during upgrade instead of removing
+# it as orphaned.
+%ghost %config(noreplace) %{_sysconfdir}/%{_name}/vector.yaml
 %config %{_sysconfdir}/%{_name}/examples/*
 %dir %{_sharedstatedir}/%{_name}
 %doc README.md

--- a/scripts/verify-install.sh
+++ b/scripts/verify-install.sh
@@ -26,8 +26,10 @@ getent passwd vector || (echo "vector user missing" && exit 1)
 getent group vector || (echo "vector group  missing" && exit 1)
 vector --version || (echo "vector --version failed" && exit 1)
 test -f /etc/default/vector || (echo "/etc/default/vector doesn't exist" && exit 1)
-test -f /etc/vector/vector.yaml || (echo "/etc/vector/vector.yaml doesn't exist" && exit 1)
+test ! -e /etc/vector/vector.yaml || (echo "/etc/vector/vector.yaml should not be installed by default" && exit 1)
+test -f /usr/share/vector/examples/vector.yaml || (echo "/usr/share/vector/examples/vector.yaml doesn't exist" && exit 1)
 
+mkdir -p /etc/vector
 echo "FOO=bar" > /etc/default/vector
 echo "foo: bar" > /etc/vector/vector.yaml
 
@@ -37,6 +39,6 @@ getent passwd vector || (echo "vector user missing" && exit 1)
 getent group vector || (echo "vector group  missing" && exit 1)
 vector --version || (echo "vector --version failed" && exit 1)
 grep -q "FOO=bar" "/etc/default/vector" || (echo "/etc/default/vector has incorrect contents" && exit 1)
-grep -q "foo: bar" "/etc/vector/vector.yaml" || (echo "/etc/vector/vector.yaml has incorrect contents" && exit 1)
+grep -q "foo: bar" "/etc/vector/vector.yaml" || (echo "user-provided /etc/vector/vector.yaml was not preserved on reinstall" && exit 1)
 
 dd-pkg lint "$package"


### PR DESCRIPTION
## Summary

Vector's Debian, RPM, Alpine, and distroless-static packages have been installing `config/vector.yaml` at `/etc/vector/vector.yaml`. That config runs a `demo_logs` source and prints synthesized syslog lines to stdout, which then surfaces in journald or `/var/log/` when Vector is run as a service. Users are surprised to find these synthetic logs appearing on their systems after a fresh install. That is the main motivation for this change.

This PR stops installing that file as the active config and ships it as a reference example at `/usr/share/vector/examples/vector.yaml` instead. The wider `/etc/vector/examples/` tree of sample configs is unchanged.

New installs will have no active config on disk. The user must provide one at `/etc/vector/vector.yaml` (or pass `--config <path>`) before starting Vector. The systemd unit's `ExecStartPre=/usr/bin/vector validate` will fail loudly if no config is present, which is the desired behavior.

Existing installs are not disturbed on upgrade: dpkg and rpm both preserve on-disk files that are no longer owned by the package.

The Docker README has been updated to reflect the new state.

This is an attempt to redo the relevant part of #13483, which previously removed this default but was reverted (alongside unrelated systemd/packaging changes) in #13997 due to k8s e2e failures. This PR touches only the default-config removal.

## Vector configuration

n/a

## How did you test this PR?

- ``./scripts/check_changelog_fragments.sh`` passes for the new fragment
- ``make check-markdown`` passes (exit 0)
- Manually inspected the deb/rpm/Dockerfile diffs for layout correctness; release-time CI will validate the actual package builds

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

(New installs no longer come up with a working config out of the box. Existing installs are preserved on upgrade.)

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the ``no-changelog`` label to this PR.

## References

- Closes: #15513
- Related: #13483, #13997

## Notes

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use ``@vectordotdev/vector`` to reach out to us regarding this PR.