### PR TITLE
enhancement(transforms): Add metric to measure concurrency blockage in Function Transforms

### DIFF
--- a/changelog.d/25070_transform_scheduling_pressure_metric.enhancement.md
+++ b/changelog.d/25070_transform_scheduling_pressure_metric.enhancement.md
@@ -1,0 +1,6 @@
+Added a new internal metric `estimated_concurrent_transform_scheduling_pressure` that measures the
+fraction of in-flight concurrent transform tasks that have already completed but are blocked from
+having their outputs sent because the runner is waiting on earlier tasks to preserve event ordering.
+A value near 1.0 indicates the transform's ordering guarantees are throttling throughput.
+
+authors: ArunPiduguDD

--- a/lib/vector-common/src/internal_event/metric_name.rs
+++ b/lib/vector-common/src/internal_event/metric_name.rs
@@ -129,6 +129,7 @@ pub enum HistogramName {
     HttpClientErrorRttSeconds,
     SourceBufferUtilization,
     TransformBufferUtilization,
+    EstimatedConcurrentTransformSchedulingPressure,
 }
 
 impl HistogramName {
@@ -164,6 +165,9 @@ impl HistogramName {
             Self::HttpClientErrorRttSeconds => "http_client_error_rtt_seconds",
             Self::SourceBufferUtilization => "source_buffer_utilization",
             Self::TransformBufferUtilization => "transform_buffer_utilization",
+            Self::EstimatedConcurrentTransformSchedulingPressure => {
+                "estimated_concurrent_transform_scheduling_pressure"
+            }
         }
     }
 }

--- a/lib/vector-core/src/lib.rs
+++ b/lib/vector-core/src/lib.rs
@@ -34,6 +34,7 @@ pub mod ipallowlist;
 pub mod latency;
 pub mod metrics;
 pub mod partition;
+pub mod scheduling_pressure;
 pub mod schema;
 pub mod serde;
 pub mod sink;

--- a/lib/vector-core/src/scheduling_pressure.rs
+++ b/lib/vector-core/src/scheduling_pressure.rs
@@ -1,0 +1,53 @@
+use std::sync::{
+    Arc,
+    atomic::{AtomicU64, Ordering},
+};
+
+use metrics::Histogram;
+use vector_common::{histogram, internal_event::HistogramName};
+
+#[derive(Debug)]
+pub struct SchedulingPressureRecorder {
+    histogram: Histogram,
+    concurrency_limit: usize,
+    completed: Arc<AtomicU64>,
+    yielded_since_last_sample: u64,
+}
+
+impl SchedulingPressureRecorder {
+    pub fn new(component_id: &str, concurrency_limit: usize) -> Self {
+        Self {
+            histogram: histogram!(
+                HistogramName::EstimatedConcurrentTransformSchedulingPressure,
+                "component_id" => component_id.to_owned(),
+            ),
+            concurrency_limit,
+            completed: Arc::new(AtomicU64::new(0)),
+            yielded_since_last_sample: 0,
+        }
+    }
+
+    pub fn on_task_yielded(&mut self) {
+        self.yielded_since_last_sample += 1;
+    }
+
+    pub fn task_completion_signal(&self) -> impl FnOnce() + Send + 'static {
+        let completed = Arc::clone(&self.completed);
+        move || {
+            completed.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    pub fn record_sample(&mut self) {
+        let count = self
+            .completed
+            .fetch_sub(self.yielded_since_last_sample, Ordering::Relaxed);
+        self.yielded_since_last_sample = 0;
+        #[expect(
+            clippy::cast_precision_loss,
+            reason = "metric value, precision loss acceptable"
+        )]
+        let pressure = (count as f64 / self.concurrency_limit as f64).min(1.0);
+        self.histogram.record(pressure);
+    }
+}

--- a/lib/vector-lib/src/lib.rs
+++ b/lib/vector-lib/src/lib.rs
@@ -22,8 +22,8 @@ pub use vector_core::compile_vrl;
 pub use vector_core::{
     EstimatedJsonEncodedSizeOf, SpanField, buckets, default_data_dir, emit, event, fanout,
     ipallowlist, latency, metric_tags, metrics, partition, quantiles, register,
-    register_extra_span_field, samples, schema, serde, sink, source, source_sender, tcp, tls,
-    transform,
+    register_extra_span_field, samples, scheduling_pressure, schema, serde, sink, source,
+    source_sender, tcp, tls, transform,
 };
 pub use vector_lookup as lookup;
 pub use vector_stream as stream;

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -29,6 +29,7 @@ use vector_lib::{
     },
     internal_event::{self, CountByteSize, EventsSent, InternalEventHandle as _, Registered},
     latency::LatencyRecorder,
+    scheduling_pressure::SchedulingPressureRecorder,
     schema::Definition,
     source_sender::{CHUNK_SIZE, SourceSenderItem},
     transform::update_runtime_schema_definition,
