### PR TITLE
chore(dev): upload merged-lcov artifact from coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Upload merged coverage artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: merged-lcov
+          name: coverage-lcov-merged-report
           path: merged-lcov.info
           retention-days: 90
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -97,6 +97,13 @@ jobs:
 
       - uses: ./.github/actions/dd-token
 
+      - name: Upload merged coverage artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: merged-lcov
+          path: merged-lcov.info
+          retention-days: 90
+
       - name: Upload to Datadog
         env:
           DD_SITE: datadoghq.com


### PR DESCRIPTION
## Summary

Saves `merged-lcov.info` as a GitHub Actions artifact (90-day retention) after the coverage merge step in `coverage-upload`. Makes the full LCOV report available for local download without Datadog API access — useful for debugging coverage gaps and for tooling that needs per-file line coverage data.

## Vector configuration

N/A — CI-only change.

## How did you test this PR?

Change is additive (new `upload-artifact` step); existing Datadog upload is unaffected. Will verify artifact appears after the next coverage run.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

https://github.com/vectordotdev/vector/pull/25518