### PR TITLE
feat(api): add GetCapabilities RPC to expose allocation tracing status and metric names

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -437,6 +437,7 @@ seahash = { version = "4.1.0", default-features = false }
 smallvec = { version = "1", default-features = false, features = ["union", "serde"] }
 snap = { version = "1.1.1", default-features = false }
 socket2.workspace = true
+strum.workspace = true
 sqlx = { version = "0.8.6", default-features = false, features = ["derive", "postgres", "chrono", "runtime-tokio", "tls-rustls-ring"], optional = true }
 stream-cancel = { version = "0.8.2", default-features = false }
 strip-ansi-escapes = { version = "0.2.1", default-features = false }

--- a/changelog.d/25427_get_capabilities_rpc.feature.md
+++ b/changelog.d/25427_get_capabilities_rpc.feature.md
@@ -1,1 +1,3 @@
 Added a `GetCapabilities` RPC to the Vector observability gRPC API. Clients such as `vector top` can call this once at connection time to discover whether allocation tracing is active and the full set of metric names (counters, gauges, histograms) available on the running instance.
+
+authors: thomasqueirozb

--- a/changelog.d/25427_get_capabilities_rpc.feature.md
+++ b/changelog.d/25427_get_capabilities_rpc.feature.md
@@ -1,0 +1,1 @@
+Added a `GetCapabilities` RPC to the Vector observability gRPC API. Clients such as `vector top` can call this once at connection time to discover whether allocation tracing is active and the full set of metric names (counters, gauges, histograms) available on the running instance.

--- a/lib/vector-api-client/src/client.rs
+++ b/lib/vector-api-client/src/client.rs
@@ -9,12 +9,12 @@ use crate::{
     error::{Error, Result},
     proto::{
         GetAllocationTracingStatusRequest, GetAllocationTracingStatusResponse,
-        GetCapabilitiesRequest, GetCapabilitiesResponse, GetComponentsRequest, GetComponentsResponse,
-        GetMetaRequest, GetMetaResponse, MetricName, StreamComponentAllocatedBytesRequest,
-        StreamComponentAllocatedBytesResponse, StreamComponentMetricsRequest,
-        StreamComponentMetricsResponse, StreamHeartbeatRequest, StreamHeartbeatResponse,
-        StreamOutputEventsRequest, StreamOutputEventsResponse, StreamUptimeRequest,
-        StreamUptimeResponse,
+        GetCapabilitiesRequest, GetCapabilitiesResponse, GetComponentsRequest,
+        GetComponentsResponse, GetMetaRequest, GetMetaResponse, MetricName,
+        StreamComponentAllocatedBytesRequest, StreamComponentAllocatedBytesResponse,
+        StreamComponentMetricsRequest, StreamComponentMetricsResponse, StreamHeartbeatRequest,
+        StreamHeartbeatResponse, StreamOutputEventsRequest, StreamOutputEventsResponse,
+        StreamUptimeRequest, StreamUptimeResponse,
         observability_service_client::ObservabilityServiceClient,
     },
 };

--- a/lib/vector-api-client/src/client.rs
+++ b/lib/vector-api-client/src/client.rs
@@ -9,11 +9,12 @@ use crate::{
     error::{Error, Result},
     proto::{
         GetAllocationTracingStatusRequest, GetAllocationTracingStatusResponse,
-        GetComponentsRequest, GetComponentsResponse, GetMetaRequest, GetMetaResponse, MetricName,
-        StreamComponentAllocatedBytesRequest, StreamComponentAllocatedBytesResponse,
-        StreamComponentMetricsRequest, StreamComponentMetricsResponse, StreamHeartbeatRequest,
-        StreamHeartbeatResponse, StreamOutputEventsRequest, StreamOutputEventsResponse,
-        StreamUptimeRequest, StreamUptimeResponse,
+        GetCapabilitiesRequest, GetCapabilitiesResponse, GetComponentsRequest, GetComponentsResponse,
+        GetMetaRequest, GetMetaResponse, MetricName, StreamComponentAllocatedBytesRequest,
+        StreamComponentAllocatedBytesResponse, StreamComponentMetricsRequest,
+        StreamComponentMetricsResponse, StreamHeartbeatRequest, StreamHeartbeatResponse,
+        StreamOutputEventsRequest, StreamOutputEventsResponse, StreamUptimeRequest,
+        StreamUptimeResponse,
         observability_service_client::ObservabilityServiceClient,
     },
 };
