### PR TITLE
feat(cli): add --data-dir flag and VECTOR_DATA_DIR env var

### DIFF
--- a/changelog.d/9766_data_dir_cli_env.feature.md
+++ b/changelog.d/9766_data_dir_cli_env.feature.md
@@ -1,0 +1,3 @@
+Added a `--data-dir` command-line flag (and corresponding `VECTOR_DATA_DIR` environment variable) to override the `data_dir` global configuration option. When set, it takes precedence over any `data_dir` value in the configuration file. This is useful for keeping deployment-specific paths out of the configuration file, for example when validating a configuration in a CI environment where the configured `data_dir` may not exist.
+
+authors: xfocus3

--- a/src/app.rs
+++ b/src/app.rs
@@ -85,6 +85,7 @@ impl ApplicationConfig {
             &config_paths,
             watcher_conf,
             opts.require_healthy,
+            opts.data_dir.clone(),
             opts.allow_empty_config,
             !opts.disable_env_var_interpolation,
             graceful_shutdown_duration,
@@ -555,10 +556,12 @@ pub fn build_runtime(threads: Option<usize>, thread_name: &str) -> Result<Runtim
     Ok(rt_builder.build().expect("Unable to create async runtime"))
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn load_configs(
     config_paths: &[ConfigPath],
     watcher_conf: Option<config::watcher::WatcherConfig>,
     require_healthy: Option<bool>,
+    data_dir: Option<PathBuf>,
     allow_empty_config: bool,
     interpolate_env: bool,
     graceful_shutdown_duration: Option<Duration>,
@@ -648,6 +651,13 @@ pub async fn load_configs(
         info!("Health checks are disabled.");
     }
     config.healthchecks.set_require_healthy(require_healthy);
+    if let Some(data_dir) = data_dir {
+        debug!(
+            message = "Overriding data_dir from command line.",
+            ?data_dir
+        );
+        config.global.data_dir = Some(data_dir);
+    }
     config.graceful_shutdown_duration = graceful_shutdown_duration;
 
     Ok(config)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -125,6 +125,15 @@ pub struct RootOpts {
     #[arg(short, long, env = "VECTOR_REQUIRE_HEALTHY")]
     pub require_healthy: Option<bool>,
 
+    /// The directory used for persisting Vector state data.
+    ///
+    /// This overrides the `data_dir` global option set in the configuration file. It is
+    /// useful for keeping deployment-specific paths out of the configuration file, for
+    /// example when validating a configuration in a CI environment where the configured
+    /// `data_dir` may not exist.
+    #[arg(long, env = "VECTOR_DATA_DIR")]
+    pub data_dir: Option<PathBuf>,
+
     /// Number of threads to use for processing (default is number of available cores)
     #[arg(short, long, env = "VECTOR_THREADS")]
     pub threads: Option<usize>,
@@ -423,4 +432,25 @@ pub fn handle_config_errors(errors: Vec<String>) -> exitcode::ExitCode {
     }
 
     exitcode::CONFIG
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use clap::Parser;
+
+    use super::RootOpts;
+
+    #[test]
+    fn data_dir_defaults_to_none() {
+        let opts = RootOpts::try_parse_from(["vector"]).unwrap();
+        assert_eq!(opts.data_dir, None);
+    }
+
+    #[test]
+    fn data_dir_parsed_from_flag() {
+        let opts = RootOpts::try_parse_from(["vector", "--data-dir", "/tmp/vector"]).unwrap();
+        assert_eq!(opts.data_dir, Some(PathBuf::from("/tmp/vector")));
+    }
 }


### PR DESCRIPTION
## Summary

Closes #9766.

Adds a `--data-dir` command-line flag and corresponding `VECTOR_DATA_DIR` environment variable to override the `data_dir` [global option](https://vector.dev/docs/reference/configuration/global-options/).

This follows the same pattern Vector already uses for other deployment-level settings such as `--require-healthy` / `VECTOR_REQUIRE_HEALTHY`. As @jszwedko noted in the issue, exposing `VECTOR_DATA_DIR` is desirable.

## Motivation

As described in the issue, `data_dir` is a deployment concern rather than a pipeline concern. Today users work around this by templating it inside the config file:

```yaml
data_dir: ${VECTOR_DATA_DIR:-/var/lib/vector}
```

This also makes `vector validate` painful in CI, where the configured `data_dir` often does not exist:

```
$ vector validate vector.yaml
√ Loaded ["vector.yaml"]
x data_dir "/var/lib/vector/" does not exist
```

With this change, the path can be supplied out-of-band without editing the config:

```
$ VECTOR_DATA_DIR=/tmp vector validate vector.yaml
# or
$ vector validate --data-dir /tmp vector.yaml
```

## Behavior

- When `--data-dir` / `VECTOR_DATA_DIR` is set, it overrides the `data_dir` value from the configuration file (env/CLI takes precedence), matching the precedence requested in the issue.
- When unset, behavior is unchanged — the config file value (or the `/var/lib/vector` default) is used.
- The override is applied once after the config is loaded, so it works for every load path (run, validate, etc.).

## Scope

This PR intentionally scopes to `data_dir`, which was the primary request. The other globals mentioned in the issue (`timezone`, `healthchecks.*`) can follow the same pattern in separate PRs if desired.

## How did you test this PR?

- Added unit tests verifying the flag parses into `Option<PathBuf>` and defaults to `None`.
- `cargo check`, `cargo clippy -- -D warnings`, and `cargo fmt --check` all pass locally.
