### PR TITLE
fix(ci): use each commit's own Dockerfile for regression baseline/comparison builds

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -220,7 +220,7 @@ jobs:
           context: baseline-vector/
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          file: regression/Dockerfile
+          file: baseline-vector/regression/Dockerfile
           builder: ${{ steps.buildx.outputs.name }}
           outputs: type=docker,dest=${{ runner.temp }}/baseline-image.tar
           tags: |
@@ -259,7 +259,7 @@ jobs:
           context: comparison-vector/
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          file: regression/Dockerfile
+          file: comparison-vector/regression/Dockerfile
           builder: ${{ steps.buildx.outputs.name }}
           outputs: type=docker,dest=${{ runner.temp }}/comparison-image.tar
           tags: |


### PR DESCRIPTION
## Summary

The regression workflow builds baseline and comparison Vector images by checking out each commit's source code into separate directories (`baseline-vector/` and `comparison-vector/`), but was using the current HEAD's `regression/Dockerfile` for both builds.

This broke when `ec27f907e5` moved apt dependencies into `scripts/environment/install-debian-build-deps.sh` — the baseline context (7-day-old code) doesn't have that script, so the Docker build fails with exit code 127.

Fix: point each build's `file:` at the Dockerfile from its own checkout so the Dockerfile and build context are always in sync.

## Vector configuration

NA

## How did you test this PR?

Inspected the failing CI run: https://github.com/vectordotdev/vector/actions/runs/26021900696/attempts/2

`/ci-run-regression`

CI run: https://github.com/vectordotdev/vector/actions/runs/26040100474?pr=25452

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: #25436