### PR TITLE
enhancement(dev): make prepare.sh safer on workstations

### DIFF
--- a/scripts/environment/prepare.sh
+++ b/scripts/environment/prepare.sh
@@ -147,7 +147,24 @@ maybe_install_cargo_tool() {
   fi
 
   if ! $version_cmd --version 2>/dev/null | grep -q "^${version_pattern}"; then
-    cargo "${installer[@]}" "$tool" --version "$version" --force --locked
+    local should_install=true
+    # Outside CI, preserve a newer-than-pin version the user already has.
+    # `cargo install --force` would otherwise silently downgrade them.
+    if [[ -z "${CI:-}" ]]; then
+      local current
+      current=$($version_cmd --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)
+      if [[ -n "$current" ]] && [[ "$current" != "$version" ]]; then
+        local newest
+        newest=$(printf '%s\n%s\n' "$current" "$version" | sort -V | tail -1)
+        if [[ "$newest" == "$current" ]]; then
+          echo "Keeping ${tool} ${current} (newer than pin ${version}). Set CI=1 to force the pin."
+          should_install=false
+        fi
+      fi
+    fi
+    if [[ "$should_install" == "true" ]]; then
+      cargo "${installer[@]}" "$tool" --version "$version" --force --locked
+    fi
   fi
 
   # cargo-llvm-cov requires the llvm-tools-preview rustup component
@@ -199,6 +216,15 @@ maybe_install_npm_tools() {
 
   npm ci --prefix "${npm_tools_dir}"
 
+  # Outside CI, skip the global symlink and print a PATH hint instead.
+  # Avoids a sudo write to /usr/local/bin (or equivalent) on workstations.
+  if [[ -z "${CI:-}" ]]; then
+    echo "npm tools installed under ${npm_tools_dir}/node_modules/.bin"
+    echo "To use them on PATH, add that directory to your shell rc:"
+    echo "  export PATH=\"${npm_tools_dir}/node_modules/.bin:\$PATH\""
+    return 0
+  fi
+
   # Use sudo only when the target directory is not writable (e.g. /usr/local/bin
   # on Linux CI runners is root-owned, but Homebrew dirs on macOS are user-owned).
   local ln_cmd=(ln -sf)
@@ -210,8 +236,12 @@ maybe_install_npm_tools() {
   done
 }
 
-# Always ensure git safe.directory is set
-git config --global --add safe.directory "$(pwd)"
+# Set git safe.directory in CI where the repo may be checked out by a different
+# uid than the user running git. Skipped on workstations: the contributor owns
+# the checkout and a global config write is unnecessary.
+if [[ -n "${CI:-}" ]]; then
+  git config --global --add safe.directory "$(pwd)"
+fi
 
 REQUIRES_RUSTUP=(dd-rust-license-tool cargo-deb cross cargo-nextest cargo-deny cargo-msrv cargo-hack cargo-llvm-cov wasm-pack vdev)
 REQUIRES_BINSTALL=(cargo-deb cross cargo-nextest cargo-deny cargo-msrv cargo-hack cargo-llvm-cov wasm-pack vdev)


### PR DESCRIPTION
## Summary

`prepare.sh` is primarily a CI bootstrap, but #25429 promotes it as the recommended one-shot install for contributor tooling in `docs/DEVELOPING.md`. That doc commit added a warning about three specific surprises the script causes on a personal laptop. This PR removes those surprises so the warning can shrink.

Each change is a CI-gated guard: behavior on CI is unchanged (because the workflows set `CI=true`); behavior differs only when `CI` is unset.

## What changes

- `git config --global --add safe.directory "$(pwd)"` runs only when `CI` is set. Contributors own their checkouts and don't hit git's dubious-ownership error, so the global config write is unnecessary on a workstation.
- The cargo tool version check no longer downgrades a newer locally installed version. CI starts from nothing and keeps pinning exactly; on a workstation, if the installed version is newer than the pin, the script keeps it and prints a notice. Setting `CI=1` forces the pin.
- The npm tool symlinks into the global npm bin dir (`$(npm config get prefix -g)/bin`) are skipped outside CI. This avoids `sudo ln -sf /usr/local/bin/...` without the user opting in. The script prints a PATH hint pointing at the project-local `node_modules/.bin` instead.

## How did you test this PR?

- `bash -n scripts/environment/prepare.sh` passes.
- `shellcheck scripts/environment/prepare.sh` is clean.
- Each guard's `if [[ -n "${CI:-}" ]]` / `if [[ -z "${CI:-}" ]]` reads correctly for both `CI=true` (CI path retained) and `CI` unset (new local path taken).
- Version-extraction regex (`grep -oE '[0-9]+\.[0-9]+\.[0-9]+'`) and `sort -V` produce the expected newer/older ordering on the pinned tools.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Builds on #25429 (introduces `prepare.sh` as a contributor shortcut and adds the workstation warning this PR shortens).