### PR TITLE
fix(ci): pass GITHUB_TOKEN to prepare.sh for authenticated binstall requests

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -252,6 +252,8 @@ runs:
 
     - name: Run prepare.sh
       shell: bash
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
       run: |
         mods=()
         [[ "${{ inputs.rust == 'true' || env.NEEDS_RUST == 'true' }}" == "true" ]] && mods+=("rustup")


### PR DESCRIPTION
## Summary

`cargo binstall` queries the GitHub API to resolve pre-built binaries. Without an authenticated token, unauthenticated requests hit GitHub's rate limit (403), causing binstall to fall back to compiling from source.

## Vector configuration

NA

## How did you test this PR?

Verified the root cause by inspecting the binstall log output in the failing CI job.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: https://github.com/vectordotdev/vector/actions/runs/25827313018/job/75883679093