### PR TITLE
chore(buffers): replace str metric names with GaugeName/HistogramName

### DIFF
--- a/lib/vector-buffers/src/topology/channel/limited_queue.rs
+++ b/lib/vector-buffers/src/topology/channel/limited_queue.rs
@@ -502,7 +502,9 @@ mod tests {
     use tokio_test::{assert_pending, assert_ready, task::spawn};
     use vector_common::byte_size_of::ByteSizeOf;
 
-    use super::{BufferChannelKind, ChannelMetricMetadata, LimitedReceiver, LimitedSender, limited};
+    use super::{
+        BufferChannelKind, ChannelMetricMetadata, LimitedReceiver, LimitedSender, limited,
+    };
     use crate::{
         MemoryBufferSize,
         test::MultiEventRecord,

--- a/lib/vector-buffers/src/topology/channel/limited_queue.rs
+++ b/lib/vector-buffers/src/topology/channel/limited_queue.rs
@@ -543,7 +543,7 @@ mod tests {
         let limit = MemoryBufferSize::MaxEvents(NonZeroUsize::new(2).unwrap());
         let (mut tx, mut rx) = limited(
             limit,
-            Some(ChannelMetricMetadata::new("test_channel", None)),
+            Some(ChannelMetricMetadata::new(BufferChannelKind::Source, None)),
             None,
         );
 
@@ -565,7 +565,7 @@ mod tests {
         let limit = MemoryBufferSize::MaxEvents(NonZeroUsize::new(2).unwrap());
         let (mut tx, mut rx) = limited(
             limit,
-            Some(ChannelMetricMetadata::new("test_channel_oversized", None)),
+            Some(ChannelMetricMetadata::new(BufferChannelKind::Source, None)),
             None,
         );
         let metrics = tx.inner.metrics.as_ref().unwrap().recorded_values.clone();
@@ -948,7 +948,7 @@ mod tests {
             let limit = NonZeroUsize::new(size * 10).unwrap();
             let (tx, rx) = limited(
                 MemoryBufferSize::MaxEvents(limit),
-                Some(ChannelMetricMetadata::new("test_channel_concurrent", None)),
+                Some(ChannelMetricMetadata::new(BufferChannelKind::Source, None)),
                 None,
             );
             let metrics = tx.inner.metrics.as_ref().unwrap().recorded_values.clone();

--- a/lib/vector-buffers/src/topology/channel/limited_queue.rs
+++ b/lib/vector-buffers/src/topology/channel/limited_queue.rs
@@ -144,41 +144,42 @@ impl Metrics {
         let ewma_half_life_seconds =
             ewma_half_life_seconds.unwrap_or(DEFAULT_EWMA_HALF_LIFE_SECONDS);
         let ChannelMetricMetadata { kind, output } = metadata;
-        let (max_name, legacy_name, histogram_name, level_name, mean_name, max_value) =
-            match (kind, limit) {
-                (BufferChannelKind::Source, MemoryBufferSize::MaxEvents(n)) => (
-                    GaugeName::SourceBufferMaxSizeEvents,
-                    GaugeName::SourceBufferMaxEventSize,
-                    HistogramName::SourceBufferUtilization,
-                    GaugeName::SourceBufferUtilizationLevel,
-                    GaugeName::SourceBufferUtilizationMean,
-                    n.get() as f64,
-                ),
-                (BufferChannelKind::Source, MemoryBufferSize::MaxSize(n)) => (
-                    GaugeName::SourceBufferMaxSizeBytes,
-                    GaugeName::SourceBufferMaxByteSize,
-                    HistogramName::SourceBufferUtilization,
-                    GaugeName::SourceBufferUtilizationLevel,
-                    GaugeName::SourceBufferUtilizationMean,
-                    n.get() as f64,
-                ),
-                (BufferChannelKind::Transform, MemoryBufferSize::MaxEvents(n)) => (
-                    GaugeName::TransformBufferMaxSizeEvents,
-                    GaugeName::TransformBufferMaxEventSize,
-                    HistogramName::TransformBufferUtilization,
-                    GaugeName::TransformBufferUtilizationLevel,
-                    GaugeName::TransformBufferUtilizationMean,
-                    n.get() as f64,
-                ),
-                (BufferChannelKind::Transform, MemoryBufferSize::MaxSize(n)) => (
-                    GaugeName::TransformBufferMaxSizeBytes,
-                    GaugeName::TransformBufferMaxByteSize,
-                    HistogramName::TransformBufferUtilization,
-                    GaugeName::TransformBufferUtilizationLevel,
-                    GaugeName::TransformBufferUtilizationMean,
-                    n.get() as f64,
-                ),
-            };
+
+        let (histogram_name, level_name, mean_name) = match kind {
+            BufferChannelKind::Source => (
+                HistogramName::SourceBufferUtilization,
+                GaugeName::SourceBufferUtilizationLevel,
+                GaugeName::SourceBufferUtilizationMean,
+            ),
+            BufferChannelKind::Transform => (
+                HistogramName::TransformBufferUtilization,
+                GaugeName::TransformBufferUtilizationLevel,
+                GaugeName::TransformBufferUtilizationMean,
+            ),
+        };
+
+        let (max_name, legacy_name, max_value) = match (kind, limit) {
+            (BufferChannelKind::Source, MemoryBufferSize::MaxEvents(n)) => (
+                GaugeName::SourceBufferMaxSizeEvents,
+                GaugeName::SourceBufferMaxEventSize,
+                n.get() as f64,
+            ),
+            (BufferChannelKind::Source, MemoryBufferSize::MaxSize(n)) => (
+                GaugeName::SourceBufferMaxSizeBytes,
+                GaugeName::SourceBufferMaxByteSize,
+                n.get() as f64,
+            ),
+            (BufferChannelKind::Transform, MemoryBufferSize::MaxEvents(n)) => (
+                GaugeName::TransformBufferMaxSizeEvents,
+                GaugeName::TransformBufferMaxEventSize,
+                n.get() as f64,
+            ),
+            (BufferChannelKind::Transform, MemoryBufferSize::MaxSize(n)) => (
+                GaugeName::TransformBufferMaxSizeBytes,
+                GaugeName::TransformBufferMaxByteSize,
+                n.get() as f64,
+            ),
+        };
         #[cfg(test)]
         let recorded_values = Arc::new(Mutex::new(Vec::new()));
         if let Some(label_value) = output {

--- a/lib/vector-buffers/src/topology/channel/limited_queue.rs
+++ b/lib/vector-buffers/src/topology/channel/limited_queue.rs
@@ -564,6 +564,31 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn records_utilization_transform_channel() {
+        let limit = MemoryBufferSize::MaxEvents(NonZeroUsize::new(2).unwrap());
+        let (mut tx, mut rx) = limited(
+            limit,
+            Some(ChannelMetricMetadata::new(
+                BufferChannelKind::Transform,
+                None,
+            )),
+            None,
+        );
+
+        let metrics = tx.inner.metrics.as_ref().unwrap().recorded_values.clone();
+
+        tx.send(Sample::new(1)).await.expect("send should succeed");
+        let records = metrics.lock().unwrap().clone();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records.last().copied(), Some(1));
+
+        assert_eq!(Sample::new(1), rx.next().await.unwrap());
+        let records = metrics.lock().unwrap();
+        assert_eq!(records.len(), 2);
+        assert_eq!(records.last().copied(), Some(0));
+    }
+
+    #[tokio::test]
     async fn oversized_send_records_true_utilization_via_normal_send_path() {
         let limit = MemoryBufferSize::MaxEvents(NonZeroUsize::new(2).unwrap());
         let (mut tx, mut rx) = limited(

--- a/lib/vector-buffers/src/topology/channel/limited_queue.rs
+++ b/lib/vector-buffers/src/topology/channel/limited_queue.rs
@@ -502,7 +502,7 @@ mod tests {
     use tokio_test::{assert_pending, assert_ready, task::spawn};
     use vector_common::byte_size_of::ByteSizeOf;
 
-    use super::{ChannelMetricMetadata, LimitedReceiver, LimitedSender, limited};
+    use super::{BufferChannelKind, ChannelMetricMetadata, LimitedReceiver, LimitedSender, limited};
     use crate::{
         MemoryBufferSize,
         test::MultiEventRecord,

--- a/lib/vector-buffers/src/topology/channel/limited_queue.rs
+++ b/lib/vector-buffers/src/topology/channel/limited_queue.rs
@@ -16,13 +16,22 @@ use std::sync::Mutex;
 use async_stream::stream;
 use crossbeam_queue::{ArrayQueue, SegQueue};
 use futures::Stream;
-use metrics::{Gauge, Histogram, gauge, histogram};
+use metrics::{Gauge, Histogram};
 use tokio::sync::{Notify, OwnedSemaphorePermit, Semaphore, TryAcquireError};
+use vector_common::internal_event::{GaugeName, HistogramName};
 use vector_common::stats::TimeEwmaGauge;
+use vector_common::{gauge, histogram};
 
 use crate::{InMemoryBufferable, config::MemoryBufferSize};
 
 pub const DEFAULT_EWMA_HALF_LIFE_SECONDS: f64 = 5.0;
+
+/// Identifies which buffer channel is being instrumented, determining the metric name prefix.
+#[derive(Clone, Copy, Debug)]
+pub enum BufferChannelKind {
+    Source,
+    Transform,
+}
 
 /// Error returned by `LimitedSender::send` when the receiver has disconnected.
 #[derive(Debug, PartialEq, Eq)]
@@ -99,13 +108,13 @@ where
 
 #[derive(Clone, Debug)]
 pub struct ChannelMetricMetadata {
-    prefix: &'static str,
+    kind: BufferChannelKind,
     output: Option<String>,
 }
 
 impl ChannelMetricMetadata {
-    pub fn new(prefix: &'static str, output: Option<String>) -> Self {
-        Self { prefix, output }
+    pub fn new(kind: BufferChannelKind, output: Option<String>) -> Self {
+        Self { kind, output }
     }
 }
 
@@ -127,7 +136,6 @@ struct Metrics {
 
 impl Metrics {
     #[expect(clippy::cast_precision_loss)] // We have to convert buffer sizes for a gauge, it's okay to lose precision here.
-    #[allow(clippy::disallowed_macros)] // Metric names are constructed dynamically from runtime prefixes.
     fn new(
         limit: MemoryBufferSize,
         metadata: ChannelMetricMetadata,
@@ -135,34 +143,54 @@ impl Metrics {
     ) -> Self {
         let ewma_half_life_seconds =
             ewma_half_life_seconds.unwrap_or(DEFAULT_EWMA_HALF_LIFE_SECONDS);
-        let ChannelMetricMetadata { prefix, output } = metadata;
-        let (legacy_suffix, gauge_suffix, max_value) = match limit {
-            MemoryBufferSize::MaxEvents(max_events) => (
-                "_max_event_size",
-                "_max_size_events",
-                max_events.get() as f64,
-            ),
-            MemoryBufferSize::MaxSize(max_bytes) => {
-                ("_max_byte_size", "_max_size_bytes", max_bytes.get() as f64)
-            }
-        };
-        let max_gauge_name = format!("{prefix}{gauge_suffix}");
-        let legacy_max_gauge_name = format!("{prefix}{legacy_suffix}");
-        let histogram_name = format!("{prefix}_utilization");
-        let gauge_name = format!("{prefix}_utilization_level");
-        let mean_name = format!("{prefix}_utilization_mean");
+        let ChannelMetricMetadata { kind, output } = metadata;
+        let (max_name, legacy_name, histogram_name, level_name, mean_name, max_value) =
+            match (kind, limit) {
+                (BufferChannelKind::Source, MemoryBufferSize::MaxEvents(n)) => (
+                    GaugeName::SourceBufferMaxSizeEvents,
+                    GaugeName::SourceBufferMaxEventSize,
+                    HistogramName::SourceBufferUtilization,
+                    GaugeName::SourceBufferUtilizationLevel,
+                    GaugeName::SourceBufferUtilizationMean,
+                    n.get() as f64,
+                ),
+                (BufferChannelKind::Source, MemoryBufferSize::MaxSize(n)) => (
+                    GaugeName::SourceBufferMaxSizeBytes,
+                    GaugeName::SourceBufferMaxByteSize,
+                    HistogramName::SourceBufferUtilization,
+                    GaugeName::SourceBufferUtilizationLevel,
+                    GaugeName::SourceBufferUtilizationMean,
+                    n.get() as f64,
+                ),
+                (BufferChannelKind::Transform, MemoryBufferSize::MaxEvents(n)) => (
+                    GaugeName::TransformBufferMaxSizeEvents,
+                    GaugeName::TransformBufferMaxEventSize,
+                    HistogramName::TransformBufferUtilization,
+                    GaugeName::TransformBufferUtilizationLevel,
+                    GaugeName::TransformBufferUtilizationMean,
+                    n.get() as f64,
+                ),
+                (BufferChannelKind::Transform, MemoryBufferSize::MaxSize(n)) => (
+                    GaugeName::TransformBufferMaxSizeBytes,
+                    GaugeName::TransformBufferMaxByteSize,
+                    HistogramName::TransformBufferUtilization,
+                    GaugeName::TransformBufferUtilizationLevel,
+                    GaugeName::TransformBufferUtilizationMean,
+                    n.get() as f64,
+                ),
+            };
         #[cfg(test)]
         let recorded_values = Arc::new(Mutex::new(Vec::new()));
         if let Some(label_value) = output {
-            let max_gauge = gauge!(max_gauge_name, "output" => label_value.clone());
+            let max_gauge = gauge!(max_name, "output" => label_value.clone());
             max_gauge.set(max_value);
             let mean_gauge_handle = gauge!(mean_name, "output" => label_value.clone());
             // DEPRECATED: buffer-bytes-events-metrics
-            let legacy_max_gauge = gauge!(legacy_max_gauge_name, "output" => label_value.clone());
+            let legacy_max_gauge = gauge!(legacy_name, "output" => label_value.clone());
             legacy_max_gauge.set(max_value);
             Self {
                 histogram: histogram!(histogram_name, "output" => label_value.clone()),
-                gauge: gauge!(gauge_name, "output" => label_value.clone()),
+                gauge: gauge!(level_name, "output" => label_value.clone()),
                 mean_gauge: TimeEwmaGauge::new(mean_gauge_handle, ewma_half_life_seconds),
                 max_gauge,
                 legacy_max_gauge,
@@ -170,15 +198,15 @@ impl Metrics {
                 recorded_values,
             }
         } else {
-            let max_gauge = gauge!(max_gauge_name);
+            let max_gauge = gauge!(max_name);
             max_gauge.set(max_value);
             let mean_gauge_handle = gauge!(mean_name);
             // DEPRECATED: buffer-bytes-events-metrics
-            let legacy_max_gauge = gauge!(legacy_max_gauge_name);
+            let legacy_max_gauge = gauge!(legacy_name);
             legacy_max_gauge.set(max_value);
             Self {
                 histogram: histogram!(histogram_name),
-                gauge: gauge!(gauge_name),
+                gauge: gauge!(level_name),
                 mean_gauge: TimeEwmaGauge::new(mean_gauge_handle, ewma_half_life_seconds),
                 max_gauge,
                 legacy_max_gauge,

--- a/lib/vector-buffers/src/topology/channel/mod.rs
+++ b/lib/vector-buffers/src/topology/channel/mod.rs
@@ -3,8 +3,8 @@ mod receiver;
 mod sender;
 
 pub use limited_queue::{
-    ChannelMetricMetadata, DEFAULT_EWMA_HALF_LIFE_SECONDS, LimitedReceiver, LimitedSender,
-    SendError, limited,
+    BufferChannelKind, ChannelMetricMetadata, DEFAULT_EWMA_HALF_LIFE_SECONDS, LimitedReceiver,
+    LimitedSender, SendError, limited,
 };
 pub use receiver::*;
 pub use sender::*;

--- a/lib/vector-common/src/internal_event/metric_name.rs
+++ b/lib/vector-common/src/internal_event/metric_name.rs
@@ -127,6 +127,8 @@ pub enum HistogramName {
     HttpClientRttSeconds,
     HttpClientResponseRttSeconds,
     HttpClientErrorRttSeconds,
+    SourceBufferUtilization,
+    TransformBufferUtilization,
 }
 
 impl HistogramName {
@@ -160,6 +162,8 @@ impl HistogramName {
             Self::HttpClientRttSeconds => "http_client_rtt_seconds",
             Self::HttpClientResponseRttSeconds => "http_client_response_rtt_seconds",
             Self::HttpClientErrorRttSeconds => "http_client_error_rtt_seconds",
+            Self::SourceBufferUtilization => "source_buffer_utilization",
+            Self::TransformBufferUtilization => "transform_buffer_utilization",
         }
     }
 }
@@ -168,6 +172,18 @@ impl HistogramName {
 #[strum(serialize_all = "snake_case")]
 pub enum GaugeName {
     ComponentLatencyMeanSeconds,
+    SourceBufferMaxSizeEvents,
+    SourceBufferMaxSizeBytes,
+    SourceBufferMaxEventSize,
+    SourceBufferMaxByteSize,
+    SourceBufferUtilizationLevel,
+    SourceBufferUtilizationMean,
+    TransformBufferMaxSizeEvents,
+    TransformBufferMaxSizeBytes,
+    TransformBufferMaxEventSize,
+    TransformBufferMaxByteSize,
+    TransformBufferUtilizationLevel,
+    TransformBufferUtilizationMean,
     BufferMaxSizeEvents,
     BufferMaxEventSize,
     BufferMaxSizeBytes,
@@ -199,6 +215,18 @@ impl GaugeName {
     pub const fn as_str(self) -> &'static str {
         match self {
             Self::ComponentLatencyMeanSeconds => "component_latency_mean_seconds",
+            Self::SourceBufferMaxSizeEvents => "source_buffer_max_size_events",
+            Self::SourceBufferMaxSizeBytes => "source_buffer_max_size_bytes",
+            Self::SourceBufferMaxEventSize => "source_buffer_max_event_size",
+            Self::SourceBufferMaxByteSize => "source_buffer_max_byte_size",
+            Self::SourceBufferUtilizationLevel => "source_buffer_utilization_level",
+            Self::SourceBufferUtilizationMean => "source_buffer_utilization_mean",
+            Self::TransformBufferMaxSizeEvents => "transform_buffer_max_size_events",
+            Self::TransformBufferMaxSizeBytes => "transform_buffer_max_size_bytes",
+            Self::TransformBufferMaxEventSize => "transform_buffer_max_event_size",
+            Self::TransformBufferMaxByteSize => "transform_buffer_max_byte_size",
+            Self::TransformBufferUtilizationLevel => "transform_buffer_utilization_level",
+            Self::TransformBufferUtilizationMean => "transform_buffer_utilization_mean",
             Self::BufferMaxSizeEvents => "buffer_max_size_events",
             Self::BufferMaxEventSize => "buffer_max_event_size",
             Self::BufferMaxSizeBytes => "buffer_max_size_bytes",

--- a/lib/vector-core/src/source_sender/output.rs
+++ b/lib/vector-core/src/source_sender/output.rs
@@ -11,7 +11,7 @@ use metrics::Histogram;
 use tracing::Span;
 use vector_buffers::{
     config::MemoryBufferSize,
-    topology::channel::{self, ChannelMetricMetadata, LimitedReceiver, LimitedSender},
+    topology::channel::{self, BufferChannelKind, ChannelMetricMetadata, LimitedReceiver, LimitedSender},
 };
 use vector_common::{
     byte_size_of::ByteSizeOf,
@@ -30,7 +30,6 @@ use crate::{
     schema::Definition,
 };
 
-const UTILIZATION_METRIC_PREFIX: &str = "source_buffer";
 
 /// UnsentEvents tracks the number of events yet to be sent in the buffer. This is used to
 /// increment the appropriate counters when a future is not polled to completion. Particularly,
@@ -140,7 +139,7 @@ impl Output {
     ) -> (Self, LimitedReceiver<SourceSenderItem>) {
         let limit = MemoryBufferSize::MaxEvents(NonZeroUsize::new(n).unwrap());
         let channel_metrics =
-            ChannelMetricMetadata::new(UTILIZATION_METRIC_PREFIX, Some(output.clone()));
+            ChannelMetricMetadata::new(BufferChannelKind::Source, Some(output.clone()));
         let (tx, rx) = channel::limited(limit, Some(channel_metrics), ewma_half_life_seconds);
         (
             Self {

--- a/lib/vector-core/src/source_sender/output.rs
+++ b/lib/vector-core/src/source_sender/output.rs
@@ -11,7 +11,9 @@ use metrics::Histogram;
 use tracing::Span;
 use vector_buffers::{
     config::MemoryBufferSize,
-    topology::channel::{self, BufferChannelKind, ChannelMetricMetadata, LimitedReceiver, LimitedSender},
+    topology::channel::{
+        self, BufferChannelKind, ChannelMetricMetadata, LimitedReceiver, LimitedSender,
+    },
 };
 use vector_common::{
     byte_size_of::ByteSizeOf,
@@ -29,7 +31,6 @@ use crate::{
     event::{Event, EventArray, EventContainer as _, EventRef, array},
     schema::Definition,
 };
-
 
 /// UnsentEvents tracks the number of events yet to be sent in the buffer. This is used to
 /// increment the appropriate counters when a future is not polled to completion. Particularly,

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -21,7 +21,7 @@ use vector_lib::{
         BufferType, WhenFull,
         topology::{
             builder::TopologyBuilder,
-            channel::{BufferReceiver, BufferSender, ChannelMetricMetadata, LimitedReceiver},
+            channel::{BufferChannelKind, BufferReceiver, BufferSender, ChannelMetricMetadata, LimitedReceiver},
         },
     },
     internal_event::{self, CountByteSize, EventsSent, InternalEventHandle as _, Registered},
@@ -67,7 +67,6 @@ pub(crate) static SOURCE_SENDER_BUFFER_SIZE: LazyLock<usize> =
 
 const READY_ARRAY_CAPACITY: NonZeroUsize = NonZeroUsize::new(CHUNK_SIZE * 4).unwrap();
 pub(crate) const TOPOLOGY_BUFFER_SIZE: NonZeroUsize = NonZeroUsize::new(100).unwrap();
-const TRANSFORM_CHANNEL_METRIC_PREFIX: &str = "transform_buffer";
 
 static TRANSFORM_CONCURRENCY_LIMIT: LazyLock<usize> = LazyLock::new(|| {
     crate::app::worker_threads()
@@ -508,7 +507,7 @@ impl<'a> Builder<'a> {
                 Ok(transform) => transform,
             };
 
-            let metrics = ChannelMetricMetadata::new(TRANSFORM_CHANNEL_METRIC_PREFIX, None);
+            let metrics = ChannelMetricMetadata::new(BufferChannelKind::Transform, None);
             let (input_tx, input_rx) = TopologyBuilder::standalone_memory(
                 TOPOLOGY_BUFFER_SIZE,
                 WhenFull::Block,

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -21,7 +21,10 @@ use vector_lib::{
         BufferType, WhenFull,
         topology::{
             builder::TopologyBuilder,
-            channel::{BufferChannelKind, BufferReceiver, BufferSender, ChannelMetricMetadata, LimitedReceiver},
+            channel::{
+                BufferChannelKind, BufferReceiver, BufferSender, ChannelMetricMetadata,
+                LimitedReceiver,
+            },
         },
     },
     internal_event::{self, CountByteSize, EventsSent, InternalEventHandle as _, Registered},


### PR DESCRIPTION
## Summary

Replaces the ad-hoc `&'static str` metric prefix constants (`"source_buffer"`, `"transform_buffer"`) with a `BufferChannelKind` enum. Metric names for source and transform buffer channels are now resolved via the existing `GaugeName`/`HistogramName` enum variants, removing the `clippy::disallowed_macros` suppression that was required for dynamic string construction.

## Vector configuration

NA

## How did you test this PR?

`make check-clippy`

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: #25342