### PR TITLE
fix(observability): do not hold span guards across await points

### DIFF
--- a/changelog.d/fix_topology_build_spans.fix.md
+++ b/changelog.d/fix_topology_build_spans.fix.md
@@ -1,0 +1,7 @@
+Fixed a bug in the topology builder causing component metrics registered at build
+time to miss the component tags if the component build function awaits non-trivially.
+
+This notably affected sinks using a disk buffer, and source or sinks performing
+IO work in the build function.
+
+authors: gwenaskell

--- a/clippy.toml
+++ b/clippy.toml
@@ -20,3 +20,8 @@ disallowed-types = [
   { path = "once_cell::sync::Lazy", reason = "Use `std::sync::LazyLock` instead." },
   { path = "once_cell::unsync::Lazy", reason = "Use `std::sync::LazyCell` instead." },
 ]
+
+
+await-holding-invalid-types = [
+    { path = "tracing::span::Entered", reason = "Holding a tracing span guard across an `.await` is thread-local and silently breaks when the task resumes on a different thread. Use `#[tracing::instrument]`, `future.instrument(span)`, or `Span::in_scope(|| ...)` instead." },
+]

--- a/src/sources/internal_logs.rs
+++ b/src/sources/internal_logs.rs
@@ -256,15 +256,15 @@ mod tests {
             component_id = "foo",
             component_type = "internal_logs",
         );
-        let _enter = span.enter();
+        let enter = span.enter();
 
         error!(message = "Before source started.", %test_id);
 
-        drop(_enter); // don't hold the span guard across an await point
+        drop(enter); // don't hold the span guard across an await point
 
         let rx = start_source().await;
 
-        let _enter = span.enter();
+        let enter = span.enter();
 
         error!(message = "After source started.", %test_id);
 
@@ -280,7 +280,7 @@ mod tests {
             error!(message = "In a nested span.", %test_id);
         }
 
-        drop(_enter);
+        drop(enter);
 
         sleep(Duration::from_millis(1)).await;
         let mut events = collect_ready(rx).await;

