### PR TITLE
fix(gcp_cloud_storage sink): apply timezone to key_prefix strftime

### DIFF
--- a/changelog.d/25090_gcs_key_prefix_timezone.fix.md
+++ b/changelog.d/25090_gcs_key_prefix_timezone.fix.md
@@ -1,0 +1,3 @@
+The `gcp_cloud_storage` sink now applies the configured `timezone` option (or the global `timezone`) to `strftime` specifiers in `key_prefix`, matching the behavior of the `aws_s3` sink. Previously, date-based partitioning in `key_prefix` (for example `key_prefix = "%Y%m%d/"`) was always rendered in UTC and ignored the `timezone` setting, so object paths could land in the wrong dated directory around the UTC day boundary.
+
+authors: xfocus3

--- a/src/sinks/gcp/cloud_storage.rs
+++ b/src/sinks/gcp/cloud_storage.rs
@@ -302,7 +302,12 @@ impl GcsSinkConfig {
 
         let batch_settings = self.batch.into_batcher_settings()?;
 
-        let partitioner = self.key_partitioner()?;
+        let offset = self
+            .timezone
+            .or(cx.globals.timezone)
+            .and_then(timezone_to_offset);
+
+        let partitioner = self.key_partitioner(offset)?;
 
         let protocol = get_http_scheme_from_uri(&base_url.parse::<Uri>().unwrap());
 
@@ -317,10 +322,11 @@ impl GcsSinkConfig {
         Ok(VectorSink::from_event_streamsink(sink))
     }
 
-    fn key_partitioner(&self) -> crate::Result<KeyPartitioner> {
+    fn key_partitioner(&self, offset: Option<FixedOffset>) -> crate::Result<KeyPartitioner> {
         Ok(KeyPartitioner::new(
             Template::try_from(self.key_prefix.as_deref().unwrap_or("date=%F/"))
-                .context(KeyPrefixTemplateSnafu)?,
+                .context(KeyPrefixTemplateSnafu)?
+                .with_tz_offset(offset),
             None,
         ))
     }
@@ -554,12 +560,57 @@ mod tests {
             ..default_config((None::<FramingConfig>, TextSerializerConfig::default()).into())
         };
         let key = sink_config
-            .key_partitioner()
+            .key_partitioner(None)
             .unwrap()
             .partition(&Event::Log(event))
             .expect("key wasn't provided");
 
         assert_eq!(key, "key: value");
+    }
+
+    #[test]
+    fn gcs_key_prefix_honors_timezone_offset() {
+        // Regression test for #25090: the `timezone` option must be applied to
+        // strftime specifiers in `key_prefix`, matching the `aws_s3` sink.
+        use chrono::{FixedOffset, TimeZone, Utc};
+
+        let mut event = LogEvent::from("message");
+        // 2026-04-01T00:30:00Z is still 2026-03-31 in a UTC-08:00 zone and
+        // already 2026-04-01 in a UTC+08:00 zone.
+        let timestamp = Utc.with_ymd_and_hms(2026, 4, 1, 0, 30, 0).unwrap();
+        event.insert("timestamp", timestamp);
+
+        let sink_config = GcsSinkConfig {
+            key_prefix: Some("%Y%m%d/".into()),
+            ..default_config((None::<FramingConfig>, TextSerializerConfig::default()).into())
+        };
+
+        // Positive offset (e.g. Asia/Taipei, UTC+08:00) rolls the date forward.
+        let plus_eight = FixedOffset::east_opt(8 * 3600);
+        let key = sink_config
+            .key_partitioner(plus_eight)
+            .unwrap()
+            .partition(&Event::Log(event.clone()))
+            .expect("key wasn't provided");
+        assert_eq!(key, "20260401/");
+
+        // Negative offset (e.g. America/Los_Angeles, UTC-08:00) keeps the
+        // previous calendar day.
+        let minus_eight = FixedOffset::west_opt(8 * 3600);
+        let key = sink_config
+            .key_partitioner(minus_eight)
+            .unwrap()
+            .partition(&Event::Log(event.clone()))
+            .expect("key wasn't provided");
+        assert_eq!(key, "20260331/");
+
+        // No timezone configured falls back to UTC.
+        let key = sink_config
+            .key_partitioner(None)
+            .unwrap()
+            .partition(&Event::Log(event))
+            .expect("key wasn't provided");
+        assert_eq!(key, "20260401/");
     }
 
     fn request_settings(sink_config: &GcsSinkConfig, context: SinkContext) -> RequestSettings {
@@ -584,7 +635,7 @@ mod tests {
         };
         let log = LogEvent::default().into();
         let key = sink_config
-            .key_partitioner()
+            .key_partitioner(None)
             .unwrap()
             .partition(&log)
             .expect("key wasn't provided");


### PR DESCRIPTION
## Summary

Fixes #25090. The `gcp_cloud_storage` sink ignored the configured `timezone` option when rendering `strftime` specifiers in `key_prefix`, so date-based object partitioning (e.g. `key_prefix = "%Y%m%d/"`) always used UTC. The `aws_s3` sink already honors `timezone` for `key_prefix` via `Template::with_tz_offset`; this brings the GCS sink in line.

## Root cause

`GcsSinkConfig::key_partitioner` built the `KeyPartitioner` straight from the raw `key_prefix` template:

```rust
fn key_partitioner(&self) -> crate::Result<KeyPartitioner> {
    Ok(KeyPartitioner::new(
        Template::try_from(self.key_prefix.as_deref().unwrap_or("date=%F/"))
            .context(KeyPrefixTemplateSnafu)?,
        None,
    ))
}
```

The timezone offset (`timezone` → falling back to the global `timezone`) was computed in `RequestSettings::new` and applied only to the *filename* timestamp, never to the `key_prefix` template. `aws_s3` instead does `Template::try_from(...)?.with_tz_offset(offset)` before constructing its partitioner.

## Fix

Compute the offset in `build_sink` the same way `aws_s3` does, thread it into `key_partitioner`, and apply it with `Template::with_tz_offset`. Behavior with no timezone configured is unchanged (renders in UTC).

## Testing

- `cargo test --lib --no-default-features --features sinks-gcp gcp::cloud_storage` — 16 passed, 0 failed, including the new `gcs_key_prefix_honors_timezone_offset` regression test which asserts a `2026-04-01T00:30:00Z` event renders as `20260401/` under UTC+08:00, `20260331/` under UTC-08:00, and `20260401/` with no timezone.
- `cargo clippy --lib --no-default-features --features sinks-gcp -- -D warnings` — clean.
- `cargo fmt --check` — clean.
- Changelog fragment `changelog.d/25090_gcs_key_prefix_timezone.fix.md` validated with `./scripts/check_changelog_fragments.sh`.
