### PR TITLE
chore(ci): introduce Swatinem/rust-cache for target/ caching

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -8,8 +8,13 @@ branding:
 inputs:
   cargo-cache:
     required: false
-    default: true
+    default: false
     description: "Cache Cargo registry, index, and git DB. Enabled automatically if any Rust tools are requested."
+
+  cache-save:
+    required: false
+    default: "false"
+    description: "Whether this job is allowed to write the shared cache. Only warm-cache.yml opts in."
 
   mold:
     required: false
@@ -133,33 +138,6 @@ runs:
       if: ${{ env.NEEDS_RUST == 'true' }}
       run: echo "::add-matcher::.github/matchers/rust.json"
       shell: bash
-
-    # Two steps so that the actions/cache post-step (which saves the cache) runs
-    # directly from this composite, not a nested one — nested composites break
-    # post-step input resolution (actions/runner#3514, #2030).
-    - name: Cache Cargo registry, index, and git DB
-      if: ${{ (inputs.cargo-cache == 'true' || env.NEEDS_RUST == 'true') && github.ref == 'refs/heads/master' }}
-      uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
-      with:
-        path: |
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-cargo-
-
-    - name: Restore Cargo registry, index, and git DB
-      if: ${{ (inputs.cargo-cache == 'true' || env.NEEDS_RUST == 'true') && github.ref != 'refs/heads/master' }}
-      uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
-      with:
-        path: |
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-cargo-
 
     - name: Install mold
       if: ${{ runner.os == 'Linux' && env.DISABLE_MOLD != 'true' && inputs.mold == 'true' }}
@@ -299,3 +277,18 @@ runs:
       if: ${{ inputs.vdev == 'true' }}
       shell: bash
       run: echo "VDEV=$(which vdev)" >> "$GITHUB_ENV"
+
+    # Runs after prepare.sh so Swatinem can invoke rustc/cargo (fresh
+    # self-hosted runners install rustup there). Only warm-cache.yml
+    # opts in to saving; other master-ref workflows may dispatch with
+    # a user-supplied ref and must not poison the shared cache.
+    - name: Cache Cargo + target/
+      if: ${{ inputs.cargo-cache == 'true' && env.NEEDS_RUST == 'true' }}
+      uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      with:
+        prefix-key: "v1-vector"
+        shared-key: "workspace"
+        # Rotate the key when cache mechanics change so the warmer can save a fresh entry.
+        key: ${{ hashFiles('.github/actions/setup/action.yml', '.github/workflows/warm-cache.yml') }}
+        cache-bin: "false"
+        save-if: ${{ inputs.cache-save == 'true' && github.ref == 'refs/heads/master' }}

--- a/.github/workflows/changes.yml
+++ b/.github/workflows/changes.yml
@@ -290,21 +290,29 @@ jobs:
               - ".github/workflows/test.yml"
               - ".github/workflows/unit-tests.yml"
               - ".github/workflows/changes.yml"
+              - ".github/workflows/warm-cache.yml"
+              - ".github/actions/setup/**"
             integration-yml:
               - ".github/workflows/integration.yml"
               - ".github/workflows/changes.yml"
             test-make-command-yml:
               - ".github/workflows/test-make-command.yml"
               - ".github/workflows/changes.yml"
+              - ".github/workflows/warm-cache.yml"
+              - ".github/actions/setup/**"
             msrv-yml:
               - ".github/workflows/msrv.yml"
               - ".github/workflows/changes.yml"
+              - ".github/workflows/warm-cache.yml"
+              - ".github/actions/setup/**"
             cross-yml:
               - ".github/workflows/cross.yml"
               - ".github/workflows/changes.yml"
             unit_mac-yml:
               - ".github/workflows/unit_mac.yml"
               - ".github/workflows/changes.yml"
+              - ".github/workflows/warm-cache.yml"
+              - ".github/actions/setup/**"
             unit_windows-yml:
               - ".github/workflows/unit_windows.yml"
               - ".github/workflows/changes.yml"
@@ -361,7 +369,6 @@ jobs:
         with:
           vdev: true
           mold: false
-          cargo-cache: false
 
       # creates a yaml file that contains the filters for each integration,
       # extracted from the output of the `vdev int ci-paths` command, which
@@ -455,7 +462,6 @@ jobs:
         with:
           vdev: true
           mold: false
-          cargo-cache: false
 
       # creates a yaml file that contains the filters for each test,
       # extracted from the output of the `vdev int ci-paths` command, which

--- a/.github/workflows/check_generated_vrl_docs.yml
+++ b/.github/workflows/check_generated_vrl_docs.yml
@@ -54,6 +54,7 @@ jobs:
           rust: true
           protoc: true
           vdev: false
+          cargo-cache: true
 
       - uses: ./.github/actions/install-vrl-doc-builder
 

--- a/.github/workflows/component_features.yml
+++ b/.github/workflows/component_features.yml
@@ -50,5 +50,6 @@ jobs:
           protoc: true
           libsasl2: true
           cargo-hack: true
+          cargo-cache: true
 
       - run: make check-component-features

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -175,7 +175,6 @@ jobs:
         with:
           vdev: true
           mold: false
-          cargo-cache: false
           datadog-ci: true
 
       - name: Pull test runner image
@@ -257,7 +256,6 @@ jobs:
         with:
           vdev: true
           mold: false
-          cargo-cache: false
           datadog-ci: true
 
       - name: Pull test runner image

