### PR TITLE
feat(top): add backpressure and buffer metrics to vector top

### DIFF
--- a/lib/vector-api-client/src/client.rs
+++ b/lib/vector-api-client/src/client.rs
@@ -9,10 +9,11 @@ use crate::{
     error::{Error, Result},
     proto::{
         GetAllocationTracingStatusRequest, GetAllocationTracingStatusResponse,
-        GetComponentsRequest, GetComponentsResponse, GetMetaRequest, GetMetaResponse, MetricName,
-        StreamComponentAllocatedBytesRequest, StreamComponentAllocatedBytesResponse,
-        StreamComponentMetricsRequest, StreamComponentMetricsResponse, StreamHeartbeatRequest,
-        StreamHeartbeatResponse, StreamOutputEventsRequest, StreamOutputEventsResponse,
+        GetComponentsRequest, GetComponentsResponse, GetMetaRequest, GetMetaResponse, MetricMode,
+        MetricName, RawComponentMetricValue, StreamComponentAllocatedBytesRequest,
+        StreamComponentAllocatedBytesResponse, StreamComponentMetricsRequest,
+        StreamComponentMetricsResponse, StreamHeartbeatRequest, StreamHeartbeatResponse,
+        StreamOutputEventsRequest, StreamOutputEventsResponse, StreamRawComponentMetricsRequest,
         StreamUptimeRequest, StreamUptimeResponse,
         observability_service_client::ObservabilityServiceClient,
     },
@@ -182,6 +183,30 @@ impl Client {
             .stream_component_metrics(StreamComponentMetricsRequest {
                 interval_ms,
                 metric: metric as i32,
+            })
+            .await?;
+        Ok(response.into_inner().map(|r| r.map_err(Error::from)))
+    }
+
+    /// Stream per-component values for any named internal metric.
+    ///
+    /// # Arguments
+    ///
+    /// * `metric_name` - Internal metric name (e.g. `"component_discarded_events_total"`, `"utilization"`)
+    /// * `mode` - Whether to stream cumulative totals or per-second throughput
+    /// * `interval_ms` - Update interval in milliseconds
+    pub async fn stream_raw_component_metrics(
+        &mut self,
+        metric_name: impl Into<String>,
+        mode: MetricMode,
+        interval_ms: i32,
+    ) -> Result<impl Stream<Item = Result<RawComponentMetricValue>>> {
+        let client = self.ensure_connected()?;
+        let response = client
+            .stream_raw_component_metrics(StreamRawComponentMetricsRequest {
+                interval_ms,
+                metric_name: metric_name.into(),
+                mode: mode as i32,
             })
             .await?;
         Ok(response.into_inner().map(|r| r.map_err(Error::from)))

--- a/lib/vector-top/src/dashboard.rs
+++ b/lib/vector-top/src/dashboard.rs
@@ -137,10 +137,46 @@ fn format_metric_bytes(total: i64, throughput: i64, human_metrics: bool) -> Stri
     }
 }
 