@@ -102,6 +103,17 @@ impl Client {
         let response = client
             .get_components(GetComponentsRequest { limit })
             .await?;
+        Ok(response.into_inner())
+    }
+
+    /// Get capabilities of the connected Vector instance.
+    ///
+    /// Returns allocation tracing status and all registered metric names with their kinds.
+    /// On older servers that don't support this RPC, returns a default response (no metrics,
+    /// allocation tracing disabled).
+    pub async fn get_capabilities(&mut self) -> Result<GetCapabilitiesResponse> {
+        let client = self.ensure_connected()?;
+        let response = client.get_capabilities(GetCapabilitiesRequest {}).await?;
         Ok(response.into_inner())
     }
 

--- a/lib/vector-common/src/internal_event/metric_name.rs
+++ b/lib/vector-common/src/internal_event/metric_name.rs
@@ -1,4 +1,4 @@
-use strum::{AsRefStr, Display, EnumIter};
+use strum::{AsRefStr, Display, EnumIter, IntoEnumIterator as _};
 
 /// Canonical list of all per-component internal metric names emitted by Vector.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Display, AsRefStr, EnumIter)]
@@ -338,4 +338,19 @@ impl CounterName {
             Self::MemoryEnrichmentTableTtlExpirations => "memory_enrichment_table_ttl_expirations",
         }
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MetricKind {
+    Counter,
+    Gauge,
+    Histogram,
+}
+
+/// Returns an iterator over every known Vector metric name paired with its kind.
+pub fn all_metrics() -> impl Iterator<Item = (&'static str, MetricKind)> {
+    CounterName::iter()
+        .map(|n| (n.as_ref(), MetricKind::Counter))
+        .chain(GaugeName::iter().map(|n| (n.as_ref(), MetricKind::Gauge)))
+        .chain(HistogramName::iter().map(|n| (n.as_ref(), MetricKind::Histogram)))
 }

