### PR TITLE
fix(aggregate transform): Fix incorrectly dropped events bug in metrics aggregate transform

### DIFF
--- a/changelog.d/aggregate_passthrough_ignored_kind.fix.md
+++ b/changelog.d/aggregate_passthrough_ignored_kind.fix.md
@@ -1,3 +1,14 @@
-The `aggregate` transform now correctly passes through metrics whose kind is not supported by the configured mode, rather than silently dropping them. For example, `absolute` metrics flowing through a `sum`-mode aggregate are forwarded to the output unchanged without any aggregation & without being dropped
+The `aggregate` transform now correctly passes through/ignores metrics whose kind is not supported
+by the configured mode. Prior to this change these metrics would be silently dropped, contrary to
+the officially documented behavior. For example, `absolute` metrics flowing through a `sum`-mode aggregate
+transform are now forwarded to the next step in the pipeline unchanged rather than being dropped:
+
+```text
+{kind: incremental, type: counter, name: "http.requests", value: 10}  → summed into aggregate
+{kind: absolute,    type: gauge,   name: "cpu.usage",     value: 0.83} → previously dropped, now passes through unchanged
+{kind: incremental, type: counter, name: "http.requests", value: 5}   → summed into aggregate
+```
+
+If the previous drop behavior was intentional, add a `filter` transform before the aggregate transform to discard the unwanted metric kind.
 
 authors: ArunPiduguDD

