### PR TITLE
fix(metrics): add _total suffix to memory enrichment counters

### DIFF
--- a/lib/vector-common/src/internal_event/metric_name.rs
+++ b/lib/vector-common/src/internal_event/metric_name.rs
@@ -93,12 +93,12 @@ pub enum CounterName {
     SqsS3EventRecordIgnoredTotal,
     ComponentAllocatedBytesTotal,
     ComponentDeallocatedBytesTotal,
-    MemoryEnrichmentTableFailedInsertions,
-    MemoryEnrichmentTableFailedReads,
+    MemoryEnrichmentTableFailedInsertionsTotal,
+    MemoryEnrichmentTableFailedReadsTotal,
     MemoryEnrichmentTableFlushesTotal,
     MemoryEnrichmentTableInsertionsTotal,
     MemoryEnrichmentTableReadsTotal,
-    MemoryEnrichmentTableTtlExpirations,
+    MemoryEnrichmentTableTtlExpirationsTotal,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Display, AsRefStr, EnumIter)]
@@ -354,16 +354,20 @@ impl CounterName {
             Self::SqsS3EventRecordIgnoredTotal => "sqs_s3_event_record_ignored_total",
             Self::ComponentAllocatedBytesTotal => "component_allocated_bytes_total",
             Self::ComponentDeallocatedBytesTotal => "component_deallocated_bytes_total",
-            Self::MemoryEnrichmentTableFailedInsertions => {
-                "memory_enrichment_table_failed_insertions"
+            Self::MemoryEnrichmentTableFailedInsertionsTotal => {
+                "memory_enrichment_table_failed_insertions_total"
             }
-            Self::MemoryEnrichmentTableFailedReads => "memory_enrichment_table_failed_reads",
+            Self::MemoryEnrichmentTableFailedReadsTotal => {
+                "memory_enrichment_table_failed_reads_total"
+            }
             Self::MemoryEnrichmentTableFlushesTotal => "memory_enrichment_table_flushes_total",
             Self::MemoryEnrichmentTableInsertionsTotal => {
                 "memory_enrichment_table_insertions_total"
             }
             Self::MemoryEnrichmentTableReadsTotal => "memory_enrichment_table_reads_total",
-            Self::MemoryEnrichmentTableTtlExpirations => "memory_enrichment_table_ttl_expirations",
+            Self::MemoryEnrichmentTableTtlExpirationsTotal => {
+                "memory_enrichment_table_ttl_expirations_total"
+            }
         }
     }
 }

--- a/src/enrichment_tables/memory/internal_events.rs
+++ b/src/enrichment_tables/memory/internal_events.rs
@@ -82,12 +82,12 @@ impl InternalEvent for MemoryEnrichmentTableTtlExpired<'_> {
     fn emit(self) {
         if self.include_key_metric_tag {
             counter!(
-                CounterName::MemoryEnrichmentTableTtlExpirations,
+                CounterName::MemoryEnrichmentTableTtlExpirationsTotal,
                 "key" => self.key.to_owned()
             )
             .increment(1);
         } else {
-            counter!(CounterName::MemoryEnrichmentTableTtlExpirations,).increment(1);
+            counter!(CounterName::MemoryEnrichmentTableTtlExpirationsTotal,).increment(1);
         }
     }
 }
@@ -102,12 +102,12 @@ impl InternalEvent for MemoryEnrichmentTableReadFailed<'_> {
     fn emit(self) {
         if self.include_key_metric_tag {
             counter!(
-                CounterName::MemoryEnrichmentTableFailedReads,
+                CounterName::MemoryEnrichmentTableFailedReadsTotal,
                 "key" => self.key.to_owned()
             )
             .increment(1);
         } else {
-            counter!(CounterName::MemoryEnrichmentTableFailedReads,).increment(1);
+            counter!(CounterName::MemoryEnrichmentTableFailedReadsTotal,).increment(1);
         }
     }
 }
@@ -122,12 +122,12 @@ impl InternalEvent for MemoryEnrichmentTableInsertFailed<'_> {
     fn emit(self) {
         if self.include_key_metric_tag {
             counter!(
-                CounterName::MemoryEnrichmentTableFailedInsertions,
+                CounterName::MemoryEnrichmentTableFailedInsertionsTotal,
                 "key" => self.key.to_owned()
             )
             .increment(1);
         } else {
-            counter!(CounterName::MemoryEnrichmentTableFailedInsertions,).increment(1);
+            counter!(CounterName::MemoryEnrichmentTableFailedInsertionsTotal,).increment(1);
         }
     }
 }


### PR DESCRIPTION
## Summary

Renames three memory enrichment table counter metrics to end with `_total`, per [instrumentation spec](https://github.com/vectordotdev/vector/blob/master/docs/specs/instrumentation.md) (*"Counters MUST end with `total`"*).

Fixes #25455

| Before | After |
|--------|-------|
| `memory_enrichment_table_failed_insertions` | `memory_enrichment_table_failed_insertions_total` |
| `memory_enrichment_table_failed_reads` | `memory_enrichment_table_failed_reads_total` |
| `memory_enrichment_table_ttl_expirations` | `memory_enrichment_table_ttl_expirations_total` |

## Breaking change

Anyone scraping the old metric names will need to update dashboards/alerts. These metrics were introduced with the memory enrichment table feature; happy to add deprecated aliases if maintainers prefer.

## Test plan

```bash
cargo test -p vector-common
```

```
test result: ok. 29 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 1.00s
```