### PR TITLE
fix(loki sink): validate endpoint is an absolute URL

### DIFF
--- a/changelog.d/10980_loki_endpoint_validation.fix.md
+++ b/changelog.d/10980_loki_endpoint_validation.fix.md
@@ -1,0 +1,1 @@
+The `loki` sink now validates the `endpoint` option at startup and returns a clear error when it is not an absolute URL (for example, a host name with a missing or mistyped scheme). Previously such values were accepted during configuration parsing but later failed with an opaque `invalid format` error.

--- a/src/sinks/loki/config.rs
+++ b/src/sinks/loki/config.rs
@@ -225,6 +225,8 @@ impl SinkConfig for LokiConfig {
             }
         }
 
+        validate_endpoint(&self.endpoint)?;
+
         let client = self.build_client(cx)?;
 
         let config = LokiConfig {
@@ -277,11 +279,30 @@ pub fn valid_label_name(label: &Template) -> bool {
     }
 }
 
+/// Validates that the configured `endpoint` is a usable absolute URL.
+///
+/// `endpoint` is deserialized as a permissive `UriSerde`, so values without a
+/// scheme (for example a bare host name with a typo) are accepted at parse time
+/// but later fail with an opaque "invalid format" error when the request URI is
+/// built. Checking here lets us surface a clear, actionable message instead.
+fn validate_endpoint(endpoint: &UriSerde) -> crate::Result<()> {
+    let uri = &endpoint.uri;
+    if uri.scheme().is_none() || uri.authority().is_none() {
+        return Err(format!(
+            "Invalid `endpoint`: {endpoint:?} is not an absolute URL. \
+             Expected a value with a scheme and host, such as \"http://localhost:3100\"."
+        )
+        .into());
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use std::convert::TryInto;
 
-    use super::valid_label_name;
+    use super::{valid_label_name, validate_endpoint};
+    use crate::sinks::util::UriSerde;
 
     #[test]
     fn valid_label_names() {
@@ -298,5 +319,23 @@ mod tests {
         assert!(!valid_label_name(&" ".try_into().unwrap()));
 
         assert!(valid_label_name(&"{{field}}".try_into().unwrap()));
+    }
+
+    #[test]
+    fn validates_endpoint() {
+        let parse = |s: &str| s.parse::<UriSerde>().unwrap();
+
+        // Valid absolute URLs.
+        assert!(validate_endpoint(&parse("http://localhost:3100")).is_ok());
+        assert!(validate_endpoint(&parse("https://loki.example.com/")).is_ok());
+
+        // Scheme-less values (such as a host name with a typo) are rejected with
+        // a clear error instead of failing later with "invalid format".
+        let error = validate_endpoint(&parse("typo-host-no-scheme"))
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("not an absolute URL"), "{error}");
+
+        assert!(validate_endpoint(&parse("/loki/api/v1/push")).is_err());
     }
 }


### PR DESCRIPTION
## Summary

Closes #10980.

The `loki` sink's `endpoint` option is deserialized as a permissive `UriSerde`, which accepts incomplete URIs. A value with a missing or mistyped scheme (for example a bare host name) is accepted at configuration parse time, but then fails later — when the request URI is assembled via `append_path` — with an opaque error:

```
Configuration error. error=Sink "loki": invalid format
```

This gives the user no indication that the problem is the `endpoint` value.

This PR validates the endpoint when the sink is built (alongside the existing label validation) and returns a clear, actionable error instead.

### Before

```toml
[sinks.loki]
type = "loki"
inputs = ["in"]
labels.host = "localhost"
endpoint = "something-with-a-typo-that-is-hard-to-notice"
encoding.codec = "logfmt"
```

```
Configuration error. error=Sink "loki": invalid format
```

### After

```
Configuration error. error=Sink "loki": Invalid `endpoint`: ... is not an absolute URL. Expected a value with a scheme and host, such as "http://localhost:3100".
```

## How did you test this PR?

- `cargo check --lib --no-default-features --features sinks-loki` — passes
- `cargo test --lib --no-default-features --features sinks-loki loki::config` — passes (added `validates_endpoint` unit test; existing `valid_label_names` still passes)
- `cargo fmt --check` — passes
- `cargo clippy --lib --no-default-features --features sinks-loki -- -D warnings` — passes

The fix matches the direction suggested by @jszwedko in the issue thread (checking for the needed URL parts at the configuration layer).

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

A configuration with a scheme-less `endpoint` already failed to start (with an unclear error); it now fails with a clear one. Valid absolute-URL endpoints are unaffected.

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Closes: #10980
