### PR TITLE
chore(ci): consolidate dependabot cargo groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,10 +25,6 @@ updates:
       aws:
         patterns:
           - "aws-*"
-      aws-security:
-        applies-to: security-updates
-        patterns:
-          - "aws-*"
       azure:
         patterns:
           - "azure_*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -86,6 +86,15 @@ updates:
       zstd:
         patterns:
           - "zstd*"
+
+      cargo-other:
+        applies-to: version-updates
+        patterns:
+          - "*"
+      cargo-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
   - package-ecosystem: "docker"
     directory: "/distribution/docker/alpine"
     schedule:


### PR DESCRIPTION
## Summary

Reduce dependabot PR noise in the cargo ecosystem by:

- Adding a `cargo-other` catch-all that bundles non-patch version updates outside named groups (aws, tokio, serde, etc.) into one PR.
- Adding a `cargo-security` catch-all for security updates.
- Dropping the now-redundant `aws-security` group.

Named groups keep their precedence (declaration order) and the existing `patches` group still handles patch-level bumps.

## How did you test this PR?

YAML reviewed manually. Real validation comes from the next dependabot run.

## Change Type

- [x] Non-functional (chore, refactoring, docs)

## Is this a breaking change?

- [x] No

## Does this PR include user facing changes?

- [x] No. A maintainer will apply the `no-changelog` label to this PR.