@@ -788,6 +789,7 @@ impl<'a> Builder<'a> {
             node.input_details.data_type(),
             outputs,
             LatencyRecorder::new(self.config.global.latency_ewma_alpha),
+            node.key.id().to_owned(),
         );
         let transform = if node.enable_concurrency {
             runner.run_concurrently().boxed()
@@ -1177,6 +1179,7 @@ struct Runner {
     timer_tx: UtilizationComponentSender,
     latency_recorder: LatencyRecorder,
     events_received: Registered<EventsReceived>,
+    component_id: String,
 }
 
 impl Runner {
@@ -1187,6 +1190,7 @@ impl Runner {
         input_type: DataType,
         outputs: TransformOutputs,
         latency_recorder: LatencyRecorder,
+        component_id: String,
     ) -> Self {
         Self {
             transform,
@@ -1196,6 +1200,7 @@ impl Runner {
             timer_tx,
             latency_recorder,
             events_received: register!(EventsReceived),
+            component_id,
         }
     }
 
@@ -1253,6 +1258,8 @@ impl Runner {
 
         let mut in_flight = FuturesOrdered::new();
         let mut shutting_down = false;
+        let mut pressure =
+            SchedulingPressureRecorder::new(&self.component_id, *TRANSFORM_CONCURRENCY_LIMIT);
 
         self.timer_tx.try_send_start_wait();
         loop {
@@ -1260,6 +1267,7 @@ impl Runner {
                 biased;
 
                 result = in_flight.next(), if !in_flight.is_empty() => {
+                    pressure.on_task_yielded();
                     match result {
                         Some(Ok(mut outputs_buf)) => {
                             self.send_outputs(&mut outputs_buf).await
@@ -1270,6 +1278,7 @@ impl Runner {
                 }
 
                 input_arrays = input_rx.next(), if in_flight.len() < *TRANSFORM_CONCURRENCY_LIMIT && !shutting_down => {
+                    pressure.record_sample();
                     match input_arrays {
                         Some(input_arrays) => {
                             let mut len = 0;
@@ -1280,10 +1289,12 @@ impl Runner {
 
                             let mut t = self.transform.clone();
                             let mut outputs_buf = self.outputs.new_buf_with_capacity(len);
+                            let signal_completion = pressure.task_completion_signal();
                             let task = tokio::spawn(async move {
                                 for events in input_arrays {
                                     t.transform_all(events, &mut outputs_buf);
                                 }
+                                signal_completion();
                                 outputs_buf
                             }.in_current_span());
                             in_flight.push_back(task);

--- a/website/cue/reference/components/sources/internal_metrics.cue
+++ b/website/cue/reference/components/sources/internal_metrics.cue
@@ -295,6 +295,14 @@ components: sources: internal_metrics: {
 			default_namespace: "vector"
 			tags:              _internal_metrics_tags
 		}
+		estimated_concurrent_transform_scheduling_pressure: {
+			description: """
+				For a concurrent function transform, the fraction of in-flight tasks that have completed but are blocked from emitting because the runner is preserving event ordering. A value near 1.0 indicates the ordering guarantee is throttling throughput.
+				"""
+			type:              "histogram"
+			default_namespace: "vector"
+			tags:              _component_tags
+		}
 		buffer_byte_size: {
 			description:        "The number of bytes currently in the buffer."
 			type:               "gauge"


### PR DESCRIPTION
## Summary
Introduces a new metric `estimated_concurrent_transform_scheduling_pressure` to measure how often head-of-line blocking in FunctionTransforms causes concurrency inefficiencies.

## Detailed Context

In Vector's existing [concurrency model ](https://vector.dev/docs/architecture/concurrency-model/) stateless function transforms are run concurrently (e.g. a function transform can have multiple threads working on batches of events in parallel). However, the [existing implementation](https://github.com/vectordotdev/vector/blob/master/src/topology/builder.rs#L1207) still guarantees event ordering (e.g. if 1000 events arrive at a transform and are processed across 10 batches/Tasks, they will still leave the transform in the same order they arrived, even if later batches complete before earlier batches).

In cases where processing latency of the events within the transform is both high & variable, then this can lead to inefficiencies - as mentioned above events that are processed in later batches can be blocked by batches/Tasks scheduled earlier (if the earlier batch is still processing when the later batch finishes)

The effect can be illustrated by this wall-time profile (measured during a benchmark test with 8 CPUs / parallel threads)


<img width="2626" height="1075" alt="579586858-6711d6b9-8c5f-4562-bddc-41cc07744a12" src="https://github.com/user-attachments/assets/a1231fe5-0f61-4ae3-b694-313311f1b559" />

<br/>

In this test the vector instance was constantly flooded with events so there are always events waiting to be processed. Multiple threads finish processing their batch, however new batches / Tasks are unable to be scheduled for these idle threads due to the fact that the head Task in the `FuturesOrdered` [queue](https://github.com/vectordotdev/vector/blob/master/src/topology/builder.rs#L1215) is still processing its batch, leading to a CPU utilization inefficiency and overall lower throughput.

<br/>

As a test, tried switching this to an ordered queue, the the transform is not held up by long-running tasks and the overall ingress throughput increases (graph below shows bytes / second throughput of ordered vs unordered queue - test was done using remap processor with many regex rules)

<br/>

<img width="2868" height="797" alt="Screenshot 2026-04-17 at 1 41 42 PM" src="https://github.com/user-attachments/assets/d13181d4-56ad-42ca-8294-2001b0eefd59" />

<br/>

## Changes

This PR adds a new metric `estimated_concurrent_transform_scheduling_pressure` which keeps track of how many Tasks have been completed and are blocked by the head task from being scheduled (metric is a distribution which ranges from 0-1). B/c this introduces a shared counter to the transform "hot path", ran regression benchmark tests to confirm there are no issues: https://github.com/vectordotdev/vector/actions/runs/24585515449 (note: a few tests failed to run but seems to be unrelated issues - tests also failing to run on the latest merged commit in master)

## How did you test this PR?

Ran regression tests

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Closes: #<issue/PR number or link>
-->
<!--
- Related: #<issue/PR number or link>
-->

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details [here](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
