### PR TITLE
feat(external docs): add "View open issues" link to component pages

### DIFF
--- a/website/layouts/partials/docs/component-under-hero.html
+++ b/website/layouts/partials/docs/component-under-hero.html
@@ -100,9 +100,7 @@
 
 <div class="mt-4 text-sm">
   <a href="{{ $issuesUrl }}" rel="noopener" target="_blank" class="inline-flex items-center space-x-2 text-primary-dark dark:text-primary hover:underline">
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16" fill="currentColor" aria-hidden="true">
-      <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z"/>
-    </svg>
+    <ion-icon name="logo-github" aria-hidden="true"></ion-icon>
     <span>View open issues for this component on GitHub</span>
   </a>
 </div>

--- a/website/layouts/partials/docs/component-under-hero.html
+++ b/website/layouts/partials/docs/component-under-hero.html
@@ -8,6 +8,9 @@
 {{ $input := $config.input }}
 {{ $output := $config.output }}
 
+{{ $singularType := strings.TrimSuffix "s" $type }}
+{{ $issuesUrl := printf "https://github.com/vectordotdev/vector/issues?q=sort%%3Aupdated-desc+is%%3Aissue+is%%3Aopen+label%%3A%%22%s%%3A+%s%%22" $singularType $tag }}
+
 <div class="block space-y-1">
   {{ if eq $classes.development "beta" }}
   {{ partial "badge.html" (dict "prefix" "status" "word" "beta" "color" "red" "inline" true) }}
@@ -94,3 +97,12 @@
   {{ partial "badge.html" (dict "prefix" "status" "word" "deprecated" "color" "red" "inline" true) }}
 </div>
 {{ end }}
+
+<div class="mt-4 text-sm">
+  <a href="{{ $issuesUrl }}" rel="noopener" target="_blank" class="inline-flex items-center space-x-2 text-primary-dark dark:text-primary hover:underline">
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16" fill="currentColor" aria-hidden="true">
+      <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z"/>
+    </svg>
+    <span>View open issues for this component on GitHub</span>
+  </a>
+</div>

--- a/website/layouts/partials/docs/component-under-hero.html
+++ b/website/layouts/partials/docs/component-under-hero.html
@@ -56,6 +56,7 @@
   {{ end }}
 </div>
 
+{{ if or $input.logs $input.metrics $input.traces }}
 <div class="w-full mt-4">
   {{ if $input.logs }}
   {{ partial "badge.html" (dict "prefix" "input" "word" "logs" "color" "blue" "inline" true) }}
@@ -67,7 +68,9 @@
   {{ partial "badge.html" (dict "prefix" "input" "word" "traces" "color" "blue" "inline" true) }}
   {{ end }}
 </div>
+{{ end }}
 
+{{ if $output }}
 <div class="w-full mt-4">
   {{ range $k, $v := $output }}
   {{ if eq $k "logs" }}
@@ -83,6 +86,7 @@
   {{ end }}
   {{ end }}
 </div>
+{{ end }}
 
 
 {{ if .Params.deprecated }}


### PR DESCRIPTION
## Summary

- Adds a small `View open issues for this component on GitHub` link to every component page hero. The link points to a pre-filtered issue search using the component's GitHub label (e.g. `label:"source: syslog"`, `label:"sink: aws_s3"`, `label:"transform: remap"`), sorted by `updated-desc`.
- Wraps the input and output badge rows in `{{ if }}` guards so they don't render an empty `<div class="w-full mt-4">` when a component has no inputs (sources) or no outputs (sinks). Previously each empty row contributed ~1rem of stray vertical whitespace under the badges.

## Vector configuration

N/A. Hugo template change only.

## How did you test this PR?

<img width="687" height="276" alt="Screenshot 2026-05-14 at 3 11 36 PM" src="https://github.com/user-attachments/assets/1ad92927-c529-44d0-9490-5cfad7d13042" />

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: #21735