### PR TITLE
enhancement(sinks): Add Databend ingest modes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -579,6 +579,8 @@ dependencies = [
  "arrow-schema 56.2.0",
  "arrow-select 56.2.0",
  "flatbuffers 25.9.23",
+ "lz4_flex 0.11.6",
+ "zstd 0.13.2",
 ]
 
 [[package]]
@@ -3507,11 +3509,17 @@ checksum = "5c297a1c74b71ae29df00c3e22dd9534821d60eb9af5a0192823fa2acea70c2a"
 
 [[package]]
 name = "databend-client"
-version = "0.28.2"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d689ffeaa08b1e4be3f035fcdadd4ea69db3dbf529ec5668c6911b8a301fc06"
+checksum = "a76c24bd8e4aa91e0b0fcf6569178535c06ccbeb950225b823f009649af9b469"
 dependencies = [
+ "arrow-array 56.2.0",
+ "arrow-ipc 56.2.0",
+ "arrow-schema 56.2.0",
+ "base64 0.22.1",
+ "bytes",
  "cookie",
+ "jiff",
  "log",
  "once_cell",
  "parking_lot",
@@ -6120,10 +6128,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
 dependencies = [
  "jiff-static",
+ "jiff-tzdb",
+ "jiff-tzdb-platform",
  "log",
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -6135,6 +6146,21 @@ dependencies = [
  "proc-macro2 1.0.106",
  "quote 1.0.45",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -377,7 +377,7 @@ chrono.workspace = true
 chrono-tz.workspace = true
 colored.workspace = true
 csv = { version = "1.3", default-features = false }
-databend-client = { version = "0.28.0", default-features = false, features = ["rustls"], optional = true }
+databend-client = { version = "0.34.0", default-features = false, features = ["rustls"], optional = true }
 derivative.workspace = true
 dirs-next = { version = "2.0.0", default-features = false, optional = true }
 dyn-clone = { version = "1.0.20", default-features = false }

--- a/changelog.d/databend_sink_ingest_modes.enhancement.md
+++ b/changelog.d/databend_sink_ingest_modes.enhancement.md
@@ -1,0 +1,3 @@
+Enhance the `databend` sink with zstd compression, staged replace mode via `primary_key`, configurable load mode, staged COPY `on_error`, raw ingest table creation, and metadata path selection for raw records.
+
+authors: sundy

--- a/changelog.d/databend_sink_ingest_modes.enhancement.md
+++ b/changelog.d/databend_sink_ingest_modes.enhancement.md
@@ -1,3 +1,3 @@
-Enhance the `databend` sink with zstd compression, staged replace mode via `primary_key`, configurable load mode, and staged COPY `on_error`.
+Enhance the `databend` sink with zstd compression, staged replace mode via `primary_key`, configurable load mode, staged COPY `on_error`, and `databend-client` 0.34.0.
 
 authors: sundy

--- a/changelog.d/databend_sink_ingest_modes.enhancement.md
+++ b/changelog.d/databend_sink_ingest_modes.enhancement.md
@@ -1,3 +1,3 @@
-Enhance the `databend` sink with zstd compression, staged replace mode via `primary_key`, configurable load mode, staged COPY `on_error`, raw ingest table creation, and metadata path selection for raw records.
+Enhance the `databend` sink with zstd compression, staged replace mode via `primary_key`, configurable load mode, staged COPY `on_error`, raw ingest table creation, and metadata-driven columns for raw records.
 
 authors: sundy

--- a/changelog.d/databend_sink_ingest_modes.enhancement.md
+++ b/changelog.d/databend_sink_ingest_modes.enhancement.md
@@ -1,3 +1,3 @@
-Enhance the `databend` sink with zstd compression, staged replace mode via `primary_key`, configurable load mode, staged COPY `on_error`, raw ingest table creation, and metadata-driven columns for raw records.
+Enhance the `databend` sink with zstd compression, staged replace mode via `primary_key`, configurable load mode, and staged COPY `on_error`.
 
 authors: sundy

--- a/src/sinks/databend/compression.rs
+++ b/src/sinks/databend/compression.rs
@@ -17,4 +17,9 @@ pub enum DatabendCompression {
     ///
     /// [gzip]: https://www.gzip.org/
     Gzip,
+
+    /// [Zstandard][zstd] compression.
+    ///
+    /// [zstd]: https://facebook.github.io/zstd/
+    Zstd,
 }

--- a/src/sinks/databend/config.rs
+++ b/src/sinks/databend/config.rs
@@ -38,51 +38,6 @@ fn default_stage_path_prefix() -> String {
     "vector".to_string()
 }
 
-fn default_raw_message_key() -> String {
-    "message".to_string()
-}
-
-pub(crate) fn raw_metadata_column_name(path: &str) -> Option<String> {
-    let path = path.trim();
-    if path.is_empty() {
-        return None;
-    }
-
-    if path == "*" {
-        Some("metadata".to_string())
-    } else {
-        Some(path.to_string())
-    }
-}
-
-fn quote_databend_identifier(identifier: &str) -> String {
-    format!("\"{}\"", identifier.replace('"', "\"\""))
-}
-
-fn raw_create_table_sql(table: &str, raw: &DatabendRawOptions) -> String {
-    let mut columns = vec![
-        "raw_data JSON".to_string(),
-        "add_time TIMESTAMP".to_string(),
-    ];
-    let mut seen_columns = std::collections::BTreeSet::new();
-
-    for path in &raw.metadata.includes {
-        let Some(column) = raw_metadata_column_name(path) else {
-            continue;
-        };
-
-        if seen_columns.insert(column.clone()) {
-            columns.push(format!("{} JSON", quote_databend_identifier(&column)));
-        }
-    }
-
-    format!(
-        "CREATE TABLE IF NOT EXISTS {} ({})",
-        table,
-        columns.join(", ")
-    )
-}
-
 /// Databend load API to use for this sink.
 #[configurable_component]
 #[derive(Clone, Copy, Debug, Default)]
@@ -94,30 +49,6 @@ pub enum DatabendLoadMode {
 
     /// Stream each batch directly through Databend's `/v1/streaming_load` endpoint.
     Streaming,
-}
-
-/// Metadata options for raw ingest records.
-#[configurable_component]
-#[derive(Clone, Debug)]
-#[serde(default)]
-pub struct DatabendRawMetadataOptions {
-    /// Vector metadata paths to include as raw metadata columns.
-    ///
-    /// If unset, all metadata is included in the `metadata` column. If set to an empty array,
-    /// no metadata columns are included.
-    pub includes: Vec<String>,
-}
-
-impl Default for DatabendRawMetadataOptions {
-    fn default() -> Self {
-        Self {
-            includes: vec!["*".to_string()],
-        }
-    }
-}
-
-fn default_raw_metadata() -> DatabendRawMetadataOptions {
-    DatabendRawMetadataOptions::default()
 }
 
 /// COPY options used by staged Databend loads.
@@ -167,37 +98,6 @@ impl DatabendCopyOnError {
         match self {
             Self::Abort => "abort",
             Self::Continue => "continue",
-        }
-    }
-}
-
-/// Raw ingest mode.
-#[configurable_component]
-#[derive(Clone, Debug)]
-#[serde(default)]
-pub struct DatabendRawOptions {
-    /// Enable raw records.
-    pub enabled: bool,
-
-    /// Controls which Vector metadata fields are copied into generated raw metadata columns.
-    #[serde(default = "default_raw_metadata")]
-    pub metadata: DatabendRawMetadataOptions,
-
-    /// Create the raw target table during sink startup if it does not exist.
-    pub create_table: bool,
-
-    /// Event field containing the raw Kafka payload.
-    #[serde(default = "default_raw_message_key")]
-    pub message_key: String,
-}
-
-impl Default for DatabendRawOptions {
-    fn default() -> Self {
-        Self {
-            enabled: false,
-            metadata: default_raw_metadata(),
-            create_table: false,
-            message_key: default_raw_message_key(),
         }
     }
 }
@@ -262,13 +162,9 @@ pub struct DatabendConfig {
     /// Columns used for `REPLACE INTO ... ON (...)`.
     ///
     /// When empty, Databend uses normal insert mode. When non-empty, Databend uses replace mode.
-    /// This is independent of raw mode. Configure it to match the target table's logical key.
+    /// Configure it to match the target table's logical key.
     #[serde(default)]
     pub primary_key: Vec<String>,
-
-    /// Raw ingest options.
-    #[serde(default)]
-    pub raw: DatabendRawOptions,
 
     #[configurable(derived)]
     #[serde(default)]
@@ -412,10 +308,6 @@ impl SinkConfig for DatabendConfig {
         copy_options.insert("on_error", self.copy_options.on_error.as_str());
 
         let client = DatabendAPIClient::new(&endpoint, Some(ua)).await?;
-        if self.raw.create_table {
-            let sql = raw_create_table_sql(&self.table, &self.raw);
-            client.query_all(&sql).await?;
-        }
         let service = DatabendService::new(
             client,
             DatabendServiceSettings {
@@ -433,8 +325,7 @@ impl SinkConfig for DatabendConfig {
             .service(service);
 
         let encoder = Encoder::<Framer>::new(framer, serializer);
-        let request_builder =
-            DatabendRequestBuilder::new(compression, (transformer, encoder), self.raw.clone());
+        let request_builder = DatabendRequestBuilder::new(compression, (transformer, encoder));
 
         let sink = DatabendSink::new(batch_settings, request_builder, service);
 
@@ -524,10 +415,6 @@ mod tests {
             copy_options.disable_variant_check = true
             copy_options.on_error = "continue"
             primary_key = ["id", "source"]
-            raw.enabled = true
-            raw.create_table = true
-            raw.message_key = "message"
-            raw.metadata.includes = ["%kafka.topic", "%kafka.partition", "%kafka.offset", "%kafka.message_key"]
         "#,
         )
         .unwrap();
@@ -544,61 +431,6 @@ mod tests {
             DatabendCopyOnError::Continue
         ));
         assert_eq!(cfg.primary_key, ["id", "source"]);
-        assert!(cfg.raw.enabled);
-        assert!(cfg.raw.create_table);
-        assert_eq!(
-            cfg.raw.metadata.includes,
-            [
-                "%kafka.topic",
-                "%kafka.partition",
-                "%kafka.offset",
-                "%kafka.message_key",
-            ]
-        );
-    }
-
-    #[test]
-    fn parse_config_with_default_raw_metadata_includes_all() {
-        let cfg = toml::from_str::<DatabendConfig>(
-            r#"
-            endpoint = "databend://localhost:8000/mydatabase?sslmode=disable"
-            table = "mytable"
-            raw.enabled = true
-        "#,
-        )
-        .unwrap();
-
-        assert_eq!(cfg.raw.metadata.includes, [String::from("*")]);
-    }
-
-    #[test]
-    fn parse_config_with_empty_raw_metadata_config_includes_all() {
-        let cfg = toml::from_str::<DatabendConfig>(
-            r#"
-            endpoint = "databend://localhost:8000/mydatabase?sslmode=disable"
-            table = "mytable"
-            raw.enabled = true
-            raw.metadata = {}
-        "#,
-        )
-        .unwrap();
-
-        assert_eq!(cfg.raw.metadata.includes, [String::from("*")]);
-    }
-
-    #[test]
-    fn parse_config_with_empty_raw_metadata_includes_none() {
-        let cfg = toml::from_str::<DatabendConfig>(
-            r#"
-            endpoint = "databend://localhost:8000/mydatabase?sslmode=disable"
-            table = "mytable"
-            raw.enabled = true
-            raw.metadata.includes = []
-        "#,
-        )
-        .unwrap();
-
-        assert!(cfg.raw.metadata.includes.is_empty());
     }
 
     #[test]
@@ -612,40 +444,5 @@ mod tests {
         .unwrap();
 
         assert!(cfg.primary_key.is_empty());
-    }
-
-    #[test]
-    fn raw_metadata_column_names_are_sanitized() {
-        assert_eq!(
-            raw_metadata_column_name("%kafka.topic"),
-            Some("%kafka.topic".to_string())
-        );
-        assert_eq!(
-            raw_metadata_column_name("%kafka.partition"),
-            Some("%kafka.partition".to_string())
-        );
-        assert_eq!(raw_metadata_column_name("*"), Some("metadata".to_string()));
-        assert_eq!(raw_metadata_column_name(""), None);
-    }
-
-    #[test]
-    fn raw_create_table_uses_metadata_includes_as_columns() {
-        let raw = DatabendRawOptions {
-            enabled: true,
-            metadata: DatabendRawMetadataOptions {
-                includes: vec![
-                    "%kafka.topic".to_string(),
-                    "%kafka.partition".to_string(),
-                    "%kafka.topic".to_string(),
-                ],
-            },
-            create_table: true,
-            message_key: default_raw_message_key(),
-        };
-
-        assert_eq!(
-            raw_create_table_sql("raw_events", &raw),
-            "CREATE TABLE IF NOT EXISTS raw_events (raw_data JSON, add_time TIMESTAMP, \"%kafka.topic\" JSON, \"%kafka.partition\" JSON)"
-        );
     }
 }

--- a/src/sinks/databend/config.rs
+++ b/src/sinks/databend/config.rs
@@ -338,7 +338,7 @@ impl SinkConfig for DatabendConfig {
 }
 
 async fn select_one(client: Arc<DatabendAPIClient>) -> crate::Result<()> {
-    client.query_all("SELECT 1").await?;
+    client.query_all("SELECT 1", None).await?;
     Ok(())
 }
 

--- a/src/sinks/databend/config.rs
+++ b/src/sinks/databend/config.rs
@@ -42,6 +42,66 @@ fn default_raw_message_key() -> String {
     "message".to_string()
 }
 
+pub(crate) fn raw_metadata_column_name(path: &str) -> Option<String> {
+    let path = path.trim();
+    let path = if path == "*" {
+        "metadata"
+    } else {
+        path.trim_start_matches('%')
+    };
+
+    let mut column = String::new();
+    let mut previous_was_underscore = false;
+    for char in path.chars() {
+        if char.is_ascii_alphanumeric() {
+            column.push(char.to_ascii_lowercase());
+            previous_was_underscore = false;
+        } else if !previous_was_underscore {
+            column.push('_');
+            previous_was_underscore = true;
+        }
+    }
+    let column = column.trim_matches('_');
+    if column.is_empty() {
+        return None;
+    }
+
+    let mut column = column.to_string();
+    if column
+        .chars()
+        .next()
+        .is_some_and(|char| char.is_ascii_digit())
+    {
+        column.insert(0, '_');
+    }
+
+    Some(column)
+}
+
+fn raw_create_table_sql(table: &str, raw: &DatabendRawOptions) -> String {
+    let mut columns = vec![
+        "raw_data JSON".to_string(),
+        "add_time TIMESTAMP".to_string(),
+    ];
+    let mut seen_columns = std::collections::BTreeSet::new();
+
+    for path in &raw.metadata.includes {
+        let Some(column) = raw_metadata_column_name(path) else {
+            continue;
+        };
+
+        if seen_columns.insert(column.clone()) {
+            columns.push(format!("{column} JSON"));
+        }
+    }
+
+    format!(
+        "CREATE TABLE IF NOT EXISTS {} ({})",
+        table,
+        columns.join(", ")
+    )
+}
+
 /// Databend load API to use for this sink.
 #[configurable_component]
 #[derive(Clone, Copy, Debug, Default)]
@@ -60,10 +120,10 @@ pub enum DatabendLoadMode {
 #[derive(Clone, Debug)]
 #[serde(default)]
 pub struct DatabendRawMetadataOptions {
-    /// Vector metadata paths to include in `record_metadata`.
+    /// Vector metadata paths to include as raw metadata columns.
     ///
-    /// If unset, all supported metadata fields are included. If set to an empty array, no
-    /// metadata fields are included.
+    /// If unset, all metadata is included in the `metadata` column. If set to an empty array,
+    /// no metadata columns are included.
     pub includes: Vec<String>,
 }
 
@@ -130,15 +190,15 @@ impl DatabendCopyOnError {
     }
 }
 
-/// Raw Kafka ingest compatibility mode.
+/// Raw ingest mode.
 #[configurable_component]
 #[derive(Clone, Debug)]
 #[serde(default)]
 pub struct DatabendRawOptions {
-    /// Enable bend-ingest-kafka compatible raw records.
+    /// Enable raw records.
     pub enabled: bool,
 
-    /// Controls which Vector metadata fields are copied into `record_metadata`.
+    /// Controls which Vector metadata fields are copied into generated raw metadata columns.
     #[serde(default = "default_raw_metadata")]
     pub metadata: DatabendRawMetadataOptions,
 
@@ -225,7 +285,7 @@ pub struct DatabendConfig {
     #[serde(default)]
     pub primary_key: Vec<String>,
 
-    /// bend-ingest-kafka compatible raw Kafka ingest options.
+    /// Raw ingest options.
     #[serde(default)]
     pub raw: DatabendRawOptions,
 
@@ -372,10 +432,7 @@ impl SinkConfig for DatabendConfig {
 
         let client = DatabendAPIClient::new(&endpoint, Some(ua)).await?;
         if self.raw.create_table {
-            let sql = format!(
-                "CREATE TABLE IF NOT EXISTS {} (uuid String, koffset BIGINT, kpartition INT, raw_data JSON, record_metadata JSON, add_time TIMESTAMP)",
-                self.table
-            );
+            let sql = raw_create_table_sql(&self.table, &self.raw);
             client.query_all(&sql).await?;
         }
         let service = DatabendService::new(
@@ -574,5 +631,40 @@ mod tests {
         .unwrap();
 
         assert!(cfg.primary_key.is_empty());
+    }
+
+    #[test]
+    fn raw_metadata_column_names_are_sanitized() {
+        assert_eq!(
+            raw_metadata_column_name("%kafka.topic"),
+            Some("kafka_topic".to_string())
+        );
+        assert_eq!(
+            raw_metadata_column_name("%kafka.partition"),
+            Some("kafka_partition".to_string())
+        );
+        assert_eq!(raw_metadata_column_name("*"), Some("metadata".to_string()));
+        assert_eq!(raw_metadata_column_name(""), None);
+    }
+
+    #[test]
+    fn raw_create_table_uses_metadata_includes_as_columns() {
+        let raw = DatabendRawOptions {
+            enabled: true,
+            metadata: DatabendRawMetadataOptions {
+                includes: vec![
+                    "%kafka.topic".to_string(),
+                    "%kafka.partition".to_string(),
+                    "%kafka.topic".to_string(),
+                ],
+            },
+            create_table: true,
+            message_key: default_raw_message_key(),
+        };
+
+        assert_eq!(
+            raw_create_table_sql("raw_events", &raw),
+            "CREATE TABLE IF NOT EXISTS raw_events (raw_data JSON, add_time TIMESTAMP, kafka_topic JSON, kafka_partition JSON)"
+        );
     }
 }

--- a/src/sinks/databend/config.rs
+++ b/src/sinks/databend/config.rs
@@ -12,7 +12,7 @@ use super::{
     compression::DatabendCompression,
     encoding::{DatabendEncodingConfig, DatabendMissingFieldAS, DatabendSerializerConfig},
     request_builder::DatabendRequestBuilder,
-    service::{DatabendRetryLogic, DatabendService},
+    service::{DatabendRetryLogic, DatabendService, DatabendServiceSettings},
     sink::DatabendSink,
 };
 use crate::{
@@ -29,6 +29,137 @@ use crate::{
     tls::TlsConfig,
     vector_version,
 };
+
+fn default_stage() -> String {
+    "~".to_string()
+}
+
+fn default_stage_path_prefix() -> String {
+    "vector".to_string()
+}
+
+fn default_raw_message_key() -> String {
+    "message".to_string()
+}
+
+/// Databend load API to use for this sink.
+#[configurable_component]
+#[derive(Clone, Copy, Debug, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum DatabendLoadMode {
+    /// Upload each batch to a stage, then load it into the table.
+    #[default]
+    Staged,
+
+    /// Stream each batch directly through Databend's `/v1/streaming_load` endpoint.
+    Streaming,
+}
+
+/// Metadata options for raw ingest records.
+#[configurable_component]
+#[derive(Clone, Debug)]
+#[serde(default)]
+pub struct DatabendRawMetadataOptions {
+    /// Vector metadata paths to include in `record_metadata`.
+    ///
+    /// If unset, all supported metadata fields are included. If set to an empty array, no
+    /// metadata fields are included.
+    pub includes: Vec<String>,
+}
+
+impl Default for DatabendRawMetadataOptions {
+    fn default() -> Self {
+        Self {
+            includes: vec!["*".to_string()],
+        }
+    }
+}
+
+fn default_raw_metadata() -> DatabendRawMetadataOptions {
+    DatabendRawMetadataOptions::default()
+}
+
+/// COPY options used by staged Databend loads.
+#[configurable_component]
+#[derive(Clone, Debug)]
+#[serde(default)]
+pub struct DatabendCopyOptions {
+    /// Whether to remove loaded files from the stage after a successful load.
+    pub purge: bool,
+
+    /// Whether to load files even if Databend has loaded them before.
+    pub force: bool,
+
+    /// Whether to disable variant type checks while loading.
+    pub disable_variant_check: bool,
+
+    /// How Databend handles errors while loading staged files.
+    pub on_error: DatabendCopyOnError,
+}
+
+impl Default for DatabendCopyOptions {
+    fn default() -> Self {
+        Self {
+            purge: true,
+            force: false,
+            disable_variant_check: false,
+            on_error: DatabendCopyOnError::Abort,
+        }
+    }
+}
+
+/// COPY `ON_ERROR` behavior.
+#[configurable_component]
+#[derive(Clone, Copy, Debug, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum DatabendCopyOnError {
+    /// Abort the load when an error is encountered.
+    #[default]
+    Abort,
+
+    /// Continue loading other rows when an error is encountered.
+    Continue,
+}
+
+impl DatabendCopyOnError {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Abort => "abort",
+            Self::Continue => "continue",
+        }
+    }
+}
+
+/// Raw Kafka ingest compatibility mode.
+#[configurable_component]
+#[derive(Clone, Debug)]
+#[serde(default)]
+pub struct DatabendRawOptions {
+    /// Enable bend-ingest-kafka compatible raw records.
+    pub enabled: bool,
+
+    /// Controls which Vector metadata fields are copied into `record_metadata`.
+    #[serde(default = "default_raw_metadata")]
+    pub metadata: DatabendRawMetadataOptions,
+
+    /// Create the raw target table during sink startup if it does not exist.
+    pub create_table: bool,
+
+    /// Event field containing the raw Kafka payload.
+    #[serde(default = "default_raw_message_key")]
+    pub message_key: String,
+}
+
+impl Default for DatabendRawOptions {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            metadata: default_raw_metadata(),
+            create_table: false,
+            message_key: default_raw_message_key(),
+        }
+    }
+}
 
 /// Configuration for the `databend` sink.
 #[configurable_component(sink("databend", "Deliver log data to a Databend database."))]
@@ -70,6 +201,33 @@ pub struct DatabendConfig {
     #[configurable(derived)]
     #[serde(default)]
     pub compression: DatabendCompression,
+
+    /// The Databend load API to use.
+    #[serde(default)]
+    pub load_mode: DatabendLoadMode,
+
+    /// The user stage to upload staged batch files into.
+    #[serde(default = "default_stage")]
+    pub stage: String,
+
+    /// Path prefix used under `stage` for staged batch files.
+    #[serde(default = "default_stage_path_prefix")]
+    pub stage_path_prefix: String,
+
+    /// COPY options for staged loads.
+    #[serde(default)]
+    pub copy_options: DatabendCopyOptions,
+
+    /// Columns used for `REPLACE INTO ... ON (...)`.
+    ///
+    /// When empty, Databend uses normal insert mode. When non-empty, Databend uses replace mode.
+    /// This is independent of raw mode. Configure it to match the target table's logical key.
+    #[serde(default)]
+    pub primary_key: Vec<String>,
+
+    /// bend-ingest-kafka compatible raw Kafka ingest options.
+    #[serde(default)]
+    pub raw: DatabendRawOptions,
 
     #[configurable(derived)]
     #[serde(default)]
@@ -158,6 +316,10 @@ impl SinkConfig for DatabendConfig {
                 file_format_options.insert("compression", "NONE");
                 Compression::None
             }
+            DatabendCompression::Zstd => {
+                file_format_options.insert("compression", "ZSTD");
+                Compression::zstd_default()
+            }
         };
         let encoding: EncodingConfig = self.encoding.clone().into();
         let serializer = match self.encoding.config() {
@@ -177,22 +339,64 @@ impl SinkConfig for DatabendConfig {
         let framer = FramingConfig::NewlineDelimited.build();
         let transformer = encoding.transformer();
 
+        if matches!(self.load_mode, DatabendLoadMode::Streaming) {
+            file_format_options.insert("compression", "AUTO");
+        }
+
         let mut copy_options = BTreeMap::new();
-        copy_options.insert("purge", "true");
+        copy_options.insert(
+            "purge",
+            if self.copy_options.purge {
+                "true"
+            } else {
+                "false"
+            },
+        );
+        copy_options.insert(
+            "force",
+            if self.copy_options.force {
+                "true"
+            } else {
+                "false"
+            },
+        );
+        copy_options.insert(
+            "disable_variant_check",
+            if self.copy_options.disable_variant_check {
+                "true"
+            } else {
+                "false"
+            },
+        );
+        copy_options.insert("on_error", self.copy_options.on_error.as_str());
 
         let client = DatabendAPIClient::new(&endpoint, Some(ua)).await?;
+        if self.raw.create_table {
+            let sql = format!(
+                "CREATE TABLE IF NOT EXISTS {} (uuid String, koffset BIGINT, kpartition INT, raw_data JSON, record_metadata JSON, add_time TIMESTAMP)",
+                self.table
+            );
+            client.query_all(&sql).await?;
+        }
         let service = DatabendService::new(
             client,
-            self.table.clone(),
-            file_format_options,
-            copy_options,
+            DatabendServiceSettings {
+                table: self.table.clone(),
+                load_mode: self.load_mode,
+                stage: self.stage.clone(),
+                stage_path_prefix: self.stage_path_prefix.clone(),
+                file_format_options,
+                copy_options,
+                primary_key: self.primary_key.clone(),
+            },
         )?;
         let service = ServiceBuilder::new()
             .settings(request_settings, DatabendRetryLogic)
             .service(service);
 
         let encoder = Encoder::<Framer>::new(framer, serializer);
-        let request_builder = DatabendRequestBuilder::new(compression, (transformer, encoder));
+        let request_builder =
+            DatabendRequestBuilder::new(compression, (transformer, encoder), self.raw.clone());
 
         let sink = DatabendSink::new(batch_settings, request_builder, service);
 
@@ -265,5 +469,110 @@ mod tests {
             DatabendSerializerConfig::Csv(_)
         ));
         assert!(matches!(cfg.compression, DatabendCompression::Gzip));
+    }
+
+    #[test]
+    fn parse_config_with_ingest_options() {
+        let cfg = toml::from_str::<DatabendConfig>(
+            r#"
+            endpoint = "databend://localhost:8000/mydatabase?sslmode=disable"
+            table = "mytable"
+            compression = "zstd"
+            load_mode = "streaming"
+            stage = "ingest_stage"
+            stage_path_prefix = "kafka"
+            copy_options.purge = false
+            copy_options.force = true
+            copy_options.disable_variant_check = true
+            copy_options.on_error = "continue"
+            primary_key = ["id", "source"]
+            raw.enabled = true
+            raw.create_table = true
+            raw.message_key = "message"
+            raw.metadata.includes = ["%kafka.topic", "%kafka.partition", "%kafka.offset", "%kafka.message_key"]
+        "#,
+        )
+        .unwrap();
+
+        assert!(matches!(cfg.compression, DatabendCompression::Zstd));
+        assert!(matches!(cfg.load_mode, DatabendLoadMode::Streaming));
+        assert_eq!(cfg.stage, "ingest_stage");
+        assert_eq!(cfg.stage_path_prefix, "kafka");
+        assert!(!cfg.copy_options.purge);
+        assert!(cfg.copy_options.force);
+        assert!(cfg.copy_options.disable_variant_check);
+        assert!(matches!(
+            cfg.copy_options.on_error,
+            DatabendCopyOnError::Continue
+        ));
+        assert_eq!(cfg.primary_key, ["id", "source"]);
+        assert!(cfg.raw.enabled);
+        assert!(cfg.raw.create_table);
+        assert_eq!(
+            cfg.raw.metadata.includes,
+            [
+                "%kafka.topic",
+                "%kafka.partition",
+                "%kafka.offset",
+                "%kafka.message_key",
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_config_with_default_raw_metadata_includes_all() {
+        let cfg = toml::from_str::<DatabendConfig>(
+            r#"
+            endpoint = "databend://localhost:8000/mydatabase?sslmode=disable"
+            table = "mytable"
+            raw.enabled = true
+        "#,
+        )
+        .unwrap();
+
+        assert_eq!(cfg.raw.metadata.includes, [String::from("*")]);
+    }
+
+    #[test]
+    fn parse_config_with_empty_raw_metadata_config_includes_all() {
+        let cfg = toml::from_str::<DatabendConfig>(
+            r#"
+            endpoint = "databend://localhost:8000/mydatabase?sslmode=disable"
+            table = "mytable"
+            raw.enabled = true
+            raw.metadata = {}
+        "#,
+        )
+        .unwrap();
+
+        assert_eq!(cfg.raw.metadata.includes, [String::from("*")]);
+    }
+
+    #[test]
+    fn parse_config_with_empty_raw_metadata_includes_none() {
+        let cfg = toml::from_str::<DatabendConfig>(
+            r#"
+            endpoint = "databend://localhost:8000/mydatabase?sslmode=disable"
+            table = "mytable"
+            raw.enabled = true
+            raw.metadata.includes = []
+        "#,
+        )
+        .unwrap();
+
+        assert!(cfg.raw.metadata.includes.is_empty());
+    }
+
+    #[test]
+    fn parse_config_with_default_primary_key_empty() {
+        let cfg = toml::from_str::<DatabendConfig>(
+            r#"
+            endpoint = "databend://localhost:8000/mydatabase?sslmode=disable"
+            table = "mytable"
+        "#,
+        )
+        .unwrap();
+
+        assert!(cfg.primary_key.is_empty());
     }
 }

--- a/src/sinks/databend/config.rs
+++ b/src/sinks/databend/config.rs
@@ -276,10 +276,6 @@ impl SinkConfig for DatabendConfig {
         let framer = FramingConfig::NewlineDelimited.build();
         let transformer = encoding.transformer();
 
-        if matches!(self.load_mode, DatabendLoadMode::Streaming) {
-            file_format_options.insert("compression", "AUTO");
-        }
-
         let mut copy_options = BTreeMap::new();
         copy_options.insert(
             "purge",

--- a/src/sinks/databend/config.rs
+++ b/src/sinks/databend/config.rs
@@ -44,38 +44,19 @@ fn default_raw_message_key() -> String {
 
 pub(crate) fn raw_metadata_column_name(path: &str) -> Option<String> {
     let path = path.trim();
-    let path = if path == "*" {
-        "metadata"
-    } else {
-        path.trim_start_matches('%')
-    };
-
-    let mut column = String::new();
-    let mut previous_was_underscore = false;
-    for char in path.chars() {
-        if char.is_ascii_alphanumeric() {
-            column.push(char.to_ascii_lowercase());
-            previous_was_underscore = false;
-        } else if !previous_was_underscore {
-            column.push('_');
-            previous_was_underscore = true;
-        }
-    }
-    let column = column.trim_matches('_');
-    if column.is_empty() {
+    if path.is_empty() {
         return None;
     }
 
-    let mut column = column.to_string();
-    if column
-        .chars()
-        .next()
-        .is_some_and(|char| char.is_ascii_digit())
-    {
-        column.insert(0, '_');
+    if path == "*" {
+        Some("metadata".to_string())
+    } else {
+        Some(path.to_string())
     }
+}
 
-    Some(column)
+fn quote_databend_identifier(identifier: &str) -> String {
+    format!("\"{}\"", identifier.replace('"', "\"\""))
 }
 
 fn raw_create_table_sql(table: &str, raw: &DatabendRawOptions) -> String {
@@ -91,7 +72,7 @@ fn raw_create_table_sql(table: &str, raw: &DatabendRawOptions) -> String {
         };
 
         if seen_columns.insert(column.clone()) {
-            columns.push(format!("{column} JSON"));
+            columns.push(format!("{} JSON", quote_databend_identifier(&column)));
         }
     }
 
@@ -637,11 +618,11 @@ mod tests {
     fn raw_metadata_column_names_are_sanitized() {
         assert_eq!(
             raw_metadata_column_name("%kafka.topic"),
-            Some("kafka_topic".to_string())
+            Some("%kafka.topic".to_string())
         );
         assert_eq!(
             raw_metadata_column_name("%kafka.partition"),
-            Some("kafka_partition".to_string())
+            Some("%kafka.partition".to_string())
         );
         assert_eq!(raw_metadata_column_name("*"), Some("metadata".to_string()));
         assert_eq!(raw_metadata_column_name(""), None);
@@ -664,7 +645,7 @@ mod tests {
 
         assert_eq!(
             raw_create_table_sql("raw_events", &raw),
-            "CREATE TABLE IF NOT EXISTS raw_events (raw_data JSON, add_time TIMESTAMP, kafka_topic JSON, kafka_partition JSON)"
+            "CREATE TABLE IF NOT EXISTS raw_events (raw_data JSON, add_time TIMESTAMP, \"%kafka.topic\" JSON, \"%kafka.partition\" JSON)"
         );
     }
 }

--- a/src/sinks/databend/integration_tests.rs
+++ b/src/sinks/databend/integration_tests.rs
@@ -111,7 +111,7 @@ fn make_copy_error_event(id: Value, value: &str) -> Event {
 async fn insert_event_with_cfg(cfg: String, table: String, client: Arc<DatabendAPIClient>) {
     let create_table_sql =
         format!("create table `{table}` (host String, timestamp String, message String)");
-    client.query_all(&create_table_sql).await.unwrap();
+    client.query_all(&create_table_sql, None).await.unwrap();
 
     let (config, _) = load_sink::<DatabendConfig>(&cfg).unwrap();
     let (sink, _hc) = config.build(SinkContext::default()).await.unwrap();
@@ -125,7 +125,7 @@ async fn insert_event_with_cfg(cfg: String, table: String, client: Arc<DatabendA
     .await;
 
     let select_all_sql = format!("select * from `{table}`");
-    let resp = client.query_all(&select_all_sql).await.unwrap();
+    let resp = client.query_all(&select_all_sql, None).await.unwrap();
     assert_eq!(1, resp.data.len());
 
     // drop input_event after comparing with response
@@ -180,7 +180,10 @@ async fn staged_copy_on_error_continue_skips_bad_rows() {
         .await
         .unwrap();
     client
-        .query_all(&format!("create table `{table}` (id Int64, value String)"))
+        .query_all(
+            &format!("create table `{table}` (id Int64, value String)"),
+            None,
+        )
         .await
         .unwrap();
 
@@ -208,7 +211,10 @@ async fn staged_copy_on_error_continue_skips_bad_rows() {
     .await;
 
     let resp = client
-        .query_all(&format!("select id, value from `{table}` order by id"))
+        .query_all(
+            &format!("select id, value from `{table}` order by id"),
+            None,
+        )
         .await
         .unwrap();
     assert_eq!(1, resp.data.len());
@@ -226,9 +232,10 @@ async fn replace_event_with_primary_key() {
         .await
         .unwrap();
     client
-        .query_all(&format!(
-            "create table `{table}` (id Int64, source String, value String)"
-        ))
+        .query_all(
+            &format!("create table `{table}` (id Int64, source String, value String)"),
+            None,
+        )
         .await
         .unwrap();
 
@@ -257,9 +264,10 @@ async fn replace_event_with_primary_key() {
     .await;
 
     let resp = client
-        .query_all(&format!(
-            "select id, source, value from `{table}` order by id"
-        ))
+        .query_all(
+            &format!("select id, source, value from `{table}` order by id"),
+            None,
+        )
         .await
         .unwrap();
     assert_eq!(2, resp.data.len());

--- a/src/sinks/databend/integration_tests.rs
+++ b/src/sinks/databend/integration_tests.rs
@@ -2,10 +2,7 @@ use std::{collections::BTreeMap, sync::Arc};
 
 use databend_client::{APIClient as DatabendAPIClient, Page};
 use futures::{future::ready, stream};
-use vector_lib::{
-    event::{BatchNotifier, BatchStatus, BatchStatusReceiver, Event, LogEvent, ObjectMap, Value},
-    lookup::{PathPrefix, path},
-};
+use vector_lib::event::{BatchNotifier, BatchStatus, BatchStatusReceiver, Event, LogEvent, Value};
 
 use super::config::DatabendConfig;
 use crate::{
@@ -96,30 +93,6 @@ async fn prepare_config(
     (cfg, table, client)
 }
 
-async fn prepare_raw_config() -> (String, String, Arc<DatabendAPIClient>) {
-    trace_init();
-
-    let table = random_table_name();
-    let endpoint = databend_endpoint();
-    let client = DatabendAPIClient::new(&endpoint, Some("vector/integration-test".to_string()))
-        .await
-        .unwrap();
-
-    let cfg = format!(
-        r#"
-            endpoint = "{endpoint}"
-            table = "{table}"
-            batch.max_events = 1
-            encoding.codec = "json"
-            raw.enabled = true
-            raw.create_table = true
-            raw.metadata.includes = ["%file.path", "%file.offset"]
-        "#,
-    );
-
-    (cfg, table, client)
-}
-
 fn make_replace_event(id: i64, source: &str, value: &str) -> Event {
     let mut event = LogEvent::default();
     event.insert("id", id);
@@ -132,15 +105,6 @@ fn make_copy_error_event(id: Value, value: &str) -> Event {
     let mut event = LogEvent::default();
     event.insert("id", id);
     event.insert("value", value);
-    event.into()
-}
-
-fn make_raw_event(message: &str) -> Event {
-    let mut event = LogEvent::from(message);
-    let mut file = ObjectMap::new();
-    file.insert("path".into(), "/tmp/vector/raw.log".into());
-    file.insert("offset".into(), 42.into());
-    event.insert((PathPrefix::Metadata, path!("file")), Value::Object(file));
     event.into()
 }
 
@@ -304,34 +268,6 @@ async fn replace_event_with_primary_key() {
     assert_eq!(Some("new".to_string()), resp.data[0][2]);
     assert_eq!(Some("2".to_string()), resp.data[1][0]);
     assert_eq!(Some("steady".to_string()), resp.data[1][2]);
-}
-
-#[tokio::test]
-async fn raw_auto_create_table_with_metadata_paths() {
-    let (cfg, table, client) = prepare_raw_config().await;
-    let (config, _) = load_sink::<DatabendConfig>(&cfg).unwrap();
-    let (sink, _hc) = config.build(SinkContext::default()).await.unwrap();
-
-    run_and_assert_sink_compliance(
-        sink,
-        stream::once(ready(make_raw_event(r#"{"event":"raw-a","n":1}"#))),
-        &HTTP_SINK_TAGS,
-    )
-    .await;
-
-    let resp = client
-        .query_all(&format!(
-            "select raw_data::String, \"%file.path\"::String, \"%file.offset\"::String from `{table}`"
-        ))
-        .await
-        .unwrap();
-    assert_eq!(1, resp.data.len());
-    assert_eq!(
-        Some(r#"{"event":"raw-a","n":1}"#.to_string()),
-        resp.data[0][0]
-    );
-    assert_eq!(Some("/tmp/vector/raw.log".to_string()), resp.data[0][1]);
-    assert_eq!(Some("42".to_string()), resp.data[0][2]);
 }
 
 fn response_to_map(resp: &Page) -> Vec<BTreeMap<String, Option<String>>> {

--- a/src/sinks/databend/integration_tests.rs
+++ b/src/sinks/databend/integration_tests.rs
@@ -113,7 +113,7 @@ async fn prepare_raw_config() -> (String, String, Arc<DatabendAPIClient>) {
             encoding.codec = "json"
             raw.enabled = true
             raw.create_table = true
-            raw.metadata.includes = ["%file"]
+            raw.metadata.includes = ["%file.path", "%file.offset"]
         "#,
     );
 
@@ -321,7 +321,7 @@ async fn raw_auto_create_table_with_metadata_paths() {
 
     let resp = client
         .query_all(&format!(
-            "select raw_data::String, record_metadata::String from `{table}`"
+            "select raw_data::String, file_path::String, file_offset::String from `{table}`"
         ))
         .await
         .unwrap();
@@ -330,10 +330,8 @@ async fn raw_auto_create_table_with_metadata_paths() {
         Some(r#"{"event":"raw-a","n":1}"#.to_string()),
         resp.data[0][0]
     );
-    let metadata = resp.data[0][1].as_ref().unwrap();
-    let metadata: serde_json::Value = serde_json::from_str(metadata).unwrap();
-    assert_eq!(metadata["file"]["path"], "/tmp/vector/raw.log");
-    assert_eq!(metadata["file"]["offset"], 42);
+    assert_eq!(Some("/tmp/vector/raw.log".to_string()), resp.data[0][1]);
+    assert_eq!(Some("42".to_string()), resp.data[0][2]);
 }
 
 fn response_to_map(resp: &Page) -> Vec<BTreeMap<String, Option<String>>> {

--- a/src/sinks/databend/integration_tests.rs
+++ b/src/sinks/databend/integration_tests.rs
@@ -2,7 +2,10 @@ use std::{collections::BTreeMap, sync::Arc};
 
 use databend_client::{APIClient as DatabendAPIClient, Page};
 use futures::{future::ready, stream};
-use vector_lib::event::{BatchNotifier, BatchStatus, BatchStatusReceiver, Event, LogEvent};
+use vector_lib::{
+    event::{BatchNotifier, BatchStatus, BatchStatusReceiver, Event, LogEvent, ObjectMap, Value},
+    lookup::{PathPrefix, path},
+};
 
 use super::config::DatabendConfig;
 use crate::{
@@ -69,6 +72,13 @@ async fn prepare_config(
                 "#,
             );
         }
+        "zstd" => {
+            cfg.push_str(
+                r#"
+                    compression = "zstd"
+                "#,
+            );
+        }
         "none" => {
             cfg.push_str(
                 r#"
@@ -84,6 +94,54 @@ async fn prepare_config(
         .unwrap();
 
     (cfg, table, client)
+}
+
+async fn prepare_raw_config() -> (String, String, Arc<DatabendAPIClient>) {
+    trace_init();
+
+    let table = random_table_name();
+    let endpoint = databend_endpoint();
+    let client = DatabendAPIClient::new(&endpoint, Some("vector/integration-test".to_string()))
+        .await
+        .unwrap();
+
+    let cfg = format!(
+        r#"
+            endpoint = "{endpoint}"
+            table = "{table}"
+            batch.max_events = 1
+            encoding.codec = "json"
+            raw.enabled = true
+            raw.create_table = true
+            raw.metadata.includes = ["%file"]
+        "#,
+    );
+
+    (cfg, table, client)
+}
+
+fn make_replace_event(id: i64, source: &str, value: &str) -> Event {
+    let mut event = LogEvent::default();
+    event.insert("id", id);
+    event.insert("source", source);
+    event.insert("value", value);
+    event.into()
+}
+
+fn make_copy_error_event(id: Value, value: &str) -> Event {
+    let mut event = LogEvent::default();
+    event.insert("id", id);
+    event.insert("value", value);
+    event.into()
+}
+
+fn make_raw_event(message: &str) -> Event {
+    let mut event = LogEvent::from(message);
+    let mut file = ObjectMap::new();
+    file.insert("path".into(), "/tmp/vector/raw.log".into());
+    file.insert("offset".into(), 42.into());
+    event.insert((PathPrefix::Metadata, path!("file")), Value::Object(file));
+    event.into()
 }
 
 async fn insert_event_with_cfg(cfg: String, table: String, client: Arc<DatabendAPIClient>) {
@@ -131,6 +189,12 @@ async fn insert_event_json_gzip() {
 }
 
 #[tokio::test]
+async fn insert_event_json_zstd() {
+    let (cfg, table, client) = prepare_config("json", "zstd").await;
+    insert_event_with_cfg(cfg, table, client).await;
+}
+
+#[tokio::test]
 async fn insert_event_csv() {
     let (cfg, table, client) = prepare_config("csv", "none").await;
     insert_event_with_cfg(cfg, table, client).await;
@@ -140,6 +204,136 @@ async fn insert_event_csv() {
 async fn insert_event_csv_gzip() {
     let (cfg, table, client) = prepare_config("csv", "gzip").await;
     insert_event_with_cfg(cfg, table, client).await;
+}
+
+#[tokio::test]
+async fn staged_copy_on_error_continue_skips_bad_rows() {
+    trace_init();
+
+    let table = random_table_name();
+    let endpoint = databend_endpoint();
+    let client = DatabendAPIClient::new(&endpoint, Some("vector/integration-test".to_string()))
+        .await
+        .unwrap();
+    client
+        .query_all(&format!("create table `{table}` (id Int64, value String)"))
+        .await
+        .unwrap();
+
+    let cfg = format!(
+        r#"
+            endpoint = "{endpoint}"
+            table = "{table}"
+            batch.max_events = 2
+            encoding.codec = "csv"
+            encoding.csv.fields = ["id", "value"]
+            copy_options.on_error = "continue"
+        "#,
+    );
+    let (config, _) = load_sink::<DatabendConfig>(&cfg).unwrap();
+    let (sink, _hc) = config.build(SinkContext::default()).await.unwrap();
+
+    run_and_assert_sink_compliance(
+        sink,
+        stream::iter(vec![
+            make_copy_error_event(1.into(), "good"),
+            make_copy_error_event("not-an-int".into(), "bad"),
+        ]),
+        &HTTP_SINK_TAGS,
+    )
+    .await;
+
+    let resp = client
+        .query_all(&format!("select id, value from `{table}` order by id"))
+        .await
+        .unwrap();
+    assert_eq!(1, resp.data.len());
+    assert_eq!(Some("1".to_string()), resp.data[0][0]);
+    assert_eq!(Some("good".to_string()), resp.data[0][1]);
+}
+
+#[tokio::test]
+async fn replace_event_with_primary_key() {
+    trace_init();
+
+    let table = random_table_name();
+    let endpoint = databend_endpoint();
+    let client = DatabendAPIClient::new(&endpoint, Some("vector/integration-test".to_string()))
+        .await
+        .unwrap();
+    client
+        .query_all(&format!(
+            "create table `{table}` (id Int64, source String, value String)"
+        ))
+        .await
+        .unwrap();
+
+    let cfg = format!(
+        r#"
+            endpoint = "{endpoint}"
+            table = "{table}"
+            batch.max_events = 1
+            encoding.codec = "json"
+            compression = "zstd"
+            primary_key = ["id", "source"]
+        "#,
+    );
+    let (config, _) = load_sink::<DatabendConfig>(&cfg).unwrap();
+    let (sink, _hc) = config.build(SinkContext::default()).await.unwrap();
+
+    run_and_assert_sink_compliance(
+        sink,
+        stream::iter(vec![
+            make_replace_event(1, "file", "old"),
+            make_replace_event(1, "file", "new"),
+            make_replace_event(2, "file", "steady"),
+        ]),
+        &HTTP_SINK_TAGS,
+    )
+    .await;
+
+    let resp = client
+        .query_all(&format!(
+            "select id, source, value from `{table}` order by id"
+        ))
+        .await
+        .unwrap();
+    assert_eq!(2, resp.data.len());
+    assert_eq!(Some("1".to_string()), resp.data[0][0]);
+    assert_eq!(Some("file".to_string()), resp.data[0][1]);
+    assert_eq!(Some("new".to_string()), resp.data[0][2]);
+    assert_eq!(Some("2".to_string()), resp.data[1][0]);
+    assert_eq!(Some("steady".to_string()), resp.data[1][2]);
+}
+
+#[tokio::test]
+async fn raw_auto_create_table_with_metadata_paths() {
+    let (cfg, table, client) = prepare_raw_config().await;
+    let (config, _) = load_sink::<DatabendConfig>(&cfg).unwrap();
+    let (sink, _hc) = config.build(SinkContext::default()).await.unwrap();
+
+    run_and_assert_sink_compliance(
+        sink,
+        stream::once(ready(make_raw_event(r#"{"event":"raw-a","n":1}"#))),
+        &HTTP_SINK_TAGS,
+    )
+    .await;
+
+    let resp = client
+        .query_all(&format!(
+            "select raw_data::String, record_metadata::String from `{table}`"
+        ))
+        .await
+        .unwrap();
+    assert_eq!(1, resp.data.len());
+    assert_eq!(
+        Some(r#"{"event":"raw-a","n":1}"#.to_string()),
+        resp.data[0][0]
+    );
+    let metadata = resp.data[0][1].as_ref().unwrap();
+    let metadata: serde_json::Value = serde_json::from_str(metadata).unwrap();
+    assert_eq!(metadata["file"]["path"], "/tmp/vector/raw.log");
+    assert_eq!(metadata["file"]["offset"], 42);
 }
 
 fn response_to_map(resp: &Page) -> Vec<BTreeMap<String, Option<String>>> {

--- a/src/sinks/databend/integration_tests.rs
+++ b/src/sinks/databend/integration_tests.rs
@@ -321,7 +321,7 @@ async fn raw_auto_create_table_with_metadata_paths() {
 
     let resp = client
         .query_all(&format!(
-            "select raw_data::String, file_path::String, file_offset::String from `{table}`"
+            "select raw_data::String, \"%file.path\"::String, \"%file.offset\"::String from `{table}`"
         ))
         .await
         .unwrap();

--- a/src/sinks/databend/request_builder.rs
+++ b/src/sinks/databend/request_builder.rs
@@ -1,25 +1,19 @@
 use std::io;
 
 use bytes::Bytes;
-use chrono::Utc;
-use serde_json::Value as JsonValue;
 use vector_lib::{
     codecs::encoding::Framer,
-    event::{Event, LogEvent, Value},
+    event::Event,
     finalization::{EventFinalizers, Finalizable},
-    lookup::{OwnedTargetPath, OwnedValuePath},
     request_metadata::RequestMetadata,
 };
 
-use super::{
-    config::{DatabendRawOptions, raw_metadata_column_name},
-    service::DatabendRequest,
-};
+use super::service::DatabendRequest;
 use crate::{
     codecs::{Encoder, Transformer},
     sinks::util::{
-        Compression, RequestBuilder, encoding::Encoder as RequestEncoder,
-        metadata::RequestMetadataBuilder, request_builder::EncodeResult,
+        Compression, RequestBuilder, metadata::RequestMetadataBuilder,
+        request_builder::EncodeResult,
     },
 };
 
@@ -27,72 +21,14 @@ use crate::{
 pub struct DatabendRequestBuilder {
     compression: Compression,
     encoder: (Transformer, Encoder<Framer>),
-    raw: DatabendRawOptions,
 }
 
 impl DatabendRequestBuilder {
-    pub const fn new(
-        compression: Compression,
-        encoder: (Transformer, Encoder<Framer>),
-        raw: DatabendRawOptions,
-    ) -> Self {
+    pub const fn new(compression: Compression, encoder: (Transformer, Encoder<Framer>)) -> Self {
         Self {
             compression,
             encoder,
-            raw,
         }
-    }
-
-    fn get_path<'a>(log: &'a LogEvent, path: &str) -> Option<&'a Value> {
-        log.parse_path_and_get_value(path).ok().flatten()
-    }
-
-    fn raw_payload(log: &LogEvent, path: &str) -> Value {
-        let Some(value) = Self::get_path(log, path) else {
-            return Value::Null;
-        };
-
-        match value {
-            Value::Bytes(bytes) => serde_json::from_slice::<JsonValue>(bytes)
-                .ok()
-                .map(Value::from)
-                .unwrap_or_else(|| Value::Bytes(bytes.clone())),
-            value => value.clone(),
-        }
-    }
-
-    fn insert_raw_column(raw_log: &mut LogEvent, column: &str, value: Value) {
-        let path = OwnedTargetPath::event(OwnedValuePath::single_field(column));
-        raw_log.insert(&path, value);
-    }
-
-    fn raw_record(&self, event: Event) -> Event {
-        let Event::Log(log) = &event else {
-            return event;
-        };
-
-        let raw_data = Self::raw_payload(log, &self.raw.message_key);
-
-        let mut raw_log = LogEvent::default();
-        raw_log.insert("raw_data", raw_data);
-        raw_log.insert("add_time", Utc::now());
-
-        for path in &self.raw.metadata.includes {
-            let Some(column) = raw_metadata_column_name(path) else {
-                continue;
-            };
-
-            if path == "*" {
-                Self::insert_raw_column(&mut raw_log, &column, log.metadata().value().clone());
-                continue;
-            }
-
-            if let Some(value) = Self::get_path(log, path) {
-                Self::insert_raw_column(&mut raw_log, &column, value.clone());
-            }
-        }
-
-        Event::Log(raw_log)
     }
 }
 
@@ -110,34 +46,6 @@ impl RequestBuilder<Vec<Event>> for DatabendRequestBuilder {
 
     fn encoder(&self) -> &Self::Encoder {
         &self.encoder
-    }
-
-    fn encode_events(
-        &self,
-        events: Self::Events,
-    ) -> Result<EncodeResult<Self::Payload>, Self::Error> {
-        let events = if self.raw.enabled {
-            events
-                .into_iter()
-                .map(|event| self.raw_record(event))
-                .collect::<Vec<_>>()
-        } else {
-            events
-        };
-
-        let mut compressor = crate::sinks::util::Compressor::from(self.compression());
-        let is_compressed = compressor.is_compressed();
-        let (_, json_size) = self.encoder().encode_input(events, &mut compressor)?;
-
-        let payload = compressor.into_inner().freeze();
-        let result = if is_compressed {
-            let compressed_byte_size = payload.len();
-            EncodeResult::compressed(payload, compressed_byte_size, json_size)
-        } else {
-            EncodeResult::uncompressed(payload, json_size)
-        };
-
-        Ok(result)
     }
 
     fn split_input(

--- a/src/sinks/databend/request_builder.rs
+++ b/src/sinks/databend/request_builder.rs
@@ -1,19 +1,22 @@
 use std::io;
 
 use bytes::Bytes;
+use chrono::Utc;
+use serde_json::Value as JsonValue;
+use uuid::Uuid;
 use vector_lib::{
     codecs::encoding::Framer,
-    event::Event,
+    event::{Event, LogEvent, ObjectMap, Value},
     finalization::{EventFinalizers, Finalizable},
     request_metadata::RequestMetadata,
 };
 
-use super::service::DatabendRequest;
+use super::{config::DatabendRawOptions, service::DatabendRequest};
 use crate::{
     codecs::{Encoder, Transformer},
     sinks::util::{
-        Compression, RequestBuilder, metadata::RequestMetadataBuilder,
-        request_builder::EncodeResult,
+        Compression, RequestBuilder, encoding::Encoder as RequestEncoder,
+        metadata::RequestMetadataBuilder, request_builder::EncodeResult,
     },
 };
 
@@ -21,14 +24,107 @@ use crate::{
 pub struct DatabendRequestBuilder {
     compression: Compression,
     encoder: (Transformer, Encoder<Framer>),
+    raw: DatabendRawOptions,
 }
 
 impl DatabendRequestBuilder {
-    pub const fn new(compression: Compression, encoder: (Transformer, Encoder<Framer>)) -> Self {
+    pub const fn new(
+        compression: Compression,
+        encoder: (Transformer, Encoder<Framer>),
+        raw: DatabendRawOptions,
+    ) -> Self {
         Self {
             compression,
             encoder,
+            raw,
         }
+    }
+
+    fn get_path<'a>(log: &'a LogEvent, path: &str) -> Option<&'a Value> {
+        log.parse_path_and_get_value(path).ok().flatten()
+    }
+
+    fn raw_i64(log: &LogEvent, path: &str) -> Option<i64> {
+        Self::get_path(log, path).and_then(Value::as_integer)
+    }
+
+    fn raw_payload(log: &LogEvent, path: &str) -> Value {
+        let Some(value) = Self::get_path(log, path) else {
+            return Value::Null;
+        };
+
+        match value {
+            Value::Bytes(bytes) => serde_json::from_slice::<JsonValue>(bytes)
+                .ok()
+                .map(Value::from)
+                .unwrap_or_else(|| Value::Bytes(bytes.clone())),
+            value => value.clone(),
+        }
+    }
+
+    fn insert_metadata_path(record_metadata: &mut ObjectMap, path: &str, value: Value) {
+        let path = path.trim_start_matches('%');
+        let mut segments = path.split('.').filter(|segment| !segment.is_empty());
+        let Some(first) = segments.next() else {
+            return;
+        };
+
+        let mut current = record_metadata
+            .entry(first.into())
+            .or_insert_with(|| Value::Object(ObjectMap::new()));
+
+        for segment in segments {
+            if !matches!(current, Value::Object(_)) {
+                *current = Value::Object(ObjectMap::new());
+            }
+            let Value::Object(map) = current else {
+                return;
+            };
+            current = map
+                .entry(segment.into())
+                .or_insert_with(|| Value::Object(ObjectMap::new()));
+        }
+
+        *current = value;
+    }
+
+    fn record_metadata(&self, log: &LogEvent) -> ObjectMap {
+        let mut record_metadata = ObjectMap::new();
+
+        for path in &self.raw.metadata.includes {
+            if path == "*" {
+                if let Value::Object(metadata) = log.metadata().value() {
+                    record_metadata.extend(metadata.clone());
+                }
+                continue;
+            }
+
+            if let Some(value) = Self::get_path(log, path) {
+                Self::insert_metadata_path(&mut record_metadata, path, value.clone());
+            }
+        }
+
+        record_metadata
+    }
+
+    fn raw_record(&self, event: Event) -> Event {
+        let Event::Log(log) = &event else {
+            return event;
+        };
+
+        let offset = Self::raw_i64(log, "%kafka.offset").unwrap_or_default();
+        let partition = Self::raw_i64(log, "%kafka.partition").unwrap_or_default();
+        let raw_data = Self::raw_payload(log, &self.raw.message_key);
+        let record_metadata = self.record_metadata(log);
+
+        let mut raw_log = LogEvent::default();
+        raw_log.insert("uuid", Uuid::new_v4().to_string());
+        raw_log.insert("koffset", offset);
+        raw_log.insert("kpartition", partition);
+        raw_log.insert("raw_data", raw_data);
+        raw_log.insert("record_metadata", Value::Object(record_metadata));
+        raw_log.insert("add_time", Utc::now());
+        Event::Log(raw_log)
     }
 }
 
@@ -46,6 +142,34 @@ impl RequestBuilder<Vec<Event>> for DatabendRequestBuilder {
 
     fn encoder(&self) -> &Self::Encoder {
         &self.encoder
+    }
+
+    fn encode_events(
+        &self,
+        events: Self::Events,
+    ) -> Result<EncodeResult<Self::Payload>, Self::Error> {
+        let events = if self.raw.enabled {
+            events
+                .into_iter()
+                .map(|event| self.raw_record(event))
+                .collect::<Vec<_>>()
+        } else {
+            events
+        };
+
+        let mut compressor = crate::sinks::util::Compressor::from(self.compression());
+        let is_compressed = compressor.is_compressed();
+        let (_, json_size) = self.encoder().encode_input(events, &mut compressor)?;
+
+        let payload = compressor.into_inner().freeze();
+        let result = if is_compressed {
+            let compressed_byte_size = payload.len();
+            EncodeResult::compressed(payload, compressed_byte_size, json_size)
+        } else {
+            EncodeResult::uncompressed(payload, json_size)
+        };
+
+        Ok(result)
     }
 
     fn split_input(

--- a/src/sinks/databend/request_builder.rs
+++ b/src/sinks/databend/request_builder.rs
@@ -3,15 +3,17 @@ use std::io;
 use bytes::Bytes;
 use chrono::Utc;
 use serde_json::Value as JsonValue;
-use uuid::Uuid;
 use vector_lib::{
     codecs::encoding::Framer,
-    event::{Event, LogEvent, ObjectMap, Value},
+    event::{Event, LogEvent, Value},
     finalization::{EventFinalizers, Finalizable},
     request_metadata::RequestMetadata,
 };
 
-use super::{config::DatabendRawOptions, service::DatabendRequest};
+use super::{
+    config::{DatabendRawOptions, raw_metadata_column_name},
+    service::DatabendRequest,
+};
 use crate::{
     codecs::{Encoder, Transformer},
     sinks::util::{
@@ -44,10 +46,6 @@ impl DatabendRequestBuilder {
         log.parse_path_and_get_value(path).ok().flatten()
     }
 
-    fn raw_i64(log: &LogEvent, path: &str) -> Option<i64> {
-        Self::get_path(log, path).and_then(Value::as_integer)
-    }
-
     fn raw_payload(log: &LogEvent, path: &str) -> Value {
         let Some(value) = Self::get_path(log, path) else {
             return Value::Null;
@@ -62,68 +60,32 @@ impl DatabendRequestBuilder {
         }
     }
 
-    fn insert_metadata_path(record_metadata: &mut ObjectMap, path: &str, value: Value) {
-        let path = path.trim_start_matches('%');
-        let mut segments = path.split('.').filter(|segment| !segment.is_empty());
-        let Some(first) = segments.next() else {
-            return;
-        };
-
-        let mut current = record_metadata
-            .entry(first.into())
-            .or_insert_with(|| Value::Object(ObjectMap::new()));
-
-        for segment in segments {
-            if !matches!(current, Value::Object(_)) {
-                *current = Value::Object(ObjectMap::new());
-            }
-            let Value::Object(map) = current else {
-                return;
-            };
-            current = map
-                .entry(segment.into())
-                .or_insert_with(|| Value::Object(ObjectMap::new()));
-        }
-
-        *current = value;
-    }
-
-    fn record_metadata(&self, log: &LogEvent) -> ObjectMap {
-        let mut record_metadata = ObjectMap::new();
-
-        for path in &self.raw.metadata.includes {
-            if path == "*" {
-                if let Value::Object(metadata) = log.metadata().value() {
-                    record_metadata.extend(metadata.clone());
-                }
-                continue;
-            }
-
-            if let Some(value) = Self::get_path(log, path) {
-                Self::insert_metadata_path(&mut record_metadata, path, value.clone());
-            }
-        }
-
-        record_metadata
-    }
-
     fn raw_record(&self, event: Event) -> Event {
         let Event::Log(log) = &event else {
             return event;
         };
 
-        let offset = Self::raw_i64(log, "%kafka.offset").unwrap_or_default();
-        let partition = Self::raw_i64(log, "%kafka.partition").unwrap_or_default();
         let raw_data = Self::raw_payload(log, &self.raw.message_key);
-        let record_metadata = self.record_metadata(log);
 
         let mut raw_log = LogEvent::default();
-        raw_log.insert("uuid", Uuid::new_v4().to_string());
-        raw_log.insert("koffset", offset);
-        raw_log.insert("kpartition", partition);
         raw_log.insert("raw_data", raw_data);
-        raw_log.insert("record_metadata", Value::Object(record_metadata));
         raw_log.insert("add_time", Utc::now());
+
+        for path in &self.raw.metadata.includes {
+            let Some(column) = raw_metadata_column_name(path) else {
+                continue;
+            };
+
+            if path == "*" {
+                raw_log.insert(column.as_str(), log.metadata().value().clone());
+                continue;
+            }
+
+            if let Some(value) = Self::get_path(log, path) {
+                raw_log.insert(column.as_str(), value.clone());
+            }
+        }
+
         Event::Log(raw_log)
     }
 }

--- a/src/sinks/databend/request_builder.rs
+++ b/src/sinks/databend/request_builder.rs
@@ -7,6 +7,7 @@ use vector_lib::{
     codecs::encoding::Framer,
     event::{Event, LogEvent, Value},
     finalization::{EventFinalizers, Finalizable},
+    lookup::{OwnedTargetPath, OwnedValuePath},
     request_metadata::RequestMetadata,
 };
 
@@ -60,6 +61,11 @@ impl DatabendRequestBuilder {
         }
     }
 
+    fn insert_raw_column(raw_log: &mut LogEvent, column: &str, value: Value) {
+        let path = OwnedTargetPath::event(OwnedValuePath::single_field(column));
+        raw_log.insert(&path, value);
+    }
+
     fn raw_record(&self, event: Event) -> Event {
         let Event::Log(log) = &event else {
             return event;
@@ -77,12 +83,12 @@ impl DatabendRequestBuilder {
             };
 
             if path == "*" {
-                raw_log.insert(column.as_str(), log.metadata().value().clone());
+                Self::insert_raw_column(&mut raw_log, &column, log.metadata().value().clone());
                 continue;
             }
 
             if let Some(value) = Self::get_path(log, path) {
-                raw_log.insert(column.as_str(), value.clone());
+                Self::insert_raw_column(&mut raw_log, &column, value.clone());
             }
         }
 

--- a/src/sinks/databend/service.rs
+++ b/src/sinks/databend/service.rs
@@ -21,6 +21,8 @@ use vector_lib::{
 
 use crate::{internal_events::EndpointBytesSent, sinks::util::retries::RetryLogic};
 
+use super::config::DatabendLoadMode;
+
 #[derive(Clone)]
 pub struct DatabendRetryLogic;
 
@@ -54,8 +56,22 @@ impl RetryLogic for DatabendRetryLogic {
 pub struct DatabendService {
     client: Arc<DatabendAPIClient>,
     table: String,
+    load_mode: DatabendLoadMode,
+    stage: String,
+    stage_path_prefix: String,
     file_format_options: BTreeMap<&'static str, &'static str>,
     copy_options: BTreeMap<&'static str, &'static str>,
+    primary_key: Vec<String>,
+}
+
+pub struct DatabendServiceSettings {
+    pub table: String,
+    pub load_mode: DatabendLoadMode,
+    pub stage: String,
+    pub stage_path_prefix: String,
+    pub file_format_options: BTreeMap<&'static str, &'static str>,
+    pub copy_options: BTreeMap<&'static str, &'static str>,
+    pub primary_key: Vec<String>,
 }
 
 #[derive(Clone)]
@@ -103,18 +119,35 @@ impl DriverResponse for DatabendResponse {
 impl DatabendService {
     pub(super) fn new(
         client: Arc<DatabendAPIClient>,
-        table: String,
-        file_format_options: BTreeMap<&'static str, &'static str>,
-        copy_options: BTreeMap<&'static str, &'static str>,
+        settings: DatabendServiceSettings,
     ) -> Result<Self, DatabendError> {
+        let DatabendServiceSettings {
+            table,
+            load_mode,
+            stage,
+            stage_path_prefix,
+            file_format_options,
+            copy_options,
+            primary_key,
+        } = settings;
+
         if table.is_empty() {
             return Err(DatabendError::BadArgument("table is required".to_string()));
+        }
+        if matches!(load_mode, DatabendLoadMode::Streaming) && !primary_key.is_empty() {
+            return Err(DatabendError::BadArgument(
+                "primary_key is not supported with load_mode = streaming".to_string(),
+            ));
         }
         Ok(Self {
             client,
             table,
+            load_mode,
+            stage,
+            stage_path_prefix,
             file_format_options,
             copy_options,
+            primary_key,
         })
     }
 
@@ -129,10 +162,30 @@ impl DatabendService {
             .take(8)
             .map(char::from)
             .collect::<String>();
-        format!("@~/vector/{}/{}/{}-{}", database, self.table, now, suffix,)
+        let stage = self.stage.trim_start_matches('@');
+        let prefix = self.stage_path_prefix.trim_matches('/');
+        if prefix.is_empty() {
+            format!("@{}/{}/{}/{}-{}", stage, database, self.table, now, suffix,)
+        } else {
+            format!(
+                "@{}/{}/{}/{}/{}-{}",
+                stage, prefix, database, self.table, now, suffix,
+            )
+        }
     }
 
-    pub(crate) async fn insert_with_stage(&self, data: Bytes) -> Result<(), DatabendError> {
+    pub(crate) async fn load(&self, data: Bytes) -> Result<(), DatabendError> {
+        match (self.load_mode, self.primary_key.is_empty()) {
+            (DatabendLoadMode::Staged, true) => self.insert_with_stage(data).await,
+            (DatabendLoadMode::Staged, false) => self.replace_with_stage(data).await,
+            (DatabendLoadMode::Streaming, true) => self.streaming_load(data).await,
+            (DatabendLoadMode::Streaming, false) => {
+                unreachable!("validated in DatabendService::new")
+            }
+        }
+    }
+
+    async fn insert_with_stage(&self, data: Bytes) -> Result<(), DatabendError> {
         let stage = self.new_stage_location().await;
         let size = data.len() as u64;
         let reader = Box::new(Cursor::new(data));
@@ -148,6 +201,58 @@ impl DatabendService {
             )
             .await?;
         Ok(())
+    }
+
+    async fn streaming_load(&self, data: Bytes) -> Result<(), DatabendError> {
+        let reader = Box::new(Cursor::new(data));
+        let sql = format!(
+            "INSERT INTO {} FROM @_databend_load FILE_FORMAT=({})",
+            self.table,
+            self.file_format_options_sql()
+        );
+        let _ = self
+            .client
+            .streaming_load(
+                &sql,
+                reader,
+                &format!("vector-batch.{}", self.file_extension()),
+            )
+            .await?;
+        Ok(())
+    }
+
+    async fn replace_with_stage(&self, data: Bytes) -> Result<(), DatabendError> {
+        let stage = self.new_stage_location().await;
+        let size = data.len() as u64;
+        let reader = Box::new(Cursor::new(data));
+        self.client.upload_to_stage(&stage, reader, size).await?;
+        let primary_key = self.primary_key.join(", ");
+        let sql = format!("REPLACE INTO {} ON ({primary_key}) VALUES", self.table);
+        let _ = self
+            .client
+            .insert_with_stage(
+                &sql,
+                &stage,
+                self.file_format_options.clone(),
+                self.copy_options.clone(),
+            )
+            .await?;
+        Ok(())
+    }
+
+    fn file_extension(&self) -> &'static str {
+        match self.file_format_options.get("type").copied() {
+            Some("CSV") => "csv",
+            _ => "ndjson",
+        }
+    }
+
+    fn file_format_options_sql(&self) -> String {
+        self.file_format_options
+            .iter()
+            .map(|(key, value)| format!("{key}={value}"))
+            .collect::<Vec<_>>()
+            .join(" ")
     }
 }
 
@@ -169,7 +274,7 @@ impl Service<DatabendRequest> for DatabendService {
             let host_port = format!("{}:{}", service.client.host(), service.client.port());
             let endpoint = host_port.as_str();
             let byte_size = request.data.len();
-            service.insert_with_stage(request.data).await?;
+            service.load(request.data).await?;
             emit!(EndpointBytesSent {
                 byte_size,
                 protocol,

--- a/src/sinks/databend/service.rs
+++ b/src/sinks/databend/service.rs
@@ -46,7 +46,7 @@ fn quote_sql_string(value: &str) -> String {
 
 fn file_format_option_sql(key: &str, value: &str) -> String {
     let value = match key {
-        "field_delimiter" | "record_delimiter" | "missing_field_as" => quote_sql_string(value),
+        "field_delimiter" | "record_delimiter" => quote_sql_string(value),
         _ => value.to_string(),
     };
 
@@ -353,6 +353,10 @@ mod tests {
             file_format_option_sql("record_delimiter", "\n"),
             "record_delimiter='\\n'"
         );
+        assert_eq!(
+            file_format_option_sql("missing_field_as", "NULL"),
+            "missing_field_as=NULL"
+        );
         assert_eq!(file_format_option_sql("skip_header", "0"), "skip_header=0");
     }
 
@@ -361,6 +365,7 @@ mod tests {
         let options = BTreeMap::from([
             ("compression", "GZIP"),
             ("field_delimiter", ","),
+            ("missing_field_as", "FIELD_DEFAULT"),
             ("record_delimiter", "\n"),
             ("skip_header", "0"),
             ("type", "CSV"),
@@ -374,7 +379,7 @@ mod tests {
 
         assert_eq!(
             sql,
-            "compression=GZIP field_delimiter=',' record_delimiter='\\n' skip_header=0 type=CSV"
+            "compression=GZIP field_delimiter=',' missing_field_as=FIELD_DEFAULT record_delimiter='\\n' skip_header=0 type=CSV"
         );
     }
 }

--- a/src/sinks/databend/service.rs
+++ b/src/sinks/databend/service.rs
@@ -75,7 +75,7 @@ impl RetryLogic for DatabendRetryLogic {
                     _ => false,
                 }
             }
-            DatabendError::WithContext(boxed_error, ..) => self.is_retriable_error(boxed_error),
+            DatabendError::WithContext { inner, .. } => self.is_retriable_error(inner),
             DatabendError::IO(_) => true,
             _ => false,
         }

--- a/src/sinks/databend/service.rs
+++ b/src/sinks/databend/service.rs
@@ -23,6 +23,36 @@ use crate::{internal_events::EndpointBytesSent, sinks::util::retries::RetryLogic
 
 use super::config::DatabendLoadMode;
 
+fn quote_identifier(identifier: &str) -> String {
+    format!("`{}`", identifier.replace('`', "``"))
+}
+
+fn quote_sql_string(value: &str) -> String {
+    let mut quoted = String::with_capacity(value.len() + 2);
+    quoted.push('\'');
+    for char in value.chars() {
+        match char {
+            '\'' => quoted.push_str("''"),
+            '\\' => quoted.push_str("\\\\"),
+            '\n' => quoted.push_str("\\n"),
+            '\r' => quoted.push_str("\\r"),
+            '\t' => quoted.push_str("\\t"),
+            char => quoted.push(char),
+        }
+    }
+    quoted.push('\'');
+    quoted
+}
+
+fn file_format_option_sql(key: &str, value: &str) -> String {
+    let value = match key {
+        "field_delimiter" | "record_delimiter" | "missing_field_as" => quote_sql_string(value),
+        _ => value.to_string(),
+    };
+
+    format!("{key}={value}")
+}
+
 #[derive(Clone)]
 pub struct DatabendRetryLogic;
 
@@ -190,7 +220,8 @@ impl DatabendService {
         let size = data.len() as u64;
         let reader = Box::new(Cursor::new(data));
         self.client.upload_to_stage(&stage, reader, size).await?;
-        let sql = format!("INSERT INTO `{}` VALUES", self.table);
+        let table = quote_identifier(&self.table);
+        let sql = format!("INSERT INTO {table} VALUES");
         let _ = self
             .client
             .insert_with_stage(
@@ -205,9 +236,9 @@ impl DatabendService {
 
     async fn streaming_load(&self, data: Bytes) -> Result<(), DatabendError> {
         let reader = Box::new(Cursor::new(data));
+        let table = quote_identifier(&self.table);
         let sql = format!(
-            "INSERT INTO {} FROM @_databend_load FILE_FORMAT=({})",
-            self.table,
+            "INSERT INTO {table} FROM @_databend_load FILE_FORMAT=({})",
             self.file_format_options_sql()
         );
         let _ = self
@@ -226,8 +257,14 @@ impl DatabendService {
         let size = data.len() as u64;
         let reader = Box::new(Cursor::new(data));
         self.client.upload_to_stage(&stage, reader, size).await?;
-        let primary_key = self.primary_key.join(", ");
-        let sql = format!("REPLACE INTO {} ON ({primary_key}) VALUES", self.table);
+        let table = quote_identifier(&self.table);
+        let primary_key = self
+            .primary_key
+            .iter()
+            .map(|key| quote_identifier(key))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let sql = format!("REPLACE INTO {table} ON ({primary_key}) VALUES");
         let _ = self
             .client
             .insert_with_stage(
@@ -250,7 +287,7 @@ impl DatabendService {
     fn file_format_options_sql(&self) -> String {
         self.file_format_options
             .iter()
-            .map(|(key, value)| format!("{key}={value}"))
+            .map(|(key, value)| file_format_option_sql(key, value))
             .collect::<Vec<_>>()
             .join(" ")
     }
@@ -283,5 +320,61 @@ impl Service<DatabendRequest> for DatabendService {
             Ok(DatabendResponse { metadata })
         };
         Box::pin(future)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use super::{file_format_option_sql, quote_identifier, quote_sql_string};
+
+    #[test]
+    fn quote_identifier_escapes_backticks() {
+        assert_eq!(quote_identifier("events"), "`events`");
+        assert_eq!(quote_identifier("odd`table"), "`odd``table`");
+    }
+
+    #[test]
+    fn quote_sql_string_escapes_special_characters() {
+        assert_eq!(quote_sql_string(","), "','");
+        assert_eq!(quote_sql_string("\n"), "'\\n'");
+        assert_eq!(quote_sql_string("it's"), "'it''s'");
+    }
+
+    #[test]
+    fn file_format_option_sql_quotes_string_values() {
+        assert_eq!(file_format_option_sql("type", "CSV"), "type=CSV");
+        assert_eq!(
+            file_format_option_sql("field_delimiter", ","),
+            "field_delimiter=','"
+        );
+        assert_eq!(
+            file_format_option_sql("record_delimiter", "\n"),
+            "record_delimiter='\\n'"
+        );
+        assert_eq!(file_format_option_sql("skip_header", "0"), "skip_header=0");
+    }
+
+    #[test]
+    fn file_format_options_are_stable_for_streaming_sql() {
+        let options = BTreeMap::from([
+            ("compression", "GZIP"),
+            ("field_delimiter", ","),
+            ("record_delimiter", "\n"),
+            ("skip_header", "0"),
+            ("type", "CSV"),
+        ]);
+
+        let sql = options
+            .iter()
+            .map(|(key, value)| file_format_option_sql(key, value))
+            .collect::<Vec<_>>()
+            .join(" ");
+
+        assert_eq!(
+            sql,
+            "compression=GZIP field_delimiter=',' record_delimiter='\\n' skip_header=0 type=CSV"
+        );
     }
 }

--- a/website/content/en/docs/reference/configuration/sinks/databend.md
+++ b/website/content/en/docs/reference/configuration/sinks/databend.md
@@ -12,3 +12,88 @@ This doc is generated using:
 1. The template in layouts/docs/component.html
 2. The relevant CUE data in cue/reference/components/...
 */}}
+
+## Raw ingest and replace mode
+
+The Databend sink supports staged batch loading by default. Set `load_mode` to
+`streaming` to use Databend's streaming load API for normal inserts.
+
+For staged loads, `copy_options.on_error` controls Databend COPY error handling.
+It defaults to `abort`. Set it to `continue` to skip bad rows and continue
+loading the rest of the staged file:
+
+```yaml
+sinks:
+  databend:
+    type: databend
+    inputs: ["logs"]
+    endpoint: "databend://root:@127.0.0.1:8000/default?sslmode=disable"
+    table: "events"
+    copy_options:
+      on_error: continue
+```
+
+Set `primary_key` to use `REPLACE INTO ... ON (...)` with staged loading. When
+`primary_key` is empty, the sink uses normal insert mode.
+
+```yaml
+sinks:
+  databend:
+    type: databend
+    inputs: ["logs"]
+    endpoint: "databend://root:@127.0.0.1:8000/default?sslmode=disable"
+    table: "events"
+    primary_key: ["id", "source"]
+```
+
+`primary_key` is independent of raw mode. Databend does not currently support
+replace with streaming load, so `primary_key` cannot be used with
+`load_mode: streaming`.
+
+Raw mode writes each event into a fixed raw ingest schema:
+
+```sql
+uuid String,
+koffset BIGINT,
+kpartition INT,
+raw_data JSON,
+record_metadata JSON,
+add_time TIMESTAMP
+```
+
+Enable `raw.create_table` to create this table during sink startup:
+
+```yaml
+sinks:
+  databend:
+    type: databend
+    inputs: ["logs"]
+    endpoint: "databend://root:@127.0.0.1:8000/default?sslmode=disable"
+    table: "raw_events"
+    raw:
+      enabled: true
+      create_table: true
+      metadata:
+        includes: ["*"]
+```
+
+`raw.metadata.includes` accepts Vector metadata paths. If the option is not
+configured, it defaults to `["*"]`, which copies all metadata. Set it to an empty array to omit
+metadata:
+
+```yaml
+raw:
+  metadata:
+    includes: []
+```
+
+You can include specific metadata paths:
+
+```yaml
+raw:
+  metadata:
+    includes:
+      - "%kafka.topic"
+      - "%kafka.partition"
+      - "%kafka.offset"
+```

--- a/website/content/en/docs/reference/configuration/sinks/databend.md
+++ b/website/content/en/docs/reference/configuration/sinks/databend.md
@@ -59,12 +59,12 @@ add_time TIMESTAMP
 ```
 
 `raw.metadata.includes` adds metadata columns to that schema. Metadata paths are
-converted to column names by removing `%` and replacing separators with `_`. For
-example, `%kafka.topic` becomes `kafka_topic`.
+used as column names as-is and quoted in the generated Databend SQL. For
+example, `%kafka.topic` creates a `"%kafka.topic"` column.
 
 Enable `raw.create_table` to create this table during sink startup. With the
 following configuration, the generated table includes `raw_data`, `add_time`,
-`kafka_topic`, `kafka_partition`, and `kafka_offset`:
+`"%kafka.topic"`, `"%kafka.partition"`, and `"%kafka.offset"`:
 
 ```yaml
 sinks:

--- a/website/content/en/docs/reference/configuration/sinks/databend.md
+++ b/website/content/en/docs/reference/configuration/sinks/databend.md
@@ -13,7 +13,7 @@ This doc is generated using:
 2. The relevant CUE data in cue/reference/components/...
 */}}
 
-## Raw ingest and replace mode
+## Ingest Modes
 
 The Databend sink supports staged batch loading by default. Set `load_mode` to
 `streaming` to use Databend's streaming load API for normal inserts.
@@ -46,60 +46,5 @@ sinks:
     primary_key: ["id", "source"]
 ```
 
-`primary_key` is independent of raw mode. Databend does not currently support
-replace with streaming load, so `primary_key` cannot be used with
-`load_mode: streaming`.
-
-Raw mode writes each event into a generated raw ingest schema. The sink always
-uses these columns:
-
-```sql
-raw_data JSON,
-add_time TIMESTAMP
-```
-
-`raw.metadata.includes` adds metadata columns to that schema. Metadata paths are
-used as column names as-is and quoted in the generated Databend SQL. For
-example, `%kafka.topic` creates a `"%kafka.topic"` column.
-
-Enable `raw.create_table` to create this table during sink startup. With the
-following configuration, the generated table includes `raw_data`, `add_time`,
-`"%kafka.topic"`, `"%kafka.partition"`, and `"%kafka.offset"`:
-
-```yaml
-sinks:
-  databend:
-    type: databend
-    inputs: ["logs"]
-    endpoint: "databend://root:@127.0.0.1:8000/default?sslmode=disable"
-    table: "raw_events"
-    raw:
-      enabled: true
-      create_table: true
-      metadata:
-        includes:
-          - "%kafka.topic"
-          - "%kafka.partition"
-          - "%kafka.offset"
-```
-
-`raw.metadata.includes` accepts Vector metadata paths. If the option is not
-configured, it defaults to `["*"]`, which copies all metadata into a `metadata`
-JSON column. Set it to an empty array to omit metadata columns:
-
-```yaml
-raw:
-  metadata:
-    includes: []
-```
-
-You can include specific metadata paths as separate columns:
-
-```yaml
-raw:
-  metadata:
-    includes:
-      - "%kafka.topic"
-      - "%kafka.partition"
-      - "%kafka.offset"
-```
+Databend does not currently support replace with streaming load, so
+`primary_key` cannot be used with `load_mode: streaming`.

--- a/website/content/en/docs/reference/configuration/sinks/databend.md
+++ b/website/content/en/docs/reference/configuration/sinks/databend.md
@@ -50,18 +50,21 @@ sinks:
 replace with streaming load, so `primary_key` cannot be used with
 `load_mode: streaming`.
 
-Raw mode writes each event into a fixed raw ingest schema:
+Raw mode writes each event into a generated raw ingest schema. The sink always
+uses these columns:
 
 ```sql
-uuid String,
-koffset BIGINT,
-kpartition INT,
 raw_data JSON,
-record_metadata JSON,
 add_time TIMESTAMP
 ```
 
-Enable `raw.create_table` to create this table during sink startup:
+`raw.metadata.includes` adds metadata columns to that schema. Metadata paths are
+converted to column names by removing `%` and replacing separators with `_`. For
+example, `%kafka.topic` becomes `kafka_topic`.
+
+Enable `raw.create_table` to create this table during sink startup. With the
+following configuration, the generated table includes `raw_data`, `add_time`,
+`kafka_topic`, `kafka_partition`, and `kafka_offset`:
 
 ```yaml
 sinks:
@@ -74,12 +77,15 @@ sinks:
       enabled: true
       create_table: true
       metadata:
-        includes: ["*"]
+        includes:
+          - "%kafka.topic"
+          - "%kafka.partition"
+          - "%kafka.offset"
 ```
 
 `raw.metadata.includes` accepts Vector metadata paths. If the option is not
-configured, it defaults to `["*"]`, which copies all metadata. Set it to an empty array to omit
-metadata:
+configured, it defaults to `["*"]`, which copies all metadata into a `metadata`
+JSON column. Set it to an empty array to omit metadata columns:
 
 ```yaml
 raw:
@@ -87,7 +93,7 @@ raw:
     includes: []
 ```
 
-You can include specific metadata paths:
+You can include specific metadata paths as separate columns:
 
 ```yaml
 raw:


### PR DESCRIPTION
## Summary

This expands the `databend` sink with additional ingestion controls for staged and streaming writes:

- Adds `load_mode` to choose staged loading or Databend streaming load.
- Adds `primary_key` to use staged `REPLACE INTO ... ON (...)` writes.
- Adds staged COPY options for `purge`, `force`, `disable_variant_check`, and `on_error`.
- Adds `zstd` compression support.
- Updates `databend-client` to 0.34.0.
- Adds integration coverage for the new load options.

Event shaping and raw event layouts are intentionally left to Vector transforms. The Databend sink does not create or infer tables; it stays focused on delivery behavior and expects users to manage the target table shape explicitly.

## Vector configuration

```yaml
sinks:
  databend:
    type: databend
    inputs: ["logs"]
    endpoint: "databend://user:password@databend.example.com:8000/default"
    table: "events"
    compression: zstd
    load_mode: staged
    primary_key: ["id", "source"]
    copy_options:
      on_error: continue
```

## How did you test this PR?

- Ran Databend sink config unit tests.
- Ran Databend sink service unit tests.
- Ran a focused `cargo check` with Databend sink features enabled.
- Ran a focused `cargo check` with Databend integration features enabled.
- Ran a focused `cargo clippy` with Databend integration features enabled.
- Ran the Databend sink integration tests against Databend.

The integration tests cover JSON and CSV inserts, zstd compression, staged replace mode via `primary_key`, and `copy_options.on_error = "continue"` skipping malformed rows.

## Change Type

- [ ] Bug fix
- [x] New feature
- [x] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

Closes #25304.
Closes #25012.