### PR TITLE
chore(ci): unify Dockerfile apt deps into one script

### DIFF
--- a/regression/Dockerfile
+++ b/regression/Dockerfile
@@ -4,26 +4,11 @@
 ARG RUST_VERSION=1
 FROM docker.io/rust:${RUST_VERSION}-slim-trixie AS builder
 
-# TODO: unify this apt list with tests/e2e/Dockerfile.
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    build-essential \
-    clang \
-    cmake \
-    curl \
-    git \
-    libclang-dev \
-    libsasl2-dev \
-    libssl-dev \
-    libxxhash-dev \
-    perl \
-    pkg-config \
-    unzip \
-    zlib1g-dev \
-  && rm -rf /var/lib/apt/lists/*
-
 # Copy the whole scripts/environment/ tree so prepare.sh can source its sibling
 # scripts on older checkouts in regression baseline builds.
 COPY scripts/environment/ /scripts/environment/
+
+RUN bash /scripts/environment/install-debian-build-deps.sh
 
 WORKDIR /vector
 COPY rust-toolchain.toml .
@@ -35,7 +20,7 @@ COPY . .
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
     --mount=type=cache,target=/vector/target \
-    cargo build --bin vector --release && \
+    /usr/bin/mold -run cargo build --bin vector --release && \
     cp target/release/vector .
 
 #

--- a/scripts/environment/install-debian-build-deps.sh
+++ b/scripts/environment/install-debian-build-deps.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Canonical apt-get build dependencies for Vector's Debian-based builder images.
+
+apt-get update
+apt-get install -y --no-install-recommends \
+  build-essential \
+  clang \
+  cmake \
+  curl \
+  git \
+  libclang-dev \
+  libsasl2-dev \
+  libssl-dev \
+  libxxhash-dev \
+  mold \
+  perl \
+  pkg-config \
+  unzip \
+  zlib1g-dev
+rm -rf /var/lib/apt/lists/*

--- a/tests/e2e/Dockerfile
+++ b/tests/e2e/Dockerfile
@@ -4,21 +4,8 @@ ARG BUILD=false
 
 FROM docker.io/rust:${RUST_VERSION}-slim-trixie
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    build-essential \
-    cmake \
-    curl \
-    git \
-    clang \
-    libclang-dev \
-    libsasl2-dev \
-    libssl-dev \
-    libxxhash-dev \
-    zlib1g-dev \
-    zlib1g \
-    unzip \
-    mold \
-  && rm -rf /var/lib/apt/lists/*
+COPY scripts/environment/install-debian-build-deps.sh /
+RUN bash /install-debian-build-deps.sh
 
 COPY tests/data/ca/certs /certs
 


### PR DESCRIPTION
## Summary

`regression/Dockerfile` and `tests/e2e/Dockerfile` maintained two near-identical apt-get lists. Drifts like this is invisible until something breaks. This PR introduces `scripts/environment/install-debian-build-deps.sh` as the single source of truth and points both Dockerfiles at it.

While auditing the drift I noticed `mold` had also been dropped from regression in #25411. Adding mold support back in this PR.

## How did you test this PR?

Visual review of the diff. Both Dockerfiles will be exercised on this PR by CI.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: #25411