### PR TITLE
fix(file source): fix checkpoint write race on shutdown and flaky tests

### DIFF
--- a/changelog.d/25447_fix_file_source_checkpoint_write_race.fix.md
+++ b/changelog.d/25447_fix_file_source_checkpoint_write_race.fix.md
@@ -1,0 +1,3 @@
+Fixed a bug in the file source where checkpoints recording the last-read file position were not always fully written before Vector shut down. On the next startup, the file source could start reading from an earlier position, causing events to be re-processed or lost.
+
+authors: thomasqueirozb

--- a/changelog.d/25447_fix_file_source_checkpoint_write_race.fix.md
+++ b/changelog.d/25447_fix_file_source_checkpoint_write_race.fix.md
@@ -1,3 +1,3 @@
-Fixed a bug in the file source where checkpoints recording the last-read file position were not always fully written before Vector shut down. On the next startup, the file source could start reading from an earlier position, causing events to be re-processed or lost.
+Fixed a bug in the `file` source where checkpoints recording the last-read file position were not always fully written before Vector shut down. On the next startup, the `file` source could start reading from an earlier position, causing events to be re-processed.
 
 authors: thomasqueirozb

--- a/lib/file-source/src/file_server.rs
+++ b/lib/file-source/src/file_server.rs
@@ -411,7 +411,7 @@ where
             };
             futures::pin_mut!(sleep);
             match select(shutdown_data, sleep).await {
-                Either::Left((_, _)) => {
+                Either::Left((_shutdown_token, _)) => {
                     chans
                         .close()
                         .await
@@ -423,6 +423,8 @@ where
                         error!(?error, "Error writing checkpoints before shutdown");
                     }
                     return Ok(Shutdown);
+                    // _shutdown_token is dropped here, after checkpoints are written,
+                    // which signals shutdown_done to the caller.
                 }
                 Either::Right((_, future)) => shutdown_data = future,
             }

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -1729,8 +1729,12 @@ mod tests {
             LogNamespace::Legacy,
             Some(Arc::clone(&event_count)),
             async {
-                wait_for_atomic_usize_timeout_ms(Arc::clone(&event_count), |n| n >= remaining, 5_000)
-                    .await;
+                wait_for_atomic_usize_timeout_ms(
+                    Arc::clone(&event_count),
+                    |n| n >= remaining,
+                    5_000,
+                )
+                .await;
             },
         )
         .await;

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -1726,7 +1726,7 @@ mod tests {
             LogNamespace::Legacy,
             Some(Arc::clone(&event_count)),
             async {
-                crate::test_util::wait_for_atomic_usize(event_count.clone(), |n| n >= remaining)
+                crate::test_util::wait_for_atomic_usize(Arc::clone(&event_count), |n| n >= remaining)
                     .await;
             },
         )
@@ -1949,7 +1949,7 @@ mod tests {
 
                 // Block until event 5 is observed: the timeout fired and
                 // "INFO hello" was emitted before we write "too slow".
-                crate::test_util::wait_for_atomic_usize(event_count.clone(), |n| n >= 5).await;
+                crate::test_util::wait_for_atomic_usize(Arc::clone(&event_count), |n| n >= 5).await;
 
                 writeln!(&mut file, "too slow").unwrap();
                 writeln!(&mut file, "INFO doesn't have").unwrap();
@@ -1959,7 +1959,7 @@ mod tests {
 
                 // Wait for events 6 ("too slow") and 7 ("INFO doesn't have")
                 // before triggering shutdown.
-                crate::test_util::wait_for_atomic_usize(event_count.clone(), |n| n >= 7).await;
+                crate::test_util::wait_for_atomic_usize(Arc::clone(&event_count), |n| n >= 7).await;
             },
         )
         .await;
@@ -2020,7 +2020,7 @@ mod tests {
 
                 // Block until event 5 is observed: the timeout fired and
                 // "INFO hello" was emitted before we write "too slow".
-                crate::test_util::wait_for_atomic_usize(event_count.clone(), |n| n >= 5).await;
+                crate::test_util::wait_for_atomic_usize(Arc::clone(&event_count), |n| n >= 5).await;
 
                 writeln!(&mut file, "too slow").unwrap();
                 writeln!(&mut file, "INFO doesn't have").unwrap();
@@ -2030,7 +2030,7 @@ mod tests {
 
                 // Wait for events 6 ("too slow") and 7 ("INFO doesn't have")
                 // before triggering shutdown.
-                crate::test_util::wait_for_atomic_usize(event_count.clone(), |n| n >= 7).await;
+                crate::test_util::wait_for_atomic_usize(Arc::clone(&event_count), |n| n >= 7).await;
             },
         )
         .await;

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -832,6 +832,10 @@ mod tests {
         fs::{self, File},
         future::Future,
         io::{Seek, Write},
+        sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        },
     };
 
     use encoding_rs::UTF_16LE;