--- a/.github/workflows/k8s_e2e.yml
+++ b/.github/workflows/k8s_e2e.yml
@@ -179,7 +179,6 @@ jobs:
         with:
           vdev: true
           mold: false
-          cargo-cache: false
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -31,4 +31,5 @@ jobs:
           protoc: true
           libsasl2: true
           cargo-msrv: true
+          cargo-cache: true
       - run: cargo msrv verify

--- a/.github/workflows/test-make-command.yml
+++ b/.github/workflows/test-make-command.yml
@@ -54,6 +54,7 @@ jobs:
           libsasl2: true
           cargo-nextest: ${{ inputs.cargo_nextest }}
           datadog-ci: ${{ inputs.upload_test_results }}
+          cargo-cache: true
       - run: make ${{ inputs.command }}
       - name: Upload test results
         run: scripts/upload-test-results.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,7 @@ jobs:
           rust: true
           protoc: true
           libsasl2: true
+          cargo-cache: true
       - run: make check-clippy
 
   test:
@@ -75,7 +76,6 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup
         with:
-          cargo-cache: false
           mold: false
           vdev: true
       - run: make check-scripts
@@ -89,7 +89,6 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup
         with:
-          cargo-cache: false
           mold: false
           vdev: true
       - run: make check-events
@@ -103,7 +102,6 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup
         with:
-          cargo-cache: false
           mold: false
           vdev: true
           dd-rust-license-tool: true
@@ -150,6 +148,7 @@ jobs:
           protoc: true
           cue: true
           libsasl2: true
+          cargo-cache: true
       - run: make check-generated-docs
 
   check-rust-docs:
@@ -162,6 +161,7 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           rust: true
+          cargo-cache: true
       - run: cd rust-doc && make ci-docs-build
 
   test-vrl:
@@ -176,6 +176,7 @@ jobs:
           rust: true
           protoc: true
           wasm-pack: true
+          cargo-cache: true
       - run: make test-vrl
 
   build-vrl-playground:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -80,6 +80,7 @@ jobs:
           datadog-ci: ${{ !inputs.coverage }}
           protoc: true
           libsasl2: true
+          cargo-cache: true
 
       - name: Run tests
         run: |

--- a/.github/workflows/unit_mac.yml
+++ b/.github/workflows/unit_mac.yml
@@ -26,6 +26,7 @@ jobs:
           rust: true
           cargo-nextest: true
           protoc: true
+          cargo-cache: true
 
       # Some tests e.g. `reader_exits_cleanly_when_writer_done_and_in_flight_acks` are flaky.
       - name: Run tests

--- a/.github/workflows/warm-cache.yml
+++ b/.github/workflows/warm-cache.yml
@@ -36,7 +36,7 @@ jobs:
           protoc: true
           libsasl2: true
           cargo-cache: true
-          cache-save: "true"
+          cache-save: true
 
       # cargo build (not check) so cached deps include .rlib for cargo test consumers.
       # --all-features to match `vdev check rust` used by check-clippy, so

--- a/.github/workflows/warm-cache.yml
+++ b/.github/workflows/warm-cache.yml
@@ -1,0 +1,45 @@
+name: Warm Cache
+
+# Producer for the shared Rust build cache consumed by test.yml jobs.
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - "Cargo.lock"
+      - "rust-toolchain.toml"
+      - ".cargo/config.toml"
+      - "**/Cargo.toml"
+      - ".github/actions/setup/**"
+      - ".github/workflows/warm-cache.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: warm-cache
+  cancel-in-progress: false
+
+jobs:
+  warm:
+    name: Warm shared workspace cache
+    runs-on: ubuntu-24.04-8core
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: ./.github/actions/setup
+        with:
+          rust: true
+          protoc: true
+          libsasl2: true
+          cargo-cache: true
+          cache-save: "true"
+
+      # cargo build (not check) so cached deps include .rlib for cargo test consumers.
+      # --all-features to match `vdev check rust` used by check-clippy, so
+      # optional deps (rdkafka, ...) are in the cache.
+      - name: Seed build
+        run: cargo build --workspace --tests --all-features --locked


### PR DESCRIPTION
## Summary

Caches `~/.cargo` + `target/` build artifacts so slow-to-compile deps (rdkafka-sys, openssl-sys, AWS SDK) are reused across PR runs instead of rebuilt from scratch.

**Producer**: `.github/workflows/warm-cache.yml` — runs `cargo build --workspace --tests --all-features --locked` on master whenever `Cargo.lock`, any `Cargo.toml`, or setup files change. Only this workflow writes the cache (`cache-save: true` + `github.ref == refs/heads/master` gate).

**Consumer**: `.github/actions/setup/action.yml` 
* restores from `shared-key: "workspace"` with `save-if: false`. 
* All compiling jobs opt in via `cargo-cache: true`
* the input defaults to `false` so some jobs (vdev-only, cross-compile, cargo-deny, etc.) skip the cache step without any explicit config.

## Test results (vectordotdev/ci-sandbox)

| Scenario | Build time |
|---|---|
| Cold (no cache) | 120s |
| PR, src-only change (exact key hit) | 12s |
| PR, Cargo.lock bump (prefix-match hit) | 9s |

Seeder command matters — `cargo check --tests` leaves consumers rebuilding all deps (50s); `cargo build --tests` produces `.rlib` files and consumers run in 8s.

## Change Type

- [x] Non-functional (chore, refactoring, docs)

## Is this a breaking change?

- [x] No

## Does this PR include user facing changes?

- [x] No. A maintainer will apply the `no-changelog` label to this PR.