### PR TITLE
enhancement(tag_cardinality_limit transform): Remove HashSet initialization with capacity to improve memory usage

### DIFF
--- a/changelog.d/tag_cardinality_limit_improve_memory_usage.enhancement.md
+++ b/changelog.d/tag_cardinality_limit_improve_memory_usage.enhancement.md
@@ -1,0 +1,3 @@
+Reduce the memory usage of the `tag_cardinality_limit` transform when running in `exact` mode by allocating less unused memory on initialization.
+
+authors: ArunPiduguDD

--- a/src/transforms/tag_cardinality_limit/mod.rs
+++ b/src/transforms/tag_cardinality_limit/mod.rs
@@ -213,7 +213,7 @@ impl TagCardinalityLimit {
         let metric_accepted_tags = self.accepted_tags.entry(metric_key_owned).or_default();
         let tag_value_set = metric_accepted_tags
             .entry_ref(key)
-            .or_insert_with(|| AcceptedTagValueSet::new(config.value_limit, &config.mode));
+            .or_insert_with(|| AcceptedTagValueSet::new(&config.mode));
 
         if tag_value_set.contains(value) {
             // Tag value has already been accepted, nothing more to do.
@@ -300,7 +300,7 @@ impl TagCardinalityLimit {
         let metric_accepted_tags = self.accepted_tags.entry(metric_key_owned).or_default();
         metric_accepted_tags
             .entry_ref(key)
-            .or_insert_with(|| AcceptedTagValueSet::new(config.value_limit, &config.mode))
+            .or_insert_with(|| AcceptedTagValueSet::new(&config.mode))
             .insert(value.clone());
         false
     }

--- a/src/transforms/tag_cardinality_limit/tag_value_set.rs
+++ b/src/transforms/tag_cardinality_limit/tag_value_set.rs
@@ -59,9 +59,9 @@ impl fmt::Debug for TagValueSetStorage {
 }
 
 impl AcceptedTagValueSet {
-    pub fn new(value_limit: usize, mode: &Mode) -> Self {
+    pub fn new(mode: &Mode) -> Self {
         let storage = match &mode {
-            Mode::Exact => TagValueSetStorage::Set(HashSet::with_capacity(value_limit)),
+            Mode::Exact => TagValueSetStorage::Set(HashSet::new()),
             Mode::Probabilistic(config) => {
                 TagValueSetStorage::Bloom(BloomFilterStorage::new(config.cache_size_per_key))
             }
@@ -100,7 +100,7 @@ mod tests {
 
     #[test]
     fn test_accepted_tag_value_set_exact() {
-        let mut accepted_tag_value_set = AcceptedTagValueSet::new(2, &Mode::Exact);
+        let mut accepted_tag_value_set = AcceptedTagValueSet::new(&Mode::Exact);
 
         assert!(!accepted_tag_value_set.contains(&TagValueSet::from(["value1".to_string()])));
         assert_eq!(accepted_tag_value_set.len(), 0);
@@ -116,7 +116,7 @@ mod tests {
 
     #[test]
     fn test_accepted_tag_value_set_probabilistic() {
-        let mut accepted_tag_value_set = AcceptedTagValueSet::new(2, &Mode::Exact);
+        let mut accepted_tag_value_set = AcceptedTagValueSet::new(&Mode::Exact);
 
         assert!(!accepted_tag_value_set.contains(&TagValueSet::from(["value1".to_string()])));
         assert_eq!(accepted_tag_value_set.len(), 0);


### PR DESCRIPTION
## Summary

When initializing a new in-memory map/set to keep track of values seen for a new tag key, the HashSet is initalized with a capacity of `value_limit`. However this causes unnecessary memory usage, especially in cases where the `value_limit` is high and the overall cardinality of each tag key is low. 

Changing this to initializing with default `HashSet` capacity to prevent unnecessary memory usage

## Vector configuration
```
sources:
  otel:
    type: opentelemetry
    grpc:
      address: "0.0.0.0:4317"
    http:
      address: "0.0.0.0:4318"

transforms:
  strip_resource_tags:
    type: remap
    inputs: ["otel.metrics"]
    source: |
      del(.tags."resource.telemetry.sdk.version")
      del(.tags."resource.telemetry.sdk.language")
      del(.tags."resource.telemetry.sdk.name")
      del(.tags."resource.service.name")
      del(.tags."resource.service.version")

  cardinality:
    type: tag_cardinality_limit
    inputs: ["strip_resource_tags"]
    value_limit: 5
    mode: exact
    limit_exceeded_action: drop_event

    # The new setting under test. Try toggling between `global` (current behavior:
    # all metrics without a `per_metric_limits` entry share one bucket) and
    # `per_metric` (every metric name gets its own bucket).
    tracking_scope: per_metric

    per_metric_limits:
      # Tighter override on this specific metric — applies regardless of `tracking_scope`.
      demo_value_gauge:
        value_limit: 2
        mode: exact
        limit_exceeded_action: drop_event

      demo_value_counter:
        value_limit: 6
        mode: exact
        limit_exceeded_action: drop_tag

sinks:
  console:
    type: console
    inputs: ["cardinality"]
    encoding:
      codec: json

```

## How did you test this PR?
Tested with Vector config and monitored memory usage

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [x] Performance

## Is this a breaking change?

- [ ] Yes
- [ ] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Closes: #<issue/PR number or link>
-->
<!--
- Related: #<issue/PR number or link>
-->

## Notes

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details on the [dd-rust-license-tool](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