@@ -856,12 +860,16 @@ mod tests {
     }
 
     fn test_default_file_config(dir: &tempfile::TempDir) -> file::FileConfig {
+        // Store checkpoints in a subdirectory so they don't appear in the
+        // glob-watched directory (which covers dir.path()/*).
+        let data_dir = dir.path().join(".data");
+        fs::create_dir_all(&data_dir).unwrap();
         file::FileConfig {
             fingerprint: FingerprintConfig::Checksum {
                 ignored_header_bytes: 0,
                 lines: 1,
             },
-            data_dir: Some(dir.path().to_path_buf()),
+            data_dir: Some(data_dir),
             glob_minimum_cooldown_ms: Duration::from_millis(100),
             internal_metrics: FileInternalMetricsConfig {
                 include_file_tag: true,
@@ -962,9 +970,10 @@ mod tests {
         config.global.data_dir = global_dir.keep().into();
 
         // local path given -- local should win
+        let local_data_dir = Some(local_dir.path().to_path_buf());
         let res = config
             .global
-            .resolve_and_validate_data_dir(test_default_file_config(&local_dir).data_dir.as_ref())
+            .resolve_and_validate_data_dir(local_data_dir.as_ref())
             .unwrap();
         assert_eq!(res, local_dir.path());
 
@@ -1153,7 +1162,7 @@ mod tests {
         let path1 = dir.path().join("file1");
         let path2 = dir.path().join("file2");
 
-        let received = run_file_source(&config, false, NoAcks, LogNamespace::Legacy, async {
+        let received = run_file_source(&config, false, NoAcks, LogNamespace::Legacy, None, async {
             let mut file1 = File::create(&path1).unwrap();
             let mut file2 = File::create(&path2).unwrap();
 
@@ -1208,7 +1217,7 @@ mod tests {
 
         let path = dir.path().join("file");
 
-        let received = run_file_source(&config, false, NoAcks, LogNamespace::Legacy, async {
+        let received = run_file_source(&config, false, NoAcks, LogNamespace::Legacy, None, async {
             let mut file = File::create(&path).unwrap();
 
             writeln!(&mut file, "line for checkpointing").unwrap();
@@ -1234,7 +1243,7 @@ mod tests {
             ..test_default_file_config(&dir)
         };
         let path = dir.path().join("file");
-        let received = run_file_source(&config, false, NoAcks, LogNamespace::Legacy, async {
+        let received = run_file_source(&config, false, NoAcks, LogNamespace::Legacy, None, async {
             let mut file = File::create(&path).unwrap();
 
             for i in 0..n {
@@ -1297,7 +1306,7 @@ mod tests {
 
         let path = dir.path().join("file");
         let archive_path = dir.path().join("file");
-        let received = run_file_source(&config, false, NoAcks, LogNamespace::Legacy, async {
+        let received = run_file_source(&config, false, NoAcks, LogNamespace::Legacy, None, async {
             let mut file = File::create(&path).unwrap();
 
             for i in 0..n {
@@ -1365,7 +1374,7 @@ mod tests {
         let path2 = dir.path().join("b.txt");
         let path3 = dir.path().join("a.log");
         let path4 = dir.path().join("a.ignore.txt");
-        let received = run_file_source(&config, false, NoAcks, LogNamespace::Legacy, async {
+        let received = run_file_source(&config, false, NoAcks, LogNamespace::Legacy, None, async {
             let mut file1 = File::create(&path1).unwrap();
             let mut file2 = File::create(&path2).unwrap();
             let mut file3 = File::create(&path3).unwrap();
@@ -1416,7 +1425,7 @@ mod tests {
 
         let path1 = dir.path().join("a//b/a.log.1");
         let path2 = dir.path().join("a//b/test.log.1");
-        let received = run_file_source(&config, false, NoAcks, LogNamespace::Legacy, async {
+        let received = run_file_source(&config, false, NoAcks, LogNamespace::Legacy, None, async {
             std::fs::create_dir_all(dir.path().join("a/b")).unwrap();
             let mut file1 = File::create(&path1).unwrap();
             let mut file2 = File::create(&path2).unwrap();
@@ -1469,15 +1478,16 @@ mod tests {
             };
 
             let path = dir.path().join("file");
-            let received = run_file_source(&config, true, acks, LogNamespace::Legacy, async {
-                let mut file = File::create(&path).unwrap();
+            let received =
+                run_file_source(&config, true, acks, LogNamespace::Legacy, None, async {
+                    let mut file = File::create(&path).unwrap();
 
-                writeln!(&mut file, "hello there").unwrap();
-                file.flush().unwrap();
+                    writeln!(&mut file, "hello there").unwrap();
+                    file.flush().unwrap();
 
-                sleep_500_millis().await;
-            })
-            .await;
+                    sleep_500_millis().await;
+                })
+                .await;
 
             assert_eq!(received.len(), 1);
             assert_eq!(
@@ -1496,15 +1506,16 @@ mod tests {
             };
 
             let path = dir.path().join("file");
-            let received = run_file_source(&config, true, acks, LogNamespace::Legacy, async {
-                let mut file = File::create(&path).unwrap();
+            let received =
+                run_file_source(&config, true, acks, LogNamespace::Legacy, None, async {
+                    let mut file = File::create(&path).unwrap();
 
-                writeln!(&mut file, "hello there").unwrap();
-                file.flush().unwrap();
+                    writeln!(&mut file, "hello there").unwrap();
+                    file.flush().unwrap();
 
-                sleep_500_millis().await;
-            })
-            .await;
+                    sleep_500_millis().await;
+                })
+                .await;
 
             assert_eq!(received.len(), 1);
             assert_eq!(
@@ -1522,15 +1533,16 @@ mod tests {
             };
 
             let path = dir.path().join("file");
-            let received = run_file_source(&config, true, acks, LogNamespace::Legacy, async {
-                let mut file = File::create(&path).unwrap();
+            let received =
+                run_file_source(&config, true, acks, LogNamespace::Legacy, None, async {
+                    let mut file = File::create(&path).unwrap();
 
-                writeln!(&mut file, "hello there").unwrap();
+                    writeln!(&mut file, "hello there").unwrap();
 
-                file.flush().unwrap();
-                sleep_500_millis().await;
-            })
-            .await;
+                    file.flush().unwrap();
+                    sleep_500_millis().await;
+                })
+                .await;
 
             assert_eq!(received.len(), 1);
             assert_eq!(
@@ -1576,26 +1588,28 @@ mod tests {
 
         // First time server runs it picks up existing lines.
         {
-            let received = run_file_source(&config, true, acking, LogNamespace::Legacy, async {
-                sleep_500_millis().await;
-                writeln!(&mut file, "first line").unwrap();
-                file.flush().unwrap();
-                sleep_500_millis().await;
-            })
-            .await;
+            let received =
+                run_file_source(&config, true, acking, LogNamespace::Legacy, None, async {
+                    sleep_500_millis().await;
+                    writeln!(&mut file, "first line").unwrap();
+                    file.flush().unwrap();
+                    sleep_500_millis().await;
+                })
+                .await;
 
             let lines = extract_messages_string(received);
             assert_eq!(lines, vec!["zeroth line", "first line"]);
         }
         // Restart server, read file from checkpoint.
         {
-            let received = run_file_source(&config, true, acking, LogNamespace::Legacy, async {
-                sleep_500_millis().await;
-                writeln!(&mut file, "second line").unwrap();
-                file.flush().unwrap();
-                sleep_500_millis().await;
-            })
-            .await;
+            let received =
+                run_file_source(&config, true, acking, LogNamespace::Legacy, None, async {
+                    sleep_500_millis().await;
+                    writeln!(&mut file, "second line").unwrap();
+                    file.flush().unwrap();
+                    sleep_500_millis().await;
+                })
+                .await;
 
             let lines = extract_messages_string(received);
             assert_eq!(lines, vec!["second line"]);
@@ -1608,13 +1622,14 @@ mod tests {
                 read_from: ReadFromConfig::Beginning,
                 ..test_default_file_config(&dir)
             };
-            let received = run_file_source(&config, false, acking, LogNamespace::Legacy, async {
-                sleep_500_millis().await;
-                writeln!(&mut file, "third line").unwrap();
-                file.flush().unwrap();
-                sleep_500_millis().await;
-            })
-            .await;
+            let received =
+                run_file_source(&config, false, acking, LogNamespace::Legacy, None, async {
+                    sleep_500_millis().await;
+                    writeln!(&mut file, "third line").unwrap();
+                    file.flush().unwrap();
+                    sleep_500_millis().await;
+                })
+                .await;
 
             let lines = extract_messages_string(received);
             assert_eq!(
@@ -1643,6 +1658,7 @@ mod tests {
             false,
             Unfinalized,
             LogNamespace::Legacy,
+            None,
             sleep(Duration::from_secs(5)),
         )
         .await;
@@ -1655,6 +1671,7 @@ mod tests {
             false,
             Unfinalized,
             LogNamespace::Legacy,
+            None,
             sleep(Duration::from_secs(5)),
         )
         .await;
@@ -1685,6 +1702,7 @@ mod tests {
             true,
             Acks,
             LogNamespace::Legacy,
+            None,
             // shutdown signal is sent after this duration
             sleep_500_millis(),
         )
@@ -1695,13 +1713,22 @@ mod tests {
         // bug we're testing for, which happens if the finalizer stream exits on shutdown with pending acks
         assert!(lines.len() < line_count);
 
-        // Restart the server, and it should read the rest without duplicating any
+        // Restart the server, and it should read the rest without duplicating any.
+        // Use the event counter to drain rx continuously (removing backpressure so
+        // the file server can read all remaining lines without being stalled), then
+        // trigger shutdown once all expected events have been received.
+        let remaining = line_count - lines.len();
+        let event_count = Arc::new(AtomicUsize::new(0));
         let received = run_file_source(
             &config,
             true,
             Acks,
             LogNamespace::Legacy,
-            sleep(Duration::from_secs(5)),
+            Some(Arc::clone(&event_count)),
+            async {
+                crate::test_util::wait_for_atomic_usize(event_count.clone(), |n| n >= remaining)
+                    .await;
+            },
         )
         .await;
         let lines2 = extract_messages_string(received);
@@ -1731,13 +1758,14 @@ mod tests {
         let path_for_old_file = dir.path().join("file.old");
         // Run server first time, collect some lines.
         {
-            let received = run_file_source(&config, true, acking, LogNamespace::Legacy, async {
-                let mut file = File::create(&path).unwrap();
-                writeln!(&mut file, "first line").unwrap();
-                file.flush().unwrap();
-                sleep_500_millis().await;
-            })
-            .await;
+            let received =
+                run_file_source(&config, true, acking, LogNamespace::Legacy, None, async {
+                    let mut file = File::create(&path).unwrap();
+                    writeln!(&mut file, "first line").unwrap();
+                    file.flush().unwrap();
+                    sleep_500_millis().await;
+                })
+                .await;
 
             let lines = extract_messages_string(received);
             assert_eq!(lines, vec!["first line"]);
@@ -1747,13 +1775,14 @@ mod tests {
         // Restart the server and make sure it does not re-read the old file
         // even though it has a new name.
         {
-            let received = run_file_source(&config, false, acking, LogNamespace::Legacy, async {
-                let mut file = File::create(&path).unwrap();
-                writeln!(&mut file, "second line").unwrap();
-                file.flush().unwrap();
-                sleep_500_millis().await;
-            })
-            .await;
+            let received =
+                run_file_source(&config, false, acking, LogNamespace::Legacy, None, async {
+                    let mut file = File::create(&path).unwrap();
+                    writeln!(&mut file, "second line").unwrap();
+                    file.flush().unwrap();
+                    sleep_500_millis().await;
+                })
+                .await;
 
             let lines = extract_messages_string(received);
             assert_eq!(lines, vec!["second line"]);
@@ -1815,7 +1844,7 @@ mod tests {
         before_file.sync_all().unwrap();
         after_file.sync_all().unwrap();
 
-        let received = run_file_source(&config, false, NoAcks, LogNamespace::Legacy, async {
+        let received = run_file_source(&config, false, NoAcks, LogNamespace::Legacy, None, async {
             sleep_500_millis().await;
             writeln!(&mut before_file, "second line").unwrap();
             writeln!(&mut after_file, "_second line").unwrap();
@@ -1854,7 +1883,7 @@ mod tests {
         };
 
         let path = dir.path().join("file");
-        let received = run_file_source(&config, false, NoAcks, LogNamespace::Legacy, async {
+        let received = run_file_source(&config, false, NoAcks, LogNamespace::Legacy, None, async {
             let mut file = File::create(&path).unwrap();
 
             writeln!(&mut file, "short").unwrap();
@@ -1891,37 +1920,48 @@ mod tests {
         let config = file::FileConfig {
             include: vec![dir.path().join("*")],
             message_start_indicator: Some("INFO".into()),
-            multi_line_timeout: 25, // less than 50 in sleep()
+            multi_line_timeout: 25,
             ..test_default_file_config(&dir)
         };
 
         let path = dir.path().join("file");
-        let received = run_file_source(&config, false, NoAcks, LogNamespace::Legacy, async {
-            let mut file = File::create(&path).unwrap();
+        let event_count = Arc::new(AtomicUsize::new(0));
+        let received = run_file_source(
+            &config,
+            false,
+            NoAcks,
+            LogNamespace::Legacy,
+            Some(Arc::clone(&event_count)),
+            async {
+                let mut file = File::create(&path).unwrap();
 
-            writeln!(&mut file, "leftover foo").unwrap();
-            writeln!(&mut file, "INFO hello").unwrap();
-            writeln!(&mut file, "INFO goodbye").unwrap();
-            writeln!(&mut file, "part of goodbye").unwrap();
+                // Write all lines through the second "INFO hello". Events 1-4
+                // are emitted immediately by EndExclude; event 5 ("INFO hello"
+                // standalone) requires the 25ms timeout to fire.
+                writeln!(&mut file, "leftover foo").unwrap();
+                writeln!(&mut file, "INFO hello").unwrap();
+                writeln!(&mut file, "INFO goodbye").unwrap();
+                writeln!(&mut file, "part of goodbye").unwrap();
+                writeln!(&mut file, "INFO hi again").unwrap();
+                writeln!(&mut file, "and some more").unwrap();
+                writeln!(&mut file, "INFO hello").unwrap();
+                file.flush().unwrap();
 
-            file.flush().unwrap();
-            sleep_500_millis().await;
+                // Block until event 5 is observed: the timeout fired and
+                // "INFO hello" was emitted before we write "too slow".
+                crate::test_util::wait_for_atomic_usize(event_count.clone(), |n| n >= 5).await;
 
-            writeln!(&mut file, "INFO hi again").unwrap();
-            writeln!(&mut file, "and some more").unwrap();
-            writeln!(&mut file, "INFO hello").unwrap();
+                writeln!(&mut file, "too slow").unwrap();
+                writeln!(&mut file, "INFO doesn't have").unwrap();
+                writeln!(&mut file, "to be INFO in").unwrap();
+                writeln!(&mut file, "the middle").unwrap();
+                file.flush().unwrap();
 
-            file.flush().unwrap();
-            sleep_500_millis().await;
-
-            writeln!(&mut file, "too slow").unwrap();
-            writeln!(&mut file, "INFO doesn't have").unwrap();
-            writeln!(&mut file, "to be INFO in").unwrap();
-            writeln!(&mut file, "the middle").unwrap();
-
-            file.flush().unwrap();
-            sleep_500_millis().await;
-        })
+                // Wait for events 6 ("too slow") and 7 ("INFO doesn't have")
+                // before triggering shutdown.
+                crate::test_util::wait_for_atomic_usize(event_count.clone(), |n| n >= 7).await;
+            },
+        )
         .await;
 
         let received = extract_messages_value(received);
@@ -1950,38 +1990,49 @@ mod tests {
                 start_pattern: "INFO".to_owned(),
                 condition_pattern: "INFO".to_owned(),
                 mode: line_agg::Mode::HaltBefore,
-                timeout_ms: Duration::from_millis(25), // less than 50 in sleep()
+                timeout_ms: Duration::from_millis(25),
             }),
             ..test_default_file_config(&dir)
         };
 
         let path = dir.path().join("file");
-        let received = run_file_source(&config, false, NoAcks, LogNamespace::Legacy, async {
-            let mut file = File::create(&path).unwrap();
+        let event_count = Arc::new(AtomicUsize::new(0));
+        let received = run_file_source(
+            &config,
+            false,
+            NoAcks,
+            LogNamespace::Legacy,
+            Some(Arc::clone(&event_count)),
+            async {
+                let mut file = File::create(&path).unwrap();
 
-            writeln!(&mut file, "leftover foo").unwrap();
-            writeln!(&mut file, "INFO hello").unwrap();
-            writeln!(&mut file, "INFO goodbye").unwrap();
-            writeln!(&mut file, "part of goodbye").unwrap();
+                // Write all lines through the second "INFO hello". Events 1-4
+                // are emitted immediately by EndExclude; event 5 ("INFO hello"
+                // standalone) requires the 25ms timeout to fire.
+                writeln!(&mut file, "leftover foo").unwrap();
+                writeln!(&mut file, "INFO hello").unwrap();
+                writeln!(&mut file, "INFO goodbye").unwrap();
+                writeln!(&mut file, "part of goodbye").unwrap();
+                writeln!(&mut file, "INFO hi again").unwrap();
+                writeln!(&mut file, "and some more").unwrap();
+                writeln!(&mut file, "INFO hello").unwrap();
+                file.flush().unwrap();
 
-            file.flush().unwrap();
-            sleep_500_millis().await;
+                // Block until event 5 is observed: the timeout fired and
+                // "INFO hello" was emitted before we write "too slow".
+                crate::test_util::wait_for_atomic_usize(event_count.clone(), |n| n >= 5).await;
 
-            writeln!(&mut file, "INFO hi again").unwrap();
-            writeln!(&mut file, "and some more").unwrap();
-            writeln!(&mut file, "INFO hello").unwrap();
+                writeln!(&mut file, "too slow").unwrap();
+                writeln!(&mut file, "INFO doesn't have").unwrap();
+                writeln!(&mut file, "to be INFO in").unwrap();
+                writeln!(&mut file, "the middle").unwrap();
+                file.flush().unwrap();
 
-            file.flush().unwrap();
-            sleep_500_millis().await;
-
-            writeln!(&mut file, "too slow").unwrap();
-            writeln!(&mut file, "INFO doesn't have").unwrap();
-            writeln!(&mut file, "to be INFO in").unwrap();
-            writeln!(&mut file, "the middle").unwrap();
-
-            file.flush().unwrap();
-            sleep_500_millis().await;
-        })
+                // Wait for events 6 ("too slow") and 7 ("INFO doesn't have")
+                // before triggering shutdown.
+                crate::test_util::wait_for_atomic_usize(event_count.clone(), |n| n >= 7).await;
+            },
+        )
         .await;
 
         let received = extract_messages_value(received);
@@ -2024,12 +2075,14 @@ mod tests {
 
         file.sync_all().unwrap();
 
-        // Read and aggregate existing lines
+        // Read and aggregate existing lines. wait_shutdown=true ensures the
+        // checkpoint is fully written to disk before the second run reads it.
         let received = run_file_source(
             &config,
-            false,
+            true,
             Acks,
             LogNamespace::Legacy,
+            None,
             sleep_500_millis(),
         )
         .await;
@@ -2041,7 +2094,7 @@ mod tests {
 
         // After restart, we should not see any part of the previously aggregated lines
         let received_after_restart =
-            run_file_source(&config, false, Acks, LogNamespace::Legacy, async {
+            run_file_source(&config, false, Acks, LogNamespace::Legacy, None, async {
                 writeln!(&mut file, "INFO goodbye").unwrap();
                 file.flush().unwrap();
                 sleep_500_millis().await;
@@ -2086,6 +2139,7 @@ mod tests {
             false,
             NoAcks,
             LogNamespace::Legacy,
+            None,
             sleep_500_millis(),
         )
         .await;
@@ -2148,6 +2202,7 @@ mod tests {
             false,
             NoAcks,
             LogNamespace::Legacy,
+            None,
             sleep_500_millis(),
         )
         .await;
@@ -2182,7 +2237,7 @@ mod tests {
         writeln!(&mut file, "hello i am a normal line").unwrap();
         file.sync_all().unwrap();
 
-        let received = run_file_source(&config, false, NoAcks, LogNamespace::Legacy, async {
+        let received = run_file_source(&config, false, NoAcks, LogNamespace::Legacy, None, async {
             sleep_500_millis().await;
 
             write!(&mut file, "i am not a full line").unwrap();
@@ -2229,6 +2284,7 @@ mod tests {
             false,
             NoAcks,
             LogNamespace::Legacy,
+            None,
             sleep_500_millis(),
         )
         .await;
@@ -2261,6 +2317,7 @@ mod tests {
             false,
             NoAcks,
             LogNamespace::Legacy,
+            None,
             sleep_500_millis(),
         )
         .await;
@@ -2289,7 +2346,7 @@ mod tests {
         };
 
         let path = dir.path().join("file");
-        let received = run_file_source(&config, false, NoAcks, LogNamespace::Legacy, async {
+        let received = run_file_source(&config, false, NoAcks, LogNamespace::Legacy, None, async {
             let mut file = File::create(&path).unwrap();
 
             write!(&mut file, "hello i am a line\r\n").unwrap();
@@ -2328,7 +2385,7 @@ mod tests {
         };
 
         let path = dir.path().join("file");
-        let received = run_file_source(&config, false, NoAcks, LogNamespace::Legacy, async {
+        let received = run_file_source(&config, false, NoAcks, LogNamespace::Legacy, None, async {
             let mut file = File::create(&path).unwrap();
 
             sleep_500_millis().await;
@@ -2417,7 +2474,7 @@ mod tests {
         };
 
         let path = dir.path().join("file");
-        let received = run_file_source(&config, false, Acks, LogNamespace::Legacy, async {
+        let received = run_file_source(&config, false, Acks, LogNamespace::Legacy, None, async {
             let mut file = File::create(&path).unwrap();
 
             for i in 0..n {
@@ -2459,6 +2516,11 @@ mod tests {
         wait_shutdown: bool,
         acking_mode: AckingMode,
         log_namespace: LogNamespace,
+        // When `Some`, events are relayed through an unbounded channel and the
+        // counter is incremented for each event received.  The inner future can
+        // call `wait_for_atomic_usize` on this counter to gate writes on
+        // observed events instead of relying on wall-clock sleeps.
+        event_counter: Option<Arc<AtomicUsize>>,
         inner: impl Future<Output = ()>,
     ) -> Vec<Event> {
         assert_source_compliance(&FILE_SOURCE_TAGS, async move {
@@ -2494,21 +2556,47 @@ mod tests {
                 log_namespace,
             ));
 
-            inner.await;
+            let result = if let Some(counter) = event_counter {
+                // Relay mode: a background task forwards events and increments
+                // the counter so `inner` can observe them without arbitrary sleeps.
+                let (relay_tx, mut relay_rx) = tokio::sync::mpsc::unbounded_channel::<Event>();
+                tokio::spawn(async move {
+                    let mut rx = rx;
+                    while let Some(event) = rx.next().await {
+                        counter.fetch_add(1, Ordering::SeqCst);
+                        let _ = relay_tx.send(event);
+                    }
+                });
 
-            drop(trigger_shutdown);
+                inner.await;
+                drop(trigger_shutdown);
 
-            let result = if acking_mode == Unfinalized {
-                rx.take_until(tokio::time::sleep(Duration::from_secs(5)))
-                    .collect::<Vec<_>>()
-                    .await
+                timeout(Duration::from_secs(5), async move {
+                    let mut events = Vec::new();
+                    while let Some(event) = relay_rx.recv().await {
+                        events.push(event);
+                    }
+                    events
+                })
+                .await
+                .expect("Unclosed channel: may indicate file-server could not shutdown gracefully.")
             } else {
-                timeout(Duration::from_secs(5), rx.collect::<Vec<_>>())
-                    .await
-                    .expect(
-                        "Unclosed channel: may indicate file-server could not shutdown gracefully.",
-                    )
+                inner.await;
+                drop(trigger_shutdown);
+
+                if acking_mode == Unfinalized {
+                    rx.take_until(tokio::time::sleep(Duration::from_secs(5)))
+                        .collect::<Vec<_>>()
+                        .await
+                } else {
+                    timeout(Duration::from_secs(5), rx.collect::<Vec<_>>())
+                        .await
+                        .expect(
+                            "Unclosed channel: may indicate file-server could not shutdown gracefully.",
+                        )
+                }
             };
+
             if wait_shutdown {
                 shutdown_done.await;
             }

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -851,7 +851,10 @@ mod tests {
         event::{Event, EventStatus, Value},
         shutdown::ShutdownSignal,
         sources::file,
-        test_util::components::{FILE_SOURCE_TAGS, assert_source_compliance},
+        test_util::{
+            components::{FILE_SOURCE_TAGS, assert_source_compliance},
+            wait_for_atomic_usize_timeout_ms,
+        },
     };
 
     #[test]
@@ -1726,7 +1729,7 @@ mod tests {
             LogNamespace::Legacy,
             Some(Arc::clone(&event_count)),
             async {
-                crate::test_util::wait_for_atomic_usize(Arc::clone(&event_count), |n| n >= remaining)
+                wait_for_atomic_usize_timeout_ms(Arc::clone(&event_count), |n| n >= remaining, 5_000)
                     .await;
             },
         )
@@ -1949,7 +1952,7 @@ mod tests {
 
                 // Block until event 5 is observed: the timeout fired and
                 // "INFO hello" was emitted before we write "too slow".
-                crate::test_util::wait_for_atomic_usize(Arc::clone(&event_count), |n| n >= 5).await;
+                wait_for_atomic_usize_timeout_ms(Arc::clone(&event_count), |n| n >= 5, 500).await;
 
                 writeln!(&mut file, "too slow").unwrap();
                 writeln!(&mut file, "INFO doesn't have").unwrap();
@@ -1959,7 +1962,7 @@ mod tests {
 
                 // Wait for events 6 ("too slow") and 7 ("INFO doesn't have")
                 // before triggering shutdown.
-                crate::test_util::wait_for_atomic_usize(Arc::clone(&event_count), |n| n >= 7).await;
+                wait_for_atomic_usize_timeout_ms(Arc::clone(&event_count), |n| n >= 7, 500).await;
             },
         )
         .await;
@@ -2020,7 +2023,7 @@ mod tests {
 
                 // Block until event 5 is observed: the timeout fired and
                 // "INFO hello" was emitted before we write "too slow".
-                crate::test_util::wait_for_atomic_usize(Arc::clone(&event_count), |n| n >= 5).await;
+                wait_for_atomic_usize_timeout_ms(Arc::clone(&event_count), |n| n >= 5, 500).await;
 
                 writeln!(&mut file, "too slow").unwrap();
                 writeln!(&mut file, "INFO doesn't have").unwrap();
@@ -2030,7 +2033,7 @@ mod tests {
 
                 // Wait for events 6 ("too slow") and 7 ("INFO doesn't have")
                 // before triggering shutdown.
-                crate::test_util::wait_for_atomic_usize(Arc::clone(&event_count), |n| n >= 7).await;
+                wait_for_atomic_usize_timeout_ms(Arc::clone(&event_count), |n| n >= 7, 500).await;
             },
         )
         .await;

--- a/src/test_util/mod.rs
+++ b/src/test_util/mod.rs
@@ -554,6 +554,19 @@ where
     wait_for(|| ready(unblock(value.load(Ordering::SeqCst)))).await
 }
 
+pub async fn wait_for_atomic_usize_timeout_ms<T, F>(value: T, unblock: F, timeout_ms: u64)
+where
+    T: AsRef<AtomicUsize>,
+    F: Fn(usize) -> bool,
+{
+    let value = value.as_ref();
+    wait_for_duration(
+        || ready(unblock(value.load(Ordering::SeqCst))),
+        Duration::from_millis(timeout_ms),
+    )
+    .await
+}
+
 // Retries a func every `retry` duration until given an Ok(T); panics after `until` elapses
 pub async fn retry_until<'a, F, Fut, T, E>(mut f: F, retry: Duration, until: Duration) -> T
 where


### PR DESCRIPTION
## Summary

Two related fixes in the file source:

**Production fix (`lib/file-source/src/file_server.rs`):** The `ShutdownSignalToken` was being dropped via a `_` wildcard at the start of the match arm, causing `shutdown_done` to fire before `chans.close()`, `checkpoint_task_handle.await`, and `write_checkpoints()` had run. Renamed to `_shutdown_token` so it lives until the end of the arm, guaranteeing that `shutdown_done` only resolves after checkpoints are fully persisted. This prevented a race in `file_duplicate_processing_after_restart` where a restarted server could read a stale or missing checkpoint.

**Test fixes (`src/sources/file.rs`):**
- `test_multi_line_aggregation` / `test_multi_line_aggregation_legacy`: Replaced wall-clock sleeps with an event counter + `wait_for_atomic_usize` barrier. The `run_file_source` helper gained an optional `Arc<AtomicUsize>` parameter that relays events through a side channel so the inner future can gate on observed event counts rather than timing.
- `file_duplicate_processing_after_restart`: Second run now uses the event counter to drain `rx` continuously (removing backpressure), then triggers shutdown once all expected events are received—eliminating the race with the 5-second `rx.collect()` timeout.
- `test_multi_line_checkpointing`: Changed first run to `wait_shutdown=true` so the checkpoint is guaranteed written before the second run reads it.
- `test_default_file_config`: Moved `data_dir` to a `.data/` subdirectory so checkpoint files don't appear in the glob-watched directory and get read as data.

---

This is a partial fix for #23813. The full fix is to remove sleeps all throughout the file and use the new helper everywhere.

## Vector configuration

NA

## How did you test this PR?

Ran `cargo nextest run --no-default-features --features=sources-file sources::file::tests` (with `retries = 1` in `.config/nextest.toml`) 1000 times with no failures.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: #23813