### PR TITLE
chore(releasing): extend deb-verify and rpm-verify to cover aarch64

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -273,7 +273,7 @@ jobs:
 
   deb-verify:
     name: Verify DEB Packages
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 5
     needs:
       - generate-publish-metadata
@@ -284,6 +284,9 @@ jobs:
       DD_PKG_VERSION: "latest"
     strategy:
       matrix:
+        runner:
+          - ubuntu-24.04
+          - ubuntu-24.04-arm
         container:
           - ubuntu:20.04
           - ubuntu:22.04
@@ -304,25 +307,28 @@ jobs:
           make
       - name: Install dd-pkg for linting
         run: |
-          curl -sSL "https://dd-package-tools.s3.amazonaws.com/dd-pkg/${DD_PKG_VERSION}/dd-pkg_Linux_x86_64.tar.gz" | tar -xz -C /usr/local/bin dd-pkg
+          ARCH=$(uname -m)
+          curl -sSL "https://dd-package-tools.s3.amazonaws.com/dd-pkg/${DD_PKG_VERSION}/dd-pkg_Linux_${ARCH/aarch64/arm64}.tar.gz" | tar -xz -C /usr/local/bin dd-pkg
       - name: Fix Git safe directories issue when in containers (actions/checkout#760)
         run: git config --global --add safe.directory /__w/vector/vector
       - name: Checkout Vector
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.git_ref }}
-      - name: Download staged package artifacts (x86_64-unknown-linux-gnu)
+      - name: Set artifact name
+        run: echo "ARTIFACT=$(uname -m)-unknown-linux-gnu" >> "$GITHUB_ENV"
+      - name: Download staged package artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: vector-${{ env.VECTOR_VERSION }}-x86_64-unknown-linux-gnu
+          name: vector-${{ env.VECTOR_VERSION }}-${{ env.ARTIFACT }}
           path: target/artifacts
       - name: Verify install of DEB package.
         run: |
-          ./scripts/verify-install.sh target/artifacts/vector_${{ env.VECTOR_VERSION }}-1_amd64.deb
+          ./scripts/verify-install.sh "target/artifacts/vector_${{ env.VECTOR_VERSION }}-1_$(dpkg --print-architecture).deb"
 
   rpm-verify:
     name: Verify RPM Packages
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 10
     needs:
       - generate-publish-metadata
@@ -333,6 +339,9 @@ jobs:
       DD_PKG_VERSION: "latest"
     strategy:
       matrix:
+        runner:
+          - ubuntu-24.04
+          - ubuntu-24.04-arm
         container:
           # Lowest supported glibc tier (EL8 family, glibc 2.28). Catches glibc-floor regressions.
           - "almalinux:8@sha256:ca871b110064fe81bff0250ed5cc56fbb0a9840715f09811c33bbf9d72cef56c"
@@ -358,21 +367,24 @@ jobs:
           fi
       - name: Install dd-pkg for linting
         run: |
-          curl -sSL "https://dd-package-tools.s3.amazonaws.com/dd-pkg/${DD_PKG_VERSION}/dd-pkg_Linux_x86_64.tar.gz" | tar -xz -C /usr/local/bin dd-pkg
+          ARCH=$(uname -m)
+          curl -sSL "https://dd-package-tools.s3.amazonaws.com/dd-pkg/${DD_PKG_VERSION}/dd-pkg_Linux_${ARCH/aarch64/arm64}.tar.gz" | tar -xz -C /usr/local/bin dd-pkg
       - name: Fix Git safe directories issue when in containers (actions/checkout#760)
         run: git config --global --add safe.directory /__w/vector/vector
       - name: Checkout Vector
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ inputs.git_ref }}
-      - name: Download staged package artifacts (x86_64-unknown-linux-gnu)
+      - name: Set artifact name
+        run: echo "ARTIFACT=$(uname -m)-unknown-linux-gnu" >> "$GITHUB_ENV"
+      - name: Download staged package artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: vector-${{ env.VECTOR_VERSION }}-x86_64-unknown-linux-gnu
+          name: vector-${{ env.VECTOR_VERSION }}-${{ env.ARTIFACT }}
           path: target/artifacts
       - name: Verify install of RPM package.
         run: |
-          ./scripts/verify-install.sh target/artifacts/vector-${{ env.VECTOR_VERSION }}-1.x86_64.rpm
+          ./scripts/verify-install.sh "target/artifacts/vector-${{ env.VECTOR_VERSION }}-1.$(uname -m).rpm"
 
   macos-verify:
     name: Verify macOS Package

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -308,7 +308,8 @@ jobs:
       - name: Install dd-pkg for linting
         run: |
           ARCH=$(uname -m)
-          curl -sSL "https://dd-package-tools.s3.amazonaws.com/dd-pkg/${DD_PKG_VERSION}/dd-pkg_Linux_${ARCH/aarch64/arm64}.tar.gz" | tar -xz -C /usr/local/bin dd-pkg
+          case "$ARCH" in aarch64) ARCH_DL=arm64 ;; *) ARCH_DL="$ARCH" ;; esac
+          curl -sSL "https://dd-package-tools.s3.amazonaws.com/dd-pkg/${DD_PKG_VERSION}/dd-pkg_Linux_${ARCH_DL}.tar.gz" | tar -xz -C /usr/local/bin dd-pkg
       - name: Fix Git safe directories issue when in containers (actions/checkout#760)
         run: git config --global --add safe.directory /__w/vector/vector
       - name: Checkout Vector
@@ -368,7 +369,8 @@ jobs:
       - name: Install dd-pkg for linting
         run: |
           ARCH=$(uname -m)
-          curl -sSL "https://dd-package-tools.s3.amazonaws.com/dd-pkg/${DD_PKG_VERSION}/dd-pkg_Linux_${ARCH/aarch64/arm64}.tar.gz" | tar -xz -C /usr/local/bin dd-pkg
+          case "$ARCH" in aarch64) ARCH_DL=arm64 ;; *) ARCH_DL="$ARCH" ;; esac
+          curl -sSL "https://dd-package-tools.s3.amazonaws.com/dd-pkg/${DD_PKG_VERSION}/dd-pkg_Linux_${ARCH_DL}.tar.gz" | tar -xz -C /usr/local/bin dd-pkg
       - name: Fix Git safe directories issue when in containers (actions/checkout#760)
         run: git config --global --add safe.directory /__w/vector/vector
       - name: Checkout Vector


### PR DESCRIPTION
## Summary

Extends the `deb-verify` and `rpm-verify` jobs to run on both `ubuntu-24.04` and `ubuntu-24.04-arm` runners, covering the `aarch64-unknown-linux-gnu` packages alongside the existing x86_64 coverage.

Each job now uses a two-dimensional matrix (`runner` × `container`) and derives all arch-specific values at runtime (`uname -m` for the artifact name, `dpkg --print-architecture` for the DEB filename, and a bash substitution for the dd-pkg binary name). This eliminates the separate `*-aarch64` jobs that were added and immediately consolidated.

Without this, a regression in the aarch64 glibc floor (as happened in #25253 / #25484) would ship undetected — the build fix in #25387 compiles inside `almalinux:8` but there was no CI gate verifying the resulting binary actually runs there.

## Vector configuration

NA

## How did you test this PR?

Manually verified the latest nightly `aarch64-unknown-linux-gnu` tar.gz and Docker image on an aarch64 host. The binary runs and reports `GLIBC_2.28` as the highest required glibc version.

`/ci-run-packaging` - ci run: https://github.com/vectordotdev/vector/actions/runs/26302357902?pr=25487

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: #25387
- Related: #25484
- Related: #25253