+fn format_utilization(util: Option<f64>) -> (String, Style) {
+    match util {
+        None => ("N/A".to_string(), Style::default().fg(Color::DarkGray)),
+        Some(v) => {
+            let pct = v * 100.0;
+            let text = format!("{pct:.1}%");
+            let style = if v >= 0.95 {
+                Style::default().fg(Color::Red)
+            } else if v >= 0.80 {
+                Style::default().fg(Color::Yellow)
+            } else {
+                Style::default()
+            };
+            (text, style)
+        }
+    }
+}
+
+fn format_buffer_fill(fill: Option<f64>) -> (String, Style) {
+    match fill {
+        None => ("N/A".to_string(), Style::default().fg(Color::DarkGray)),
+        Some(v) => {
+            let pct = v * 100.0;
+            let text = format!("{pct:.1}%");
+            let style = if v >= 0.80 {
+                Style::default().fg(Color::Red)
+            } else if v >= 0.50 {
+                Style::default().fg(Color::Yellow)
+            } else {
+                Style::default()
+            };
+            (text, style)
+        }
+    }
+}
+
 const NUM_COLUMNS: usize = if is_allocation_tracing_enabled() {
-    10
+    15
 } else {
-    9
+    14
 };
 
 pub mod columns {
@@ -157,6 +193,11 @@ pub mod columns {
     pub const BYTES_OUT: &str = "Bytes Out";
     pub const BYTES_OUT_TOTAL: &str = "Bytes Out Total";
     pub const ERRORS: &str = "Errors";
+    pub const DISCARDED: &str = "Discarded";
+    pub const BUF_DROPPED: &str = "BufDrop";
+    pub const CHAN_FILL: &str = "ChanFill";
+    pub const UTIL: &str = "Util%";
+    pub const FILL: &str = "Fill%";
     #[cfg(feature = "allocation-tracing")]
     pub const MEMORY_USED: &str = "Memory Used";
 }
@@ -173,6 +214,11 @@ static HEADER: [&str; NUM_COLUMNS] = [
     #[cfg(feature = "allocation-tracing")]
     columns::MEMORY_USED,
     columns::ERRORS,
+    columns::DISCARDED,
+    columns::BUF_DROPPED,
+    columns::CHAN_FILL,
+    columns::UTIL,
+    columns::FILL,
 ];
 
 struct Widgets<'a> {
@@ -273,7 +319,7 @@ impl<'a> Widgets<'a> {
         let mut items = Vec::new();
         let mut sorted = state.components.iter().collect::<Vec<_>>();
         if let Some(column) = state.sort_state.column {
-            let sort_fn = match column {
+            let sort_fn: fn(&ComponentRow, &ComponentRow) -> std::cmp::Ordering = match column {
                 SortColumn::Id => row_comparator!(key),
                 SortColumn::Kind => row_comparator!(kind),
                 SortColumn::Type => row_comparator!(component_type),
@@ -286,6 +332,17 @@ impl<'a> Widgets<'a> {
                 SortColumn::BytesOut => row_comparator!(sent_bytes_throughput_sec),
                 SortColumn::BytesOutTotal => row_comparator!(sent_bytes_total),
                 SortColumn::Errors => row_comparator!(errors),
+                SortColumn::Discarded => row_comparator!(discarded_events_total),
+                SortColumn::BufDropped => row_comparator!(buffer_discarded_total),
+                SortColumn::ChanFill => {
+                    |l: &ComponentRow, r: &ComponentRow| l.channel_fill_ord().cmp(&r.channel_fill_ord())
+                }
+                SortColumn::BufferUtil => |l: &ComponentRow, r: &ComponentRow| {
+                    l.buffer_util_ord().cmp(&r.buffer_util_ord())
+                },
+                SortColumn::BufferFill => |l: &ComponentRow, r: &ComponentRow| {
+                    l.buffer_fill_ord().cmp(&r.buffer_fill_ord())
+                },
                 #[cfg(feature = "allocation-tracing")]
                 SortColumn::MemoryUsed => row_comparator!(allocated_bytes),
             };
@@ -315,53 +372,89 @@ impl<'a> Widgets<'a> {
                 true
             }
         }) {
-            let mut data = vec![
-                r.key.id().to_string(),
-                if !r.has_displayable_outputs() {
-                    "--"
-                } else {
-                    Default::default()
-                }
-                .to_string(),
-                r.kind.clone(),
-                r.component_type.clone(),
-            ];
+            let discarded_text = format_metric(
+                r.discarded_events_total,
+                r.discarded_events_throughput_sec,
+                self.human_metrics,
+            );
+            let discarded_cell = if r.discarded_events_total > 0 {
+                Cell::from(discarded_text).style(Style::default().fg(Color::Yellow))
+            } else {
+                Cell::from(discarded_text)
+            };
 
-            let formatted_metrics = [
-                format_metric(
+            let buf_dropped_text = format_metric(
+                r.buffer_discarded_total,
+                r.buffer_discarded_throughput_sec,
+                self.human_metrics,
+            );
+            let buf_dropped_cell = if r.buffer_discarded_total > 0 {
+                Cell::from(buf_dropped_text).style(Style::default().fg(Color::Red))
+            } else {
+                Cell::from(buf_dropped_text)
+            };
+
+            let (util_text, util_style) = format_utilization(r.buffer_utilization);
+            let util_cell = Cell::from(util_text).style(util_style);
+
+            let (fill_text, fill_style) = format_buffer_fill(r.buffer_fill);
+            let fill_cell = Cell::from(fill_text).style(fill_style);
+
+            let (chan_fill_text, chan_fill_style) = format_buffer_fill(r.channel_fill);
+            let chan_fill_cell = Cell::from(chan_fill_text).style(chan_fill_style);
+
+            let mut data: Vec<Cell> = vec![
+                Cell::from(r.key.id().to_string()),
+                Cell::from(
+                    if !r.has_displayable_outputs() {
+                        "--"
+                    } else {
+                        Default::default()
+                    }
+                    .to_string(),
+                ),
+                Cell::from(r.kind.clone()),
+                Cell::from(r.component_type.clone()),
+                Cell::from(format_metric(
                     r.received_events_total,
                     r.received_events_throughput_sec,
                     self.human_metrics,
-                ),
-                format_metric_bytes(
+                )),
+                Cell::from(format_metric_bytes(
                     r.received_bytes_total,
                     r.received_bytes_throughput_sec,
                     self.human_metrics,
-                ),
-                format_metric(
+                )),
+                Cell::from(format_metric(
                     r.sent_events_total,
                     r.sent_events_throughput_sec,
                     self.human_metrics,
-                ),
-                format_metric_bytes(
+                )),
+                Cell::from(format_metric_bytes(
                     r.sent_bytes_total,
                     r.sent_bytes_throughput_sec,
                     self.human_metrics,
-                ),
-                #[cfg(feature = "allocation-tracing")]
-                if state.allocation_tracing_active {
-                    r.allocated_bytes.human_format_bytes()
-                } else {
-                    "disabled".to_string()
-                },
-                if self.human_metrics {
-                    r.errors.human_format()
-                } else {
-                    r.errors.thousands_format()
-                },
+                )),
             ];
 
-            data.extend_from_slice(&formatted_metrics);
+            #[cfg(feature = "allocation-tracing")]
+            data.push(Cell::from(if state.allocation_tracing_active {
+                r.allocated_bytes.human_format_bytes()
+            } else {
+                "disabled".to_string()
+            }));
+
+            data.push(Cell::from(if self.human_metrics {
+                r.errors.human_format()
+            } else {
+                r.errors.thousands_format()
+            }));
+            data.push(discarded_cell);
+            data.push(buf_dropped_cell);
+            data.push(chan_fill_cell);
+            data.push(util_cell);
+            data.push(fill_cell);
+
             items.push(Row::new(data).style(Style::default()));
 
             // Add output rows
@@ -385,28 +478,38 @@ impl<'a> Widgets<'a> {
 
         let widths: &[Constraint] = if is_allocation_tracing_enabled() {
             &[
-                Constraint::Percentage(13), // ID
-                Constraint::Percentage(8),  // Output
-                Constraint::Percentage(5),  // Kind
-                Constraint::Percentage(9),  // Type
-                Constraint::Percentage(10), // Events In
-                Constraint::Percentage(12), // Bytes In
-                Constraint::Percentage(10), // Events Out
-                Constraint::Percentage(12), // Bytes Out
-                Constraint::Percentage(14), // Memory Used
-                Constraint::Percentage(7),  // Errors
+                Constraint::Percentage(9),  // ID
+                Constraint::Percentage(4),  // Output
+                Constraint::Percentage(4),  // Kind
+                Constraint::Percentage(5),  // Type
+                Constraint::Percentage(7),  // Events In
+                Constraint::Percentage(8),  // Bytes In
+                Constraint::Percentage(7),  // Events Out
+                Constraint::Percentage(8),  // Bytes Out
+                Constraint::Percentage(9),  // Memory Used
+                Constraint::Percentage(4),  // Errors
+                Constraint::Percentage(7),  // Discarded
+                Constraint::Percentage(7),  // BufDrop
+                Constraint::Percentage(7),  // ChanFill
+                Constraint::Percentage(7),  // Util%
+                Constraint::Percentage(7),  // Fill%
             ]
         } else {
             &[
-                Constraint::Percentage(13), // ID
-                Constraint::Percentage(12), // Output
-                Constraint::Percentage(10), // Kind
-                Constraint::Percentage(6),  // Type
-                Constraint::Percentage(12), // Events In
-                Constraint::Percentage(14), // Bytes In
-                Constraint::Percentage(12), // Events Out
-                Constraint::Percentage(14), // Bytes Out
-                Constraint::Percentage(7),  // Errors
+                Constraint::Percentage(9),  // ID
+                Constraint::Percentage(6),  // Output
+                Constraint::Percentage(5),  // Kind
+                Constraint::Percentage(4),  // Type
+                Constraint::Percentage(8),  // Events In
+                Constraint::Percentage(9),  // Bytes In
+                Constraint::Percentage(8),  // Events Out
+                Constraint::Percentage(9),  // Bytes Out
+                Constraint::Percentage(4),  // Errors
+                Constraint::Percentage(7),  // Discarded
+                Constraint::Percentage(7),  // BufDrop
+                Constraint::Percentage(7),  // ChanFill
+                Constraint::Percentage(8),  // Util%
+                Constraint::Percentage(9),  // Fill%
             ]
         };
         let w = Table::new(items, widths)

--- a/lib/vector-top/src/metrics.rs
+++ b/lib/vector-top/src/metrics.rs
@@ -10,7 +10,9 @@ use tokio::task::JoinHandle;
 use tokio_stream::StreamExt;
 use vector_api_client::{
     Client,
-    proto::{Component, ComponentType, MetricName, stream_component_metrics_response::Value},
+    proto::{
+        Component, ComponentType, MetricMode, MetricName, stream_component_metrics_response::Value,
+    },
 };
 
 use crate::state::{self, OutputMetrics, SentEventsMetric};
@@ -121,6 +123,13 @@ fn component_to_row(component: &Component) -> state::ComponentRow {
         #[cfg(feature = "allocation-tracing")]
         allocated_bytes: 0,
         errors: 0,
+        discarded_events_total: 0,
+        discarded_events_throughput_sec: 0,
+        buffer_utilization: None,
+        buffer_fill: None,
+        buffer_discarded_total: 0,
+        buffer_discarded_throughput_sec: 0,
+        channel_fill: None,
     }
 }
 
@@ -424,6 +433,211 @@ async fn errors_totals(
     }
 }
 
+async fn discarded_events_totals(
+    mut client: Client,
+    tx: state::EventTx,
+    interval: i64,
+    components_patterns: Arc<Vec<Pattern>>,
+) {
+    let Ok(mut stream) = client
+        .stream_raw_component_metrics(
+            "component_discarded_events_total",
+            MetricMode::Total,
+            interval as i32,
+        )
+        .await
+    else {
+        return;
+    };
+
+    while let Some(Ok(response)) = stream.next().await {
+        let component_id = &response.component_id;
+        if !component_matches_patterns(component_id, &components_patterns) {
+            continue;
+        }
+        _ = tx
+            .send(state::EventType::DiscardedEventsTotals(vec![(
+                ComponentKey::from(component_id.as_str()),
+                response.value as i64,
+            )]))
+            .await;
+    }
+}
+
+async fn discarded_events_throughputs(
+    mut client: Client,
+    tx: state::EventTx,
+    interval: i64,
+    components_patterns: Arc<Vec<Pattern>>,
+) {
+    let Ok(mut stream) = client
+        .stream_raw_component_metrics(
+            "component_discarded_events_total",
+            MetricMode::Throughput,
+            interval as i32,
+        )
+        .await
+    else {
+        return;
+    };
+
+    while let Some(Ok(response)) = stream.next().await {
+        let component_id = &response.component_id;
+        if !component_matches_patterns(component_id, &components_patterns) {
+            continue;
+        }
+        _ = tx
+            .send(state::EventType::DiscardedEventsThroughputs(vec![(
+                ComponentKey::from(component_id.as_str()),
+                response.value as i64,
+            )]))
+            .await;
+    }
+}
+
+async fn buffer_utilizations(
+    mut client: Client,
+    tx: state::EventTx,
+    interval: i64,
+    components_patterns: Arc<Vec<Pattern>>,
+) {
+    let Ok(mut stream) = client
+        .stream_raw_component_metrics("utilization", MetricMode::Total, interval as i32)
+        .await
+    else {
+        return;
+    };
+
+    while let Some(Ok(response)) = stream.next().await {
+        let component_id = &response.component_id;
+        if !component_matches_patterns(component_id, &components_patterns) {
+            continue;
+        }
+        _ = tx
+            .send(state::EventType::BufferUtilizations(vec![(
+                ComponentKey::from(component_id.as_str()),
+                response.value,
+            )]))
+            .await;
+    }
+}
+
+async fn channel_fills(
+    mut client: Client,
+    tx: state::EventTx,
+    interval: i64,
+    components_patterns: Arc<Vec<Pattern>>,
+) {
+    let Ok(mut stream) = client
+        .stream_raw_component_metrics("channel_fill", MetricMode::Total, interval as i32)
+        .await
+    else {
+        return;
+    };
+
+    while let Some(Ok(response)) = stream.next().await {
+        let component_id = &response.component_id;
+        if !component_matches_patterns(component_id, &components_patterns) {
+            continue;
+        }
+        _ = tx
+            .send(state::EventType::ChannelFills(vec![(
+                ComponentKey::from(component_id.as_str()),
+                response.value,
+            )]))
+            .await;
+    }
+}
+
+async fn buffer_discarded_totals(
+    mut client: Client,
+    tx: state::EventTx,
+    interval: i64,
+    components_patterns: Arc<Vec<Pattern>>,
+) {
+    let Ok(mut stream) = client
+        .stream_raw_component_metrics(
+            "buffer_discarded_events_total",
+            MetricMode::Total,
+            interval as i32,
+        )
+        .await
+    else {
+        return;
+    };
+
+    while let Some(Ok(response)) = stream.next().await {
+        let component_id = &response.component_id;
+        if !component_matches_patterns(component_id, &components_patterns) {
+            continue;
+        }
+        _ = tx
+            .send(state::EventType::BufferDiscardedTotals(vec![(
+                ComponentKey::from(component_id.as_str()),
+                response.value as i64,
+            )]))
+            .await;
+    }
+}
+
+async fn buffer_discarded_throughputs(
+    mut client: Client,
+    tx: state::EventTx,
+    interval: i64,
+    components_patterns: Arc<Vec<Pattern>>,
+) {
+    let Ok(mut stream) = client
+        .stream_raw_component_metrics(
+            "buffer_discarded_events_total",
+            MetricMode::Throughput,
+            interval as i32,
+        )
+        .await
+    else {
+        return;
+    };
+
+    while let Some(Ok(response)) = stream.next().await {
+        let component_id = &response.component_id;
+        if !component_matches_patterns(component_id, &components_patterns) {
+            continue;
+        }
+        _ = tx
+            .send(state::EventType::BufferDiscardedThroughputs(vec![(
+                ComponentKey::from(component_id.as_str()),
+                response.value as i64,
+            )]))
+            .await;
+    }
+}
+
+async fn buffer_fills(
+    mut client: Client,
+    tx: state::EventTx,
+    interval: i64,
+    components_patterns: Arc<Vec<Pattern>>,
+) {
+    let Ok(mut stream) = client
+        .stream_raw_component_metrics("buffer_fill", MetricMode::Total, interval as i32)
+        .await
+    else {
+        return;
+    };
+
+    while let Some(Ok(response)) = stream.next().await {
+        let component_id = &response.component_id;
+        if !component_matches_patterns(component_id, &components_patterns) {
+            continue;
+        }
+        _ = tx
+            .send(state::EventType::BufferFills(vec![(
+                ComponentKey::from(component_id.as_str()),
+                response.value,
+            )]))
+            .await;
+    }
+}
+
 async fn uptime_changed(mut client: Client, tx: state::EventTx, interval: i64) {
     let Ok(mut stream) = client.stream_uptime(interval as i32).await else {
         return;
@@ -523,6 +737,48 @@ pub async fn subscribe(
             Arc::clone(&components_patterns),
         )),
         tokio::spawn(errors_totals(
+            client.clone(),
+            tx.clone(),
+            interval,
+            Arc::clone(&components_patterns),
+        )),
+        tokio::spawn(discarded_events_totals(
+            client.clone(),
+            tx.clone(),
+            interval,
+            Arc::clone(&components_patterns),
+        )),
+        tokio::spawn(discarded_events_throughputs(
+            client.clone(),
+            tx.clone(),
+            interval,
+            Arc::clone(&components_patterns),
+        )),
+        tokio::spawn(buffer_utilizations(
+            client.clone(),
+            tx.clone(),
+            interval,
+            Arc::clone(&components_patterns),
+        )),
+        tokio::spawn(channel_fills(
+            client.clone(),
+            tx.clone(),
+            interval,
+            Arc::clone(&components_patterns),
+        )),
+        tokio::spawn(buffer_discarded_totals(
+            client.clone(),
+            tx.clone(),
+            interval,
+            Arc::clone(&components_patterns),
+        )),
+        tokio::spawn(buffer_discarded_throughputs(
+            client.clone(),
+            tx.clone(),
+            interval,
+            Arc::clone(&components_patterns),
+        )),
+        tokio::spawn(buffer_fills(
             client.clone(),
             tx.clone(),
             interval,

--- a/lib/vector-top/src/state.rs
+++ b/lib/vector-top/src/state.rs
@@ -46,6 +46,19 @@ pub enum EventType {
     /// Throughput values already normalized to per-second by the server
     SentEventsThroughputs(Vec<SentEventsMetric>),
     ErrorsTotals(Vec<IdentifiedMetric>),
+    DiscardedEventsTotals(Vec<IdentifiedMetric>),
+    /// Throughput values already normalized to per-second by the server
+    DiscardedEventsThroughputs(Vec<IdentifiedMetric>),
+    /// Buffer utilization as a ratio 0.0–1.0 per component
+    BufferUtilizations(Vec<(ComponentKey, f64)>),
+    /// Buffer fill as a ratio 0.0–1.0 per component (buffer_size_events / buffer_max_size_events)
+    BufferFills(Vec<(ComponentKey, f64)>),
+    /// Buffer-level dropped event totals per component (buffer_discarded_events_total by buffer_id)
+    BufferDiscardedTotals(Vec<IdentifiedMetric>),
+    /// Buffer-level dropped event throughputs (per-second) per component
+    BufferDiscardedThroughputs(Vec<IdentifiedMetric>),
+    /// Internal channel fill ratio (0.0–1.0) for sources and transforms
+    ChannelFills(Vec<(ComponentKey, f64)>),
     #[cfg(feature = "allocation-tracing")]
     AllocatedBytes(Vec<IdentifiedMetric>),
     ComponentAdded(ComponentRow),
@@ -144,6 +157,26 @@ pub enum SortColumn {
     Errors = 11,
     #[cfg(feature = "allocation-tracing")]
     MemoryUsed = 12,
+    #[cfg(not(feature = "allocation-tracing"))]
+    Discarded = 12,
+    #[cfg(feature = "allocation-tracing")]
+    Discarded = 13,
+    #[cfg(not(feature = "allocation-tracing"))]
+    BufferUtil = 13,
+    #[cfg(feature = "allocation-tracing")]
+    BufferUtil = 14,
+    #[cfg(not(feature = "allocation-tracing"))]
+    BufferFill = 14,
+    #[cfg(feature = "allocation-tracing")]
+    BufferFill = 15,
+    #[cfg(not(feature = "allocation-tracing"))]
+    BufDropped = 15,
+    #[cfg(feature = "allocation-tracing")]
+    BufDropped = 16,
+    #[cfg(not(feature = "allocation-tracing"))]
+    ChanFill = 16,
+    #[cfg(feature = "allocation-tracing")]
+    ChanFill = 17,
 }
 
 #[derive(Debug, Default, Clone, Copy)]
@@ -165,6 +198,11 @@ impl SortColumn {
             SortColumn::EventsOut | SortColumn::EventsOutTotal => header == columns::EVENTS_OUT,
             SortColumn::BytesOut | SortColumn::BytesOutTotal => header == columns::BYTES_OUT,
             SortColumn::Errors => header == columns::ERRORS,
+            SortColumn::Discarded => header == columns::DISCARDED,
+            SortColumn::BufferUtil => header == columns::UTIL,
+            SortColumn::BufferFill => header == columns::FILL,
+            SortColumn::BufDropped => header == columns::BUF_DROPPED,
+            SortColumn::ChanFill => header == columns::CHAN_FILL,
             #[cfg(feature = "allocation-tracing")]
             SortColumn::MemoryUsed => header == columns::MEMORY_USED,
         }
@@ -186,6 +224,11 @@ impl SortColumn {
             columns::ERRORS,
             #[cfg(feature = "allocation-tracing")]
             columns::MEMORY_USED,
+            columns::DISCARDED,
+            columns::BUF_DROPPED,
+            columns::CHAN_FILL,
+            columns::UTIL,
+            columns::FILL,
         ]
     }
 }
@@ -220,6 +263,26 @@ impl From<usize> for SortColumn {
             11 => SortColumn::Errors,
             #[cfg(feature = "allocation-tracing")]
             12 => SortColumn::MemoryUsed,
+            #[cfg(not(feature = "allocation-tracing"))]
+            12 => SortColumn::Discarded,
+            #[cfg(feature = "allocation-tracing")]
+            13 => SortColumn::Discarded,
+            #[cfg(not(feature = "allocation-tracing"))]
+            13 => SortColumn::BufferUtil,
+            #[cfg(feature = "allocation-tracing")]
+            14 => SortColumn::BufferUtil,
+            #[cfg(not(feature = "allocation-tracing"))]
+            14 => SortColumn::BufferFill,
+            #[cfg(feature = "allocation-tracing")]
+            15 => SortColumn::BufferFill,
+            #[cfg(not(feature = "allocation-tracing"))]
+            15 => SortColumn::BufDropped,
+            #[cfg(feature = "allocation-tracing")]
+            16 => SortColumn::BufDropped,
+            #[cfg(not(feature = "allocation-tracing"))]
+            16 => SortColumn::ChanFill,
+            #[cfg(feature = "allocation-tracing")]
+            17 => SortColumn::ChanFill,
             _ => SortColumn::Id,
         }
     }
@@ -408,6 +471,18 @@ pub struct ComponentRow {
     #[cfg(feature = "allocation-tracing")]
     pub allocated_bytes: i64,
     pub errors: i64,
+    pub discarded_events_total: i64,
+    pub discarded_events_throughput_sec: i64,
+    pub buffer_discarded_total: i64,
+    pub buffer_discarded_throughput_sec: i64,
+    /// Internal channel fill ratio (source/transform channel, 0.0–1.0).
+    /// `None` for sinks (they have no internal input channel tracked here).
+    pub channel_fill: Option<f64>,
+    /// Buffer utilization ratio (0.0–1.0), `None` if not reported for this component.
+    pub buffer_utilization: Option<f64>,
+    /// Buffer fill ratio (buffer_size_events / buffer_max_size_events, 0.0–1.0).
+    /// `None` if this component has no configured buffer (e.g. sources, transforms).
+    pub buffer_fill: Option<f64>,
 }
 
 impl ComponentRow {
@@ -416,6 +491,28 @@ impl ComponentRow {
     pub fn has_displayable_outputs(&self) -> bool {
         self.outputs.len() > 1
             || (self.outputs.len() == 1 && !self.outputs.contains_key(DEFAULT_OUTPUT))
+    }
+
+    /// Buffer utilization as a fixed-point integer (scaled by 1_000_000) for `Ord`-based sorting.
+    /// Returns 0 when utilization is not available.
+    pub fn buffer_util_ord(&self) -> u64 {
+        self.buffer_utilization
+            .map(|v| (v * 1_000_000.0) as u64)
+            .unwrap_or(0)
+    }
+
+    /// Buffer fill as a fixed-point integer (scaled by 1_000_000) for `Ord`-based sorting.
+    /// Returns 0 when fill is not available.
+    pub fn buffer_fill_ord(&self) -> u64 {
+        self.buffer_fill
+            .map(|v| (v * 1_000_000.0) as u64)
+            .unwrap_or(0)
+    }
+
+    pub fn channel_fill_ord(&self) -> u64 {
+        self.channel_fill
+            .map(|v| (v * 1_000_000.0) as u64)
+            .unwrap_or(0)
     }
 }
 
@@ -508,6 +605,55 @@ pub async fn updater(mut event_rx: EventRx, mut state: State) -> StateRx {
                     for (key, v) in rows {
                         if let Some(r) = state.components.get_mut(&key) {
                             r.errors = v;
+                        }
+                    }
+                }
+                EventType::DiscardedEventsTotals(rows) => {
+                    for (key, v) in rows {
+                        if let Some(r) = state.components.get_mut(&key) {
+                            r.discarded_events_total = v;
+                        }
+                    }
+                }
+                EventType::DiscardedEventsThroughputs(rows) => {
+                    for (key, v) in rows {
+                        if let Some(r) = state.components.get_mut(&key) {
+                            r.discarded_events_throughput_sec = v;
+                        }
+                    }
+                }
+                EventType::BufferUtilizations(rows) => {
+                    for (key, v) in rows {
+                        if let Some(r) = state.components.get_mut(&key) {
+                            r.buffer_utilization = Some(v);
+                        }
+                    }
+                }
+                EventType::BufferFills(rows) => {
+                    for (key, v) in rows {
+                        if let Some(r) = state.components.get_mut(&key) {
+                            r.buffer_fill = Some(v);
+                        }
+                    }
+                }
+                EventType::BufferDiscardedTotals(rows) => {
+                    for (key, v) in rows {
+                        if let Some(r) = state.components.get_mut(&key) {
+                            r.buffer_discarded_total = v;
+                        }
+                    }
+                }
+                EventType::BufferDiscardedThroughputs(rows) => {
+                    for (key, v) in rows {
+                        if let Some(r) = state.components.get_mut(&key) {
+                            r.buffer_discarded_throughput_sec = v;
+                        }
+                    }
+                }
+                EventType::ChannelFills(rows) => {
+                    for (key, v) in rows {
+                        if let Some(r) = state.components.get_mut(&key) {
+                            r.channel_fill = Some(v);
                         }
                     }
                 }

--- a/proto/vector/observability.proto
+++ b/proto/vector/observability.proto
@@ -33,6 +33,12 @@ service ObservabilityService {
   // Replaces the former 9 per-metric streaming RPCs with a single unified endpoint.
   rpc StreamComponentMetrics(StreamComponentMetricsRequest) returns (stream StreamComponentMetricsResponse);
 
+  // Stream per-component values for any named internal metric.
+  // Accepts any metric name from Vector's internal registry (e.g. "component_discarded_events_total",
+  // "utilization"). Gauge metrics are returned as-is (float); counters support both TOTAL and
+  // THROUGHPUT modes.
+  rpc StreamRawComponentMetrics(StreamRawComponentMetricsRequest) returns (stream RawComponentMetricValue);
+
   // ========== Event Tapping ==========
 
   // Stream events from components matching the specified patterns (replaces vector tap)
@@ -97,6 +103,30 @@ message ComponentMetrics {
 message StreamComponentAllocatedBytesRequest {
   // Update interval in milliseconds
   int32 interval_ms = 1;
+}
+
+// Mode for streaming raw metrics: cumulative total or per-second throughput.
+enum MetricMode {
+  METRIC_MODE_UNSPECIFIED = 0;
+  METRIC_MODE_TOTAL = 1;
+  METRIC_MODE_THROUGHPUT = 2;
+}
+
+message StreamRawComponentMetricsRequest {
+  // Update interval in milliseconds
+  int32 interval_ms = 1;
+  // Internal metric name (e.g. "component_discarded_events_total", "utilization")
+  string metric_name = 2;
+  // Whether to stream cumulative totals or per-second throughput. Defaults to TOTAL.
+  MetricMode mode = 3;
+}
+
+// Per-component value for a raw (arbitrarily named) metric.
+// Gauge metrics are returned as their native float value; counter totals and
+// throughputs are also returned as float for a uniform response type.
+message RawComponentMetricValue {
+  string component_id = 1;
+  double value = 2;
 }
 
 // Identifies which per-component metric to stream via StreamComponentMetrics.

--- a/src/api/grpc/service.rs
+++ b/src/api/grpc/service.rs
@@ -25,7 +25,8 @@ use vector_lib::tap::{
 use crate::event::{Metric, MetricValue};
 use crate::metrics::Controller;
 use crate::proto::observability::{
-    self, Component as ProtoComponent, ComponentType, EventNotification, TappedEvent, *,
+    self, Component as ProtoComponent, ComponentType, EventNotification, MetricMode,
+    RawComponentMetricValue, StreamRawComponentMetricsRequest, TappedEvent, *,
 };
 
 type BoxStream<T> = Pin<Box<dyn Stream<Item = Result<T, Status>> + Send>>;
@@ -41,14 +42,23 @@ fn get_metric_value(metric: &Metric) -> Option<f64> {
 
 /// Helper function to filter metrics by name and group by component_id tag
 fn filter_and_group_metrics(metrics: &[Metric], metric_name: &str) -> HashMap<String, f64> {
+    filter_and_group_metrics_by_tag(metrics, metric_name, "component_id")
+}
+
+/// Filter metrics by name and group summed values by an arbitrary tag.
+fn filter_and_group_metrics_by_tag(
+    metrics: &[Metric],
+    metric_name: &str,
+    tag: &str,
+) -> HashMap<String, f64> {
     let mut result = HashMap::new();
 
     for metric in metrics.iter().filter(|m| m.name() == metric_name) {
         if let Some(tags) = metric.tags()
-            && let Some(component_id) = tags.get("component_id")
+            && let Some(tag_value) = tags.get(tag)
             && let Some(value) = get_metric_value(metric)
         {
-            *result.entry(component_id.to_string()).or_insert(0.0) += value;
+            *result.entry(tag_value.to_string()).or_insert(0.0) += value;
         }
     }
 
@@ -240,6 +250,179 @@ fn metric_throughput_stream(
                                 },
                             )),
                         })
+                    })
+                    .collect::<Vec<_>>(),
+            )
+        })
+        .flatten(),
+    ))
+}
+
+/// Builds a stream that emits raw totals grouped by an arbitrary tag.
+///
+/// Most metrics use `"component_id"`; buffer-level metrics (e.g. `buffer_discarded_events_total`)
+/// are tagged with `"buffer_id"` instead, which equals the component key.
+fn raw_metric_totals_stream_by_tag(
+    duration: Duration,
+    metric_name: String,
+    tag: &'static str,
+) -> Result<BoxStream<RawComponentMetricValue>, Status> {
+    let controller = get_controller()?;
+    Ok(Box::pin(
+        tokio_stream::StreamExt::map(IntervalStream::new(interval(duration)), move |_| {
+            let metrics = controller.capture_metrics();
+            let values = filter_and_group_metrics_by_tag(&metrics, &metric_name, tag);
+            tokio_stream::iter(
+                values
+                    .into_iter()
+                    .map(|(component_id, value)| {
+                        Ok(RawComponentMetricValue {
+                            component_id,
+                            value,
+                        })
+                    })
+                    .collect::<Vec<_>>(),
+            )
+        })
+        .flatten(),
+    ))
+}
+
+fn raw_metric_totals_stream(
+    duration: Duration,
+    metric_name: String,
+) -> Result<BoxStream<RawComponentMetricValue>, Status> {
+    raw_metric_totals_stream_by_tag(duration, metric_name, "component_id")
+}
+
+/// Builds a stream that emits raw throughputs grouped by an arbitrary tag.
+fn raw_metric_throughput_stream_by_tag(
+    duration: Duration,
+    metric_name: String,
+    tag: &'static str,
+) -> Result<BoxStream<RawComponentMetricValue>, Status> {
+    let controller = get_controller()?;
+    let interval_secs = duration.as_secs_f64();
+    let previous_values = Arc::new(Mutex::new(HashMap::new()));
+    Ok(Box::pin(
+        tokio_stream::StreamExt::map(IntervalStream::new(interval(duration)), move |_| {
+            let metrics = controller.capture_metrics();
+            let current_values = filter_and_group_metrics_by_tag(&metrics, &metric_name, tag);
+            let mut prev = match previous_values.lock() {
+                Ok(guard) => guard,
+                Err(poisoned) => {
+                    error!("Mutex poisoned for raw metric throughput, recovering.");
+                    poisoned.into_inner()
+                }
+            };
+            let throughputs = calculate_throughput(&current_values, &prev, interval_secs);
+            *prev = current_values;
+            tokio_stream::iter(
+                throughputs
+                    .into_iter()
+                    .map(|(component_id, value)| {
+                        Ok(RawComponentMetricValue {
+                            component_id,
+                            value,
+                        })
+                    })
+                    .collect::<Vec<_>>(),
+            )
+        })
+        .flatten(),
+    ))
+}
+
+fn raw_metric_throughput_stream(
+    duration: Duration,
+    metric_name: String,
+) -> Result<BoxStream<RawComponentMetricValue>, Status> {
+    raw_metric_throughput_stream_by_tag(duration, metric_name, "component_id")
+}
+
+/// Builds a stream that emits per-component buffer fill ratio (0.0–1.0).
+///
+/// Buffer metrics are tagged with `buffer_id` (= component key) rather than `component_id`,
+/// so this function uses a dedicated grouping helper. Values are summed across all buffer stages
+/// before computing the ratio, so multi-stage (overflow) buffers are reflected correctly.
+fn buffer_fill_stream(duration: Duration) -> Result<BoxStream<RawComponentMetricValue>, Status> {
+    let controller = get_controller()?;
+    Ok(Box::pin(
+        tokio_stream::StreamExt::map(IntervalStream::new(interval(duration)), move |_| {
+            let metrics = controller.capture_metrics();
+            let sizes =
+                filter_and_group_metrics_by_tag(&metrics, "buffer_size_events", "buffer_id");
+            let maxes =
+                filter_and_group_metrics_by_tag(&metrics, "buffer_max_size_events", "buffer_id");
+
+            tokio_stream::iter(
+                sizes
+                    .into_iter()
+                    .filter_map(|(buffer_id, size)| {
+                        let max = *maxes.get(&buffer_id)?;
+                        if max <= 0.0 {
+                            return None;
+                        }
+                        Some(Ok(RawComponentMetricValue {
+                            component_id: buffer_id,
+                            value: (size / max).clamp(0.0, 1.0),
+                        }))
+                    })
+                    .collect::<Vec<_>>(),
+            )
+        })
+        .flatten(),
+    ))
+}
+
+/// Builds a stream that emits internal channel fill ratios (0.0–1.0) per component.
+///
+/// Covers both source output channels (`source_buffer_*`) and transform input channels
+/// (`transform_buffer_*`). Both are tagged with `component_id` via the tracing context
+/// (unlike sink buffers which use `buffer_id`), so standard grouping applies.
+/// Values are summed across outputs before computing the ratio for multi-output sources.
+fn channel_fill_stream(duration: Duration) -> Result<BoxStream<RawComponentMetricValue>, Status> {
+    let controller = get_controller()?;
+    Ok(Box::pin(
+        tokio_stream::StreamExt::map(IntervalStream::new(interval(duration)), move |_| {
+            let metrics = controller.capture_metrics();
+
+            // Merge source and transform channel occupancy and capacity under component_id.
+            let mut sizes: HashMap<String, f64> = HashMap::new();
+            let mut maxes: HashMap<String, f64> = HashMap::new();
+            for (id, v) in
+                filter_and_group_metrics(&metrics, "source_buffer_utilization_level")
+                    .into_iter()
+                    .chain(
+                        filter_and_group_metrics(&metrics, "transform_buffer_utilization_level")
+                            .into_iter(),
+                    )
+            {
+                *sizes.entry(id).or_insert(0.0) += v;
+            }
+            for (id, v) in
+                filter_and_group_metrics(&metrics, "source_buffer_max_size_events")
+                    .into_iter()
+                    .chain(
+                        filter_and_group_metrics(&metrics, "transform_buffer_max_size_events")
+                            .into_iter(),
+                    )
+            {
+                *maxes.entry(id).or_insert(0.0) += v;
+            }
+
+            tokio_stream::iter(
+                sizes
+                    .into_iter()
+                    .filter_map(|(component_id, size)| {
+                        let max = *maxes.get(&component_id)?;
+                        if max <= 0.0 {
+                            return None;
+                        }
+                        Some(Ok(RawComponentMetricValue {
+                            component_id,
+                            value: (size / max).clamp(0.0, 1.0),
+                        }))
                     })
                     .collect::<Vec<_>>(),
             )
@@ -630,6 +813,55 @@ impl observability::Service for ObservabilityService {
             }
             MetricName::SentBytesThroughput => {
                 metric_throughput_stream(duration, "component_sent_bytes_total")?
+            }
+        };
+
+        Ok(Response::new(stream))
+    }
+
+    type StreamRawComponentMetricsStream = BoxStream<RawComponentMetricValue>;
+
+    async fn stream_raw_component_metrics(
+        &self,
+        request: Request<StreamRawComponentMetricsRequest>,
+    ) -> Result<Response<Self::StreamRawComponentMetricsStream>, Status> {
+        let req = request.into_inner();
+        let duration = Duration::from_millis(validate_interval_ms(req.interval_ms)?);
+
+        if req.metric_name.is_empty() {
+            return Err(Status::invalid_argument("metric_name must not be empty"));
+        }
+
+        // "buffer_fill" is a synthetic derived metric: buffer_size_events / buffer_max_size_events
+        // grouped by buffer_id (= component key). Mode is ignored since it is always a ratio.
+        if req.metric_name == "buffer_fill" {
+            return Ok(Response::new(buffer_fill_stream(duration)?));
+        }
+
+        // Internal channel fill: source_buffer_* and transform_buffer_* grouped by component_id.
+        if req.metric_name == "channel_fill" {
+            return Ok(Response::new(channel_fill_stream(duration)?));
+        }
+
+        // Buffer-level drop counters are tagged with buffer_id, not component_id.
+        if req.metric_name == "buffer_discarded_events_total" {
+            let mode = MetricMode::try_from(req.mode).unwrap_or(MetricMode::Unspecified);
+            let stream = match mode {
+                MetricMode::Throughput => {
+                    raw_metric_throughput_stream_by_tag(duration, req.metric_name, "buffer_id")?
+                }
+                MetricMode::Unspecified | MetricMode::Total => {
+                    raw_metric_totals_stream_by_tag(duration, req.metric_name, "buffer_id")?
+                }
+            };
+            return Ok(Response::new(stream));
+        }
+
+        let mode = MetricMode::try_from(req.mode).unwrap_or(MetricMode::Unspecified);
+        let stream = match mode {
+            MetricMode::Throughput => raw_metric_throughput_stream(duration, req.metric_name)?,
+            MetricMode::Unspecified | MetricMode::Total => {
+                raw_metric_totals_stream(duration, req.metric_name)?
             }
         };
 


### PR DESCRIPTION
## Summary

Extends `vector top` and the gRPC observability API to surface backpressure and buffer health signals that were previously invisible:

- **`StreamRawComponentMetrics` RPC** — new gRPC endpoint that streams any named internal metric by string, with `TOTAL` or `THROUGHPUT` mode. Supports arbitrary metrics from Vector's registry, with special-case handling for metrics tagged by `buffer_id` rather than `component_id` (e.g. buffer-level counters).
- **New `vector top` columns:**
  - `Discarded` — `component_discarded_events_total` (intentional drops by filter/cardinality transforms, yellow when non-zero)
  - `BufDrop` — `buffer_discarded_events_total` (overflow drops when `when_full: drop_newest/oldest` fires, red when non-zero)
  - `ChanFill` — internal channel fill ratio for sources and transforms (`source_buffer_utilization_level / source_buffer_max_size_events`, `transform_buffer_*`), showing when backpressure has propagated upstream
  - `Util%` — existing component processing time utilization (0–100%)
  - `Fill%` — sink configured-buffer fill ratio (`buffer_size_events / buffer_max_size_events`), the primary bottleneck signal for sinks

The key distinction `BufDrop` vs `Discarded`: buffer overflows are always data loss; component discards are often intentional (filter transforms). Colored differently to reflect this.

## Vector configuration

```yaml
api:
  enabled: true

sources:
  generate:
    type: demo_logs
    format: syslog
    interval: 0.0

transforms:
  parse:
    type: remap
    inputs: [generate]
    source: |
      . = parse_syslog!(string!(.message))

sinks:
  slow_http:
    type: http
    inputs: [parse]
    uri: http://127.0.0.1:9090/logs
    encoding:
      codec: json
    batch:
      max_bytes: 100000
      timeout_secs: 1
    buffer:
      type: memory
      max_events: 500
      when_full: drop_newest

  blackhole:
    type: blackhole
    inputs: [generate]
    print_interval_secs: 5
```

With a slow HTTP sink (200ms/request), `Fill%` on `slow_http` reaches 100%, `BufDrop` counts up, and `ChanFill` on `generate` reaches 100% showing backpressure reaching the source.

## How did you test this PR?

Ran `vector top` against the bottleneck config above. Verified via `VECTOR_LOG=trace` logs that `buffer_discarded_events_total` events were being emitted and confirmed they now appear in the `BufDrop` column. Confirmed `ChanFill` reflects source channel saturation under load.

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: #20739 (slow sink backpressure invisible without metrics)