### PR TITLE
chore(dev): harden merged-lcov artifact upload step

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -94,7 +94,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         continue-on-error: true
         with:
-          name: coverage-lcov-merged-report
+          name: merged-lcov-report
           path: merged-lcov.info
           retention-days: 90
           overwrite: true

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -90,19 +90,21 @@ jobs:
           done
           lcov "${ARGS[@]}" --output-file merged-lcov.info
 
+      - name: Upload merged coverage artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        continue-on-error: true
+        with:
+          name: coverage-lcov-merged-report
+          path: merged-lcov.info
+          retention-days: 90
+          overwrite: true
+
       - uses: ./.github/actions/setup
         with:
           vdev: false
           datadog-ci: true
 
       - uses: ./.github/actions/dd-token
-
-      - name: Upload merged coverage artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: coverage-lcov-merged-report
-          path: merged-lcov.info
-          retention-days: 90
 
       - name: Upload to Datadog
         env:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -94,7 +94,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         continue-on-error: true
         with:
-          name: merged-lcov-report
+          name: archive-merged-lcov-report
           path: merged-lcov.info
           retention-days: 90
           overwrite: true


### PR DESCRIPTION
## Summary

Follow-up to #25548 addressing Codex review findings:

- Move artifact upload before `dd-token` so the step does not inherit `DD_API_KEY` / `DD_APP_KEY`
- Add `overwrite: true` so rerun-failed-jobs does not fail with "artifact already exists"
- Add `continue-on-error: true` so an artifact service failure cannot block the Datadog coverage upload

## Vector configuration

N/A — CI-only change.

## How did you test this PR?

Logical / structural change only; no behaviour change to the Datadog upload path.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: #25548