### PR TITLE
fix(releasing): make libz.so.1 a consistent dynamic runtime dependency in distroless-libc

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -91,7 +91,7 @@ jobs:
         run: |
           dnf install -y --setopt=install_weak_deps=False \
             gcc gcc-c++ make cmake perl perl-IPC-Cmd \
-            openssl-devel cyrus-sasl-devel \
+            openssl-devel cyrus-sasl-devel zlib-devel \
             pkgconfig clang \
             rpm-build sudo \
             git tar gzip xz which findutils \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6671,9 +6671,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.22"
+version = "1.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b70e7a7df205e92a1a4cd9aaae7898dac0aa555503cc0a649494d0d60e7651d"
+checksum = "fc3a226e576f50782b3305c5ccf458698f92798987f551c6a02efe8276721e22"
 dependencies = [
  "cc",
  "libc",

--- a/distribution/docker/distroless-libc/Dockerfile
+++ b/distribution/docker/distroless-libc/Dockerfile
@@ -7,6 +7,12 @@ RUN dpkg -i vector_*_"$(dpkg --print-architecture)".deb
 
 RUN mkdir -p /var/lib/vector
 
+# Stage libz at its arch-specific path so it can be copied into the distroless
+# runtime. distroless/cc does not include zlib; vector (via rdkafka) links
+# against it dynamically and we deliberately keep it as a runtime dependency.
+RUN src=$(dpkg -L zlib1g | grep -E '/libz\.so\.1$') && \
+    install -D "$(realpath "$src")" "/staging${src}"
+
 # distroless doesn't use static tags
 # hadolint ignore=DL3007
 FROM gcr.io/distroless/cc-debian12:latest@sha256:329e54034ce498f9c6b345044e8f530c6691f99e94a92446f68c0adf9baa8464
@@ -21,6 +27,7 @@ COPY --from=builder /usr/share/doc/vector /usr/share/doc/vector
 COPY --from=builder /usr/share/vector /usr/share/vector
 COPY --from=builder /etc/vector /etc/vector
 COPY --from=builder /var/lib/vector /var/lib/vector
+COPY --from=builder /staging/ /
 
 # Smoke test
 RUN ["vector", "--version"]


### PR DESCRIPTION
## Summary

The nightly Docker publish started failing with \`libz.so.1: cannot open shared object file\` in the distroless-libc smoke test. This was triggered by \`338fc3805f\` switching the x86_64/aarch64 GNU release builds from cross-rs to native almalinux:8 containers. The cross-rs build happened to produce a statically-bundled zlib (no \`zlib-devel\` in the container); the almalinux:8 build picks up \`zlib-devel\` transitively via \`openssl-devel\` and dynamically links, producing a binary that requires \`libz.so.1\` at runtime. \`distroless/cc-debian12\` does not ship zlib.

Three changes:

- **libz-sys 1.1.22 → 1.1.28**: removes the cross-compiling auto-static fallback that caused the inconsistency — the new version always attempts pkg-config/\`zlib_installed()\` regardless of \`target != host\`.
- **publish.yml**: adds \`zlib-devel\` explicitly to the almalinux:8 \`dnf install\` so the dynamic link via pkg-config is guaranteed rather than relying on a transitive dep of \`openssl-devel\`.
- **distroless-libc/Dockerfile**: stages \`libz.so.1\` from the builder at its arch-specific path (via \`dpkg -L zlib1g\`) and copies it into the distroless runtime image. Handles all four supported architectures correctly since Docker buildx builds each platform independently.

## Vector configuration

NA

## How did you test this PR?

Custom build: https://github.com/vectordotdev/vector/actions/runs/25875633842

## Change Type

- [x] Bug fix
- [ ] New feature
- [x] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: #25387