### PR TITLE
fix(core): Drop empty batches before they reach downstream buffers

### DIFF
--- a/changelog.d/drop_empty_batches_fanout.fix.md
+++ b/changelog.d/drop_empty_batches_fanout.fix.md
@@ -1,5 +1,4 @@
-Drops empty event batches before they reach downstream buffers.
-Defense against possible programmer errors in new components,
-this prevents Vector from crashing and instead logs a warning.
+Fixed a crash that could occur when a source or transform emitted an empty event batch into a topology with downstream buffers. Vector now
+drops empty batches before they reach those buffers and logs a warning identifying the upstream component.
 
 authors: graphcareful

--- a/changelog.d/drop_empty_batches_fanout.fix.md
+++ b/changelog.d/drop_empty_batches_fanout.fix.md
@@ -1,0 +1,5 @@
+Drops empty event batches before they reach downstream buffers.
+Defense against possible programmer errors in new components,
+this prevents Vector from crashing and instead logs a warning.
+
+authors: graphcareful

--- a/lib/vector-core/src/fanout.rs
+++ b/lib/vector-core/src/fanout.rs
@@ -227,8 +227,7 @@ impl Fanout {
 
         // Drop empty event batches before they reach any downstream buffer, this is technically
         // programmer error. In debug/test builds the `debug_assert!` makes the underlying bug fail
-        // loudly; in release builds the batch is dropped with a rate-limited warning naming the
-        // upstream component.
+        // loudly.
         debug_assert!(
             !events.is_empty(),
             "Fanout received empty event batch from upstream component '{}'",

--- a/lib/vector-core/src/fanout.rs
+++ b/lib/vector-core/src/fanout.rs
@@ -7,7 +7,10 @@ use tokio::sync::mpsc;
 use tokio_util::sync::ReusableBoxFuture;
 use vector_buffers::topology::channel::BufferSender;
 
-use crate::{config::ComponentKey, event::EventArray};
+use crate::{
+    config::ComponentKey,
+    event::{EventArray, EventContainer},
+};
 
 pub enum ControlMessage {
     /// Adds a new sink to the fanout.
@@ -45,15 +48,17 @@ pub type ControlChannel = mpsc::UnboundedSender<ControlMessage>;
 pub struct Fanout {
     senders: IndexMap<ComponentKey, Option<Sender>>,
     control_channel: mpsc::UnboundedReceiver<ControlMessage>,
+    upstream_component: ComponentKey,
 }
 
 impl Fanout {
-    pub fn new() -> (Self, ControlChannel) {
+    pub fn new(upstream_component: ComponentKey) -> (Self, ControlChannel) {
         let (control_tx, control_rx) = mpsc::unbounded_channel();
 
         let fanout = Self {
             senders: Default::default(),
             control_channel: control_rx,
+            upstream_component,
         };
 
         (fanout, control_tx)
@@ -219,6 +224,28 @@ impl Fanout {
 
         // Wait for any senders that are paused to be replaced first before continuing with the send.
         self.wait_for_replacements().await;
+
+        // Drop empty event batches before they reach any downstream buffer, this is technically
+        // programmer error. In debug/test builds the `debug_assert!` makes the underlying bug fail
+        // loudly; in release builds the batch is dropped with a rate-limited warning naming the
+        // upstream component.
+        debug_assert!(
+            !events.is_empty(),
+            "Fanout received empty event batch from upstream component '{}'",
+            self.upstream_component,
+        );
+        // TODO: Wrap the conditional below with `std::hint::unlikely` once it stabilizes. This is an
+        // applicable situation to use it in since the following conditional should never evaluate to
+        // true.
+        #[cfg(not(debug_assertions))]
+        if events.is_empty() {
+            warn!(
+                message = "Dropping empty event batch emitted by upstream component. This is likely a bug in that component.",
+                component_id = %self.upstream_component,
+                downstream_count = self.senders.len(),
+            );
+            return Ok(());
+        }
 
         // Nothing to send if we have no sender.
         if self.senders.is_empty() {
@@ -525,7 +552,7 @@ mod tests {
         UnboundedSender<ControlMessage>,
         Vec<BufferReceiver<EventArray>>,
     ) {
-        let (mut fanout, control) = Fanout::new();
+        let (mut fanout, control) = Fanout::new(ComponentKey::from("test_upstream"));
         let pairs = build_sender_pairs(capacities);
 
         let mut receivers = Vec::new();
@@ -827,7 +854,7 @@ mod tests {
 
     #[tokio::test]
     async fn fanout_no_sinks() {
-        let (mut fanout, _) = Fanout::new();
+        let (mut fanout, _) = Fanout::new(ComponentKey::from("test_upstream"));
         let events = make_events(2);
 
         fanout
@@ -838,6 +865,37 @@ mod tests {
             .send(events[1].clone().into(), None)
             .await
             .expect("should not fail");
+    }
+
+    // The empty-batch guard panics via `debug_assert!` in debug builds and silently drops in
+    // release builds. The two tests below cover each half of that behavior.
+    #[tokio::test]
+    #[cfg(not(debug_assertions))]
+    async fn fanout_drops_empty_event_array_in_release_builds() {
+        let (mut fanout, _, receivers) = fanout_from_senders(&[2, 2]);
+        let empty: EventArray = Vec::<LogEvent>::new().into();
+
+        fanout
+            .send(empty, None)
+            .await
+            .expect("empty batch should be dropped, not errored");
+
+        for receiver in receivers {
+            assert!(
+                collect_ready(receiver.into_stream()).is_empty(),
+                "no downstream receiver should observe the empty batch",
+            );
+        }
+    }
+
+    #[tokio::test]
+    #[cfg(debug_assertions)]
+    #[should_panic(expected = "Fanout received empty event batch from upstream component")]
+    async fn fanout_panics_on_empty_event_array_in_debug_builds() {
+        let (mut fanout, _, _receivers) = fanout_from_senders(&[2, 2]);
+        let empty: EventArray = Vec::<LogEvent>::new().into();
+
+        let _ = fanout.send(empty, None).await;
     }
 
     #[tokio::test]

--- a/lib/vector-core/src/fanout.rs
+++ b/lib/vector-core/src/fanout.rs
@@ -867,28 +867,7 @@ mod tests {
             .expect("should not fail");
     }
 
-    // The empty-batch guard panics via `debug_assert!` in debug builds and silently drops in
-    // release builds. The two tests below cover each half of that behavior.
     #[tokio::test]
-    async fn fanout_drops_empty_event_array_in_release_builds() {
-        let (mut fanout, _, receivers) = fanout_from_senders(&[2, 2]);
-        let empty: EventArray = Vec::<LogEvent>::new().into();
-
-        fanout
-            .send(empty, None)
-            .await
-            .expect("empty batch should be dropped, not errored");
-
-        for receiver in receivers {
-            assert!(
-                collect_ready(receiver.into_stream()).is_empty(),
-                "no downstream receiver should observe the empty batch",
-            );
-        }
-    }
-
-    #[tokio::test]
-    #[cfg(debug_assertions)]
     #[should_panic(expected = "Fanout received empty event batch from upstream component")]
     async fn fanout_panics_on_empty_event_array_in_debug_builds() {
         let (mut fanout, _, _receivers) = fanout_from_senders(&[2, 2]);

--- a/lib/vector-core/src/fanout.rs
+++ b/lib/vector-core/src/fanout.rs
@@ -870,7 +870,6 @@ mod tests {
     // The empty-batch guard panics via `debug_assert!` in debug builds and silently drops in
     // release builds. The two tests below cover each half of that behavior.
     #[tokio::test]
-    #[cfg(not(debug_assertions))]
     async fn fanout_drops_empty_event_array_in_release_builds() {
         let (mut fanout, _, receivers) = fanout_from_senders(&[2, 2]);
         let empty: EventArray = Vec::<LogEvent>::new().into();

--- a/lib/vector-core/src/transform/outputs.rs
+++ b/lib/vector-core/src/transform/outputs.rs
@@ -42,7 +42,7 @@ impl TransformOutputs {
         let mut controls = HashMap::new();
 
         for output in outputs_in {
-            let (fanout, control) = Fanout::new();
+            let (fanout, control) = Fanout::new(component_key.clone());
 
             let log_schema_definitions = output
                 .log_schema_definitions

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -300,7 +300,7 @@ impl<'a> Builder<'a> {
         for output in source_outputs.into_iter() {
             let rx = builder.add_source_output(output.clone(), key.clone());
 
-            let (fanout, control) = Fanout::new();
+            let (fanout, control) = Fanout::new(key.clone());
             let source_type = source.inner.get_component_name();
             let source = Arc::new(key.clone());
 
@@ -832,7 +832,7 @@ impl<'a> Builder<'a> {
         key: &ComponentKey,
         outputs: &[TransformOutput],
     ) -> (Task, HashMap<OutputId, fanout::ControlChannel>) {
-        let (mut fanout, control) = Fanout::new();
+        let (mut fanout, control) = Fanout::new(key.clone());
 
         let sender = self
             .utilization_registry


### PR DESCRIPTION
## Summary
This change drops empty batches in the fanout before they reach downstream buffers. This error is classified as a programmer error, and it can only happen if there is a bug in a transform (or source) which emits an empty batch into the pipeline. 

However with disk buffering enabled if this bug does arise Vector crashes. This change drop the batch and logs, when in debug mode an assertion is instead raised. 

## How did you test this PR?
Additional unit tests

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Closes: #<issue/PR number or link>
-->
<!--
- Related: #<issue/PR number or link>
-->

## Notes

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details on the [dd-rust-license-tool](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
