### PR TITLE
chore(deps): update zerobus sdk to 2.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7123,7 +7123,7 @@ dependencies = [
  "serde_with",
  "sha1",
  "sha2",
- "socket2 0.6.0",
+ "socket2 0.6.3",
  "stringprep",
  "strsim",
  "take_mut",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3479,15 +3479,15 @@ dependencies = [
 
 [[package]]
 name = "databricks-zerobus-ingest-sdk"
-version = "1.2.0"
-source = "git+https://github.com/databricks/zerobus-sdk-rs?rev=273efe09130a7554e6b34d20b95df50289e58524#273efe09130a7554e6b34d20b95df50289e58524"
+version = "2.0.0"
+source = "git+https://github.com/databricks/zerobus-sdk-rs?rev=132996d05ae11c57490660643915d6dca38f9fc1#132996d05ae11c57490660643915d6dca38f9fc1"
 dependencies = [
  "async-trait",
  "bytes",
  "hyper-http-proxy",
  "hyper-util",
- "prost 0.13.5",
- "prost-types 0.13.5",
+ "prost 0.14.3",
+ "prost-types 0.14.3",
  "protoc-bin-vendored",
  "reqwest 0.12.28",
  "serde",
@@ -3498,8 +3498,9 @@ dependencies = [
  "tokio-retry",
  "tokio-stream",
  "tokio-util",
- "tonic 0.13.1",
- "tonic-build 0.13.1",
+ "tonic 0.14.5",
+ "tonic-prost",
+ "tonic-prost-build",
  "tracing 0.1.44",
 ]
 
@@ -3747,7 +3748,7 @@ checksum = "6e39034cee21a2f5bbb66ba0e3689819c4bb5d00382a282006e802a7ffa6c41d"
 dependencies = [
  "cfg-if",
  "libc",
- "socket2 0.6.0",
+ "socket2 0.6.3",
  "windows-sys 0.60.2",
 ]
 
@@ -4306,6 +4307,12 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flatbuffers"
@@ -5569,7 +5576,8 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.0",
+ "socket2 0.6.3",
+ "system-configuration 0.6.1",
  "tokio",
  "tower-service",
  "tracing 0.1.44",
@@ -6362,7 +6370,7 @@ dependencies = [
  "ena",
  "itertools 0.13.0",
  "lalrpop-util",
- "petgraph",
+ "petgraph 0.6.4",
  "regex",
  "regex-syntax",
  "sha3",
@@ -6980,15 +6988,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4569e456d394deccd22ce1c1913e6ea0e54519f577285001215d33557431afe4"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
- "hermit-abi 0.3.9",
  "libc",
  "log",
  "wasi",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -7584,7 +7591,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.21.7",
  "chrono",
  "getrandom 0.2.15",
  "http 1.3.1",
@@ -8078,7 +8085,18 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
- "fixedbitset",
+ "fixedbitset 0.4.2",
+ "indexmap 2.12.0",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset 0.5.7",
+ "hashbrown 0.15.2",
  "indexmap 2.12.0",
 ]
 
@@ -8591,7 +8609,7 @@ dependencies = [
  "log",
  "multimap",
  "once_cell",
- "petgraph",
+ "petgraph 0.6.4",
  "prettyplease",
  "prost 0.12.6",
  "prost-types 0.12.6",
@@ -8611,10 +8629,31 @@ dependencies = [
  "log",
  "multimap",
  "once_cell",
- "petgraph",
+ "petgraph 0.6.4",
  "prettyplease",
  "prost 0.13.5",
  "prost-types 0.13.5",
+ "regex",
+ "syn 2.0.117",
+ "tempfile",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
+dependencies = [
+ "heck 0.5.0",
+ "itertools 0.10.5",
+ "log",
+ "multimap",
+ "petgraph 0.8.3",
+ "prettyplease",
+ "prost 0.14.3",
+ "prost-types 0.14.3",
+ "pulldown-cmark",
+ "pulldown-cmark-to-cmark",
  "regex",
  "syn 2.0.117",
  "tempfile",
@@ -8807,6 +8846,26 @@ checksum = "6f42ea446cab60335f76979ec15e12619a2165b5ae2c12166bef27d283a9fadf"
 dependencies = [
  "idna",
  "psl-types",
+]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
+dependencies = [
+ "bitflags 2.10.0",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-to-cmark"
+version = "22.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50793def1b900256624a709439404384204a5dc3a6ec580281bfaac35e882e90"
+dependencies = [
+ "pulldown-cmark",
 ]
 
 [[package]]
@@ -9310,7 +9369,7 @@ dependencies = [
  "pin-project-lite",
  "rand 0.9.4",
  "ryu",
- "socket2 0.6.0",
+ "socket2 0.6.3",
  "tokio",
  "tokio-native-tls",
  "tokio-util",
@@ -10597,9 +10656,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-mio"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
 dependencies = [
  "libc",
  "mio",
@@ -10838,12 +10897,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.0"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -11663,9 +11722,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.52.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
 dependencies = [
  "bytes",
  "libc",
@@ -11673,7 +11732,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.0",
+ "socket2 0.6.3",
  "tokio-macros",
  "tracing 0.1.44",
  "windows-sys 0.61.0",
@@ -11691,9 +11750,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2 1.0.106",
  "quote 1.0.45",
@@ -11741,7 +11800,7 @@ dependencies = [
  "postgres-protocol",
  "postgres-types",
  "rand 0.9.4",
- "socket2 0.6.0",
+ "socket2 0.6.3",
  "tokio",
  "tokio-util",
  "whoami",
@@ -12013,37 +12072,6 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
-dependencies = [
- "async-trait",
- "axum 0.8.9",
- "base64 0.22.1",
- "bytes",
- "h2 0.4.13",
- "http 1.3.1",
- "http-body 1.0.1",
- "http-body-util",
- "hyper 1.7.0",
- "hyper-timeout 0.5.1",
- "hyper-util",
- "percent-encoding",
- "pin-project",
- "prost 0.13.5",
- "rustls-native-certs 0.8.1",
- "socket2 0.5.10",
- "tokio",
- "tokio-rustls 0.26.2",
- "tokio-stream",
- "tower 0.5.3",
- "tower-layer",
- "tower-service",
- "tracing 0.1.44",
-]
-
-[[package]]
-name = "tonic"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
@@ -12062,7 +12090,8 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "socket2 0.6.0",
+ "rustls-native-certs 0.8.1",
+ "socket2 0.6.3",
  "sync_wrapper 1.0.2",
  "tokio",
  "tokio-rustls 0.26.2",
@@ -12089,14 +12118,12 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.13.1"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac6f67be712d12f0b41328db3137e0d0757645d8904b4cb7d51cd9c2279e847"
+checksum = "c68f61875ac5293cf72e6c8cf0158086428c82c37229e98c840878f1706b0322"
 dependencies = [
  "prettyplease",
  "proc-macro2 1.0.106",
- "prost-build 0.13.5",
- "prost-types 0.13.5",
  "quote 1.0.45",
  "syn 2.0.117",
 ]
@@ -12123,6 +12150,22 @@ dependencies = [
  "bytes",
  "prost 0.14.3",
  "tonic 0.14.5",
+]
+
+[[package]]
+name = "tonic-prost-build"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "654e5643eff75d7f8c99197ce1440ed19a3474eada74c12bbac488b2cafdae27"
+dependencies = [
+ "prettyplease",
+ "proc-macro2 1.0.106",
+ "prost-build 0.14.3",
+ "prost-types 0.14.3",
+ "quote 1.0.45",
+ "syn 2.0.117",
+ "tempfile",
+ "tonic-build 0.14.6",
 ]
 
 [[package]]
@@ -12957,9 +13000,11 @@ dependencies = [
  "proptest",
  "proptest-derive",
  "prost 0.12.6",
+ "prost 0.14.3",
  "prost-build 0.12.6",
  "prost-reflect",
  "prost-types 0.12.6",
+ "prost-types 0.14.3",
  "pulsar",
  "quick-junit",
  "quick-xml 0.31.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3479,8 +3479,9 @@ dependencies = [
 
 [[package]]
 name = "databricks-zerobus-ingest-sdk"
-version = "2.0.0"
-source = "git+https://github.com/databricks/zerobus-sdk-rs?rev=132996d05ae11c57490660643915d6dca38f9fc1#132996d05ae11c57490660643915d6dca38f9fc1"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f87c99484cd20e2c9c361e2fe8884f614f35d8cde7d630cfaacbc09c4c21e9"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5577,7 +5578,6 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.3",
- "system-configuration 0.6.1",
  "tokio",
  "tower-service",
  "tracing 0.1.44",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -336,7 +336,11 @@ prost-reflect = { workspace = true, optional = true }
 prost-types = { workspace = true, optional = true }
 
 # Databricks Zerobus
-databricks-zerobus-ingest-sdk = { git = "https://github.com/databricks/zerobus-sdk-rs", rev = "273efe09130a7554e6b34d20b95df50289e58524", optional = true }
+databricks-zerobus-ingest-sdk = { git = "https://github.com/databricks/zerobus-sdk-rs", rev = "132996d05ae11c57490660643915d6dca38f9fc1", optional = true }
+# The SDK returns prost-types 0.14 DescriptorProto values; prost-reflect (used by the rest
+# of the sink) is on prost-types 0.13. We bridge the two via wire-format re-encoding.
+prost-014 = { package = "prost", version = "0.14", optional = true }
+prost-types-014 = { package = "prost-types", version = "0.14", optional = true }
 
 # GCP
 goauth = { version = "0.16.0", optional = true }
@@ -927,7 +931,7 @@ sinks-chronicle = []
 sinks-clickhouse = ["dep:nom", "dep:rust_decimal", "codecs-arrow"]
 sinks-console = []
 sinks-databend = ["dep:databend-client"]
-sinks-databricks-zerobus = ["dep:databricks-zerobus-ingest-sdk", "dep:prost-reflect", "dep:base64"]
+sinks-databricks-zerobus = ["dep:databricks-zerobus-ingest-sdk", "dep:prost-reflect", "dep:prost-014", "dep:prost-types-014", "dep:base64"]
 sinks-datadog_events = []
 sinks-datadog_logs = []
 sinks-datadog_metrics = ["protobuf-build", "dep:prost", "dep:prost-reflect"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -336,7 +336,7 @@ prost-reflect = { workspace = true, optional = true }
 prost-types = { workspace = true, optional = true }
 
 # Databricks Zerobus
-databricks-zerobus-ingest-sdk = { git = "https://github.com/databricks/zerobus-sdk-rs", rev = "132996d05ae11c57490660643915d6dca38f9fc1", optional = true }
+databricks-zerobus-ingest-sdk = { version = "2.0.1", optional = true }
 # The SDK returns prost-types 0.14 DescriptorProto values; prost-reflect (used by the rest
 # of the sink) is on prost-types 0.13. We bridge the two via wire-format re-encoding.
 prost-014 = { package = "prost", version = "0.14", optional = true }

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -705,7 +705,7 @@ sha2,https://github.com/RustCrypto/hashes,MIT OR Apache-2.0,RustCrypto Developer
 sha3,https://github.com/RustCrypto/hashes,MIT OR Apache-2.0,RustCrypto Developers
 sharded-slab,https://github.com/hawkw/sharded-slab,MIT,Eliza Weisman <eliza@buoyant.io>
 signal-hook,https://github.com/vorner/signal-hook,Apache-2.0 OR MIT,"Michal 'vorner' Vaner <vorner@vorner.cz>, Thomas Himmelstoss <thimm@posteo.de>"
-signal-hook-mio,https://github.com/vorner/signal-hook,Apache-2.0 OR MIT,"Michal 'vorner' Vaner <vorner@vorner.cz>, Thomas Himmelstoss <thimm@posteo.de>"
+signal-hook-mio,https://github.com/vorner/signal-hook,MIT OR Apache-2.0,"Michal 'vorner' Vaner <vorner@vorner.cz>, Thomas Himmelstoss <thimm@posteo.de>"
 signal-hook-registry,https://github.com/vorner/signal-hook,Apache-2.0 OR MIT,"Michal 'vorner' Vaner <vorner@vorner.cz>, Masaki Hara <ackie.h.gmai@gmail.com>"
 signatory,https://github.com/iqlusioninc/crates/tree/main/signatory,Apache-2.0 OR MIT,Tony Arcieri <tony@iqlusion.io>
 signature,https://github.com/RustCrypto/traits/tree/master/signature,Apache-2.0 OR MIT,RustCrypto Developers

--- a/src/sinks/databricks_zerobus/service.rs
+++ b/src/sinks/databricks_zerobus/service.rs
@@ -277,7 +277,9 @@ impl MockStream {
 /// Schema and encoding state derived from the Unity Catalog table.
 pub(super) struct ResolvedSchema {
     encoder: BatchEncoder,
-    descriptor_proto: Arc<prost_reflect::prost_types::DescriptorProto>,
+    /// SDK-typed (prost-types 0.14) descriptor — held in this form so each
+    /// stream rebuild avoids re-encoding from the prost-reflect 0.13 form.
+    descriptor_proto: Arc<prost_types_014::DescriptorProto>,
 }
 
 /// Service for handling Zerobus requests.
@@ -318,10 +320,21 @@ impl ZerobusService {
     }
 
     /// Resolve the protobuf message descriptor from Unity Catalog.
+    ///
+    /// Returns both the prost-reflect `MessageDescriptor` (used by the proto
+    /// batch encoder) and the SDK-typed `DescriptorProto` (used to construct
+    /// Zerobus streams). Returning both avoids re-encoding the descriptor
+    /// every time a stream is rebuilt after a retryable failure.
     async fn resolve_descriptor(
         config: &ZerobusSinkConfig,
         http_client: &HttpClient,
-    ) -> Result<prost_reflect::MessageDescriptor, ZerobusSinkError> {
+    ) -> Result<
+        (
+            prost_reflect::MessageDescriptor,
+            prost_types_014::DescriptorProto,
+        ),
+        ZerobusSinkError,
+    > {
         let (client_id, client_secret) = config.auth.credentials();
 
         let table_schema = unity_catalog_schema::fetch_table_schema(
@@ -340,8 +353,9 @@ impl ZerobusService {
     pub(super) async fn ensure_schema(&self) -> Result<&ResolvedSchema, ZerobusSinkError> {
         self.schema
             .get_or_try_init(|| async {
-                let descriptor = Self::resolve_descriptor(&self.config, &self.http_client).await?;
-                let descriptor_proto = Arc::new(descriptor.descriptor_proto().clone());
+                let (descriptor, sdk_descriptor_proto) =
+                    Self::resolve_descriptor(&self.config, &self.http_client).await?;
+                let descriptor_proto = Arc::new(sdk_descriptor_proto);
 
                 let batch_serializer =
                     BatchSerializerConfig::ProtoBatch(ProtoBatchSerializerConfig {
@@ -403,22 +417,12 @@ impl ZerobusService {
             let (client_id, client_secret) = (client_id.to_string(), client_secret.to_string());
 
             let stream_options = &self.config.stream_options;
-            // descriptor_proto is prost-types 0.13 (via prost-reflect); the SDK
-            // expects prost-types 0.14. Bridge through the protobuf wire format.
-            let encoded = <prost_reflect::prost_types::DescriptorProto as prost_reflect::prost::Message>::encode_to_vec(&*schema.descriptor_proto);
-            let sdk_descriptor =
-                <prost_types_014::DescriptorProto as prost_014::Message>::decode(
-                    encoded.as_slice(),
-                )
-                .map_err(|e| ZerobusSinkError::ConfigError {
-                    message: format!("Failed to re-encode DescriptorProto for SDK: {}", e),
-                })?;
             let stream = self
                 .sdk
                 .stream_builder()
                 .table(self.config.table_name.clone())
                 .oauth(client_id, client_secret)
-                .compiled_proto(sdk_descriptor)
+                .compiled_proto((*schema.descriptor_proto).clone())
                 .server_lack_of_ack_timeout_ms(stream_options.server_lack_of_ack_timeout_ms)
                 .flush_timeout_ms(stream_options.flush_timeout_ms)
                 .build()

--- a/src/sinks/databricks_zerobus/service.rs
+++ b/src/sinks/databricks_zerobus/service.rs
@@ -403,12 +403,22 @@ impl ZerobusService {
             let (client_id, client_secret) = (client_id.to_string(), client_secret.to_string());
 
             let stream_options = &self.config.stream_options;
+            // descriptor_proto is prost-types 0.13 (via prost-reflect); the SDK
+            // expects prost-types 0.14. Bridge through the protobuf wire format.
+            let encoded = <prost_reflect::prost_types::DescriptorProto as prost_reflect::prost::Message>::encode_to_vec(&*schema.descriptor_proto);
+            let sdk_descriptor =
+                <prost_types_014::DescriptorProto as prost_014::Message>::decode(
+                    encoded.as_slice(),
+                )
+                .map_err(|e| ZerobusSinkError::ConfigError {
+                    message: format!("Failed to re-encode DescriptorProto for SDK: {}", e),
+                })?;
             let stream = self
                 .sdk
                 .stream_builder()
                 .table(self.config.table_name.clone())
                 .oauth(client_id, client_secret)
-                .compiled_proto((*schema.descriptor_proto).clone())
+                .compiled_proto(sdk_descriptor)
                 .server_lack_of_ack_timeout_ms(stream_options.server_lack_of_ack_timeout_ms)
                 .flush_timeout_ms(stream_options.flush_timeout_ms)
                 .build()

--- a/src/sinks/databricks_zerobus/unity_catalog_schema.rs
+++ b/src/sinks/databricks_zerobus/unity_catalog_schema.rs
@@ -313,9 +313,20 @@ fn format_kind_type(kind: &prost_reflect::Kind) -> String {
 /// wrapper adds the `FileDescriptorProto` / `DescriptorPool` plumbing that
 /// Vector needs to get a `prost_reflect::MessageDescriptor` usable for
 /// dynamic message encoding.
+///
+/// Returns both the `MessageDescriptor` (for dynamic encoding via prost-reflect)
+/// and the SDK-typed `DescriptorProto` (prost-types 0.14, used when constructing
+/// the Zerobus stream). Returning both lets us avoid re-encoding the descriptor
+/// on every stream rebuild.
 pub fn generate_descriptor_from_schema(
     schema: &UnityCatalogTableSchema,
-) -> Result<prost_reflect::MessageDescriptor, ZerobusSinkError> {
+) -> Result<
+    (
+        prost_reflect::MessageDescriptor,
+        prost_types_014::DescriptorProto,
+    ),
+    ZerobusSinkError,
+> {
     let sdk_message_proto =
         descriptor_from_uc_schema(schema).map_err(|e| ZerobusSinkError::ConfigError {
             message: format!("Failed to convert Unity Catalog schema to protobuf: {}", e),
@@ -366,7 +377,7 @@ pub fn generate_descriptor_from_schema(
         );
     }
 
-    Ok(message_descriptor)
+    Ok((message_descriptor, sdk_message_proto))
 }
 
 /// Default prefix for package name segments that start with a non-letter.
@@ -449,7 +460,7 @@ mod tests {
             ],
         };
 
-        let descriptor =
+        let (descriptor, _sdk_proto) =
             generate_descriptor_from_schema(&schema).expect("descriptor should be generated");
         assert_eq!(descriptor.fields().len(), 2);
         assert!(descriptor.get_field_by_name("id").is_some());
@@ -465,7 +476,7 @@ mod tests {
         let schema: UnityCatalogTableSchema =
             serde_json::from_str(json).expect("Failed to parse nested_structs_complete schema");
 
-        let descriptor =
+        let (descriptor, _sdk_proto) =
             generate_descriptor_from_schema(&schema).expect("Failed to generate descriptor");
 
         let proto_text = format_descriptor_as_proto(&descriptor);

--- a/src/sinks/databricks_zerobus/unity_catalog_schema.rs
+++ b/src/sinks/databricks_zerobus/unity_catalog_schema.rs
@@ -316,12 +316,23 @@ fn format_kind_type(kind: &prost_reflect::Kind) -> String {
 pub fn generate_descriptor_from_schema(
     schema: &UnityCatalogTableSchema,
 ) -> Result<prost_reflect::MessageDescriptor, ZerobusSinkError> {
-    let message_proto =
+    let sdk_message_proto =
         descriptor_from_uc_schema(schema).map_err(|e| ZerobusSinkError::ConfigError {
             message: format!("Failed to convert Unity Catalog schema to protobuf: {}", e),
         })?;
 
-    let message_name = message_proto.name().to_string();
+    // The SDK returns a prost-types 0.14 DescriptorProto, but prost-reflect (used
+    // below to build the descriptor pool) is on prost-types 0.13. Re-encode through
+    // the protobuf wire format to bridge the two versions.
+    let message_name = sdk_message_proto.name().to_string();
+    let encoded = prost_014::Message::encode_to_vec(&sdk_message_proto);
+    let message_proto =
+        <prost_reflect::prost_types::DescriptorProto as prost_reflect::prost::Message>::decode(
+            encoded.as_slice(),
+        )
+        .map_err(|e| ZerobusSinkError::ConfigError {
+            message: format!("Failed to re-decode SDK DescriptorProto: {}", e),
+        })?;
     let package_name = sanitize_package_name(&schema.catalog_name);
 
     let file_proto = prost_types::FileDescriptorProto {


### PR DESCRIPTION
## Summary
We upgrade the Zerobus SDK to latest 2.0.1 since it contains important enhancements (support for arrow schema conversion) and bug fixes that affect stability. The only major caveat is that the Zerobus SDK uses prost types 0.14 while Vector seems to be 0.13, which requires byte encoding to convert back to the types expected by Vector.

## Vector configuration

Stays the same:

```
[sinks.databricks_zerobus]
type = "databricks_zerobus"
inputs = [...]
ingestion_endpoint = "https://6051921418418893.zerobus.us-west-2.staging.cloud.databricks.com"
table_name = "main.default.test_zerobus_vector"
unity_catalog_endpoint = "https://e2-dogfood.staging.cloud.databricks.com"
[sinks.databricks_zerobus.auth]
strategy = "oauth"
client_id = "CLIENT ID"
client_secret = "SUPER SECRET"
```

## How did you test this PR?

Run unit tests and some manual smoke tests.
## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Closes: #<issue/PR number or link>
-->
<!--
- Related: #<issue/PR number or link>
-->

## Notes

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details on the [dd-rust-license-tool](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
