### PR TITLE
feat(sample transform): add optional discarded_event_tags callback

### DIFF
--- a/changelog.d/sample_discarded_event_tags.enhancement.md
+++ b/changelog.d/sample_discarded_event_tags.enhancement.md
@@ -1,0 +1,8 @@
+The `sample` transform now exposes an optional `with_discarded_event_tags`
+builder method on the `Sample` runtime type. When set, the callback returns
+`(key, value)` pairs that are merged into the `component_discarded_events_total`
+counter at the drop site. Default `None`; existing users see no behavior change.
+
+Library consumers (e.g., downstream wrappers that pre-group events) can use
+this to attach per-event tags to the discard metric without forking the
+transform.

--- a/src/transforms/sample/tests.rs
+++ b/src/transforms/sample/tests.rs
@@ -668,3 +668,41 @@ fn random_events(n: usize) -> Vec<Event> {
         .map(|e| Event::Log(LogEvent::from(e)))
         .collect()
 }
+
+#[test]
+fn discarded_event_tags_callback_is_invoked_on_drop() {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    let counter = Arc::new(AtomicUsize::new(0));
+    let counter_for_cb = Arc::clone(&counter);
+
+    // Aggressive rate — only 1 in 100 events should pass, so the vast
+    // majority of the events below will be dropped.
+    let mut sampler = Sample::new(
+        "sample".to_string(),
+        SampleMode::new_rate(100),
+        None,
+        None,
+        None,
+        default_sample_rate_key(),
+    )
+    .with_discarded_event_tags(move |_event| {
+        counter_for_cb.fetch_add(1, Ordering::SeqCst);
+        vec![("custom_tag".to_string(), "from_callback".to_string())]
+    });
+
+    let events = random_events(200);
+    for event in events {
+        let mut buf = OutputBuffer::with_capacity(1);
+        sampler.transform(&mut buf, event);
+    }
+
+    // With rate=100 and 200 events, expect close to 198 drops. Assert at
+    // least 100 to be robust to randomness without becoming a flaky test.
+    let calls = counter.load(Ordering::SeqCst);
+    assert!(
+        calls >= 100,
+        "callback was invoked {calls} times, expected at least 100"
+    );
+}

--- a/src/transforms/sample/transform.rs
+++ b/src/transforms/sample/transform.rs
@@ -3,12 +3,16 @@ use std::{
     fmt,
     hash::{Hash, Hasher},
     num::NonZeroU64,
+    sync::Arc,
 };
 
 use vector_lib::{
     config::LegacyKey,
     lookup::{OwnedTargetPath, lookup_v2::OptionalValuePath},
 };
+
+use vector_lib::counter;
+use vector_lib::internal_event::CounterName;
 
 use crate::{
     conditions::Condition,
@@ -139,6 +143,11 @@ pub enum SampleKeySource {
     },
 }
 
+/// Callback signature for [`Sample::with_discarded_event_tags`]. Returns
+/// `(key, value)` pairs that are merged into the
+/// `component_discarded_events_total` counter on each drop.
+pub type DiscardedEventTagsFn = dyn Fn(&Event) -> Vec<(String, String)> + Send + Sync;
+
 #[derive(Clone)]
 pub struct Sample {
     name: String,
@@ -147,6 +156,7 @@ pub struct Sample {
     dynamic_event_counters: HashMap<Option<String>, u64>,
     exclude: Option<Condition>,
     sample_rate_key: OptionalValuePath,
+    discarded_event_tags: Option<Arc<DiscardedEventTagsFn>>,
 }
 
 impl Sample {
@@ -204,7 +214,27 @@ impl Sample {
             dynamic_event_counters: HashMap::default(),
             exclude,
             sample_rate_key,
+            discarded_event_tags: None,
         }
+    }
+
+    /// Register a callback that returns extra `(key, value)` tags to attach
+    /// to the `component_discarded_events_total` counter each time this
+    /// transform drops an event. If unset (default), behavior is unchanged.
+    ///
+    /// The callback is invoked at the drop site with a reference to the
+    /// event being discarded. The returned tags are merged with the
+    /// standard `intentional` label on the counter.
+    ///
+    /// Intended for downstream wrappers (e.g., Observability Pipelines)
+    /// that group sampled events by user-provided fields and want the
+    /// discard metric tagged accordingly.
+    pub fn with_discarded_event_tags<F>(mut self, f: F) -> Self
+    where
+        F: Fn(&Event) -> Vec<(String, String)> + Send + Sync + 'static,
+    {
+        self.discarded_event_tags = Some(Arc::new(f));
+        self
     }
 
     #[cfg(test)]
@@ -323,6 +353,30 @@ impl Sample {
 
         self.get_event_value(event, key_field)
     }
+
+    /// Emit the discard metric. When `discarded_event_tags` is set,
+    /// bypasses the standard `SampleEventDiscarded` path so the per-event
+    /// tags can be merged onto `component_discarded_events_total`.
+    fn emit_discard(&self, event: &Event) {
+        match &self.discarded_event_tags {
+            Some(tag_fn) => {
+                let extra_tags = tag_fn(event);
+                let mut labels: Vec<metrics::Label> = Vec::with_capacity(extra_tags.len() + 1);
+                labels.push(metrics::Label::new("intentional", "true"));
+                for (k, v) in extra_tags {
+                    labels.push(metrics::Label::new(k, v));
+                }
+                counter!(CounterName::ComponentDiscardedEventsTotal, labels).increment(1);
+                tracing::debug!(
+                    message = "Events dropped",
+                    intentional = true,
+                    count = 1_u64,
+                    reason = "Sample discarded.",
+                );
+            }
+            None => emit!(SampleEventDiscarded),
+        }
+    }
 }
 
 impl FunctionTransform for Sample {
@@ -378,7 +432,7 @@ impl FunctionTransform for Sample {
             }
             output.push(event);
         } else {
-            emit!(SampleEventDiscarded);
+            self.emit_discard(&event);
         }
     }
 }


