### PR TITLE
chore(ci): install vdev via --manifest-path; drop VDEV_VERSION pin

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -73,7 +73,7 @@ inputs:
   vdev:
     required: false
     default: true
-    description: "Install vdev CLI tool via cargo binstall (uses VDEV_VERSION pinned in prepare.sh)."
+    description: "Install vdev CLI tool via cargo binstall (version from vdev/Cargo.toml)."
 
   # prepare.sh - npm
   markdownlint-cli2:
@@ -239,7 +239,7 @@ runs:
           ~/.cargo/bin/dd-rust-license-tool
           ~/.cargo/bin/wasm-pack
           ~/.cargo/bin/vdev
-        key: ${{ runner.os }}-cargo-binaries-${{ hashFiles('scripts/environment/*.sh') }}
+        key: ${{ runner.os }}-cargo-binaries-${{ hashFiles('scripts/environment/*.sh', 'vdev/Cargo.toml') }}
         restore-keys: |
           ${{ runner.os }}-cargo-binaries-
 

--- a/scripts/environment/prepare.sh
+++ b/scripts/environment/prepare.sh
@@ -170,7 +170,10 @@ maybe_install_cargo_tool() {
         cargo install -f --path vdev --locked
       fi
     else
-      cargo "${installer[@]}" vdev --force --locked
+      # binstall unavailable. `cargo install vdev` (no version) would resolve
+      # against crates.io and could pick an older version than the checkout
+      # declares; install from the working tree to match vdev/Cargo.toml.
+      cargo install -f --path vdev --locked
     fi
     return 0
   fi

--- a/scripts/environment/prepare.sh
+++ b/scripts/environment/prepare.sh
@@ -39,7 +39,6 @@ CARGO_LLVM_COV_VERSION="0.8.4"
 WASM_PACK_VERSION="0.13.1"
 # npm tool versions are defined in scripts/environment/npm-tools/package.json
 # and pinned (including transitive deps) in npm-tools/package-lock.json.
-VDEV_VERSION="0.3.3"
 
 ALL_MODULES=(
   rustup
@@ -122,11 +121,13 @@ contains_module() {
 }
 
 # Helper function to check version and install if needed
-# Usage: maybe_install_cargo_tool <tool-name> <version> [<version-check-pattern>]
+# Usage: maybe_install_cargo_tool <tool-name> [<version> [<version-check-pattern>]]
 # Note: cargo-* tools are invoked as "cargo <subcommand>", not as direct binaries
+# vdev omits the version argument: binstall reads it from vdev/Cargo.toml via
+# --manifest-path, which also provides the pkg-url so crates.io is not consulted.
 maybe_install_cargo_tool() {
   local tool="$1"
-  local version="$2"
+  local version="${2:-}"
   local version_pattern="${3:-${tool} ${version}}"  # Default to "tool version"
 
   if ! contains_module "$tool"; then
@@ -139,11 +140,39 @@ maybe_install_cargo_tool() {
     version_cmd="cargo ${tool#cargo-}"
   fi
 
-  # vdev fails fast on missing prebuilts so a cache/asset miss can't
-  # reintroduce the source-compile path that previously stalled a release.
-  local installer=("${install[@]}")
-  if [[ "$tool" == "vdev" && "${installer[0]}" == "binstall" ]]; then
-    installer+=(--disable-strategies compile)
+  # vdev: binstall reads the version and pkg-url from vdev/Cargo.toml via
+  # --manifest-path, so vdev/Cargo.toml is the single source of truth.
+  # `--disable-strategies compile` skips binstall's own crates.io compile
+  # fallback (which would fail anyway on an unpublished version, and
+  # silently slow-paths a cache flake into a multi-minute build). If
+  # binstall fails for any reason — missing prebuilt for a freshly bumped
+  # version, or a transient cache/network issue — we fall back to building
+  # from the working tree. That gives PRs that bump vdev's version a
+  # working binary built from their own changes, and keeps master CI green
+  # in the gap between merging a vdev version bump and pushing the tag.
+  if [[ "$tool" == "vdev" ]]; then
+    # Skip the install entirely when the cached binary already matches the
+    # version in vdev/Cargo.toml (the setup workflow restores ~/.cargo/bin/vdev
+    # from cache, but not binstall's resolution metadata, so without this check
+    # every job with `vdev: true` would re-hit GitHub releases).
+    local cargo_toml_version
+    cargo_toml_version=$(grep -E '^version = ' vdev/Cargo.toml | head -1 | sed -E 's/.*"([^"]+)".*/\1/')
+    if vdev --version 2>/dev/null | grep -q "^vdev ${cargo_toml_version}$"; then
+      echo "vdev ${cargo_toml_version} already installed"
+      return 0
+    fi
+
+    local installer=("${install[@]}")
+    if [[ "${installer[0]}" == "binstall" ]]; then
+      installer+=(--disable-strategies compile)
+      if ! cargo "${installer[@]}" --manifest-path vdev/Cargo.toml vdev; then
+        echo "binstall failed; building vdev from the working tree..."
+        cargo install -f --path vdev --locked
+      fi
+    else
+      cargo "${installer[@]}" vdev --force --locked
+    fi
+    return 0
   fi
 
   if ! $version_cmd --version 2>/dev/null | grep -q "^${version_pattern}"; then
@@ -163,7 +192,7 @@ maybe_install_cargo_tool() {
       fi
     fi
     if [[ "$should_install" == "true" ]]; then
-      cargo "${installer[@]}" "$tool" --version "$version" --force --locked
+      cargo "${install[@]}" "$tool" --version "$version" --force --locked
     fi
   fi
 
@@ -289,6 +318,6 @@ maybe_install_cargo_tool cargo-hack "${CARGO_HACK_VERSION}"
 maybe_install_cargo_tool cargo-llvm-cov "${CARGO_LLVM_COV_VERSION}"
 maybe_install_cargo_tool dd-rust-license-tool "${DD_RUST_LICENSE_TOOL_VERSION}"
 maybe_install_cargo_tool wasm-pack "${WASM_PACK_VERSION}"
-maybe_install_cargo_tool vdev "${VDEV_VERSION}"
+maybe_install_cargo_tool vdev
 
 maybe_install_npm_tools

--- a/vdev/README.md
+++ b/vdev/README.md
@@ -39,7 +39,7 @@ CI installs vdev from a published binary release via [cargo-binstall](https://gi
 ./scripts/environment/prepare.sh --modules=vdev
 ```
 
-This pins the vdev version defined in `prepare.sh` and fetches the matching pre-compiled binary.
+This installs the vdev version declared in `vdev/Cargo.toml` by fetching the matching pre-compiled binary from the GitHub release. If no matching release exists yet — e.g. you're on a branch that bumped the version but hasn't been tagged — `prepare.sh` falls back to building vdev from your working tree (`cargo install --path vdev`), which is slower but ensures the installed binary reflects your branch's vdev source.
 
 For a quick install of the latest published vdev (not pinned):
 


### PR DESCRIPTION
## Summary

Removes the duplicated vdev version pin in `scripts/environment/prepare.sh`. `binstall` now reads vdev's version (and `pkg-url`) from `vdev/Cargo.toml` via `--manifest-path`, so `vdev/Cargo.toml` is the single source of truth.

This collapses the previous two-PR release flow into one:

**Before:**
1. PR A: bump `vdev/Cargo.toml` + tag → workflow publishes binary
2. PR B: bump `VDEV_VERSION` in `prepare.sh` so CI uses the new binary

**After:**
1. One PR: bump `vdev/Cargo.toml` → merge → tag → workflow publishes binary → next CI run uses the new version automatically

### Working-tree fallback

binstall keeps `--disable-strategies compile` (so a cache flake on an existing binary fails fast, preserving the no-silent-slow-path guarantee that closed out the prior release incident). When binstall fails for any reason — missing prebuilt for a freshly bumped version, or a transient flake — `prepare.sh` falls back to `cargo install -f --path vdev --locked`, building from the working tree.

Net effect:
- Released version, healthy cache → fast binstall download (~2s)
- Released version, cache flake → binstall fails fast → working-tree compile (~1m)
- PR bump to unpublished version → binstall fails fast → working-tree compile of the branch's own vdev source
- Master CI between merge and tag push → working-tree compile until the tag lands

The fallback uses `--path vdev` (the local source tree), not crates.io, so a PR that modifies vdev gets tested with its own changes, not whatever's published.

Also includes `vdev/Cargo.toml` in the cargo-binaries cache key so a version bump invalidates the cache.

### Scope notes

Earlier iterations of this PR added `-pr.N` / `-rc` pre-release tag handling to `vdev_publish.yml` so a PR's own CI could validate vdev changes before merge. Dropped per review (YAGNI) — with the working-tree fallback, in-PR vdev validation works without any pre-release tag machinery.

## Vector configuration

NA

## How did you test this PR?

Locally, with both scenarios:

1. `Cargo.toml = 0.3.3` (a published version): `prepare.sh --modules=vdev` → binstall fetched the prebuilt in ~2s. `vdev --version` → `vdev 0.3.3`.
2. `Cargo.toml = 0.99.0-test` (intentionally unpublished): same command → binstall failed → wrapper fell back to `cargo install -f --path vdev --locked` → built from working tree (~55s). `vdev --version` → `vdev 0.99.0-test`.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: #25418 (initial binstall switch)