### PR TITLE
chore(internal docs): add AI contribution policy

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,6 +3,8 @@
 .github/workflows/regression.yml @vectordotdev/vector @vectordotdev/single-machine-performance
 regression/config.yaml @vectordotdev/vector @vectordotdev/single-machine-performance
 
+AI_POLICY.md @vectordotdev/vector @vectordotdev/documentation
+
 # Keep documentation team paths in sync with .github/workflows/add_docs_review_label.yml
 docs/ @vectordotdev/vector @vectordotdev/documentation
 website/ @vectordotdev/vector

--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -1,6 +1,7 @@
 acmecorp
 Acro
 addonmanager
+Agentic
 Ainol
 aiohttp
 Airis
@@ -308,6 +309,7 @@ lenovo
 levenstein
 Lexibook
 LGE
+LLMs
 Lifetab
 Lifetouch
 linkerd

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,0 +1,41 @@
+# AI Policy
+
+We use AI tools ourselves and encourage their use. This policy isn't about limiting how you work. It's about keeping contributions high-quality and reviews sustainable for a small team maintaining a popular open source project that receives a lot of PRs.
+
+## New to Vector?
+
+LLMs are genuinely great for onboarding into a large codebase. If you're just getting started, ask one to explain a component, trace a data flow, or summarize what a module does. It can save you a lot of time getting oriented.
+
+That said, there's still no substitute for some good old-fashioned reading. Spending time in the actual source, following the logic yourself, and running things locally is what builds the real intuition you'll need to contribute confidently. Use the LLM as a guide, as a helper.
+
+## You own what you submit
+
+When you open a PR or issue, you're vouching for it. Ideally that means you understand what the changes do, why they're correct, and how they fit Vector's architecture and conventions. If a reviewer asks you a question, please answer it in your own words rather than relaying AI output.
+
+This applies whether you wrote the code yourself, used AI as a coding assistant, or anything in between. The goal is the same: be the expert on your own contribution.
+
+## Keep conversations human
+
+GitHub discussions (issues, PR descriptions, review threads) are how our community thinks together. We'd love for those to be written in your own voice. Pasting AI output into a review thread isn't a great substitute for engaging with feedback.
+
+AI is great for polishing grammar and prose, and that's totally fine. We just ask that the substance and ideas are yours.
+
+## Quality over volume
+
+AI tools can generate a lot of code quickly. Please keep PRs well-scoped and focused: one clear problem, one clear solution. Our reviewers are humans with limited time, and a focused, well-tested PR that solves a real problem will get reviewed and merged faster.
+
+Before opening a PR, it helps to make sure it addresses a real need (ideally tied to an open issue), that your changes are tested, and that you've followed the standard checks described in [CONTRIBUTING.md](CONTRIBUTING.md#running-other-checks).
+
+## AI review comments
+
+Pull requests often receive automated AI code review. Please take a moment to go through those comments before requesting a human review. If a comment doesn't apply, please include a brief note when dismissing it. Resolving comments without any explanation creates friction for human reviewers, who then have to scan each one and figure out whether a follow-up commit addressed it or it was simply closed without consideration.
+
+We'd also love if you could like or dislike each AI comment. It only takes a second and it genuinely helps us understand whether the tool is pulling its weight. So far the signal has been really good and the vast majority of comments have been valid, so your feedback helps us keep measuring that.
+
+## Agentic contributions
+
+Agentic PRs aren't a special category. They're held to exactly the same bar as any other contribution: the code should be understood by the person submitting it, covered by unit tests, and validated with integration or end-to-end tests where appropriate. If you're using an agent to help you build something, that's great. We'd just ask that you've read, understood, and tested what it produced before submitting.
+
+---
+
+That's it. If something isn't covered here, the underlying principle is: please be considerate of reviewers' time, and take ownership of the work you submit. We really appreciate your contributions.

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -16,9 +16,7 @@ This applies whether you wrote the code yourself, used AI as a coding assistant,
 
 ## Keep conversations human
 
-GitHub discussions (issues, PR descriptions, review threads) are how our community thinks together. We'd love for those to be written in your own voice. Pasting AI output into a review thread isn't a great substitute for engaging with feedback.
-
-AI is great for polishing grammar and prose, and that's totally fine. We just ask that the substance and ideas are yours.
+GitHub discussions (issues, PR descriptions, review threads) are how our community thinks together. Honestly, if a response is thoughtful and on point, does it matter whether a human wrote every word? We don't think so. What we'd rather avoid is raw AI output forwarded into a thread without review — that's not engaging with feedback, it's delegating it.
 
 ## Quality over volume
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,8 @@ Vector team member will find this document useful.
 2. **You've read Vector's [docs](https://vector.dev/docs/).**
 3. **You know about the [Vector community](https://vector.dev/community/).
    Please use this for help.**
+4. **You've read our [AI Policy](AI_POLICY.md)** if you plan to use AI tools
+   in your contribution.
 
 ## Your First Contribution
 


### PR DESCRIPTION
## Summary

Define and publish an AI contribution policy and integrate it into the contributor workflow.

## Change Type

- [x] Non-functional (chore, refactoring, docs)

## Is this a breaking change?

- [x] No

## Does this PR include user facing changes?

- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- [ripgrep AI policy](https://github.com/BurntSushi/ripgrep/blob/master/AI_POLICY.md)
- [uv AI policy](https://github.com/astral-sh/.github/blob/main/AI_POLICY.md)
- [Ghostty AI policy](https://github.com/ghostty-org/ghostty/blob/main/AI_POLICY.md)
- [LLVM AI tool policy](https://llvm.org/docs/AIToolPolicy.html)
- [Linux kernel coding assistants](https://docs.kernel.org/process/coding-assistants.html)
- [CPython AI tools guidelines](https://devguide.python.org/getting-started/ai-tools/)
- [Open source AI contribution policies registry](https://github.com/melissawm/open-source-ai-contribution-policies)
- [OSS response to AI slop](https://codenote.net/en/posts/oss-ai-slop-contribution-policy-shift/)