### PR TITLE
chore(deps): bump futures to 0.3.32

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4456,9 +4456,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -4471,9 +4471,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -4481,15 +4481,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -4509,9 +4509,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-lite"
@@ -4528,9 +4528,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2 1.0.106",
  "quote 1.0.45",
@@ -4539,15 +4539,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-timer"
@@ -4557,9 +4557,9 @@ checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -4569,7 +4569,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,7 +157,7 @@ dashmap = { version = "6.1.0", default-features = false }
 derivative = { version = "2.2.0", default-features = false }
 exitcode = { version = "1.1.2", default-features = false }
 flate2 = { version = "1.1.2", default-features = false, features = ["zlib-rs"] }
-futures = { version = "0.3.31", default-features = false, features = ["std"] }
+futures = { version = "0.3.32", default-features = false, features = ["std"] }
 futures-util = { version = "0.3.29", default-features = false }
 glob = { version = "0.3.3", default-features = false }
 hickory-proto = { version = "0.26.1", default-features = false, features = ["dnssec-ring"] }

--- a/src/sinks/datadog/events/tests.rs
+++ b/src/sinks/datadog/events/tests.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use bytes::Bytes;
 use futures::{
     StreamExt,
-    channel::mpsc::{Receiver, TryRecvError},
+    channel::mpsc::Receiver,
     stream::Stream,
 };
 use hyper::StatusCode;
@@ -105,7 +105,7 @@ async fn smoke() {
 async fn handles_failure() {
     let (_expected, mut rx) = start_test(StatusCode::FORBIDDEN, BatchStatus::Rejected).await;
 
-    assert!(matches!(rx.try_next(), Err(TryRecvError { .. })));
+    assert!(rx.try_recv().is_err());
 }
 
 #[tokio::test]

--- a/src/sinks/datadog/events/tests.rs
+++ b/src/sinks/datadog/events/tests.rs
@@ -1,11 +1,7 @@
 use std::sync::Arc;
 
 use bytes::Bytes;
-use futures::{
-    StreamExt,
-    channel::mpsc::Receiver,
-    stream::Stream,
-};
+use futures::{StreamExt, channel::mpsc::Receiver, stream::Stream};
 use hyper::StatusCode;
 use indoc::indoc;
 use similar_asserts::assert_eq;

--- a/src/sinks/datadog/logs/tests.rs
+++ b/src/sinks/datadog/logs/tests.rs
@@ -4,10 +4,7 @@ use std::sync::Arc;
 
 use bytes::Bytes;
 use chrono::Utc;
-use futures::{
-    StreamExt,
-    channel::mpsc::Receiver,
-};
+use futures::{StreamExt, channel::mpsc::Receiver};
 use http::request::Parts;
 use indoc::indoc;
 use vector_lib::{

--- a/src/sinks/datadog/logs/tests.rs
+++ b/src/sinks/datadog/logs/tests.rs
@@ -6,7 +6,7 @@ use bytes::Bytes;
 use chrono::Utc;
 use futures::{
     StreamExt,
-    channel::mpsc::{Receiver, TryRecvError},
+    channel::mpsc::Receiver,
 };
 use http::request::Parts;
 use indoc::indoc;
@@ -195,9 +195,9 @@ async fn telemetry() {
 async fn handles_failure_v1() {
     let (_expected, mut rx) =
         start_test_error(ApiStatus::BadRequestv1, BatchStatus::Rejected).await;
-    let res = rx.try_next();
+    let res = rx.try_recv();
 
-    assert!(matches!(res, Err(TryRecvError { .. })));
+    assert!(res.is_err());
 }
 
 #[tokio::test]
@@ -209,9 +209,9 @@ async fn handles_failure_v1() {
 async fn handles_failure_v2() {
     let (_expected, mut rx) =
         start_test_error(ApiStatus::BadRequestv2, BatchStatus::Rejected).await;
-    let res = rx.try_next();
+    let res = rx.try_recv();
 
-    assert!(matches!(res, Err(TryRecvError { .. })));
+    assert!(res.is_err());
 }
 
 #[tokio::test]

--- a/src/sinks/mezmo.rs
+++ b/src/sinks/mezmo.rs
@@ -524,7 +524,7 @@ mod tests {
     async fn smoke_fails() {
         let (_hosts, _partitions, mut rx) =
             smoke_start(StatusCode::FORBIDDEN, BatchStatus::Rejected).await;
-        assert!(matches!(rx.try_next(), Err(mpsc::TryRecvError { .. })));
+        assert!(rx.try_recv().is_err());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

`futures 0.3.32` introduced a breaking change in `futures::channel::mpsc`: `TryRecvError` became an enum with `Empty` and `Closed` variants, and `try_next()` was removed from `Receiver`. Three failure tests used `try_next()` with the old unit-struct pattern `Err(TryRecvError { .. })`.

This PR bumps `futures` to `0.3.32` and updates the affected tests to use `try_recv().is_err()`, which correctly captures the intent (no items received) regardless of whether the channel is still open or already closed — and is immune to future `TryRecvError` variant additions.

## Vector configuration

NA

## How did you test this PR?

CI/MQ

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: #25492