--- a/changelog.d/aggregate_passthrough_ignored_kind.fix.md
+++ b/changelog.d/aggregate_passthrough_ignored_kind.fix.md
@@ -9,6 +9,6 @@ transform are now forwarded to the next step in the pipeline unchanged rather th
 {kind: incremental, type: counter, name: "http.requests", value: 5}   → summed into aggregate
 ```
 
-If the previous drop behavior was intentional, add a `filter` transform before the aggregate transform to discard the unwanted metric kind.
+If you want to preserve the previous drop behavior, add a `filter` transform before the aggregate transform to discard the unwanted metric kind.
 
 authors: ArunPiduguDD

--- a/changelog.d/aggregate_passthrough_ignored_kind.fix.md
+++ b/changelog.d/aggregate_passthrough_ignored_kind.fix.md
@@ -1,0 +1,3 @@
+The `aggregate` transform now correctly passes through metrics whose kind is not supported by the configured mode, rather than silently dropping them. For example, `absolute` metrics flowing through a `sum`-mode aggregate are forwarded to the output unchanged without any aggregation & without being dropped
+
+authors: ArunPiduguDD

--- a/src/transforms/aggregate.rs
+++ b/src/transforms/aggregate.rs
@@ -165,14 +165,6 @@ impl TransformConfig for AggregateConfig {
 
 type MetricEntry = (MetricData, EventMetadata);
 
-// Never stored in a collection, only ephemeral/transient to forward ignored events
-#[allow(clippy::large_enum_variant)]
-#[derive(Debug)]
-pub enum RecordOutcome {
-    Aggregated,
-    Passthrough(Event),
-}
-
 #[derive(Debug)]
 pub struct Aggregate {
     interval: Duration,
@@ -189,39 +181,31 @@ impl Aggregate {
         })
     }
 
-    pub fn record(&mut self, event: Event) -> RecordOutcome {
-        let kind = event.as_metric().kind();
-        if matches!(
-            (&self.mode, kind),
-            (InnerMode::Sum, MetricKind::Absolute)
-                | (
-                    InnerMode::Latest | InnerMode::Diff { .. },
-                    MetricKind::Incremental
-                )
-                | (InnerMode::Max | InnerMode::Min, MetricKind::Incremental)
-                | (
-                    InnerMode::Mean { .. } | InnerMode::Stdev { .. },
-                    MetricKind::Incremental
-                )
-        ) {
-            return RecordOutcome::Passthrough(event);
-        }
-
+    pub fn record(&mut self, event: Event, output: &mut Vec<Event>) {
         let (series, data, metadata) = event.into_metric().into_parts();
-        match &mut self.mode {
-            InnerMode::Auto => match data.kind {
-                MetricKind::Incremental => self.record_sum(series, data, metadata),
-                MetricKind::Absolute => {
-                    self.map.insert(series, (data, metadata));
-                }
-            },
-            InnerMode::Sum => self.record_sum(series, data, metadata),
-            InnerMode::Latest | InnerMode::Diff { .. } => {
+
+        match (&mut self.mode, data.kind) {
+            (InnerMode::Sum, MetricKind::Absolute)
+            | (InnerMode::Latest | InnerMode::Diff { .. }, MetricKind::Incremental)
+            | (InnerMode::Max | InnerMode::Min, MetricKind::Incremental)
+            | (InnerMode::Mean { .. } | InnerMode::Stdev { .. }, MetricKind::Incremental) => {
+                output.push(Event::Metric(Metric::from_parts(series, data, metadata)));
+                return;
+            }
+            (InnerMode::Auto | InnerMode::Sum, MetricKind::Incremental) => {
+                self.record_sum(series, data, metadata);
+            }
+            (InnerMode::Auto, MetricKind::Absolute)
+            | (InnerMode::Latest | InnerMode::Diff { .. }, MetricKind::Absolute) => {
                 self.map.insert(series, (data, metadata));
             }
-            InnerMode::Count => self.record_count(series, data, metadata),
-            InnerMode::Max | InnerMode::Min => self.record_comparison(series, data, metadata),
-            InnerMode::Mean { multi_map } | InnerMode::Stdev { multi_map } => {
+            (InnerMode::Count, _) => {
+                self.record_count(series, data, metadata);
+            }
+            (InnerMode::Max | InnerMode::Min, MetricKind::Absolute) => {
+                self.record_comparison(series, data, metadata);
+            }
+            (InnerMode::Mean { multi_map } | InnerMode::Stdev { multi_map }, MetricKind::Absolute) => {
                 if matches!(data.value, MetricValue::Gauge { value: _ }) {
                     match multi_map.entry(series) {
                         Entry::Occupied(mut entry) => entry.get_mut().push((data, metadata)),
@@ -233,13 +217,6 @@ impl Aggregate {
             }
         }
         emit!(AggregateEventRecorded);
-        RecordOutcome::Aggregated
-    }
-
-    pub fn record_into(&mut self, event: Event, output: &mut Vec<Event>) {
-        if let RecordOutcome::Passthrough(event) = self.record(event) {
-            output.push(event);
-        }
     }
 
     fn record_count(
@@ -420,7 +397,7 @@ impl TaskTransform<Event> for Aggregate {
                                 self.flush_into(&mut output);
                                 done = true;
                             }
-                            Some(event) => self.record_into(event, &mut output),
+                            Some(event) => self.record(event, &mut output),
                         }
                     }
                 };
@@ -496,7 +473,7 @@ mod tests {
         );
 
         // Single item, just stored regardless of kind
-        agg.record(counter_a_1.clone());
+        agg.record(counter_a_1.clone(), &mut vec![]);
         let mut out = vec![];
         // We should flush 1 item counter_a_1
         agg.flush_into(&mut out);
@@ -514,8 +491,8 @@ mod tests {
         assert_eq!(0, out.len());
 
         // Two increments with the same series, should sum into 1
-        agg.record(counter_a_1.clone());
-        agg.record(counter_a_2);
+        agg.record(counter_a_1.clone(), &mut vec![]);
+        agg.record(counter_a_2, &mut vec![]);
         out.clear();
         agg.flush_into(&mut out);
         assert_eq!(1, out.len());
@@ -527,8 +504,8 @@ mod tests {
             MetricValue::Counter { value: 44.0 },
         );
         // Two increments with the different series, should get each back as-is
-        agg.record(counter_a_1.clone());
-        agg.record(counter_b_1.clone());
+        agg.record(counter_a_1.clone(), &mut vec![]);
+        agg.record(counter_b_1.clone(), &mut vec![]);
         out.clear();
         agg.flush_into(&mut out);
         assert_eq!(2, out.len());
@@ -562,7 +539,7 @@ mod tests {
         );
 
         // Single item, just stored regardless of kind
-        agg.record(gauge_a_1.clone());
+        agg.record(gauge_a_1.clone(), &mut vec![]);
         let mut out = vec![];
         // We should flush 1 item gauge_a_1
         agg.flush_into(&mut out);
@@ -580,8 +557,8 @@ mod tests {
         assert_eq!(0, out.len());
 
         // Two absolutes with the same series, should get the 2nd (last) back.
-        agg.record(gauge_a_1.clone());
-        agg.record(gauge_a_2.clone());
+        agg.record(gauge_a_1.clone(), &mut vec![]);
+        agg.record(gauge_a_2.clone(), &mut vec![]);
         out.clear();
         agg.flush_into(&mut out);
         assert_eq!(1, out.len());
@@ -593,8 +570,8 @@ mod tests {
             MetricValue::Gauge { value: 44.0 },
         );
         // Two increments with the different series, should get each back as-is
-        agg.record(gauge_a_1.clone());
-        agg.record(gauge_b_1.clone());
+        agg.record(gauge_a_1.clone(), &mut vec![]);
+        agg.record(gauge_b_1.clone(), &mut vec![]);
         out.clear();
         agg.flush_into(&mut out);
         assert_eq!(2, out.len());
@@ -638,7 +615,7 @@ mod tests {
         );
 
         // Single item, counter should be 1
-        agg.record(gauge_a_1.clone());
+        agg.record(gauge_a_1.clone(), &mut vec![]);
         let mut out = vec![];
         // We should flush 1 item gauge_a_1
         agg.flush_into(&mut out);
@@ -656,8 +633,8 @@ mod tests {
         assert_eq!(0, out.len());
 
         // Two absolutes with the same series, counter should be 2
-        agg.record(gauge_a_1.clone());
-        agg.record(gauge_a_2.clone());
+        agg.record(gauge_a_1.clone(), &mut vec![]);
+        agg.record(gauge_a_2.clone(), &mut vec![]);
         out.clear();
         agg.flush_into(&mut out);
         assert_eq!(1, out.len());
@@ -684,7 +661,7 @@ mod tests {
         );
 
         // Single item, it should be returned as is
-        agg.record(gauge_a_2.clone());
+        agg.record(gauge_a_2.clone(), &mut vec![]);
         let mut out = vec![];
         // We should flush 1 item gauge_a_2
         agg.flush_into(&mut out);
@@ -702,8 +679,8 @@ mod tests {
         assert_eq!(0, out.len());
 
         // Two absolutes, result should be higher of the 2
-        agg.record(gauge_a_1.clone());
-        agg.record(gauge_a_2.clone());
+        agg.record(gauge_a_1.clone(), &mut vec![]);
+        agg.record(gauge_a_2.clone(), &mut vec![]);
         out.clear();
         agg.flush_into(&mut out);
         assert_eq!(1, out.len());
@@ -730,7 +707,7 @@ mod tests {
         );
 
         // Single item, it should be returned as is
-        agg.record(gauge_a_2.clone());
+        agg.record(gauge_a_2.clone(), &mut vec![]);
         let mut out = vec![];
         // We should flush 1 item gauge_a_2
         agg.flush_into(&mut out);
@@ -748,8 +725,8 @@ mod tests {
         assert_eq!(0, out.len());
 
         // Two absolutes, result should be lower of the 2
-        agg.record(gauge_a_1.clone());
-        agg.record(gauge_a_2.clone());
+        agg.record(gauge_a_1.clone(), &mut vec![]);
+        agg.record(gauge_a_2.clone(), &mut vec![]);
         out.clear();
         agg.flush_into(&mut out);
         assert_eq!(1, out.len());
@@ -781,7 +758,7 @@ mod tests {
         );
 
         // Single item, it should be returned as is
-        agg.record(gauge_a_2.clone());
+        agg.record(gauge_a_2.clone(), &mut vec![]);
         let mut out = vec![];
         // We should flush 1 item gauge_a_2
         agg.flush_into(&mut out);
@@ -799,13 +776,13 @@ mod tests {
         assert_eq!(0, out.len());
 
         // Two absolutes in 2 separate flushes, result should be diff between the 2
-        agg.record(gauge_a_1.clone());
+        agg.record(gauge_a_1.clone(), &mut vec![]);
         out.clear();
         agg.flush_into(&mut out);
         assert_eq!(1, out.len());
         assert_eq!(&gauge_a_1, &out[0]);
 
-        agg.record(gauge_a_2.clone());
+        agg.record(gauge_a_2.clone(), &mut vec![]);
         out.clear();
         agg.flush_into(&mut out);
         assert_eq!(1, out.len());
@@ -833,13 +810,13 @@ mod tests {
 
         let mut out = vec![];
         // Two absolutes in 2 separate flushes, result should be second one due to different types
-        agg.record(gauge_a_1.clone());
+        agg.record(gauge_a_1.clone(), &mut vec![]);
         out.clear();
         agg.flush_into(&mut out);
         assert_eq!(1, out.len());
         assert_eq!(&gauge_a_1, &out[0]);
 
-        agg.record(gauge_a_2.clone());
+        agg.record(gauge_a_2.clone(), &mut vec![]);
         out.clear();
         agg.flush_into(&mut out);
         assert_eq!(1, out.len());
@@ -877,7 +854,7 @@ mod tests {
         );
 
         // Single item, it should be returned as is
-        agg.record(gauge_a_2.clone());
+        agg.record(gauge_a_2.clone(), &mut vec![]);
         let mut out = vec![];
         // We should flush 1 item gauge_a_2
         agg.flush_into(&mut out);
@@ -895,9 +872,9 @@ mod tests {
         assert_eq!(0, out.len());
 
         // Three absolutes, result should be mean
-        agg.record(gauge_a_1.clone());
-        agg.record(gauge_a_2.clone());
-        agg.record(gauge_a_3.clone());
+        agg.record(gauge_a_1.clone(), &mut vec![]);
+        agg.record(gauge_a_2.clone(), &mut vec![]);
+        agg.record(gauge_a_3.clone(), &mut vec![]);
         out.clear();
         agg.flush_into(&mut out);
         assert_eq!(1, out.len());
@@ -956,7 +933,7 @@ mod tests {
         );
 
         for gauge in gauges {
-            agg.record(gauge);
+            agg.record(gauge, &mut vec![]);
         }
         let mut out = vec![];
         agg.flush_into(&mut out);
@@ -1000,16 +977,14 @@ mod tests {
         );
 
         // Absolute metrics pass through immediately (not held until flush).
-        assert!(
-            matches!(agg.record(gauge_1.clone()), RecordOutcome::Passthrough(e) if e == gauge_1)
-        );
-        assert!(
-            matches!(agg.record(gauge_2.clone()), RecordOutcome::Passthrough(e) if e == gauge_2)
-        );
+        let mut passthrough = vec![];
+        agg.record(gauge_1.clone(), &mut passthrough);
+        agg.record(gauge_2.clone(), &mut passthrough);
+        assert_eq!(passthrough, vec![gauge_1, gauge_2]);
 
         // Each is returned individually — no collapsing to latest.
-        agg.record(counter_1);
-        agg.record(counter_2);
+        agg.record(counter_1, &mut passthrough);
+        agg.record(counter_2, &mut passthrough);
 
         let mut out = vec![];
         agg.flush_into(&mut out);
@@ -1048,13 +1023,13 @@ mod tests {
         // when types conflict the new values replaces whatever is there
 
         // Start with an counter
-        agg.record(counter.clone());
+        agg.record(counter.clone(), &mut vec![]);
         // Another will "add" to it
-        agg.record(counter.clone());
+        agg.record(counter.clone(), &mut vec![]);
         // Then an set will replace it due to a failed update
-        agg.record(set.clone());
+        agg.record(set.clone(), &mut vec![]);
         // Then a set union would be a noop
-        agg.record(set.clone());
+        agg.record(set.clone(), &mut vec![]);
         let mut out = vec![];
         // We should flush 1 item counter
         agg.flush_into(&mut out);
@@ -1062,13 +1037,13 @@ mod tests {
         assert_eq!(&set, &out[0]);
 
         // Start out with an set
-        agg.record(set.clone());
+        agg.record(set.clone(), &mut vec![]);
         // Union with itself, a noop
-        agg.record(set);
+        agg.record(set, &mut vec![]);
         // Send an counter with the same name, will replace due to a failed update
-        agg.record(counter.clone());
+        agg.record(counter.clone(), &mut vec![]);
         // Send another counter will "add"
-        agg.record(counter);
+        agg.record(counter, &mut vec![]);
         let mut out = vec![];
         // We should flush 1 item counter
         agg.flush_into(&mut out);
@@ -1103,13 +1078,13 @@ mod tests {
         // when types conflict the new values replaces whatever is there
 
         // Start with an incremental
-        agg.record(incremental.clone());
+        agg.record(incremental.clone(), &mut vec![]);
         // Another will "add" to it
-        agg.record(incremental.clone());
+        agg.record(incremental.clone(), &mut vec![]);
         // Then an absolute will replace it with a failed update
-        agg.record(absolute.clone());
+        agg.record(absolute.clone(), &mut vec![]);
         // Then another absolute will replace it normally
-        agg.record(absolute.clone());
+        agg.record(absolute.clone(), &mut vec![]);
         let mut out = vec![];
         // We should flush 1 item incremental
         agg.flush_into(&mut out);
@@ -1117,13 +1092,13 @@ mod tests {
         assert_eq!(&absolute, &out[0]);
 
         // Start out with an absolute
-        agg.record(absolute.clone());
+        agg.record(absolute.clone(), &mut vec![]);
         // Replace it normally
-        agg.record(absolute);
+        agg.record(absolute, &mut vec![]);
         // Send an incremental with the same name, will replace due to a failed update
-        agg.record(incremental.clone());
+        agg.record(incremental.clone(), &mut vec![]);
         // Send another incremental will "add"
-        agg.record(incremental);
+        agg.record(incremental, &mut vec![]);
         let mut out = vec![];
         // We should flush 1 item incremental
         agg.flush_into(&mut out);

--- a/src/transforms/aggregate.rs
+++ b/src/transforms/aggregate.rs
@@ -49,28 +49,28 @@ pub enum AggregationMode {
     #[default]
     Auto,
 
-    /// Sums incremental metrics, ignores absolute
+    /// Sums incremental metrics; absolute metrics pass through unchanged.
     Sum,
 
-    /// Returns the latest value for absolute metrics, ignores incremental
+    /// Returns the latest value for absolute metrics; incremental metrics pass through unchanged.
     Latest,
 
     /// Counts metrics for incremental and absolute metrics
     Count,
 
-    /// Returns difference between latest value for absolute, ignores incremental
+    /// Returns difference between latest value for absolute; incremental metrics pass through unchanged.
     Diff,
 
-    /// Max value of absolute metric, ignores incremental
+    /// Max value of absolute metric; incremental metrics pass through unchanged.
     Max,
 
-    /// Min value of absolute metric, ignores incremental
+    /// Min value of absolute metric; incremental metrics pass through unchanged.
     Min,
 
-    /// Mean value of absolute metric, ignores incremental
+    /// Mean value of absolute metric; incremental metrics pass through unchanged.
     Mean,
 
-    /// Stdev value of absolute metric, ignores incremental
+    /// Stdev value of absolute metric; incremental metrics pass through unchanged.
     Stdev,
 }
 
@@ -80,32 +80,32 @@ enum InnerMode {
     #[default]
     Auto,
 
-    /// Sums incremental metrics, ignores absolute
+    /// Sums incremental metrics; absolute metrics pass through unchanged.
     Sum,
 
-    /// Returns the latest value for absolute metrics, ignores incremental
+    /// Returns the latest value for absolute metrics; incremental metrics pass through unchanged.
     Latest,
 
     /// Counts metrics for incremental and absolute metrics
     Count,
 
-    /// Returns difference between latest value for absolute, ignores incremental
+    /// Returns difference between latest value for absolute; incremental metrics pass through unchanged.
     Diff {
         prev_map: HashMap<MetricSeries, MetricEntry>,
     },
 
-    /// Max value of absolute metric, ignores incremental
+    /// Max value of absolute metric; incremental metrics pass through unchanged.
     Max,
 
-    /// Min value of absolute metric, ignores incremental
+    /// Min value of absolute metric; incremental metrics pass through unchanged.
     Min,
 
-    /// Mean value of absolute metric, ignores incremental
+    /// Mean value of absolute metric; incremental metrics pass through unchanged.
     Mean {
         multi_map: HashMap<MetricSeries, Vec<MetricEntry>>,
     },
 
-    /// Stdev value of absolute metric, ignores incremental
+    /// Stdev value of absolute metric; incremental metrics pass through unchanged.
     Stdev {
         multi_map: HashMap<MetricSeries, Vec<MetricEntry>>,
     },
@@ -181,7 +181,7 @@ impl Aggregate {
         })
     }
 
-    pub fn record(&mut self, event: Event, output: &mut Vec<Event>) {
+    pub fn record(&mut self, event: Event) -> Option<Event> {
         let (series, data, metadata) = event.into_metric().into_parts();
 
         match (&mut self.mode, data.kind) {
@@ -189,8 +189,7 @@ impl Aggregate {
             | (InnerMode::Latest | InnerMode::Diff { .. }, MetricKind::Incremental)
             | (InnerMode::Max | InnerMode::Min, MetricKind::Incremental)
             | (InnerMode::Mean { .. } | InnerMode::Stdev { .. }, MetricKind::Incremental) => {
-                output.push(Event::Metric(Metric::from_parts(series, data, metadata)));
-                return;
+                return Some(Event::Metric(Metric::from_parts(series, data, metadata)));
             }
             (InnerMode::Auto | InnerMode::Sum, MetricKind::Incremental) => {
                 self.record_sum(series, data, metadata);
@@ -220,6 +219,7 @@ impl Aggregate {
             }
         }
         emit!(AggregateEventRecorded);
+        None
     }
 
     fn record_count(
@@ -400,7 +400,11 @@ impl TaskTransform<Event> for Aggregate {
                                 self.flush_into(&mut output);
                                 done = true;
                             }
-                            Some(event) => self.record(event, &mut output),
+                            Some(event) => {
+                                if let Some(passthrough) = self.record(event) {
+                                    output.push(passthrough);
+                                }
+                            }
                         }
                     }
                 };
@@ -476,7 +480,7 @@ mod tests {
         );
 
         // Single item, just stored regardless of kind
-        agg.record(counter_a_1.clone(), &mut vec![]);
+        agg.record(counter_a_1.clone());
         let mut out = vec![];
         // We should flush 1 item counter_a_1
         agg.flush_into(&mut out);
@@ -494,8 +498,8 @@ mod tests {
         assert_eq!(0, out.len());
 
         // Two increments with the same series, should sum into 1
-        agg.record(counter_a_1.clone(), &mut vec![]);
-        agg.record(counter_a_2, &mut vec![]);
+        agg.record(counter_a_1.clone());
+        agg.record(counter_a_2);
         out.clear();
         agg.flush_into(&mut out);
         assert_eq!(1, out.len());
@@ -507,8 +511,8 @@ mod tests {
             MetricValue::Counter { value: 44.0 },
         );
         // Two increments with the different series, should get each back as-is
-        agg.record(counter_a_1.clone(), &mut vec![]);
-        agg.record(counter_b_1.clone(), &mut vec![]);
+        agg.record(counter_a_1.clone());
+        agg.record(counter_b_1.clone());
         out.clear();
         agg.flush_into(&mut out);
         assert_eq!(2, out.len());
@@ -542,7 +546,7 @@ mod tests {
         );
 
         // Single item, just stored regardless of kind
-        agg.record(gauge_a_1.clone(), &mut vec![]);
+        agg.record(gauge_a_1.clone());
         let mut out = vec![];
         // We should flush 1 item gauge_a_1
         agg.flush_into(&mut out);
@@ -560,8 +564,8 @@ mod tests {
         assert_eq!(0, out.len());
 
         // Two absolutes with the same series, should get the 2nd (last) back.
-        agg.record(gauge_a_1.clone(), &mut vec![]);
-        agg.record(gauge_a_2.clone(), &mut vec![]);
+        agg.record(gauge_a_1.clone());
+        agg.record(gauge_a_2.clone());
         out.clear();
         agg.flush_into(&mut out);
         assert_eq!(1, out.len());
@@ -573,8 +577,8 @@ mod tests {
             MetricValue::Gauge { value: 44.0 },
         );
         // Two increments with the different series, should get each back as-is
-        agg.record(gauge_a_1.clone(), &mut vec![]);
-        agg.record(gauge_b_1.clone(), &mut vec![]);
+        agg.record(gauge_a_1.clone());
+        agg.record(gauge_b_1.clone());
         out.clear();
         agg.flush_into(&mut out);
         assert_eq!(2, out.len());
@@ -618,7 +622,7 @@ mod tests {
         );
 
         // Single item, counter should be 1
-        agg.record(gauge_a_1.clone(), &mut vec![]);
+        agg.record(gauge_a_1.clone());
         let mut out = vec![];
         // We should flush 1 item gauge_a_1
         agg.flush_into(&mut out);
@@ -636,8 +640,8 @@ mod tests {
         assert_eq!(0, out.len());
 
         // Two absolutes with the same series, counter should be 2
-        agg.record(gauge_a_1.clone(), &mut vec![]);
-        agg.record(gauge_a_2.clone(), &mut vec![]);
+        agg.record(gauge_a_1.clone());
+        agg.record(gauge_a_2.clone());
         out.clear();
         agg.flush_into(&mut out);
         assert_eq!(1, out.len());
@@ -664,7 +668,7 @@ mod tests {
         );
 
         // Single item, it should be returned as is
-        agg.record(gauge_a_2.clone(), &mut vec![]);
+        agg.record(gauge_a_2.clone());
         let mut out = vec![];
         // We should flush 1 item gauge_a_2
         agg.flush_into(&mut out);
@@ -682,8 +686,8 @@ mod tests {
         assert_eq!(0, out.len());
 
         // Two absolutes, result should be higher of the 2
-        agg.record(gauge_a_1.clone(), &mut vec![]);
-        agg.record(gauge_a_2.clone(), &mut vec![]);
+        agg.record(gauge_a_1.clone());
+        agg.record(gauge_a_2.clone());
         out.clear();
         agg.flush_into(&mut out);
         assert_eq!(1, out.len());
@@ -710,7 +714,7 @@ mod tests {
         );
 
         // Single item, it should be returned as is
-        agg.record(gauge_a_2.clone(), &mut vec![]);
+        agg.record(gauge_a_2.clone());
         let mut out = vec![];
         // We should flush 1 item gauge_a_2
         agg.flush_into(&mut out);
@@ -728,8 +732,8 @@ mod tests {
         assert_eq!(0, out.len());
 
         // Two absolutes, result should be lower of the 2
-        agg.record(gauge_a_1.clone(), &mut vec![]);
-        agg.record(gauge_a_2.clone(), &mut vec![]);
+        agg.record(gauge_a_1.clone());
+        agg.record(gauge_a_2.clone());
         out.clear();
         agg.flush_into(&mut out);
         assert_eq!(1, out.len());
@@ -761,7 +765,7 @@ mod tests {
         );
 
         // Single item, it should be returned as is
-        agg.record(gauge_a_2.clone(), &mut vec![]);
+        agg.record(gauge_a_2.clone());
         let mut out = vec![];
         // We should flush 1 item gauge_a_2
         agg.flush_into(&mut out);
@@ -779,13 +783,13 @@ mod tests {
         assert_eq!(0, out.len());
 
         // Two absolutes in 2 separate flushes, result should be diff between the 2
-        agg.record(gauge_a_1.clone(), &mut vec![]);
+        agg.record(gauge_a_1.clone());
         out.clear();
         agg.flush_into(&mut out);
         assert_eq!(1, out.len());
         assert_eq!(&gauge_a_1, &out[0]);
 
-        agg.record(gauge_a_2.clone(), &mut vec![]);
+        agg.record(gauge_a_2.clone());
         out.clear();
         agg.flush_into(&mut out);
         assert_eq!(1, out.len());
@@ -813,13 +817,13 @@ mod tests {
 
         let mut out = vec![];
         // Two absolutes in 2 separate flushes, result should be second one due to different types
-        agg.record(gauge_a_1.clone(), &mut vec![]);
+        agg.record(gauge_a_1.clone());
         out.clear();
         agg.flush_into(&mut out);
         assert_eq!(1, out.len());
         assert_eq!(&gauge_a_1, &out[0]);
 
-        agg.record(gauge_a_2.clone(), &mut vec![]);
+        agg.record(gauge_a_2.clone());
         out.clear();
         agg.flush_into(&mut out);
         assert_eq!(1, out.len());
@@ -857,7 +861,7 @@ mod tests {
         );
 
         // Single item, it should be returned as is
-        agg.record(gauge_a_2.clone(), &mut vec![]);
+        agg.record(gauge_a_2.clone());
         let mut out = vec![];
         // We should flush 1 item gauge_a_2
         agg.flush_into(&mut out);
@@ -875,9 +879,9 @@ mod tests {
         assert_eq!(0, out.len());
 
         // Three absolutes, result should be mean
-        agg.record(gauge_a_1.clone(), &mut vec![]);
-        agg.record(gauge_a_2.clone(), &mut vec![]);
-        agg.record(gauge_a_3.clone(), &mut vec![]);
+        agg.record(gauge_a_1.clone());
+        agg.record(gauge_a_2.clone());
+        agg.record(gauge_a_3.clone());
         out.clear();
         agg.flush_into(&mut out);
         assert_eq!(1, out.len());
@@ -936,7 +940,7 @@ mod tests {
         );
 
         for gauge in gauges {
-            agg.record(gauge, &mut vec![]);
+            agg.record(gauge);
         }
         let mut out = vec![];
         agg.flush_into(&mut out);
@@ -980,14 +984,12 @@ mod tests {
         );
 
         // Absolute metrics pass through immediately (not held until flush).
-        let mut passthrough = vec![];
-        agg.record(gauge_1.clone(), &mut passthrough);
-        agg.record(gauge_2.clone(), &mut passthrough);
-        assert_eq!(passthrough, vec![gauge_1, gauge_2]);
+        assert_eq!(agg.record(gauge_1.clone()), Some(gauge_1));
+        assert_eq!(agg.record(gauge_2.clone()), Some(gauge_2));
 
         // Each is returned individually — no collapsing to latest.
-        agg.record(counter_1, &mut passthrough);
-        agg.record(counter_2, &mut passthrough);
+        agg.record(counter_1);
+        agg.record(counter_2);
 
         let mut out = vec![];
         agg.flush_into(&mut out);
@@ -1026,13 +1028,13 @@ mod tests {
         // when types conflict the new values replaces whatever is there
 
         // Start with an counter
-        agg.record(counter.clone(), &mut vec![]);
+        agg.record(counter.clone());
         // Another will "add" to it
-        agg.record(counter.clone(), &mut vec![]);
+        agg.record(counter.clone());
         // Then an set will replace it due to a failed update
-        agg.record(set.clone(), &mut vec![]);
+        agg.record(set.clone());
         // Then a set union would be a noop
-        agg.record(set.clone(), &mut vec![]);
+        agg.record(set.clone());
         let mut out = vec![];
         // We should flush 1 item counter
         agg.flush_into(&mut out);
@@ -1040,13 +1042,13 @@ mod tests {
         assert_eq!(&set, &out[0]);
 
         // Start out with an set
-        agg.record(set.clone(), &mut vec![]);
+        agg.record(set.clone());
         // Union with itself, a noop
-        agg.record(set, &mut vec![]);
+        agg.record(set);
         // Send an counter with the same name, will replace due to a failed update
-        agg.record(counter.clone(), &mut vec![]);
+        agg.record(counter.clone());
         // Send another counter will "add"
-        agg.record(counter, &mut vec![]);
+        agg.record(counter);
         let mut out = vec![];
         // We should flush 1 item counter
         agg.flush_into(&mut out);
@@ -1081,13 +1083,13 @@ mod tests {
         // when types conflict the new values replaces whatever is there
 
         // Start with an incremental
-        agg.record(incremental.clone(), &mut vec![]);
+        agg.record(incremental.clone());
         // Another will "add" to it
-        agg.record(incremental.clone(), &mut vec![]);
+        agg.record(incremental.clone());
         // Then an absolute will replace it with a failed update
-        agg.record(absolute.clone(), &mut vec![]);
+        agg.record(absolute.clone());
         // Then another absolute will replace it normally
-        agg.record(absolute.clone(), &mut vec![]);
+        agg.record(absolute.clone());
         let mut out = vec![];
         // We should flush 1 item incremental
         agg.flush_into(&mut out);
@@ -1095,13 +1097,13 @@ mod tests {
         assert_eq!(&absolute, &out[0]);
 
         // Start out with an absolute
-        agg.record(absolute.clone(), &mut vec![]);
+        agg.record(absolute.clone());
         // Replace it normally
-        agg.record(absolute, &mut vec![]);
+        agg.record(absolute);
         // Send an incremental with the same name, will replace due to a failed update
-        agg.record(incremental.clone(), &mut vec![]);
+        agg.record(incremental.clone());
         // Send another incremental will "add"
-        agg.record(incremental, &mut vec![]);
+        agg.record(incremental);
         let mut out = vec![];
         // We should flush 1 item incremental
         agg.flush_into(&mut out);

--- a/src/transforms/aggregate.rs
+++ b/src/transforms/aggregate.rs
@@ -205,7 +205,10 @@ impl Aggregate {
             (InnerMode::Max | InnerMode::Min, MetricKind::Absolute) => {
                 self.record_comparison(series, data, metadata);
             }
-            (InnerMode::Mean { multi_map } | InnerMode::Stdev { multi_map }, MetricKind::Absolute) => {
+            (
+                InnerMode::Mean { multi_map } | InnerMode::Stdev { multi_map },
+                MetricKind::Absolute,
+            ) => {
                 if matches!(data.value, MetricValue::Gauge { value: _ }) {
                     match multi_map.entry(series) {
                         Entry::Occupied(mut entry) => entry.get_mut().push((data, metadata)),

--- a/src/transforms/aggregate.rs
+++ b/src/transforms/aggregate.rs
@@ -49,28 +49,28 @@ pub enum AggregationMode {
     #[default]
     Auto,
 
-    /// Sums incremental metrics, ignores absolute
+    /// Sums incremental metrics; absolute metrics pass through unchanged.
     Sum,
 
-    /// Returns the latest value for absolute metrics, ignores incremental
+    /// Returns the latest value for absolute metrics; incremental metrics pass through unchanged.
     Latest,
 
     /// Counts metrics for incremental and absolute metrics
     Count,
 
-    /// Returns difference between latest value for absolute, ignores incremental
+    /// Returns difference between latest value for absolute; incremental metrics pass through unchanged.
     Diff,
 
-    /// Max value of absolute metric, ignores incremental
+    /// Max value of absolute metric; incremental metrics pass through unchanged.
     Max,
 
-    /// Min value of absolute metric, ignores incremental
+    /// Min value of absolute metric; incremental metrics pass through unchanged.
     Min,
 
-    /// Mean value of absolute metric, ignores incremental
+    /// Mean value of absolute metric; incremental metrics pass through unchanged.
     Mean,
 
-    /// Stdev value of absolute metric, ignores incremental
+    /// Stdev value of absolute metric; incremental metrics pass through unchanged.
     Stdev,
 }
 
@@ -80,32 +80,32 @@ enum InnerMode {
     #[default]
     Auto,
 
-    /// Sums incremental metrics, ignores absolute
+    /// Sums incremental metrics; absolute metrics pass through unchanged.
     Sum,
 
-    /// Returns the latest value for absolute metrics, ignores incremental
+    /// Returns the latest value for absolute metrics; incremental metrics pass through unchanged.
     Latest,
 
     /// Counts metrics for incremental and absolute metrics
     Count,
 
-    /// Returns difference between latest value for absolute, ignores incremental
+    /// Returns difference between latest value for absolute; incremental metrics pass through unchanged.
     Diff {
         prev_map: HashMap<MetricSeries, MetricEntry>,
     },
 
-    /// Max value of absolute metric, ignores incremental
+    /// Max value of absolute metric; incremental metrics pass through unchanged.
     Max,
 
-    /// Min value of absolute metric, ignores incremental
+    /// Min value of absolute metric; incremental metrics pass through unchanged.
     Min,
 
-    /// Mean value of absolute metric, ignores incremental
+    /// Mean value of absolute metric; incremental metrics pass through unchanged.
     Mean {
         multi_map: HashMap<MetricSeries, Vec<MetricEntry>>,
     },
 
-    /// Stdev value of absolute metric, ignores incremental
+    /// Stdev value of absolute metric; incremental metrics pass through unchanged.
     Stdev {
         multi_map: HashMap<MetricSeries, Vec<MetricEntry>>,
     },

--- a/src/transforms/aggregate.rs
+++ b/src/transforms/aggregate.rs
@@ -49,28 +49,28 @@ pub enum AggregationMode {
     #[default]
     Auto,
 
-    /// Sums incremental metrics; absolute metrics pass through unchanged.
+    /// Sums incremental metrics, ignores absolute
     Sum,
 
-    /// Returns the latest value for absolute metrics; incremental metrics pass through unchanged.
+    /// Returns the latest value for absolute metrics, ignores incremental
     Latest,
 
     /// Counts metrics for incremental and absolute metrics
     Count,
 
-    /// Returns difference between latest value for absolute; incremental metrics pass through unchanged.
+    /// Returns difference between latest value for absolute, ignores incremental
     Diff,
 
-    /// Max value of absolute metric; incremental metrics pass through unchanged.
+    /// Max value of absolute metric, ignores incremental
     Max,
 
-    /// Min value of absolute metric; incremental metrics pass through unchanged.
+    /// Min value of absolute metric, ignores incremental
     Min,
 
-    /// Mean value of absolute metric; incremental metrics pass through unchanged.
+    /// Mean value of absolute metric, ignores incremental
     Mean,
 
-    /// Stdev value of absolute metric; incremental metrics pass through unchanged.
+    /// Stdev value of absolute metric, ignores incremental
     Stdev,
 }
 
@@ -80,32 +80,32 @@ enum InnerMode {
     #[default]
     Auto,
 
-    /// Sums incremental metrics; absolute metrics pass through unchanged.
+    /// Sums incremental metrics, ignores absolute
     Sum,
 
-    /// Returns the latest value for absolute metrics; incremental metrics pass through unchanged.
+    /// Returns the latest value for absolute metrics, ignores incremental
     Latest,
 
     /// Counts metrics for incremental and absolute metrics
     Count,
 
-    /// Returns difference between latest value for absolute; incremental metrics pass through unchanged.
+    /// Returns difference between latest value for absolute, ignores incremental
     Diff {
         prev_map: HashMap<MetricSeries, MetricEntry>,
     },
 
-    /// Max value of absolute metric; incremental metrics pass through unchanged.
+    /// Max value of absolute metric, ignores incremental
     Max,
 
-    /// Min value of absolute metric; incremental metrics pass through unchanged.
+    /// Min value of absolute metric, ignores incremental
     Min,
 
-    /// Mean value of absolute metric; incremental metrics pass through unchanged.
+    /// Mean value of absolute metric, ignores incremental
     Mean {
         multi_map: HashMap<MetricSeries, Vec<MetricEntry>>,
     },
 
-    /// Stdev value of absolute metric; incremental metrics pass through unchanged.
+    /// Stdev value of absolute metric, ignores incremental
     Stdev {
         multi_map: HashMap<MetricSeries, Vec<MetricEntry>>,
     },

--- a/src/transforms/aggregate.rs
+++ b/src/transforms/aggregate.rs
@@ -480,7 +480,7 @@ mod tests {
         );
 
         // Single item, just stored regardless of kind
-        agg.record(counter_a_1.clone());
+        assert_eq!(agg.record(counter_a_1.clone()), None);
         let mut out = vec![];
         // We should flush 1 item counter_a_1
         agg.flush_into(&mut out);
@@ -498,8 +498,8 @@ mod tests {
         assert_eq!(0, out.len());
 
         // Two increments with the same series, should sum into 1
-        agg.record(counter_a_1.clone());
-        agg.record(counter_a_2);
+        assert_eq!(agg.record(counter_a_1.clone()), None);
+        assert_eq!(agg.record(counter_a_2), None);
         out.clear();
         agg.flush_into(&mut out);
         assert_eq!(1, out.len());
@@ -511,8 +511,8 @@ mod tests {
             MetricValue::Counter { value: 44.0 },
         );
         // Two increments with the different series, should get each back as-is
-        agg.record(counter_a_1.clone());
-        agg.record(counter_b_1.clone());
+        assert_eq!(agg.record(counter_a_1.clone()), None);
+        assert_eq!(agg.record(counter_b_1.clone()), None);
         out.clear();
         agg.flush_into(&mut out);
         assert_eq!(2, out.len());
@@ -546,7 +546,7 @@ mod tests {
         );
 
         // Single item, just stored regardless of kind
-        agg.record(gauge_a_1.clone());
+        assert_eq!(agg.record(gauge_a_1.clone()), None);
         let mut out = vec![];
         // We should flush 1 item gauge_a_1
         agg.flush_into(&mut out);
@@ -564,8 +564,8 @@ mod tests {
         assert_eq!(0, out.len());
 
         // Two absolutes with the same series, should get the 2nd (last) back.
-        agg.record(gauge_a_1.clone());
-        agg.record(gauge_a_2.clone());
+        assert_eq!(agg.record(gauge_a_1.clone()), None);
+        assert_eq!(agg.record(gauge_a_2.clone()), None);
         out.clear();
         agg.flush_into(&mut out);
         assert_eq!(1, out.len());
@@ -577,8 +577,8 @@ mod tests {
             MetricValue::Gauge { value: 44.0 },
         );
         // Two increments with the different series, should get each back as-is
-        agg.record(gauge_a_1.clone());
-        agg.record(gauge_b_1.clone());
+        assert_eq!(agg.record(gauge_a_1.clone()), None);
+        assert_eq!(agg.record(gauge_b_1.clone()), None);
         out.clear();
         agg.flush_into(&mut out);
         assert_eq!(2, out.len());
@@ -622,7 +622,7 @@ mod tests {
         );
 
         // Single item, counter should be 1
-        agg.record(gauge_a_1.clone());
+        assert_eq!(agg.record(gauge_a_1.clone()), None);
         let mut out = vec![];
         // We should flush 1 item gauge_a_1
         agg.flush_into(&mut out);
@@ -640,8 +640,8 @@ mod tests {
         assert_eq!(0, out.len());
 
         // Two absolutes with the same series, counter should be 2
-        agg.record(gauge_a_1.clone());
-        agg.record(gauge_a_2.clone());
+        assert_eq!(agg.record(gauge_a_1.clone()), None);
+        assert_eq!(agg.record(gauge_a_2.clone()), None);
         out.clear();
         agg.flush_into(&mut out);
         assert_eq!(1, out.len());
@@ -668,7 +668,7 @@ mod tests {
         );
 
         // Single item, it should be returned as is
-        agg.record(gauge_a_2.clone());
+        assert_eq!(agg.record(gauge_a_2.clone()), None);
         let mut out = vec![];
         // We should flush 1 item gauge_a_2
         agg.flush_into(&mut out);
@@ -686,8 +686,8 @@ mod tests {
         assert_eq!(0, out.len());
 
         // Two absolutes, result should be higher of the 2
-        agg.record(gauge_a_1.clone());
-        agg.record(gauge_a_2.clone());
+        assert_eq!(agg.record(gauge_a_1.clone()), None);
+        assert_eq!(agg.record(gauge_a_2.clone()), None);
         out.clear();
         agg.flush_into(&mut out);
         assert_eq!(1, out.len());
@@ -714,7 +714,7 @@ mod tests {
         );
 
         // Single item, it should be returned as is
-        agg.record(gauge_a_2.clone());
+        assert_eq!(agg.record(gauge_a_2.clone()), None);
         let mut out = vec![];
         // We should flush 1 item gauge_a_2
         agg.flush_into(&mut out);
@@ -732,8 +732,8 @@ mod tests {
         assert_eq!(0, out.len());
 
         // Two absolutes, result should be lower of the 2
-        agg.record(gauge_a_1.clone());
-        agg.record(gauge_a_2.clone());
+        assert_eq!(agg.record(gauge_a_1.clone()), None);
+        assert_eq!(agg.record(gauge_a_2.clone()), None);
         out.clear();
         agg.flush_into(&mut out);
         assert_eq!(1, out.len());
@@ -765,7 +765,7 @@ mod tests {
         );
 
         // Single item, it should be returned as is
-        agg.record(gauge_a_2.clone());
+        assert_eq!(agg.record(gauge_a_2.clone()), None);
         let mut out = vec![];
         // We should flush 1 item gauge_a_2
         agg.flush_into(&mut out);
@@ -783,13 +783,13 @@ mod tests {
         assert_eq!(0, out.len());
 
         // Two absolutes in 2 separate flushes, result should be diff between the 2
-        agg.record(gauge_a_1.clone());
+        assert_eq!(agg.record(gauge_a_1.clone()), None);
         out.clear();
         agg.flush_into(&mut out);
         assert_eq!(1, out.len());
         assert_eq!(&gauge_a_1, &out[0]);
 
-        agg.record(gauge_a_2.clone());
+        assert_eq!(agg.record(gauge_a_2.clone()), None);
         out.clear();
         agg.flush_into(&mut out);
         assert_eq!(1, out.len());
@@ -817,13 +817,13 @@ mod tests {
 
         let mut out = vec![];
         // Two absolutes in 2 separate flushes, result should be second one due to different types
-        agg.record(gauge_a_1.clone());
+        assert_eq!(agg.record(gauge_a_1.clone()), None);
         out.clear();
         agg.flush_into(&mut out);
         assert_eq!(1, out.len());
         assert_eq!(&gauge_a_1, &out[0]);
 
-        agg.record(gauge_a_2.clone());
+        assert_eq!(agg.record(gauge_a_2.clone()), None);
         out.clear();
         agg.flush_into(&mut out);
         assert_eq!(1, out.len());
@@ -861,7 +861,7 @@ mod tests {
         );
 
         // Single item, it should be returned as is
-        agg.record(gauge_a_2.clone());
+        assert_eq!(agg.record(gauge_a_2.clone()), None);
         let mut out = vec![];
         // We should flush 1 item gauge_a_2
         agg.flush_into(&mut out);
@@ -879,9 +879,9 @@ mod tests {
         assert_eq!(0, out.len());
 
         // Three absolutes, result should be mean
-        agg.record(gauge_a_1.clone());
-        agg.record(gauge_a_2.clone());
-        agg.record(gauge_a_3.clone());
+        assert_eq!(agg.record(gauge_a_1.clone()), None);
+        assert_eq!(agg.record(gauge_a_2.clone()), None);
+        assert_eq!(agg.record(gauge_a_3.clone()), None);
         out.clear();
         agg.flush_into(&mut out);
         assert_eq!(1, out.len());
@@ -940,7 +940,7 @@ mod tests {
         );
 
         for gauge in gauges {
-            agg.record(gauge);
+            assert_eq!(agg.record(gauge), None);
         }
         let mut out = vec![];
         agg.flush_into(&mut out);
@@ -988,8 +988,8 @@ mod tests {
         assert_eq!(agg.record(gauge_2.clone()), Some(gauge_2));
 
         // Each is returned individually — no collapsing to latest.
-        agg.record(counter_1);
-        agg.record(counter_2);
+        assert_eq!(agg.record(counter_1), None);
+        assert_eq!(agg.record(counter_2), None);
 
         let mut out = vec![];
         agg.flush_into(&mut out);
@@ -1028,13 +1028,13 @@ mod tests {
         // when types conflict the new values replaces whatever is there
 
         // Start with an counter
-        agg.record(counter.clone());
+        assert_eq!(agg.record(counter.clone()), None);
         // Another will "add" to it
-        agg.record(counter.clone());
+        assert_eq!(agg.record(counter.clone()), None);
         // Then an set will replace it due to a failed update
-        agg.record(set.clone());
+        assert_eq!(agg.record(set.clone()), None);
         // Then a set union would be a noop
-        agg.record(set.clone());
+        assert_eq!(agg.record(set.clone()), None);
         let mut out = vec![];
         // We should flush 1 item counter
         agg.flush_into(&mut out);
@@ -1042,13 +1042,13 @@ mod tests {
         assert_eq!(&set, &out[0]);
 
         // Start out with an set
-        agg.record(set.clone());
+        assert_eq!(agg.record(set.clone()), None);
         // Union with itself, a noop
-        agg.record(set);
+        assert_eq!(agg.record(set), None);
         // Send an counter with the same name, will replace due to a failed update
-        agg.record(counter.clone());
+        assert_eq!(agg.record(counter.clone()), None);
         // Send another counter will "add"
-        agg.record(counter);
+        assert_eq!(agg.record(counter), None);
         let mut out = vec![];
         // We should flush 1 item counter
         agg.flush_into(&mut out);
@@ -1083,13 +1083,13 @@ mod tests {
         // when types conflict the new values replaces whatever is there
 
         // Start with an incremental
-        agg.record(incremental.clone());
+        assert_eq!(agg.record(incremental.clone()), None);
         // Another will "add" to it
-        agg.record(incremental.clone());
+        assert_eq!(agg.record(incremental.clone()), None);
         // Then an absolute will replace it with a failed update
-        agg.record(absolute.clone());
+        assert_eq!(agg.record(absolute.clone()), None);
         // Then another absolute will replace it normally
-        agg.record(absolute.clone());
+        assert_eq!(agg.record(absolute.clone()), None);
         let mut out = vec![];
         // We should flush 1 item incremental
         agg.flush_into(&mut out);
@@ -1097,13 +1097,13 @@ mod tests {
         assert_eq!(&absolute, &out[0]);
 
         // Start out with an absolute
-        agg.record(absolute.clone());
+        assert_eq!(agg.record(absolute.clone()), None);
         // Replace it normally
-        agg.record(absolute);
+        assert_eq!(agg.record(absolute), None);
         // Send an incremental with the same name, will replace due to a failed update
-        agg.record(incremental.clone());
+        assert_eq!(agg.record(incremental.clone()), None);
         // Send another incremental will "add"
-        agg.record(incremental);
+        assert_eq!(agg.record(incremental), None);
         let mut out = vec![];
         // We should flush 1 item incremental
         agg.flush_into(&mut out);

--- a/src/transforms/aggregate.rs
+++ b/src/transforms/aggregate.rs
@@ -165,6 +165,14 @@ impl TransformConfig for AggregateConfig {
 
 type MetricEntry = (MetricData, EventMetadata);
 
+// Never stored in a collection, only ephemeral/transient to forward ignored events
+#[allow(clippy::large_enum_variant)]
+#[derive(Debug)]
+pub enum RecordOutcome {
+    Aggregated,
+    Passthrough(Event),
+}
+
 #[derive(Debug)]
 pub struct Aggregate {
     interval: Duration,
@@ -181,9 +189,25 @@ impl Aggregate {
         })
     }
 
-    pub fn record(&mut self, event: Event) {
-        let (series, data, metadata) = event.into_metric().into_parts();
+    pub fn record(&mut self, event: Event) -> RecordOutcome {
+        let kind = event.as_metric().kind();
+        if matches!(
+            (&self.mode, kind),
+            (InnerMode::Sum, MetricKind::Absolute)
+                | (
+                    InnerMode::Latest | InnerMode::Diff { .. },
+                    MetricKind::Incremental
+                )
+                | (InnerMode::Max | InnerMode::Min, MetricKind::Incremental)
+                | (
+                    InnerMode::Mean { .. } | InnerMode::Stdev { .. },
+                    MetricKind::Incremental
+                )
+        ) {
+            return RecordOutcome::Passthrough(event);
+        }
 
+        let (series, data, metadata) = event.into_metric().into_parts();
         match &mut self.mode {
             InnerMode::Auto => match data.kind {
                 MetricKind::Incremental => self.record_sum(series, data, metadata),
@@ -192,33 +216,30 @@ impl Aggregate {
                 }
             },
             InnerMode::Sum => self.record_sum(series, data, metadata),
-            InnerMode::Latest | InnerMode::Diff { .. } => match data.kind {
-                MetricKind::Incremental => (),
-                MetricKind::Absolute => {
-                    self.map.insert(series, (data, metadata));
-                }
-            },
+            InnerMode::Latest | InnerMode::Diff { .. } => {
+                self.map.insert(series, (data, metadata));
+            }
             InnerMode::Count => self.record_count(series, data, metadata),
             InnerMode::Max | InnerMode::Min => self.record_comparison(series, data, metadata),
-            InnerMode::Mean { multi_map } | InnerMode::Stdev { multi_map } => match data.kind {
-                MetricKind::Incremental => (),
-                MetricKind::Absolute => {
-                    if matches!(data.value, MetricValue::Gauge { value: _ }) {
-                        match multi_map.entry(series) {
-                            Entry::Occupied(mut entry) => {
-                                let existing = entry.get_mut();
-                                existing.push((data, metadata));
-                            }
-                            Entry::Vacant(entry) => {
-                                entry.insert(vec![(data, metadata)]);
-                            }
+            InnerMode::Mean { multi_map } | InnerMode::Stdev { multi_map } => {
+                if matches!(data.value, MetricValue::Gauge { value: _ }) {
+                    match multi_map.entry(series) {
+                        Entry::Occupied(mut entry) => entry.get_mut().push((data, metadata)),
+                        Entry::Vacant(entry) => {
+                            entry.insert(vec![(data, metadata)]);
                         }
                     }
                 }
-            },
+            }
         }
-
         emit!(AggregateEventRecorded);
+        RecordOutcome::Aggregated
+    }
+
+    pub fn record_into(&mut self, event: Event, output: &mut Vec<Event>) {
+        if let RecordOutcome::Passthrough(event) = self.record(event) {
+            output.push(event);
+        }
     }
 
     fn record_count(
@@ -241,23 +262,20 @@ impl Aggregate {
     }
 
     fn record_sum(&mut self, series: MetricSeries, data: MetricData, metadata: EventMetadata) {
-        match data.kind {
-            MetricKind::Incremental => match self.map.entry(series) {
-                Entry::Occupied(mut entry) => {
-                    let existing = entry.get_mut();
-                    // In order to update (add) the new and old kind's must match
-                    if existing.0.kind == data.kind && existing.0.update(&data) {
-                        existing.1.merge(metadata);
-                    } else {
-                        emit!(AggregateUpdateFailed);
-                        *existing = (data, metadata);
-                    }
+        match self.map.entry(series) {
+            Entry::Occupied(mut entry) => {
+                let existing = entry.get_mut();
+                // In order to update (add) the new and old kind's must match
+                if existing.0.kind == data.kind && existing.0.update(&data) {
+                    existing.1.merge(metadata);
+                } else {
+                    emit!(AggregateUpdateFailed);
+                    *existing = (data, metadata);
                 }
-                Entry::Vacant(entry) => {
-                    entry.insert((data, metadata));
-                }
-            },
-            MetricKind::Absolute => {}
+            }
+            Entry::Vacant(entry) => {
+                entry.insert((data, metadata));
+            }
         }
     }
 
@@ -267,36 +285,33 @@ impl Aggregate {
         data: MetricData,
         metadata: EventMetadata,
     ) {
-        match data.kind {
-            MetricKind::Incremental => (),
-            MetricKind::Absolute => match self.map.entry(series) {
-                Entry::Occupied(mut entry) => {
-                    let existing = entry.get_mut();
-                    // In order to update (add) the new and old kind's must match
-                    if existing.0.kind == data.kind {
-                        if let MetricValue::Gauge {
-                            value: existing_value,
-                        } = existing.0.value()
-                            && let MetricValue::Gauge { value: new_value } = data.value()
-                        {
-                            let should_update = match self.mode {
-                                InnerMode::Max => new_value > existing_value,
-                                InnerMode::Min => new_value < existing_value,
-                                _ => false,
-                            };
-                            if should_update {
-                                *existing = (data, metadata);
-                            }
+        match self.map.entry(series) {
+            Entry::Occupied(mut entry) => {
+                let existing = entry.get_mut();
+                // In order to update (add) the new and old kind's must match
+                if existing.0.kind == data.kind {
+                    if let MetricValue::Gauge {
+                        value: existing_value,
+                    } = existing.0.value()
+                        && let MetricValue::Gauge { value: new_value } = data.value()
+                    {
+                        let should_update = match self.mode {
+                            InnerMode::Max => new_value > existing_value,
+                            InnerMode::Min => new_value < existing_value,
+                            _ => false,
+                        };
+                        if should_update {
+                            *existing = (data, metadata);
                         }
-                    } else {
-                        emit!(AggregateUpdateFailed);
-                        *existing = (data, metadata);
                     }
+                } else {
+                    emit!(AggregateUpdateFailed);
+                    *existing = (data, metadata);
                 }
-                Entry::Vacant(entry) => {
-                    entry.insert((data, metadata));
-                }
-            },
+            }
+            Entry::Vacant(entry) => {
+                entry.insert((data, metadata));
+            }
         }
     }
 
@@ -405,7 +420,7 @@ impl TaskTransform<Event> for Aggregate {
                                 self.flush_into(&mut output);
                                 done = true;
                             }
-                            Some(event) => self.record(event),
+                            Some(event) => self.record_into(event, &mut output),
                         }
                     }
                 };
@@ -947,6 +962,60 @@ mod tests {
         agg.flush_into(&mut out);
         assert_eq!(1, out.len());
         assert_eq!(&stdev_result, &out[0]);
+    }
+
+    #[test]
+    fn passes_through_ignored_kind() {
+        // Sum mode aggregates incremental, passes through absolute without collapsing.
+        let mut agg = Aggregate::new(&AggregateConfig {
+            interval_ms: 1000_u64,
+            mode: AggregationMode::Sum,
+        })
+        .unwrap();
+
+        let counter_1 = make_metric(
+            "counter_a",
+            MetricKind::Incremental,
+            MetricValue::Counter { value: 10.0 },
+        );
+        let counter_2 = make_metric(
+            "counter_a",
+            MetricKind::Incremental,
+            MetricValue::Counter { value: 5.0 },
+        );
+        let counter_summed = make_metric(
+            "counter_a",
+            MetricKind::Incremental,
+            MetricValue::Counter { value: 15.0 },
+        );
+        let gauge_1 = make_metric(
+            "gauge_a",
+            MetricKind::Absolute,
+            MetricValue::Gauge { value: 42.0 },
+        );
+        let gauge_2 = make_metric(
+            "gauge_a",
+            MetricKind::Absolute,
+            MetricValue::Gauge { value: 99.0 },
+        );
+
+        // Absolute metrics pass through immediately (not held until flush).
+        assert!(
+            matches!(agg.record(gauge_1.clone()), RecordOutcome::Passthrough(e) if e == gauge_1)
+        );
+        assert!(
+            matches!(agg.record(gauge_2.clone()), RecordOutcome::Passthrough(e) if e == gauge_2)
+        );
+
+        // Each is returned individually — no collapsing to latest.
+        agg.record(counter_1);
+        agg.record(counter_2);
+
+        let mut out = vec![];
+        agg.flush_into(&mut out);
+        // Only the summed incremental counter appears at flush; the gauges already passed through.
+        assert_eq!(1, out.len());
+        assert_eq!(&counter_summed, &out[0]);
     }
 
     #[test]

--- a/website/cue/reference/components/transforms/generated/aggregate.cue
+++ b/website/cue/reference/components/transforms/generated/aggregate.cue
@@ -22,13 +22,13 @@ generated: components: transforms: aggregate: configuration: {
 			enum: {
 				Auto:   "Default mode. Sums incremental metrics and uses the latest value for absolute metrics."
 				Count:  "Counts metrics for incremental and absolute metrics"
-				Diff:   "Returns difference between latest value for absolute, ignores incremental"
-				Latest: "Returns the latest value for absolute metrics, ignores incremental"
-				Max:    "Max value of absolute metric, ignores incremental"
-				Mean:   "Mean value of absolute metric, ignores incremental"
-				Min:    "Min value of absolute metric, ignores incremental"
-				Stdev:  "Stdev value of absolute metric, ignores incremental"
-				Sum:    "Sums incremental metrics, ignores absolute"
+				Diff:   "Returns difference between latest value for absolute; incremental metrics pass through unchanged."
+				Latest: "Returns the latest value for absolute metrics; incremental metrics pass through unchanged."
+				Max:    "Max value of absolute metric; incremental metrics pass through unchanged."
+				Mean:   "Mean value of absolute metric; incremental metrics pass through unchanged."
+				Min:    "Min value of absolute metric; incremental metrics pass through unchanged."
+				Stdev:  "Stdev value of absolute metric; incremental metrics pass through unchanged."
+				Sum:    "Sums incremental metrics; absolute metrics pass through unchanged."
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

There appears to be a major bug in the aggregate transform. According to the [official docs](https://vector.dev/docs/reference/configuration/transforms/aggregate/#mode) for certain mode types `incremental` or `absolute` metric kinds should be ignored (e.g. in `Sum` mode `absolute` metrics should be ignored). However it seems the current behavior is to silently drop the events (in the example `absolute` metrics would be dropped if the mode is `Sum`). 

Makes a fix to stop dropping non matching events and pass them through.

## Vector configuration
```
sources:
    otel_in:
      type: opentelemetry
      grpc:
        address: "0.0.0.0:4317"

  transforms:
    agg:
      type: aggregate
      inputs: [otel_in.metrics]
      interval_ms: 5000
      mode: sum

  sinks:
    console_out:
      type: console
      inputs: [agg]
      encoding:
        codec: json
```

## How did you test this PR?
Tested with above config 

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Closes: #<issue/PR number or link>
-->
<!--
- Related: #<issue/PR number or link>
-->

## Notes

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details on the [dd-rust-license-tool](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