--- a/src/sources/internal_logs.rs
+++ b/src/sources/internal_logs.rs
@@ -260,7 +260,11 @@ mod tests {
 
         error!(message = "Before source started.", %test_id);
 
+        drop(_enter); // don't hold the span guard across an await point
+
         let rx = start_source().await;
+
+        let _enter = span.enter();
 
         error!(message = "After source started.", %test_id);
 
@@ -275,6 +279,8 @@ mod tests {
             let _enter = nested_span.enter();
             error!(message = "In a nested span.", %test_id);
         }
+
+        drop(_enter);
 
         sleep(Duration::from_millis(1)).await;
         let mut events = collect_ready(rx).await;

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -14,7 +14,7 @@ use tokio::{
     sync::{mpsc::UnboundedSender, oneshot},
     time::timeout,
 };
-use tracing::Instrument;
+use tracing::{Instrument, Span};
 use vector_lib::{
     EstimatedJsonEncodedSizeOf,
     buffers::{
@@ -46,7 +46,8 @@ use crate::{
     SourceSender,
     config::{
         ComponentKey, Config, DataType, EnrichmentTableConfig, Input, Inputs, OutputId,
-        ProxyConfig, SinkContext, SourceContext, TransformContext, TransformOuter, TransformOutput,
+        ProxyConfig, SinkContext, SinkOuter, SourceContext, SourceOuter, TransformContext,
+        TransformOuter, TransformOutput,
     },
     event::{EventArray, EventContainer},
     extra_context::ExtraContext,
@@ -252,173 +253,188 @@ impl<'a> Builder<'a> {
         {
             debug!(component_id = %key, "Building new source.");
 
-            let typetag = source.inner.get_component_name();
-            let source_outputs = source.inner.outputs(self.config.schema.log_namespace());
-
             let span = error_span!(
                 "source",
                 component_kind = "source",
                 component_id = %key.id(),
                 component_type = %source.inner.get_component_name(),
             );
-            let _entered_span = span.enter();
 
-            let task_name = format!(
-                ">> {} ({}, pump) >>",
-                source.inner.get_component_name(),
-                key.id()
-            );
-
-            let mut builder = SourceSender::builder()
-                .with_buffer(*SOURCE_SENDER_BUFFER_SIZE)
-                .with_timeout(source.inner.send_timeout())
-                .with_ewma_half_life_seconds(
-                    self.config.global.buffer_utilization_ewma_half_life_seconds,
-                );
-            let mut pumps = Vec::new();
-            let mut controls = HashMap::new();
-            let mut schema_definitions = HashMap::with_capacity(source_outputs.len());
-
-            for output in source_outputs.into_iter() {
-                let rx = builder.add_source_output(output.clone(), key.clone());
-
-                let (fanout, control) = Fanout::new();
-                let source_type = source.inner.get_component_name();
-                let source = Arc::new(key.clone());
-
-                let pump = run_source_output_pump(rx, fanout, source, source_type);
-
-                pumps.push(pump.instrument(span.clone()));
-                controls.insert(
-                    OutputId {
-                        component: key.clone(),
-                        port: output.port.clone(),
-                    },
-                    control,
-                );
-
-                let port = output.port.clone();
-                if let Some(definition) = output.schema_definition(self.config.schema.enabled) {
-                    schema_definitions.insert(port, definition);
-                }
+            if let Ok(server) = self
+                .build_instrumented_source(key, source, enrichment_tables)
+                .instrument(span)
+                .await
+            {
+                source_tasks.insert(key.clone(), server);
             }
-
-            let (pump_error_tx, mut pump_error_rx) = oneshot::channel();
-            let pump = async move {
-                debug!("Source pump supervisor starting.");
-
-                // Spawn all of the per-output pumps and then await their completion.
-                //
-                // If any of the pumps complete with an error, or panic/are cancelled, we return
-                // immediately.
-                let mut handles = FuturesUnordered::new();
-                for pump in pumps {
-                    handles.push(spawn_named(pump, task_name.as_ref()));
-                }
-
-                let mut had_pump_error = false;
-                while let Some(output) = handles.try_next().await? {
-                    if let Err(e) = output {
-                        // Immediately send the error to the source's wrapper future, but ignore any
-                        // errors during the send, since nested errors wouldn't make any sense here.
-                        _ = pump_error_tx.send(e);
-                        had_pump_error = true;
-                        break;
-                    }
-                }
-
-                if had_pump_error {
-                    debug!("Source pump supervisor task finished with an error.");
-                } else {
-                    debug!("Source pump supervisor task finished normally.");
-                }
-                Ok(TaskOutput::Source)
-            };
-            let pump = Task::new(key.clone(), typetag, pump);
-
-            let (shutdown_signal, force_shutdown_tripwire) = self
-                .shutdown_coordinator
-                .register_source(key, INTERNAL_SOURCES.contains(&typetag));
-
-            let context = SourceContext {
-                key: key.clone(),
-                globals: self.config.global.clone(),
-                enrichment_tables: enrichment_tables.clone(),
-                metrics_storage: METRICS_STORAGE.clone(),
-                shutdown: shutdown_signal,
-                out: builder.build(),
-                proxy: ProxyConfig::merge_with_env(&self.config.global.proxy, &source.proxy),
-                acknowledgements: source.sink_acknowledgements,
-                schema_definitions,
-                schema: self.config.schema,
-                extra_context: self.extra_context.clone(),
-            };
-            let server = match source.inner.build(context).await {
-                Err(error) => {
-                    self.errors.push(format!("Source \"{key}\": {error}"));
-                    continue;
-                }
-                Ok(server) => server,
-            };
-
-            // Build a wrapper future that drives the actual source future, but returns early if we've
-            // been signalled to forcefully shutdown, or if the source pump encounters an error.
-            //
-            // The forceful shutdown will only resolve if the source itself doesn't shutdown gracefully
-            // within the allotted time window. This can occur normally for certain sources, like stdin,
-            // where the I/O is blocking (in a separate thread) and won't wake up to check if it's time
-            // to shutdown unless some input is given.
-            let server = async move {
-                debug!("Source starting.");
-
-                let mut result = select! {
-                    biased;
-
-                    // We've been told that we must forcefully shut down.
-                    _ = force_shutdown_tripwire => Ok(()),
-
-                    // The source pump encountered an error, which we're now bubbling up here to stop
-                    // the source as well, since the source running makes no sense without the pump.
-                    //
-                    // We only match receiving a message, not the error of the sender being dropped,
-                    // just to keep things simpler.
-                    Ok(e) = &mut pump_error_rx => Err(e),
-
-                    // The source finished normally.
-                    result = server => result.map_err(|_| TaskError::Opaque),
-                };
-
-                // Even though we already tried to receive any pump task error above, we may have exited
-                // on the source itself returning an error due to task scheduling, where the pump task
-                // encountered an error, sent it over the oneshot, but we were polling the source
-                // already and hit an error trying to send to the now-shutdown pump task.
-                //
-                // Since the error from the source is opaque at the moment (i.e. `()`), we try a final
-                // time to see if the pump task encountered an error, using _that_ instead if so, to
-                // propagate the true error that caused the source to have to stop.
-                if let Ok(e) = pump_error_rx.try_recv() {
-                    result = Err(e);
-                }
-
-                match result {
-                    Ok(()) => {
-                        debug!("Source finished normally.");
-                        Ok(TaskOutput::Source)
-                    }
-                    Err(e) => {
-                        debug!("Source finished with an error.");
-                        Err(e)
-                    }
-                }
-            };
-            let server = Task::new(key.clone(), typetag, server);
-
-            self.outputs.extend(controls);
-            self.tasks.insert(key.clone(), pump);
-            source_tasks.insert(key.clone(), server);
         }
 
         source_tasks
+    }
+
+    async fn build_instrumented_source(
+        &mut self,
+        key: &ComponentKey,
+        source: &SourceOuter,
+        enrichment_tables: &vector_lib::enrichment::TableRegistry,
+    ) -> Result<Task, ()> {
+        let typetag = source.inner.get_component_name();
+        let source_outputs = source.inner.outputs(self.config.schema.log_namespace());
+
+        let task_name = format!(
+            ">> {} ({}, pump) >>",
+            source.inner.get_component_name(),
+            key.id()
+        );
+
+        let mut builder = SourceSender::builder()
+            .with_buffer(*SOURCE_SENDER_BUFFER_SIZE)
+            .with_timeout(source.inner.send_timeout())
+            .with_ewma_half_life_seconds(
+                self.config.global.buffer_utilization_ewma_half_life_seconds,
+            );
+        let mut pumps = Vec::new();
+        let mut controls = HashMap::new();
+        let mut schema_definitions = HashMap::with_capacity(source_outputs.len());
+
+        for output in source_outputs.into_iter() {
+            let rx = builder.add_source_output(output.clone(), key.clone());
+
+            let (fanout, control) = Fanout::new();
+            let source_type = source.inner.get_component_name();
+            let source = Arc::new(key.clone());
+
+            let pump = run_source_output_pump(rx, fanout, source, source_type);
+
+            pumps.push(pump.instrument(Span::current()));
+            controls.insert(
+                OutputId {
+                    component: key.clone(),
+                    port: output.port.clone(),
+                },
+                control,
+            );
+
+            let port = output.port.clone();
+            if let Some(definition) = output.schema_definition(self.config.schema.enabled) {
+                schema_definitions.insert(port, definition);
+            }
+        }
+
+        let (pump_error_tx, mut pump_error_rx) = oneshot::channel();
+        let pump = async move {
+            debug!("Source pump supervisor starting.");
+
+            // Spawn all of the per-output pumps and then await their completion.
+            //
+            // If any of the pumps complete with an error, or panic/are cancelled, we return
+            // immediately.
+            let mut handles = FuturesUnordered::new();
+            for pump in pumps {
+                handles.push(spawn_named(pump, task_name.as_ref()));
+            }
+
+            let mut had_pump_error = false;
+            while let Some(output) = handles.try_next().await? {
+                if let Err(e) = output {
+                    // Immediately send the error to the source's wrapper future, but ignore any
+                    // errors during the send, since nested errors wouldn't make any sense here.
+                    _ = pump_error_tx.send(e);
+                    had_pump_error = true;
+                    break;
+                }
+            }
+
+            if had_pump_error {
+                debug!("Source pump supervisor task finished with an error.");
+            } else {
+                debug!("Source pump supervisor task finished normally.");
+            }
+            Ok(TaskOutput::Source)
+        };
+        let pump = Task::new(key.clone(), typetag, pump);
+
+        let (shutdown_signal, force_shutdown_tripwire) = self
+            .shutdown_coordinator
+            .register_source(key, INTERNAL_SOURCES.contains(&typetag));
+
+        let context = SourceContext {
+            key: key.clone(),
+            globals: self.config.global.clone(),
+            enrichment_tables: enrichment_tables.clone(),
+            metrics_storage: METRICS_STORAGE.clone(),
+            shutdown: shutdown_signal,
+            out: builder.build(),
+            proxy: ProxyConfig::merge_with_env(&self.config.global.proxy, &source.proxy),
+            acknowledgements: source.sink_acknowledgements,
+            schema_definitions,
+            schema: self.config.schema,
+            extra_context: self.extra_context.clone(),
+        };
+        let server = match source.inner.build(context).await {
+            Err(error) => {
+                self.errors.push(format!("Source \"{key}\": {error}"));
+                return Err(());
+            }
+            Ok(server) => server,
+        };
+
+        // Build a wrapper future that drives the actual source future, but returns early if we've
+        // been signalled to forcefully shutdown, or if the source pump encounters an error.
+        //
+        // The forceful shutdown will only resolve if the source itself doesn't shutdown gracefully
+        // within the allotted time window. This can occur normally for certain sources, like stdin,
+        // where the I/O is blocking (in a separate thread) and won't wake up to check if it's time
+        // to shutdown unless some input is given.
+        let server = async move {
+            debug!("Source starting.");
+
+            let mut result = select! {
+                biased;
+
+                // We've been told that we must forcefully shut down.
+                _ = force_shutdown_tripwire => Ok(()),
+
+                // The source pump encountered an error, which we're now bubbling up here to stop
+                // the source as well, since the source running makes no sense without the pump.
+                //
+                // We only match receiving a message, not the error of the sender being dropped,
+                // just to keep things simpler.
+                Ok(e) = &mut pump_error_rx => Err(e),
+
+                // The source finished normally.
+                result = server => result.map_err(|_| TaskError::Opaque),
+            };
+
+            // Even though we already tried to receive any pump task error above, we may have exited
+            // on the source itself returning an error due to task scheduling, where the pump task
+            // encountered an error, sent it over the oneshot, but we were polling the source
+            // already and hit an error trying to send to the now-shutdown pump task.
+            //
+            // Since the error from the source is opaque at the moment (i.e. `()`), we try a final
+            // time to see if the pump task encountered an error, using _that_ instead if so, to
+            // propagate the true error that caused the source to have to stop.
+            if let Ok(e) = pump_error_rx.try_recv() {
+                result = Err(e);
+            }
+
+            match result {
+                Ok(()) => {
+                    debug!("Source finished normally.");
+                    Ok(TaskOutput::Source)
+                }
+                Err(e) => {
+                    debug!("Source finished with an error.");
+                    Err(e)
+                }
+            }
+        };
+        let server = Task::new(key.clone(), typetag, server);
+
+        self.outputs.extend(controls);
+        self.tasks.insert(key.clone(), pump);
+
+        Ok(server)
     }
 
     async fn build_transforms(
@@ -449,85 +465,94 @@ impl<'a> Builder<'a> {
                 }
             };
 
-            let merged_definition: Definition = input_definitions
-                .iter()
-                .map(|(_output_id, definition)| definition.clone())
-                .reduce(Definition::merge)
-                // We may not have any definitions if all the inputs are from metrics sources.
-                .unwrap_or_else(Definition::any);
-
             let span = error_span!(
                 "transform",
                 component_kind = "transform",
                 component_id = %key.id(),
                 component_type = %transform.inner.get_component_name(),
             );
-            let _span = span.enter();
 
-            // Create a map of the outputs to the list of possible definitions from those outputs.
-            let schema_definitions = transform
-                .inner
-                .outputs(
-                    &TransformContext {
-                        enrichment_tables: enrichment_tables.clone(),
-                        metrics_storage: METRICS_STORAGE.clone(),
-                        schema: self.config.schema,
-                        ..Default::default()
-                    },
-                    &input_definitions,
-                )
-                .into_iter()
-                .map(|output| {
-                    let definitions = output.schema_definitions(self.config.schema.enabled);
-                    (output.port, definitions)
-                })
-                .collect::<HashMap<_, _>>();
-
-            let context = TransformContext {
-                key: Some(key.clone()),
-                globals: self.config.global.clone(),
-                enrichment_tables: enrichment_tables.clone(),
-                metrics_storage: METRICS_STORAGE.clone(),
-                schema_definitions,
-                merged_schema_definition: merged_definition.clone(),
-                schema: self.config.schema,
-                extra_context: self.extra_context.clone(),
-            };
-
-            let node =
-                TransformNode::from_parts(key.clone(), &context, transform, &input_definitions);
-
-            let transform = match transform
-                .inner
-                .build(&context)
-                .instrument(span.clone())
-                .await
-            {
-                Err(error) => {
-                    self.errors.push(format!("Transform \"{key}\": {error}"));
-                    continue;
-                }
-                Ok(transform) => transform,
-            };
-
-            let metrics = ChannelMetricMetadata::new(BufferChannelKind::Transform, None);
-            let (input_tx, input_rx) = TopologyBuilder::standalone_memory(
-                TOPOLOGY_BUFFER_SIZE,
-                WhenFull::Block,
-                &span,
-                Some(metrics),
-                self.config.global.buffer_utilization_ewma_half_life_seconds,
-            );
-
-            self.inputs
-                .insert(key.clone(), (input_tx, node.inputs.clone()));
-
-            let (transform_task, transform_outputs) =
-                self.build_transform(transform, node, input_rx);
-
-            self.outputs.extend(transform_outputs);
-            self.tasks.insert(key.clone(), transform_task);
+            self.build_instrumented_transform(key, transform, enrichment_tables, input_definitions)
+                .instrument(span)
+                .await;
         }
+    }
+
+    async fn build_instrumented_transform(
+        &mut self,
+        key: &ComponentKey,
+        transform: &TransformOuter<OutputId>,
+        enrichment_tables: &vector_lib::enrichment::TableRegistry,
+        input_definitions: Vec<(OutputId, Definition)>,
+    ) {
+        let merged_definition: Definition = input_definitions
+            .iter()
+            .map(|(_output_id, definition)| definition.clone())
+            .reduce(Definition::merge)
+            // We may not have any definitions if all the inputs are from metrics sources.
+            .unwrap_or_else(Definition::any);
+
+        // Create a map of the outputs to the list of possible definitions from those outputs.
+        let schema_definitions = transform
+            .inner
+            .outputs(
+                &TransformContext {
+                    enrichment_tables: enrichment_tables.clone(),
+                    metrics_storage: METRICS_STORAGE.clone(),
+                    schema: self.config.schema,
+                    ..Default::default()
+                },
+                &input_definitions,
+            )
+            .into_iter()
+            .map(|output| {
+                let definitions = output.schema_definitions(self.config.schema.enabled);
+                (output.port, definitions)
+            })
+            .collect::<HashMap<_, _>>();
+
+        let context = TransformContext {
+            key: Some(key.clone()),
+            globals: self.config.global.clone(),
+            enrichment_tables: enrichment_tables.clone(),
+            metrics_storage: METRICS_STORAGE.clone(),
+            schema_definitions,
+            merged_schema_definition: merged_definition.clone(),
+            schema: self.config.schema,
+            extra_context: self.extra_context.clone(),
+        };
+
+        let node = TransformNode::from_parts(key.clone(), &context, transform, &input_definitions);
+
+        let transform = match transform
+            .inner
+            .build(&context)
+            .instrument(Span::current())
+            .await
+        {
+            Err(error) => {
+                self.errors.push(format!("Transform \"{key}\": {error}"));
+                return;
+            }
+            Ok(transform) => transform,
+        };
+
+        let metrics = ChannelMetricMetadata::new(BufferChannelKind::Transform, None);
+        let (input_tx, input_rx) = TopologyBuilder::standalone_memory(
+            TOPOLOGY_BUFFER_SIZE,
+            WhenFull::Block,
+            &Span::current(),
+            Some(metrics),
+            self.config.global.buffer_utilization_ewma_half_life_seconds,
+        );
+
+        self.inputs
+            .insert(key.clone(), (input_tx, node.inputs.clone()));
+
+        let (transform_task, transform_outputs) = self.build_transform(transform, node, input_rx);
+
+        self.outputs.extend(transform_outputs);
+        self.tasks.insert(key.clone(), transform_task);
     }
 
     async fn build_sinks(&mut self, enrichment_tables: &vector_lib::enrichment::TableRegistry) {
@@ -550,172 +575,178 @@ impl<'a> Builder<'a> {
         {
             debug!(component_id = %key, "Building new sink.");
 
-            let sink_inputs = &sink.inputs;
-            let healthcheck = sink.healthcheck();
-            let enable_healthcheck = healthcheck.enabled && self.config.healthchecks.enabled;
-            let healthcheck_timeout = healthcheck.timeout;
-
-            let typetag = sink.inner.get_component_name();
-            let input_type = sink.inner.input().data_type();
-
             let span = error_span!(
                 "sink",
                 component_kind = "sink",
                 component_id = %key.id(),
                 component_type = %sink.inner.get_component_name(),
             );
-            let _entered_span = span.enter();
 
-            // At this point, we've validated that all transforms are valid, including any
-            // transform that mutates the schema provided by their sources. We can now validate the
-            // schema expectations of each individual sink.
-            if let Err(mut err) = schema::validate_sink_expectations(
-                key,
-                sink,
-                self.config,
-                enrichment_tables.clone(),
-            ) {
-                self.errors.append(&mut err);
-            };
-
-            let (tx, rx) = match self.buffers.remove(key) {
-                Some(buffer) => buffer,
-                _ => {
-                    let buffer_type =
-                        match sink.buffer.stages().first().expect("cant ever be empty") {
-                            BufferType::Memory { .. } => "memory",
-                            BufferType::DiskV2 { .. } => "disk",
-                        };
-                    let buffer_span = error_span!("sink", buffer_type);
-                    let buffer = sink
-                        .buffer
-                        .build(
-                            self.config.global.data_dir.clone(),
-                            key.to_string(),
-                            buffer_span,
-                        )
-                        .await;
-                    match buffer {
-                        Err(error) => {
-                            self.errors.push(format!("Sink \"{key}\": {error}"));
-                            continue;
-                        }
-                        Ok((tx, rx)) => (tx, Arc::new(Mutex::new(Some(rx.into_stream())))),
-                    }
-                }
-            };
-
-            let cx = SinkContext {
-                healthcheck,
-                globals: self.config.global.clone(),
-                enrichment_tables: enrichment_tables.clone(),
-                metrics_storage: METRICS_STORAGE.clone(),
-                proxy: ProxyConfig::merge_with_env(&self.config.global.proxy, sink.proxy()),
-                schema: self.config.schema,
-                app_name: crate::get_app_name().to_string(),
-                app_name_slug: crate::get_slugified_app_name(),
-                extra_context: self.extra_context.clone(),
-            };
-
-            let (sink, healthcheck) = match sink.inner.build(cx).await {
-                Err(error) => {
-                    self.errors.push(format!("Sink \"{key}\": {error}"));
-                    continue;
-                }
-                Ok(built) => built,
-            };
-
-            let (trigger, tripwire) = Tripwire::new();
-
-            let utilization_sender = self
-                .utilization_registry
-                .add_component(key.clone(), gauge!(GaugeName::Utilization));
-            let component_key = key.clone();
-            let sink = async move {
-                debug!("Sink starting.");
-
-                // Why is this Arc<Mutex<Option<_>>> needed you ask.
-                // In case when this function build_pieces errors
-                // this future won't be run so this rx won't be taken
-                // which will enable us to reuse rx to rebuild
-                // old configuration by passing this Arc<Mutex<Option<_>>>
-                // yet again.
-                let rx = rx
-                    .lock()
-                    .unwrap()
-                    .take()
-                    .expect("Task started but input has been taken.");
-
-                let mut rx = Utilization::new(utilization_sender, component_key.clone(), rx);
-
-                let events_received = register!(EventsReceived);
-                sink.run(
-                    rx.by_ref()
-                        .filter(|events: &EventArray| ready(filter_events_type(events, input_type)))
-                        .inspect(|events| {
-                            events_received.emit(CountByteSize(
-                                events.len(),
-                                events.estimated_json_encoded_size_of(),
-                            ))
-                        })
-                        .take_until_if(tripwire),
-                )
-                .await
-                .map(|_| {
-                    debug!("Sink finished normally.");
-                    TaskOutput::Sink(rx)
-                })
-                .map_err(|_| {
-                    debug!("Sink finished with an error.");
-                    TaskError::Opaque
-                })
-            };
-
-            let task = Task::new(key.clone(), typetag, sink);
-
-            let component_key = key.clone();
-            let healthcheck_task = async move {
-                if enable_healthcheck {
-                    timeout(healthcheck_timeout, healthcheck)
-                        .map(|result| match result {
-                            Ok(Ok(_)) => {
-                                info!("Healthcheck passed.");
-                                Ok(TaskOutput::Healthcheck)
-                            }
-                            Ok(Err(error)) => {
-                                error!(
-                                    msg = "Healthcheck failed.",
-                                    %error,
-                                    component_kind = "sink",
-                                    component_type = typetag,
-                                    component_id = %component_key.id(),
-                                );
-                                Err(TaskError::wrapped(error))
-                            }
-                            Err(e) => {
-                                error!(
-                                    msg = "Healthcheck timed out.",
-                                    component_kind = "sink",
-                                    component_type = typetag,
-                                    component_id = %component_key.id(),
-                                );
-                                Err(TaskError::wrapped(Box::new(e)))
-                            }
-                        })
-                        .await
-                } else {
-                    info!("Healthcheck disabled.");
-                    Ok(TaskOutput::Healthcheck)
-                }
-            };
-
-            let healthcheck_task = Task::new(key.clone(), typetag, healthcheck_task);
-
-            self.inputs.insert(key.clone(), (tx, sink_inputs.clone()));
-            self.healthchecks.insert(key.clone(), healthcheck_task);
-            self.tasks.insert(key.clone(), task);
-            self.detach_triggers.insert(key.clone(), trigger);
+            self.build_instrumented_sink(key, sink, enrichment_tables)
+                .instrument(span)
+                .await;
         }
+    }
+
+    async fn build_instrumented_sink(
+        &mut self,
+        key: &ComponentKey,
+        sink: &SinkOuter<OutputId>,
+        enrichment_tables: &vector_lib::enrichment::TableRegistry,
+    ) {
+        let sink_inputs = &sink.inputs;
+        let healthcheck = sink.healthcheck();
+        let enable_healthcheck = healthcheck.enabled && self.config.healthchecks.enabled;
+        let healthcheck_timeout = healthcheck.timeout;
+
+        let typetag = sink.inner.get_component_name();
+        let input_type = sink.inner.input().data_type();
+
+        // At this point, we've validated that all transforms are valid, including any
+        // transform that mutates the schema provided by their sources. We can now validate the
+        // schema expectations of each individual sink.
+        if let Err(mut err) =
+            schema::validate_sink_expectations(key, sink, self.config, enrichment_tables.clone())
+        {
+            self.errors.append(&mut err);
+        };
+
+        let (tx, rx) = match self.buffers.remove(key) {
+            Some(buffer) => buffer,
+            _ => {
+                let buffer_type = match sink.buffer.stages().first().expect("cant ever be empty") {
+                    BufferType::Memory { .. } => "memory",
+                    BufferType::DiskV2 { .. } => "disk",
+                };
+                let buffer_span = error_span!("sink", buffer_type);
+                let buffer = sink
+                    .buffer
+                    .build(
+                        self.config.global.data_dir.clone(),
+                        key.to_string(),
+                        buffer_span,
+                    )
+                    .await;
+                match buffer {
+                    Err(error) => {
+                        self.errors.push(format!("Sink \"{key}\": {error}"));
+                        return;
+                    }
+                    Ok((tx, rx)) => (tx, Arc::new(Mutex::new(Some(rx.into_stream())))),
+                }
+            }
+        };
+
+        let cx = SinkContext {
+            healthcheck,
+            globals: self.config.global.clone(),
+            enrichment_tables: enrichment_tables.clone(),
+            metrics_storage: METRICS_STORAGE.clone(),
+            proxy: ProxyConfig::merge_with_env(&self.config.global.proxy, sink.proxy()),
+            schema: self.config.schema,
+            app_name: crate::get_app_name().to_string(),
+            app_name_slug: crate::get_slugified_app_name(),
+            extra_context: self.extra_context.clone(),
+        };
+
+        let (sink, healthcheck) = match sink.inner.build(cx).await {
+            Err(error) => {
+                self.errors.push(format!("Sink \"{key}\": {error}"));
+                return;
+            }
+            Ok(built) => built,
+        };
+
+        let (trigger, tripwire) = Tripwire::new();
+
+        let utilization_sender = self
+            .utilization_registry
+            .add_component(key.clone(), gauge!(GaugeName::Utilization));
+        let component_key = key.clone();
+        let sink = async move {
+            debug!("Sink starting.");
+
+            // Why is this Arc<Mutex<Option<_>>> needed you ask.
+            // In case when this function build_pieces errors
+            // this future won't be run so this rx won't be taken
+            // which will enable us to reuse rx to rebuild
+            // old configuration by passing this Arc<Mutex<Option<_>>>
+            // yet again.
+            let rx = rx
+                .lock()
+                .unwrap()
+                .take()
+                .expect("Task started but input has been taken.");
+
+            let mut rx = Utilization::new(utilization_sender, component_key.clone(), rx);
+
+            let events_received = register!(EventsReceived);
+            sink.run(
+                rx.by_ref()
+                    .filter(|events: &EventArray| ready(filter_events_type(events, input_type)))
+                    .inspect(|events| {
+                        events_received.emit(CountByteSize(
+                            events.len(),
+                            events.estimated_json_encoded_size_of(),
+                        ))
+                    })
+                    .take_until_if(tripwire),
+            )
+            .await
+            .map(|_| {
+                debug!("Sink finished normally.");
+                TaskOutput::Sink(rx)
+            })
+            .map_err(|_| {
+                debug!("Sink finished with an error.");
+                TaskError::Opaque
+            })
+        };
+
+        let task = Task::new(key.clone(), typetag, sink);
+
+        let component_key = key.clone();
+        let healthcheck_task = async move {
+            if enable_healthcheck {
+                timeout(healthcheck_timeout, healthcheck)
+                    .map(|result| match result {
+                        Ok(Ok(_)) => {
+                            info!("Healthcheck passed.");
+                            Ok(TaskOutput::Healthcheck)
+                        }
+                        Ok(Err(error)) => {
+                            error!(
+                                msg = "Healthcheck failed.",
+                                %error,
+                                component_kind = "sink",
+                                component_type = typetag,
+                                component_id = %component_key.id(),
+                            );
+                            Err(TaskError::wrapped(error))
+                        }
+                        Err(e) => {
+                            error!(
+                                msg = "Healthcheck timed out.",
+                                component_kind = "sink",
+                                component_type = typetag,
+                                component_id = %component_key.id(),
+                            );
+                            Err(TaskError::wrapped(Box::new(e)))
+                        }
+                    })
+                    .await
+            } else {
+                info!("Healthcheck disabled.");
+                Ok(TaskOutput::Healthcheck)
+            }
+        };
+
+        let healthcheck_task = Task::new(key.clone(), typetag, healthcheck_task);
+
+        self.inputs.insert(key.clone(), (tx, sink_inputs.clone()));
+        self.healthchecks.insert(key.clone(), healthcheck_task);
+        self.tasks.insert(key.clone(), task);
+        self.detach_triggers.insert(key.clone(), trigger);
     }
 
     fn build_transform(


### PR DESCRIPTION
## Summary

In the topology builder, the components builder functions enter a tracing span, which carries the tags that will automatically be injected into the metrics registered at build time below. This entered span guard is held while calling the inner source build function, which is asynchronous. Holding an entered span across an await point is strongly discouraged in [tracing docs](https://docs.rs/tracing/latest/tracing/span/struct.Span.html#in-asynchronous-code): if the awaited future is non-trivial and actually yields to the tokio runtime, the entered span guard is leaked on the current thread's stack and lost if the task is later resumed on a different thread.

What this means concretely: any source, transform or sink which build method actually performs async work that pauses it temporarily will very likely loose all component tags on the metrics registered at build time within that source / sink after the await point.
This includes (the list may not be exhaustive):

- all sinks configured with a disk buffer (which often yields during initialization due to IO work)
- sources/transforms/sinks like gcp_pubsub and microsoft_sentinel, which perform IO work for authentication at build time

## Vector configuration

Our E2E tests flagged missing metrics for gcp_pubsub, microsoft_sentinel, and sinks using disk buffers. `utilization` was frequently not reported.

## How did you test this PR?
<!-- Please describe how you tested your changes. Also include any information about your setup. -->

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Related: #<issue/PR number or link>
-->

## Notes

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details on the [dd-rust-license-tool](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
