### PR TITLE
fix(ci): validate dd-sts credentials with exponential backoff before export

### DIFF
--- a/.github/actions/dd-token/action.yml
+++ b/.github/actions/dd-token/action.yml
@@ -40,10 +40,15 @@ runs:
         if [ -n "${DD_STS_API_KEY}" ]; then
           # Poll until the API key is valid; the DD API can be slow to propagate
           # permissions after token issuance.
+          app_key_header=()
+          if [ -n "${DD_STS_APP_KEY}" ]; then
+            app_key_header=(-H "DD-APPLICATION-KEY: ${DD_STS_APP_KEY}")
+          fi
           delay=1
           for i in $(seq 1 6); do
             status=$(curl -s -o /dev/null -w "%{http_code}" \
               -H "DD-API-KEY: ${DD_STS_API_KEY}" \
+              "${app_key_header[@]}" \
               "https://api.datadoghq.com/api/v1/validate")
             if [ "$status" = "200" ]; then
               echo "DD_API_KEY=${DD_STS_API_KEY}" >> "$GITHUB_ENV"

--- a/.github/actions/dd-token/action.yml
+++ b/.github/actions/dd-token/action.yml
@@ -46,10 +46,10 @@ runs:
           fi
           delay=1
           for i in $(seq 1 6); do
-            status=$(curl -s -o /dev/null -w "%{http_code}" \
+            status=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 \
               -H "DD-API-KEY: ${DD_STS_API_KEY}" \
               "${app_key_header[@]}" \
-              "https://api.datadoghq.com/api/v1/validate")
+              "https://api.datadoghq.com/api/v1/validate") || status="000"
             if [ "$status" = "200" ]; then
               echo "DD_API_KEY=${DD_STS_API_KEY}" >> "$GITHUB_ENV"
               break

--- a/.github/actions/dd-token/action.yml
+++ b/.github/actions/dd-token/action.yml
@@ -38,7 +38,21 @@ runs:
         DD_STS_APP_KEY: ${{ steps.dd-sts.outputs.app_key }}
       run: |
         if [ -n "${DD_STS_API_KEY}" ]; then
-          echo "DD_API_KEY=${DD_STS_API_KEY}" >> "$GITHUB_ENV"
+          # Poll until the API key is valid; the DD API can be slow to propagate
+          # permissions after token issuance.
+          delay=1
+          for i in $(seq 1 6); do
+            status=$(curl -s -o /dev/null -w "%{http_code}" \
+              -H "DD-API-KEY: ${DD_STS_API_KEY}" \
+              "https://api.datadoghq.com/api/v1/validate")
+            if [ "$status" = "200" ]; then
+              echo "DD_API_KEY=${DD_STS_API_KEY}" >> "$GITHUB_ENV"
+              break
+            fi
+            echo "Credentials not yet valid (attempt ${i}/6, HTTP ${status}), retrying in ${delay}s..."
+            sleep "${delay}"
+            delay=$((delay * 2))
+          done
         fi
         if [ -n "${DD_STS_APP_KEY}" ]; then
           echo "DD_APP_KEY=${DD_STS_APP_KEY}" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Summary

After `dd-sts-action` issues credentials, the Datadog API can be slow to propagate the associated permissions. This adds a polling loop to the `dd-token` composite action that validates the API key via `GET /api/v1/validate` before exporting it to the job environment. Retries up to 6 times with exponential backoff starting at 1s (1, 2, 4, 8, 16, 32s, 63s max).

## Vector configuration

NA

## How did you test this PR?

NA

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

NA