### PR DESCRIPTION
## Summary

Adds an optional `with_discarded_event_tags` builder on the `Sample` transform's runtime type. When set, the callback is invoked at the drop site and its returned `(key, value)` pairs are merged into the `component_discarded_events_total` counter labels. Default `None` — behavior unchanged for every existing caller.

## Motivation

Downstream wrappers (concretely, the Observability Pipelines Worker — a Datadog-internal consumer that uses Vector as a library) configure `Sample` with a `group_by` template but cannot currently attach per-event group-by tags to the discard metric. The discard counter today carries only `intentional:true`, so when a customer pipeline drops events the operator has to grep logs to know which group caused the drops.

A wrapping fork or duplicating Sample wholesale was rejected; this small extension point lets library consumers attach the tags they own without Vector taking a position on what the tags mean.

## Vector configuration

No new TOML/YAML config. The callback is a programmatic API used by library consumers, not the Vector binary. Existing pipelines using `sample` see no behavior change.

## How did you test this PR?

- Added `discarded_event_tags_callback_is_invoked_on_drop` in `src/transforms/sample/tests.rs` that:
  - constructs a `Sample` with an aggressive `rate=100`
  - attaches a callback that increments an atomic counter and returns a fixed tag pair
  - drives 200 random events through `Sample::transform`
  - asserts the callback was invoked at least 100 times (most events drop)
- Confirmed existing tests pass unchanged (the `discarded_event_tags` field is `None` in every existing test path).
- Manually verified the existing `SampleEventDiscarded` emission path is taken when the callback is `None`, so the `ComponentEventsDropped<INTENTIONAL>` plumbing is unaffected for current users.

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

The new field defaults to `None`. `Sample::new` and `Sample::new_with_dynamic` signatures are unchanged. The only addition is the `with_discarded_event_tags` builder method.

## Does this PR include user facing changes?

- [x] Yes. Added `changelog.d/<id>_sample_discarded_event_tags.enhancement.md`.

Library consumers gain a new opt-in API; pipeline operators see no change unless a downstream consumer of Vector wires the callback through.

## Notes

- The metric continues to be `component_discarded_events_total`; only the label set varies based on the (optional) callback's return value.
- When the callback is set, the drop site emits the counter directly (via `metrics::counter!`) and logs a debug message in the same shape as `ComponentEventsDropped<INTENTIONAL>::emit` would. This is necessary because `ComponentEventsDropped` registers its counter with a fixed label set at registration time, so dynamic per-event labels cannot flow through it.
- The bypass is only active when the callback is `Some`. With `None`, the existing `emit!(SampleEventDiscarded)` path runs unchanged.
- The callback signature takes `&Event` (not `&LogEvent`) so trace-event drops also benefit if a future consumer wants per-trace tags. Today the existing trace-event handling in `Sample::transform` calls `emit!(SampleEventDiscarded)` via the same branch, so it gains tag support automatically when the callback is set.