### PR TITLE
chore(internal docs): add docs team to CODEOWNERS for top level md files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,7 @@
 .github/workflows/regression.yml @vectordotdev/vector @vectordotdev/single-machine-performance
 regression/config.yaml @vectordotdev/vector @vectordotdev/single-machine-performance
 
-AI_POLICY.md @vectordotdev/vector @vectordotdev/documentation
+/*.md @vectordotdev/vector @vectordotdev/documentation
 
 # Keep documentation team paths in sync with .github/workflows/add_docs_review_label.yml
 docs/ @vectordotdev/vector @vectordotdev/documentation

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,16 +3,15 @@
 .github/workflows/regression.yml @vectordotdev/vector @vectordotdev/single-machine-performance
 regression/config.yaml @vectordotdev/vector @vectordotdev/single-machine-performance
 
-/*.md @vectordotdev/vector @vectordotdev/documentation
-
-# Keep documentation team paths in sync with .github/workflows/add_docs_review_label.yml
-docs/ @vectordotdev/vector @vectordotdev/documentation
 website/ @vectordotdev/vector
-website/content @vectordotdev/vector @vectordotdev/documentation
-website/cue/reference @vectordotdev/vector @vectordotdev/documentation
-
 website/js @vectordotdev/vector @vectordotdev/vector-website
 website/layouts @vectordotdev/vector @vectordotdev/vector-website
 website/scripts @vectordotdev/vector @vectordotdev/vector-website
 website/data @vectordotdev/vector @vectordotdev/vector-website
 website/* @vectordotdev/vector @vectordotdev/vector-website
+
+# Keep documentation team paths in sync with .github/workflows/add_docs_review_label.yml
+/*.md @vectordotdev/vector @vectordotdev/documentation
+docs/ @vectordotdev/vector @vectordotdev/documentation
+website/content @vectordotdev/vector @vectordotdev/documentation
+website/cue/reference @vectordotdev/vector @vectordotdev/documentation

--- a/.github/workflows/add_docs_review_label.yml
+++ b/.github/workflows/add_docs_review_label.yml
@@ -11,6 +11,7 @@ on:
     types: [opened, reopened, synchronize]
     # Keep these paths in sync with the documentation team entries in .github/CODEOWNERS
     paths:
+      - "*.md"
       - "docs/**"
       - "website/content/**"
       - "website/cue/reference/**"


### PR DESCRIPTION
## Summary

Replace the explicit `AI_POLICY.md` entry with a `/*.md` glob so all top-level markdown files are automatically covered by the documentation team.

## Vector configuration

NA

## How did you test this PR?

NA

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

NA