--- a/lib/vector-common/src/internal_event/metric_name.rs
+++ b/lib/vector-common/src/internal_event/metric_name.rs
@@ -350,7 +350,7 @@ pub enum InternalMetricKind {
 /// Returns an iterator over every known Vector metric name paired with its kind.
 pub fn all_metrics() -> impl Iterator<Item = (&'static str, InternalMetricKind)> {
     CounterName::iter()
-        .map(|n| (n.as_ref(), InternalMetricKind::Counter))
-        .chain(GaugeName::iter().map(|n| (n.as_ref(), InternalMetricKind::Gauge)))
-        .chain(HistogramName::iter().map(|n| (n.as_ref(), InternalMetricKind::Histogram)))
+        .map(|n| (n.as_str(), InternalMetricKind::Counter))
+        .chain(GaugeName::iter().map(|n| (n.as_str(), InternalMetricKind::Gauge)))
+        .chain(HistogramName::iter().map(|n| (n.as_str(), InternalMetricKind::Histogram)))
 }

--- a/lib/vector-common/src/internal_event/metric_name.rs
+++ b/lib/vector-common/src/internal_event/metric_name.rs
@@ -348,7 +348,7 @@ pub enum InternalMetricKind {
 }
 
 /// Returns an iterator over every known Vector metric name paired with its kind.
-pub fn all_metrics() -> impl Iterator<Item = (&'static str, MetricKind)> {
+pub fn all_metrics() -> impl Iterator<Item = (&'static str, InternalMetricKind)> {
     CounterName::iter()
         .map(|n| (n.as_ref(), InternalMetricKind::Counter))
         .chain(GaugeName::iter().map(|n| (n.as_ref(), InternalMetricKind::Gauge)))

--- a/lib/vector-common/src/internal_event/metric_name.rs
+++ b/lib/vector-common/src/internal_event/metric_name.rs
@@ -341,7 +341,7 @@ impl CounterName {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum MetricKind {
+pub enum InternalMetricKind {
     Counter,
     Gauge,
     Histogram,
@@ -350,7 +350,7 @@ pub enum MetricKind {
 /// Returns an iterator over every known Vector metric name paired with its kind.
 pub fn all_metrics() -> impl Iterator<Item = (&'static str, MetricKind)> {
     CounterName::iter()
-        .map(|n| (n.as_ref(), MetricKind::Counter))
-        .chain(GaugeName::iter().map(|n| (n.as_ref(), MetricKind::Gauge)))
-        .chain(HistogramName::iter().map(|n| (n.as_ref(), MetricKind::Histogram)))
+        .map(|n| (n.as_ref(), InternalMetricKind::Counter))
+        .chain(GaugeName::iter().map(|n| (n.as_ref(), InternalMetricKind::Gauge)))
+        .chain(HistogramName::iter().map(|n| (n.as_ref(), InternalMetricKind::Histogram)))
 }

--- a/lib/vector-common/src/internal_event/mod.rs
+++ b/lib/vector-common/src/internal_event/mod.rs
@@ -20,7 +20,7 @@ pub use component_events_dropped::{ComponentEventsDropped, INTENTIONAL, UNINTENT
 pub use component_events_timed_out::ComponentEventsTimedOut;
 pub use events_received::{EventsReceived, EventsReceivedHandle};
 pub use events_sent::{DEFAULT_OUTPUT, EventsSent, TaggedEventsSent};
-pub use metric_name::{CounterName, GaugeName, HistogramName};
+pub use metric_name::{CounterName, GaugeName, HistogramName, MetricKind, all_metrics};
 pub use metrics::SharedString;
 pub use optional_tag::OptionalTag;
 pub use prelude::{error_stage, error_type};

--- a/lib/vector-common/src/internal_event/mod.rs
+++ b/lib/vector-common/src/internal_event/mod.rs
@@ -20,7 +20,7 @@ pub use component_events_dropped::{ComponentEventsDropped, INTENTIONAL, UNINTENT
 pub use component_events_timed_out::ComponentEventsTimedOut;
 pub use events_received::{EventsReceived, EventsReceivedHandle};
 pub use events_sent::{DEFAULT_OUTPUT, EventsSent, TaggedEventsSent};
-pub use metric_name::{CounterName, GaugeName, HistogramName, MetricKind, all_metrics};
+pub use metric_name::{CounterName, GaugeName, HistogramName, InternalMetricKind, all_metrics};
 pub use metrics::SharedString;
 pub use optional_tag::OptionalTag;
 pub use prelude::{error_stage, error_type};

--- a/lib/vector-top/src/metrics.rs
+++ b/lib/vector-top/src/metrics.rs
@@ -576,15 +576,15 @@ pub async fn init_components(
     let capabilities = client.get_capabilities().await.unwrap_or_default();
     let allocation_tracing_enabled = capabilities.allocation_tracing_enabled;
 
-    use vector_api_client::proto::MetricKind as ProtoKind;
+    use vector_api_client::proto::InternalMetricKind;
     let available_metrics = capabilities
         .available_metrics
         .into_iter()
         .filter_map(|m| {
-            let kind = match ProtoKind::try_from(m.kind) {
-                Ok(ProtoKind::Counter) => state::MetricKind::Counter,
-                Ok(ProtoKind::Gauge) => state::MetricKind::Gauge,
-                Ok(ProtoKind::Histogram) => state::MetricKind::Histogram,
+            let kind = match InternalMetricKind::try_from(m.kind) {
+                Ok(InternalMetricKind::Counter) => state::InternalMetricKind::Counter,
+                Ok(InternalMetricKind::Gauge) => state::InternalMetricKind::Gauge,
+                Ok(InternalMetricKind::Histogram) => state::InternalMetricKind::Histogram,
                 _ => return None,
             };
             Some(state::MetricInfo { name: m.name, kind })

--- a/lib/vector-top/src/metrics.rs
+++ b/lib/vector-top/src/metrics.rs
@@ -10,8 +10,9 @@ use tokio::task::JoinHandle;
 use tokio_stream::StreamExt;
 use vector_api_client::{
     Client,
-    proto::{Component, ComponentType, MetricName, stream_component_metrics_response::Value},
+    proto::{Component, ComponentType, InternalMetricKind, MetricName, stream_component_metrics_response::Value},
 };
+use vector_common::internal_event::all_metrics;
 
 use crate::state::{self, OutputMetrics, SentEventsMetric};
 use vector_common::config::ComponentKey;
@@ -573,33 +574,40 @@ pub async fn init_components(
     // tracing status and the full set of registered metric names. Re-evaluated on every
     // reconnect via the retry loop in `subscription()`.
     // On older servers that don't implement GetCapabilities, fall back to the legacy
-    // GetAllocationTracingStatus RPC so the allocation tracing column still works.
-    let (allocation_tracing_enabled, capabilities_metrics) = match client.get_capabilities().await
-    {
-        Ok(caps) => (caps.allocation_tracing_enabled, caps.available_metrics),
+    // GetAllocationTracingStatus RPC for the allocation tracing flag and use the
+    // compiled-in metric names as the available metrics list.
+    let (allocation_tracing_enabled, available_metrics) = match client.get_capabilities().await {
+        Ok(caps) => {
+            let metrics = caps
+                .available_metrics
+                .into_iter()
+                .filter_map(|m| {
+                    let kind = match InternalMetricKind::try_from(m.kind) {
+                        Ok(InternalMetricKind::Counter) => state::InternalMetricKind::Counter,
+                        Ok(InternalMetricKind::Gauge) => state::InternalMetricKind::Gauge,
+                        Ok(InternalMetricKind::Histogram) => state::InternalMetricKind::Histogram,
+                        _ => return None,
+                    };
+                    Some(state::MetricInfo { name: m.name, kind })
+                })
+                .collect();
+            (caps.allocation_tracing_enabled, metrics)
+        }
         Err(_) => {
             let enabled = client
                 .get_allocation_tracing_status()
                 .await
                 .map(|r| r.enabled)
                 .unwrap_or(false);
-            (enabled, vec![])
+            let metrics = all_metrics()
+                .map(|(name, kind)| state::MetricInfo {
+                    name: name.to_string(),
+                    kind,
+                })
+                .collect();
+            (enabled, metrics)
         }
     };
-
-    use vector_api_client::proto::InternalMetricKind;
-    let available_metrics = capabilities_metrics
-        .into_iter()
-        .filter_map(|m| {
-            let kind = match InternalMetricKind::try_from(m.kind) {
-                Ok(InternalMetricKind::Counter) => state::InternalMetricKind::Counter,
-                Ok(InternalMetricKind::Gauge) => state::InternalMetricKind::Gauge,
-                Ok(InternalMetricKind::Histogram) => state::InternalMetricKind::Histogram,
-                _ => return None,
-            };
-            Some(state::MetricInfo { name: m.name, kind })
-        })
-        .collect();
 
     let mut state = state::State::new(rows);
     state.available_metrics = available_metrics;

--- a/lib/vector-top/src/metrics.rs
+++ b/lib/vector-top/src/metrics.rs
@@ -570,15 +570,25 @@ pub async fn init_components(
         .collect::<BTreeMap<_, _>>();
 
     // GetCapabilities is a one-shot call made once per connection to learn allocation
-    // tracing status and the full set of registered metric names. On error (e.g. older
-    // server without this RPC) we fall back to an empty default. Re-evaluated on every
+    // tracing status and the full set of registered metric names. Re-evaluated on every
     // reconnect via the retry loop in `subscription()`.
-    let capabilities = client.get_capabilities().await.unwrap_or_default();
-    let allocation_tracing_enabled = capabilities.allocation_tracing_enabled;
+    // On older servers that don't implement GetCapabilities, fall back to the legacy
+    // GetAllocationTracingStatus RPC so the allocation tracing column still works.
+    let (allocation_tracing_enabled, capabilities_metrics) = match client.get_capabilities().await
+    {
+        Ok(caps) => (caps.allocation_tracing_enabled, caps.available_metrics),
+        Err(_) => {
+            let enabled = client
+                .get_allocation_tracing_status()
+                .await
+                .map(|r| r.enabled)
+                .unwrap_or(false);
+            (enabled, vec![])
+        }
+    };
 
     use vector_api_client::proto::InternalMetricKind;
-    let available_metrics = capabilities
-        .available_metrics
+    let available_metrics = capabilities_metrics
         .into_iter()
         .filter_map(|m| {
             let kind = match InternalMetricKind::try_from(m.kind) {

--- a/lib/vector-top/src/metrics.rs
+++ b/lib/vector-top/src/metrics.rs
@@ -576,20 +576,18 @@ pub async fn init_components(
     let capabilities = client.get_capabilities().await.unwrap_or_default();
     let allocation_tracing_enabled = capabilities.allocation_tracing_enabled;
 
+    use vector_api_client::proto::MetricKind as ProtoKind;
     let available_metrics = capabilities
         .available_metrics
         .into_iter()
-        .map(|m| {
-            use vector_api_client::proto::MetricKind as ProtoKind;
-            state::MetricInfo {
-                name: m.name,
-                kind: match ProtoKind::try_from(m.kind) {
-                    Ok(ProtoKind::Counter) => state::MetricKind::Counter,
-                    Ok(ProtoKind::Gauge) => state::MetricKind::Gauge,
-                    Ok(ProtoKind::Histogram) => state::MetricKind::Histogram,
-                    _ => state::MetricKind::Unknown,
-                },
-            }
+        .filter_map(|m| {
+            let kind = match ProtoKind::try_from(m.kind) {
+                Ok(ProtoKind::Counter) => state::MetricKind::Counter,
+                Ok(ProtoKind::Gauge) => state::MetricKind::Gauge,
+                Ok(ProtoKind::Histogram) => state::MetricKind::Histogram,
+                _ => return None,
+            };
+            Some(state::MetricInfo { name: m.name, kind })
         })
         .collect();
 

--- a/lib/vector-top/src/metrics.rs
+++ b/lib/vector-top/src/metrics.rs
@@ -569,22 +569,37 @@ pub async fn init_components(
         })
         .collect::<BTreeMap<_, _>>();
 
+    // GetCapabilities is a one-shot call made once per connection to learn allocation
+    // tracing status and the full set of registered metric names. On error (e.g. older
+    // server without this RPC) we fall back to an empty default. Re-evaluated on every
+    // reconnect via the retry loop in `subscription()`.
+    let capabilities = client.get_capabilities().await.unwrap_or_default();
+    let allocation_tracing_enabled = capabilities.allocation_tracing_enabled;
+
+    let available_metrics = capabilities
+        .available_metrics
+        .into_iter()
+        .map(|m| {
+            use vector_api_client::proto::MetricKind as ProtoKind;
+            state::MetricInfo {
+                name: m.name,
+                kind: match ProtoKind::try_from(m.kind) {
+                    Ok(ProtoKind::Counter) => state::MetricKind::Counter,
+                    Ok(ProtoKind::Gauge) => state::MetricKind::Gauge,
+                    Ok(ProtoKind::Histogram) => state::MetricKind::Histogram,
+                    _ => state::MetricKind::Unknown,
+                },
+            }
+        })
+        .collect();
+
+    let mut state = state::State::new(rows);
+    state.available_metrics = available_metrics;
+
     #[cfg(feature = "allocation-tracing")]
     {
-        // Allocation tracing is a compile-time + startup-time setting on the
-        // server, so querying once per connection is sufficient. On error
-        // (e.g. older server without this RPC) we default to false, matching
-        // pre-existing behavior. This is re-evaluated on every reconnect via
-        // the retry loop in `subscription()`.
-        let mut state = state::State::new(rows);
-        state.allocation_tracing_active = client
-            .get_allocation_tracing_status()
-            .await
-            .map(|r| r.enabled)
-            .unwrap_or(false);
-        Ok(state)
+        state.allocation_tracing_active = allocation_tracing_enabled;
     }
 
-    #[cfg(not(feature = "allocation-tracing"))]
-    Ok(state::State::new(rows))
+    Ok(state)
 }

--- a/lib/vector-top/src/metrics.rs
+++ b/lib/vector-top/src/metrics.rs
@@ -10,7 +10,10 @@ use tokio::task::JoinHandle;
 use tokio_stream::StreamExt;
 use vector_api_client::{
     Client,
-    proto::{Component, ComponentType, InternalMetricKind, MetricName, stream_component_metrics_response::Value},
+    proto::{
+        Component, ComponentType, InternalMetricKind, MetricName,
+        stream_component_metrics_response::Value,
+    },
 };
 use vector_common::internal_event::all_metrics;
 

--- a/lib/vector-top/src/state.rs
+++ b/lib/vector-top/src/state.rs
@@ -21,13 +21,7 @@ use crate::dashboard::columns;
 
 type IdentifiedMetric = (ComponentKey, i64);
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum MetricKind {
-    Counter,
-    Gauge,
-    Histogram,
-    Unknown,
-}
+pub use vector_common::internal_event::MetricKind;
 
 #[derive(Debug, Clone)]
 pub struct MetricInfo {

--- a/lib/vector-top/src/state.rs
+++ b/lib/vector-top/src/state.rs
@@ -21,12 +21,12 @@ use crate::dashboard::columns;
 
 type IdentifiedMetric = (ComponentKey, i64);
 
-pub use vector_common::internal_event::MetricKind;
+pub use vector_common::internal_event::InternalMetricKind;
 
 #[derive(Debug, Clone)]
 pub struct MetricInfo {
     pub name: String,
-    pub kind: MetricKind,
+    pub kind: InternalMetricKind,
 }
 
 #[derive(Debug, Clone)]

--- a/lib/vector-top/src/state.rs
+++ b/lib/vector-top/src/state.rs
@@ -21,6 +21,20 @@ use crate::dashboard::columns;
 
 type IdentifiedMetric = (ComponentKey, i64);
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MetricKind {
+    Counter,
+    Gauge,
+    Histogram,
+    Unknown,
+}
+
+#[derive(Debug, Clone)]
+pub struct MetricInfo {
+    pub name: String,
+    pub kind: MetricKind,
+}
+
 #[derive(Debug, Clone)]
 pub struct SentEventsMetric {
     pub key: ComponentKey,
@@ -126,6 +140,9 @@ pub struct State {
     /// indicating the connected Vector instance has allocation tracing active.
     #[cfg(feature = "allocation-tracing")]
     pub allocation_tracing_active: bool,
+    /// All metrics registered on the connected Vector instance, populated once
+    /// per connection via `GetCapabilities`.
+    pub available_metrics: Vec<MetricInfo>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -349,6 +366,7 @@ impl State {
             filter_state: FilterState::default(),
             #[cfg(feature = "allocation-tracing")]
             allocation_tracing_active: false,
+            available_metrics: Vec::new(),
         }
     }
 

--- a/proto/vector/observability.proto
+++ b/proto/vector/observability.proto
@@ -17,6 +17,9 @@ service ObservabilityService {
   // Check whether allocation tracing is active on this instance
   rpc GetAllocationTracingStatus(GetAllocationTracingStatusRequest) returns (GetAllocationTracingStatusResponse);
 
+  // Get capabilities of the Vector instance: allocation tracing status and all registered metric names with their kinds
+  rpc GetCapabilities(GetCapabilitiesRequest) returns (GetCapabilitiesResponse);
+
   // ========== Real-time Metric Streams ==========
   // All streaming RPCs send periodic updates at the specified interval
 
@@ -52,6 +55,29 @@ message GetAllocationTracingStatusRequest {}
 
 message GetAllocationTracingStatusResponse {
   bool enabled = 1;
+}
+
+// ========== Capabilities Messages ==========
+
+message GetCapabilitiesRequest {}
+
+message GetCapabilitiesResponse {
+  // Whether allocation tracing is active on this instance
+  bool allocation_tracing_enabled = 1;
+  // All metrics currently registered on this instance, deduplicated by name, sorted alphabetically
+  repeated AvailableMetric available_metrics = 2;
+}
+
+message AvailableMetric {
+  string name = 1;
+  MetricKind kind = 2;
+}
+
+enum MetricKind {
+  METRIC_KIND_UNSPECIFIED = 0;
+  METRIC_KIND_COUNTER = 1;
+  METRIC_KIND_GAUGE = 2;
+  METRIC_KIND_HISTOGRAM = 3;
 }
 
 // ========== Component Messages ==========

--- a/proto/vector/observability.proto
+++ b/proto/vector/observability.proto
@@ -64,7 +64,7 @@ message GetCapabilitiesRequest {}
 message GetCapabilitiesResponse {
   // Whether allocation tracing is active on this instance
   bool allocation_tracing_enabled = 1;
-  // All metrics currently registered on this instance, deduplicated by name, sorted alphabetically
+  // All metrics known to this build of Vector, in enum declaration order
   repeated AvailableMetric available_metrics = 2;
 }
 

--- a/proto/vector/observability.proto
+++ b/proto/vector/observability.proto
@@ -70,14 +70,14 @@ message GetCapabilitiesResponse {
 
 message AvailableMetric {
   string name = 1;
-  MetricKind kind = 2;
+  InternalMetricKind kind = 2;
 }
 
-enum MetricKind {
-  METRIC_KIND_UNSPECIFIED = 0;
-  METRIC_KIND_COUNTER = 1;
-  METRIC_KIND_GAUGE = 2;
-  METRIC_KIND_HISTOGRAM = 3;
+enum InternalMetricKind {
+  INTERNAL_METRIC_KIND_UNSPECIFIED = 0;
+  INTERNAL_METRIC_KIND_COUNTER = 1;
+  INTERNAL_METRIC_KIND_GAUGE = 2;
+  INTERNAL_METRIC_KIND_HISTOGRAM = 3;
 }
 
 // ========== Component Messages ==========

--- a/src/api/grpc/service.rs
+++ b/src/api/grpc/service.rs
@@ -22,8 +22,8 @@ use vector_lib::tap::{
     topology::WatchRx,
 };
 
-use vector_common::internal_event::{InternalMetricKind, all_metrics};
 use crate::proto::observability::InternalMetricKind as ProtoInternalMetricKind;
+use vector_common::internal_event::{InternalMetricKind, all_metrics};
 
 use crate::event::{Metric, MetricValue};
 use crate::metrics::Controller;

--- a/src/api/grpc/service.rs
+++ b/src/api/grpc/service.rs
@@ -22,6 +22,9 @@ use vector_lib::tap::{
     topology::WatchRx,
 };
 
+use strum::IntoEnumIterator as _;
+use vector_common::internal_event::{CounterName, GaugeName, HistogramName};
+
 use crate::event::{Metric, MetricValue};
 use crate::metrics::Controller;
 use crate::proto::observability::{
@@ -431,6 +434,37 @@ impl observability::Service for ObservabilityService {
         let enabled = false;
         Ok(Response::new(GetAllocationTracingStatusResponse {
             enabled,
+        }))
+    }
+
+    async fn get_capabilities(
+        &self,
+        _request: Request<GetCapabilitiesRequest>,
+    ) -> Result<Response<GetCapabilitiesResponse>, Status> {
+        #[cfg(feature = "allocation-tracing")]
+        let allocation_tracing_enabled =
+            crate::internal_telemetry::allocations::is_allocation_tracing_enabled();
+        #[cfg(not(feature = "allocation-tracing"))]
+        let allocation_tracing_enabled = false;
+
+        let available_metrics = CounterName::iter()
+            .map(|n| AvailableMetric {
+                name: n.as_ref().to_string(),
+                kind: MetricKind::Counter as i32,
+            })
+            .chain(GaugeName::iter().map(|n| AvailableMetric {
+                name: n.as_ref().to_string(),
+                kind: MetricKind::Gauge as i32,
+            }))
+            .chain(HistogramName::iter().map(|n| AvailableMetric {
+                name: n.as_ref().to_string(),
+                kind: MetricKind::Histogram as i32,
+            }))
+            .collect();
+
+        Ok(Response::new(GetCapabilitiesResponse {
+            allocation_tracing_enabled,
+            available_metrics,
         }))
     }
 

--- a/src/api/grpc/service.rs
+++ b/src/api/grpc/service.rs
@@ -22,7 +22,8 @@ use vector_lib::tap::{
     topology::WatchRx,
 };
 
-use vector_common::internal_event::{MetricKind as CommonMetricKind, all_metrics};
+use vector_common::internal_event::{InternalMetricKind, all_metrics};
+use crate::proto::observability::InternalMetricKind as ProtoInternalMetricKind;
 
 use crate::event::{Metric, MetricValue};
 use crate::metrics::Controller;
@@ -450,9 +451,9 @@ impl observability::Service for ObservabilityService {
             .map(|(name, kind)| AvailableMetric {
                 name: name.to_string(),
                 kind: match kind {
-                    CommonMetricKind::Counter => MetricKind::Counter as i32,
-                    CommonMetricKind::Gauge => MetricKind::Gauge as i32,
-                    CommonMetricKind::Histogram => MetricKind::Histogram as i32,
+                    InternalMetricKind::Counter => ProtoInternalMetricKind::Counter as i32,
+                    InternalMetricKind::Gauge => ProtoInternalMetricKind::Gauge as i32,
+                    InternalMetricKind::Histogram => ProtoInternalMetricKind::Histogram as i32,
                 },
             })
             .collect();

--- a/src/api/grpc/service.rs
+++ b/src/api/grpc/service.rs
@@ -22,8 +22,7 @@ use vector_lib::tap::{
     topology::WatchRx,
 };
 
-use strum::IntoEnumIterator as _;
-use vector_common::internal_event::{CounterName, GaugeName, HistogramName};
+use vector_common::internal_event::{MetricKind as CommonMetricKind, all_metrics};
 
 use crate::event::{Metric, MetricValue};
 use crate::metrics::Controller;
@@ -447,19 +446,15 @@ impl observability::Service for ObservabilityService {
         #[cfg(not(feature = "allocation-tracing"))]
         let allocation_tracing_enabled = false;
 
-        let available_metrics = CounterName::iter()
-            .map(|n| AvailableMetric {
-                name: n.as_ref().to_string(),
-                kind: MetricKind::Counter as i32,
+        let available_metrics = all_metrics()
+            .map(|(name, kind)| AvailableMetric {
+                name: name.to_string(),
+                kind: match kind {
+                    CommonMetricKind::Counter => MetricKind::Counter as i32,
+                    CommonMetricKind::Gauge => MetricKind::Gauge as i32,
+                    CommonMetricKind::Histogram => MetricKind::Histogram as i32,
+                },
             })
-            .chain(GaugeName::iter().map(|n| AvailableMetric {
-                name: n.as_ref().to_string(),
-                kind: MetricKind::Gauge as i32,
-            }))
-            .chain(HistogramName::iter().map(|n| AvailableMetric {
-                name: n.as_ref().to_string(),
-                kind: MetricKind::Histogram as i32,
-            }))
             .collect();
 
         Ok(Response::new(GetCapabilitiesResponse {


### PR DESCRIPTION
## Summary

Adds a `GetCapabilities` RPC to the Vector observability gRPC API. This gives `vector top` (and any other client) a single call at connection time to discover:

- Whether allocation tracing is active on the running instance
- All registered metric names with their kind (counter / gauge / histogram), sourced from the canonical `CounterName`, `GaugeName`, and `HistogramName` enums

The `InternalMetricKind` enum is defined in `vector-common` (co-located with the name enums) and mirrored in the proto. `vector top` calls `GetCapabilities` once per connection in `init_components()`, populating `State::available_metrics`. On older servers that don't implement this RPC, it falls back to `GetAllocationTracingStatus` for the allocation tracing flag and populates `available_metrics` from the compiled-in metric name enums.

## Vector configuration

NA

## How did you test this PR?

NA

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

NA
