### PR TITLE
chore(internal docs): clarify JEMALLOC_SYS_WITH_LG_PAGE comment

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,8 +2,10 @@
 vdev = "run --quiet --package vdev --"
 
 [env]
-# Build with large pages so that Vector runs on systems with 64k pages or less (e.g. 4k) to support
-# CentOS 7, 8, and a few other Linux distributions.
+# Build jemalloc assuming 64K pages so binaries also run on aarch64 hosts whose
+# kernels ship with a 64K page size (notably EL8 aarch64). On 4K-page hosts this
+# coarsens jemalloc's allocation granularity; no regression was measured in
+# https://github.com/vectordotdev/vector/pull/18481.
 JEMALLOC_SYS_WITH_LG_PAGE = "16"
 
 [target.'cfg(all())']


### PR DESCRIPTION
## Summary

Tighten the comment next to `JEMALLOC_SYS_WITH_LG_PAGE = "16"` in `.cargo/config.toml`. CentOS 7 is EOL; the setting is still needed because some aarch64 kernels (notably EL8 aarch64) ship with a 64K page size, and a jemalloc built for 4K pages will not start on those hosts. No functional change.

## Vector configuration

n/a

## How did you test this PR?

Comment-only change. No build or test impact.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: #18481