### PR TITLE
chore(website): remove commonly_used field from component definitions

### DIFF
--- a/website/cue/reference/components.cue
+++ b/website/cue/reference/components.cue
@@ -6,11 +6,6 @@ components: {
 		_args: kind: string
 		let Args = _args
 
-		// `commonly_used` specifies if the component is commonly used or not.
-		// Setting this to `true` will surface the component from other,
-		// less commonly used, components.
-		commonly_used: bool
-
 		if Args.kind == "source" || Args.kind == "sink" {
 			delivery: #DeliveryStatus
 		}

--- a/website/cue/reference/components/sinks/amqp.cue
+++ b/website/cue/reference/components/sinks/amqp.cue
@@ -4,7 +4,6 @@ components: sinks: amqp: {
 	title: "AMQP"
 
 	classes: {
-		commonly_used: true
 		delivery:      "at_least_once"
 		development:   "beta"
 		egress_method: "dynamic"

--- a/website/cue/reference/components/sinks/appsignal.cue
+++ b/website/cue/reference/components/sinks/appsignal.cue
@@ -4,7 +4,6 @@ components: sinks: appsignal: {
 	title: "AppSignal"
 
 	classes: {
-		commonly_used: false
 		delivery:      "at_least_once"
 		development:   "beta"
 		egress_method: "batch"

--- a/website/cue/reference/components/sinks/aws_cloudwatch_logs.cue
+++ b/website/cue/reference/components/sinks/aws_cloudwatch_logs.cue
@@ -4,7 +4,6 @@ components: sinks: aws_cloudwatch_logs: components._aws & {
 	title: "AWS Cloudwatch Logs"
 
 	classes: {
-		commonly_used: true
 		delivery:      "at_least_once"
 		development:   "stable"
 		egress_method: "batch"

--- a/website/cue/reference/components/sinks/aws_cloudwatch_metrics.cue
+++ b/website/cue/reference/components/sinks/aws_cloudwatch_metrics.cue
@@ -4,7 +4,6 @@ components: sinks: aws_cloudwatch_metrics: components._aws & {
 	title: "AWS Cloudwatch Metrics"
 
 	classes: {
-		commonly_used: false
 		delivery:      "at_least_once"
 		development:   "stable"
 		egress_method: "batch"

--- a/website/cue/reference/components/sinks/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sinks/aws_kinesis_firehose.cue
@@ -4,7 +4,6 @@ components: sinks: aws_kinesis_firehose: components._aws & {
 	title: "AWS Kinesis Firehose"
 
 	classes: {
-		commonly_used: false
 		delivery:      "at_least_once"
 		development:   "stable"
 		egress_method: "batch"

--- a/website/cue/reference/components/sinks/aws_kinesis_streams.cue
+++ b/website/cue/reference/components/sinks/aws_kinesis_streams.cue
@@ -4,7 +4,6 @@ components: sinks: aws_kinesis_streams: components._aws & {
 	title: "AWS Kinesis Data Streams"
 
 	classes: {
-		commonly_used: false
 		delivery:      "at_least_once"
 		development:   "stable"
 		egress_method: "batch"

--- a/website/cue/reference/components/sinks/aws_s3.cue
+++ b/website/cue/reference/components/sinks/aws_s3.cue
@@ -4,7 +4,6 @@ components: sinks: aws_s3: components._aws & {
 	title: "AWS S3"
 
 	classes: {
-		commonly_used: true
 		delivery:      "at_least_once"
 		development:   "stable"
 		egress_method: "batch"

--- a/website/cue/reference/components/sinks/aws_sns.cue
+++ b/website/cue/reference/components/sinks/aws_sns.cue
@@ -4,7 +4,6 @@ components: sinks: aws_sns: components._aws & {
 	title: "Amazon Simple Notification Service (SNS)"
 
 	classes: {
-		commonly_used: false
 		delivery:      "at_least_once"
 		development:   "stable"
 		egress_method: "stream"

--- a/website/cue/reference/components/sinks/aws_sqs.cue
+++ b/website/cue/reference/components/sinks/aws_sqs.cue
@@ -4,7 +4,6 @@ components: sinks: aws_sqs: components._aws & {
 	title: "Amazon Simple Queue Service (SQS)"
 
 	classes: {
-		commonly_used: false
 		delivery:      "at_least_once"
 		development:   "stable"
 		egress_method: "stream"

--- a/website/cue/reference/components/sinks/axiom.cue
+++ b/website/cue/reference/components/sinks/axiom.cue
@@ -4,7 +4,6 @@ components: sinks: axiom: {
 	title: "Axiom"
 
 	classes: {
-		commonly_used: false
 		delivery:      "at_least_once"
 		development:   "beta"
 		egress_method: "batch"

--- a/website/cue/reference/components/sinks/azure_blob.cue
+++ b/website/cue/reference/components/sinks/azure_blob.cue
@@ -4,7 +4,6 @@ components: sinks: azure_blob: {
 	title: "Azure Blob Storage"
 
 	classes: {
-		commonly_used: true
 		delivery:      "at_least_once"
 		development:   "stable"
 		egress_method: "batch"

--- a/website/cue/reference/components/sinks/azure_logs_ingestion.cue
+++ b/website/cue/reference/components/sinks/azure_logs_ingestion.cue
@@ -14,7 +14,6 @@ components: sinks: azure_logs_ingestion: {
 		"""
 
 	classes: {
-		commonly_used: false
 		delivery:      "at_least_once"
 		development:   "beta"
 		egress_method: "batch"

--- a/website/cue/reference/components/sinks/azure_monitor_logs.cue
+++ b/website/cue/reference/components/sinks/azure_monitor_logs.cue
@@ -4,7 +4,6 @@ components: sinks: azure_monitor_logs: {
 	title: "Azure Monitor Logs"
 
 	classes: {
-		commonly_used: false
 		delivery:      "at_least_once"
 		development:   "deprecated"
 		egress_method: "batch"

--- a/website/cue/reference/components/sinks/blackhole.cue
+++ b/website/cue/reference/components/sinks/blackhole.cue
@@ -4,7 +4,6 @@ components: sinks: blackhole: {
 	title: "Blackhole"
 
 	classes: {
-		commonly_used: false
 		delivery:      "at_least_once"
 		development:   "stable"
 		egress_method: "stream"

--- a/website/cue/reference/components/sinks/clickhouse.cue
+++ b/website/cue/reference/components/sinks/clickhouse.cue
@@ -4,7 +4,6 @@ components: sinks: clickhouse: {
 	title: "ClickHouse"
 
 	classes: {
-		commonly_used: true
 		delivery:      "at_least_once"
 		development:   "stable"
 		egress_method: "batch"

--- a/website/cue/reference/components/sinks/console.cue
+++ b/website/cue/reference/components/sinks/console.cue
@@ -4,7 +4,6 @@ components: sinks: console: {
 	title: "Console"
 
 	classes: {
-		commonly_used: false
 		delivery:      "at_least_once"
 		development:   "stable"
 		egress_method: "stream"

--- a/website/cue/reference/components/sinks/databend.cue
+++ b/website/cue/reference/components/sinks/databend.cue
@@ -4,7 +4,6 @@ components: sinks: databend: {
 	title: "Databend"
 
 	classes: {
-		commonly_used: true
 		delivery:      "at_least_once"
 		development:   "beta"
 		egress_method: "batch"

--- a/website/cue/reference/components/sinks/databricks_zerobus.cue
+++ b/website/cue/reference/components/sinks/databricks_zerobus.cue
@@ -4,7 +4,6 @@ components: sinks: databricks_zerobus: {
 	title: "Databricks Zerobus"
 
 	classes: {
-		commonly_used: false
 		delivery:      "at_least_once"
 		development:   "beta"
 		egress_method: "batch"

--- a/website/cue/reference/components/sinks/datadog.cue
+++ b/website/cue/reference/components/sinks/datadog.cue
@@ -2,7 +2,6 @@ package metadata
 
 components: sinks: _datadog: {
 	classes: {
-		commonly_used: false
 		delivery:      "at_least_once"
 		development:   string | *"stable"
 		egress_method: "batch"

--- a/website/cue/reference/components/sinks/doris.cue
+++ b/website/cue/reference/components/sinks/doris.cue
@@ -4,7 +4,6 @@ components: sinks: doris: {
 	title: "Doris"
 
 	classes: {
-		commonly_used: false
 		delivery:      "at_least_once"
 		development:   "beta"
 		egress_method: "batch"

--- a/website/cue/reference/components/sinks/elasticsearch.cue
+++ b/website/cue/reference/components/sinks/elasticsearch.cue
@@ -4,7 +4,6 @@ components: sinks: elasticsearch: {
 	title: "Elasticsearch"
 
 	classes: {
-		commonly_used: true
 		delivery:      "at_least_once"
 		development:   "stable"
 		egress_method: "batch"

--- a/website/cue/reference/components/sinks/file.cue
+++ b/website/cue/reference/components/sinks/file.cue
@@ -4,7 +4,6 @@ components: sinks: file: {
 	title: "File"
 
 	classes: {
-		commonly_used: false
 		delivery:      "at_least_once"
 
 		development:   "stable"

--- a/website/cue/reference/components/sinks/file.cue
+++ b/website/cue/reference/components/sinks/file.cue
@@ -4,7 +4,7 @@ components: sinks: file: {
 	title: "File"
 
 	classes: {
-		delivery:      "at_least_once"
+		delivery: "at_least_once"
 
 		development:   "stable"
 		egress_method: "stream"

--- a/website/cue/reference/components/sinks/gcp_chronicle_unstructured.cue
+++ b/website/cue/reference/components/sinks/gcp_chronicle_unstructured.cue
@@ -4,7 +4,6 @@ components: sinks: gcp_chronicle_unstructured: {
 	title: "GCP Chronicle Unstructured"
 
 	classes: {
-		commonly_used: true
 		delivery:      "at_least_once"
 		development:   "beta"
 		egress_method: "batch"

--- a/website/cue/reference/components/sinks/gcp_cloud_storage.cue
+++ b/website/cue/reference/components/sinks/gcp_cloud_storage.cue
@@ -4,7 +4,6 @@ components: sinks: gcp_cloud_storage: {
 	title: "GCP Cloud Storage (GCS)"
 
 	classes: {
-		commonly_used: true
 		delivery:      "at_least_once"
 		development:   "stable"
 		egress_method: "batch"

--- a/website/cue/reference/components/sinks/gcp_pubsub.cue
+++ b/website/cue/reference/components/sinks/gcp_pubsub.cue
@@ -4,7 +4,6 @@ components: sinks: gcp_pubsub: {
 	title: "GCP PubSub"
 
 	classes: {
-		commonly_used: true
 		delivery:      "at_least_once"
 		development:   "stable"
 		egress_method: "batch"

--- a/website/cue/reference/components/sinks/gcp_stackdriver_logs.cue
+++ b/website/cue/reference/components/sinks/gcp_stackdriver_logs.cue
@@ -4,7 +4,6 @@ components: sinks: gcp_stackdriver_logs: {
 	title: "GCP Operations (formerly Stackdriver) Logs"
 
 	classes: {
-		commonly_used: true
 		delivery:      "at_least_once"
 		development:   "beta"
 		egress_method: "batch"

--- a/website/cue/reference/components/sinks/gcp_stackdriver_metrics.cue
+++ b/website/cue/reference/components/sinks/gcp_stackdriver_metrics.cue
@@ -4,7 +4,6 @@ components: sinks: gcp_stackdriver_metrics: {
 	title: "GCP Cloud Monitoring (formerly Stackdriver) Metrics"
 
 	classes: {
-		commonly_used: true
 		delivery:      "at_least_once"
 		development:   "beta"
 		egress_method: "batch"

--- a/website/cue/reference/components/sinks/greptimedb_logs.cue
+++ b/website/cue/reference/components/sinks/greptimedb_logs.cue
@@ -4,7 +4,6 @@ components: sinks: greptimedb_logs: {
 	title: "GreptimeDB Logs"
 
 	classes: {
-		commonly_used: true
 		delivery:      "at_least_once"
 		development:   "beta"
 		egress_method: "batch"

--- a/website/cue/reference/components/sinks/greptimedb_metrics.cue
+++ b/website/cue/reference/components/sinks/greptimedb_metrics.cue
@@ -5,7 +5,6 @@ components: sinks: greptimedb_metrics: {
 	alias: "greptimedb"
 
 	classes: {
-		commonly_used: true
 		delivery:      "at_least_once"
 		development:   "beta"
 		egress_method: "batch"

--- a/website/cue/reference/components/sinks/honeycomb.cue
+++ b/website/cue/reference/components/sinks/honeycomb.cue
@@ -4,7 +4,6 @@ components: sinks: honeycomb: {
 	title: "Honeycomb"
 
 	classes: {
-		commonly_used: false
 		delivery:      "at_least_once"
 		development:   "stable"
 		egress_method: "batch"

--- a/website/cue/reference/components/sinks/http.cue
+++ b/website/cue/reference/components/sinks/http.cue
@@ -4,7 +4,6 @@ components: sinks: http: {
 	title: "HTTP"
 
 	classes: {
-		commonly_used: true
 		service_providers: []
 		delivery:      "at_least_once"
 		development:   "stable"

--- a/website/cue/reference/components/sinks/humio.cue
+++ b/website/cue/reference/components/sinks/humio.cue
@@ -4,7 +4,6 @@ components: sinks: _humio: {
 	_humio_encoding: enabled: false
 
 	classes: {
-		commonly_used: false
 		delivery:      "at_least_once"
 		development:   "stable"
 		egress_method: "batch"

--- a/website/cue/reference/components/sinks/influxdb_logs.cue
+++ b/website/cue/reference/components/sinks/influxdb_logs.cue
@@ -4,7 +4,6 @@ components: sinks: influxdb_logs: {
 	title: "InfluxDB Logs"
 
 	classes: {
-		commonly_used: false
 		delivery:      "at_least_once"
 		development:   "stable"
 		egress_method: "batch"

--- a/website/cue/reference/components/sinks/influxdb_metrics.cue
+++ b/website/cue/reference/components/sinks/influxdb_metrics.cue
@@ -4,7 +4,6 @@ components: sinks: influxdb_metrics: {
 	title: "InfluxDB Metrics"
 
 	classes: {
-		commonly_used: false
 		delivery:      "at_least_once"
 		development:   "stable"
 		egress_method: "batch"

--- a/website/cue/reference/components/sinks/kafka.cue
+++ b/website/cue/reference/components/sinks/kafka.cue
@@ -4,7 +4,6 @@ components: sinks: kafka: {
 	title: "Kafka"
 
 	classes: {
-		commonly_used: true
 		delivery:      "at_least_once"
 		development:   "stable"
 		egress_method: "dynamic"

--- a/website/cue/reference/components/sinks/keep.cue
+++ b/website/cue/reference/components/sinks/keep.cue
@@ -4,7 +4,6 @@ components: sinks: keep: {
 	title: "Keep"
 
 	classes: {
-		commonly_used: false
 		delivery:      "at_least_once"
 		development:   "beta"
 		egress_method: "batch"

--- a/website/cue/reference/components/sinks/loki.cue
+++ b/website/cue/reference/components/sinks/loki.cue
@@ -4,7 +4,6 @@ components: sinks: loki: {
 	title: "Loki"
 
 	classes: {
-		commonly_used: true
 		delivery:      "at_least_once"
 		development:   "stable"
 		egress_method: "batch"

--- a/website/cue/reference/components/sinks/mezmo.cue
+++ b/website/cue/reference/components/sinks/mezmo.cue
@@ -5,7 +5,6 @@ components: sinks: mezmo: {
 	alias: "logdna"
 
 	classes: {
-		commonly_used: false
 		delivery:      "at_least_once"
 		development:   "stable"
 		egress_method: "batch"

--- a/website/cue/reference/components/sinks/mqtt.cue
+++ b/website/cue/reference/components/sinks/mqtt.cue
@@ -4,7 +4,6 @@ components: sinks: mqtt: {
 	title: "MQTT"
 
 	classes: {
-		commonly_used: false
 		delivery:      "best_effort"
 		development:   "beta"
 		egress_method: "stream"

--- a/website/cue/reference/components/sinks/nats.cue
+++ b/website/cue/reference/components/sinks/nats.cue
@@ -4,7 +4,6 @@ components: sinks: nats: {
 	title: "NATS"
 
 	classes: {
-		commonly_used: false
 		delivery:      "best_effort"
 		development:   "stable"
 		egress_method: "stream"

--- a/website/cue/reference/components/sinks/new_relic.cue
+++ b/website/cue/reference/components/sinks/new_relic.cue
@@ -4,7 +4,6 @@ components: sinks: new_relic: {
 	title: "New Relic"
 
 	classes: {
-		commonly_used: false
 		delivery:      "at_least_once"
 		development:   "beta"
 		egress_method: "batch"

--- a/website/cue/reference/components/sinks/opentelemetry.cue
+++ b/website/cue/reference/components/sinks/opentelemetry.cue
@@ -4,7 +4,6 @@ components: sinks: opentelemetry: {
 	title: "Open Telemetry"
 
 	classes: {
-		commonly_used: false
 		delivery:      "at_least_once"
 		development:   "beta"
 		egress_method: "batch"

--- a/website/cue/reference/components/sinks/papertrail.cue
+++ b/website/cue/reference/components/sinks/papertrail.cue
@@ -4,7 +4,6 @@ components: sinks: papertrail: {
 	title: "Papertrail"
 
 	classes: {
-		commonly_used: false
 		delivery:      "at_least_once"
 		development:   "stable"
 		egress_method: "stream"

--- a/website/cue/reference/components/sinks/postgres.cue
+++ b/website/cue/reference/components/sinks/postgres.cue
@@ -4,7 +4,6 @@ components: sinks: postgres: {
 	title: "PostgreSQL"
 
 	classes: {
-		commonly_used: false
 		delivery:      "exactly_once"
 		development:   "beta"
 		egress_method: "batch"

--- a/website/cue/reference/components/sinks/prometheus_exporter.cue
+++ b/website/cue/reference/components/sinks/prometheus_exporter.cue
@@ -7,7 +7,6 @@ components: sinks: prometheus_exporter: {
 	alias: "prometheus"
 
 	classes: {
-		commonly_used: true
 		delivery:      "best_effort"
 		development:   "stable"
 		egress_method: "expose"

--- a/website/cue/reference/components/sinks/prometheus_remote_write.cue
+++ b/website/cue/reference/components/sinks/prometheus_remote_write.cue
@@ -4,7 +4,6 @@ components: sinks: prometheus_remote_write: {
 	title: "Prometheus Remote Write"
 
 	classes: {
-		commonly_used: true
 		delivery:      "at_least_once"
 		development:   "beta"
 		egress_method: "batch"

--- a/website/cue/reference/components/sinks/pulsar.cue
+++ b/website/cue/reference/components/sinks/pulsar.cue
@@ -4,7 +4,6 @@ components: sinks: pulsar: {
 	title: "Apache Pulsar"
 
 	classes: {
-		commonly_used: false
 		delivery:      "at_least_once"
 		development:   "stable"
 		egress_method: "stream"

--- a/website/cue/reference/components/sinks/redis.cue
+++ b/website/cue/reference/components/sinks/redis.cue
@@ -3,7 +3,6 @@ package metadata
 components: sinks: redis: {
 	title: "Redis"
 	classes: {
-		commonly_used: false
 		delivery:      "best_effort"
 		development:   "stable"
 		egress_method: "batch"

--- a/website/cue/reference/components/sinks/sematext_logs.cue
+++ b/website/cue/reference/components/sinks/sematext_logs.cue
@@ -4,7 +4,6 @@ components: sinks: sematext_logs: {
 	title: "Sematext Logs"
 
 	classes: {
-		commonly_used: false
 		delivery:      "at_least_once"
 		development:   "stable"
 		egress_method: "batch"

--- a/website/cue/reference/components/sinks/sematext_metrics.cue
+++ b/website/cue/reference/components/sinks/sematext_metrics.cue
@@ -4,8 +4,8 @@ components: sinks: sematext_metrics: {
 	title: "Sematext Metrics"
 
 	classes: {
-		delivery:      "at_least_once"
-		development:   "stable"
+		delivery:    "at_least_once"
+		development: "stable"
 		service_providers: ["Sematext"]
 		egress_method: "batch"
 		stateful:      true

--- a/website/cue/reference/components/sinks/sematext_metrics.cue
+++ b/website/cue/reference/components/sinks/sematext_metrics.cue
@@ -4,7 +4,6 @@ components: sinks: sematext_metrics: {
 	title: "Sematext Metrics"
 
 	classes: {
-		commonly_used: false
 		delivery:      "at_least_once"
 		development:   "stable"
 		service_providers: ["Sematext"]

--- a/website/cue/reference/components/sinks/socket.cue
+++ b/website/cue/reference/components/sinks/socket.cue
@@ -4,7 +4,6 @@ components: sinks: socket: {
 	title: "Socket"
 
 	classes: {
-		commonly_used: true
 		delivery:      "best_effort"
 		development:   "stable"
 		egress_method: "stream"

--- a/website/cue/reference/components/sinks/splunk_hec_logs.cue
+++ b/website/cue/reference/components/sinks/splunk_hec_logs.cue
@@ -5,7 +5,6 @@ components: sinks: splunk_hec_logs: {
 	alias: "splunk_hec"
 
 	classes: {
-		commonly_used: true
 		delivery:      "at_least_once"
 		development:   "stable"
 		egress_method: "batch"

--- a/website/cue/reference/components/sinks/splunk_hec_metrics.cue
+++ b/website/cue/reference/components/sinks/splunk_hec_metrics.cue
@@ -4,7 +4,6 @@ components: sinks: splunk_hec_metrics: {
 	title: "Splunk HEC metrics"
 
 	classes: {
-		commonly_used: false
 		delivery:      "at_least_once"
 		development:   "stable"
 		egress_method: "batch"

--- a/website/cue/reference/components/sinks/vector.cue
+++ b/website/cue/reference/components/sinks/vector.cue
@@ -10,7 +10,6 @@ components: sinks: vector: {
 		"""
 
 	classes: {
-		commonly_used: false
 		delivery:      "best_effort"
 		development:   "stable"
 		egress_method: "batch"

--- a/website/cue/reference/components/sinks/webhdfs.cue
+++ b/website/cue/reference/components/sinks/webhdfs.cue
@@ -4,7 +4,7 @@ components: sinks: webhdfs: {
 	title: "WebHDFS"
 
 	classes: {
-		delivery:      "at_least_once"
+		delivery: "at_least_once"
 
 		development:   "beta"
 		egress_method: "stream"

--- a/website/cue/reference/components/sinks/webhdfs.cue
+++ b/website/cue/reference/components/sinks/webhdfs.cue
@@ -4,7 +4,6 @@ components: sinks: webhdfs: {
 	title: "WebHDFS"
 
 	classes: {
-		commonly_used: false
 		delivery:      "at_least_once"
 
 		development:   "beta"

--- a/website/cue/reference/components/sinks/websocket.cue
+++ b/website/cue/reference/components/sinks/websocket.cue
@@ -4,7 +4,6 @@ components: sinks: websocket: {
 	title: "WebSocket"
 
 	classes: {
-		commonly_used: false
 		delivery:      "best_effort"
 		development:   "beta"
 		egress_method: "stream"

--- a/website/cue/reference/components/sinks/websocket_server.cue
+++ b/website/cue/reference/components/sinks/websocket_server.cue
@@ -5,7 +5,6 @@ components: sinks: websocket_server: {
 	title: "WebSocket server"
 
 	classes: {
-		commonly_used: false
 		delivery:      "best_effort"
 		development:   "beta"
 		egress_method: "stream"

--- a/website/cue/reference/components/sources/amqp.cue
+++ b/website/cue/reference/components/sources/amqp.cue
@@ -28,7 +28,6 @@ components: sources: amqp: {
 	}
 
 	classes: {
-		commonly_used: true
 		deployment_roles: ["aggregator"]
 		delivery:      "at_least_once"
 		development:   "beta"

--- a/website/cue/reference/components/sources/apache_metrics.cue
+++ b/website/cue/reference/components/sources/apache_metrics.cue
@@ -4,7 +4,6 @@ components: sources: apache_metrics: {
 	title: "Apache HTTP Server (HTTPD) Metrics"
 
 	classes: {
-		commonly_used: false
 		delivery:      "at_least_once"
 		deployment_roles: ["daemon", "sidecar"]
 		development:   "stable"

--- a/website/cue/reference/components/sources/apache_metrics.cue
+++ b/website/cue/reference/components/sources/apache_metrics.cue
@@ -4,7 +4,7 @@ components: sources: apache_metrics: {
 	title: "Apache HTTP Server (HTTPD) Metrics"
 
 	classes: {
-		delivery:      "at_least_once"
+		delivery: "at_least_once"
 		deployment_roles: ["daemon", "sidecar"]
 		development:   "stable"
 		egress_method: "batch"

--- a/website/cue/reference/components/sources/aws_ecs_metrics.cue
+++ b/website/cue/reference/components/sources/aws_ecs_metrics.cue
@@ -9,7 +9,6 @@ components: sources: aws_ecs_metrics: {
 		"""
 
 	classes: {
-		commonly_used: false
 		delivery:      "at_least_once"
 		deployment_roles: ["sidecar"]
 		development:   "stable"

--- a/website/cue/reference/components/sources/aws_ecs_metrics.cue
+++ b/website/cue/reference/components/sources/aws_ecs_metrics.cue
@@ -9,7 +9,7 @@ components: sources: aws_ecs_metrics: {
 		"""
 
 	classes: {
-		delivery:      "at_least_once"
+		delivery: "at_least_once"
 		deployment_roles: ["sidecar"]
 		development:   "stable"
 		egress_method: "batch"

--- a/website/cue/reference/components/sources/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sources/aws_kinesis_firehose.cue
@@ -6,7 +6,7 @@ components: sources: aws_kinesis_firehose: {
 	title: "AWS Kinesis Firehose"
 
 	classes: {
-		delivery:      "at_least_once"
+		delivery: "at_least_once"
 		deployment_roles: ["aggregator"]
 		development:   "stable"
 		egress_method: "batch"

--- a/website/cue/reference/components/sources/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sources/aws_kinesis_firehose.cue
@@ -6,7 +6,6 @@ components: sources: aws_kinesis_firehose: {
 	title: "AWS Kinesis Firehose"
 
 	classes: {
-		commonly_used: false
 		delivery:      "at_least_once"
 		deployment_roles: ["aggregator"]
 		development:   "stable"

--- a/website/cue/reference/components/sources/aws_s3.cue
+++ b/website/cue/reference/components/sources/aws_s3.cue
@@ -22,7 +22,6 @@ components: sources: aws_s3: components._aws & {
 	}
 
 	classes: {
-		commonly_used: true
 		deployment_roles: ["aggregator"]
 		delivery:      "at_least_once"
 		development:   "stable"

--- a/website/cue/reference/components/sources/aws_sqs.cue
+++ b/website/cue/reference/components/sources/aws_sqs.cue
@@ -26,7 +26,6 @@ components: sources: aws_sqs: components._aws & {
 	}
 
 	classes: {
-		commonly_used: true
 		deployment_roles: ["aggregator"]
 		delivery:      "at_least_once"
 		development:   "stable"

--- a/website/cue/reference/components/sources/datadog_agent.cue
+++ b/website/cue/reference/components/sources/datadog_agent.cue
@@ -10,7 +10,7 @@ components: sources: datadog_agent: {
 		"""
 
 	classes: {
-		delivery:      "at_least_once"
+		delivery: "at_least_once"
 		deployment_roles: ["aggregator", "sidecar"]
 		development:   "stable"
 		egress_method: "batch"

--- a/website/cue/reference/components/sources/datadog_agent.cue
+++ b/website/cue/reference/components/sources/datadog_agent.cue
@@ -10,7 +10,6 @@ components: sources: datadog_agent: {
 		"""
 
 	classes: {
-		commonly_used: false
 		delivery:      "at_least_once"
 		deployment_roles: ["aggregator", "sidecar"]
 		development:   "stable"

--- a/website/cue/reference/components/sources/demo_logs.cue
+++ b/website/cue/reference/components/sources/demo_logs.cue
@@ -10,7 +10,6 @@ components: sources: demo_logs: {
 		"""
 
 	classes: {
-		commonly_used: false
 		delivery:      "at_least_once"
 		deployment_roles: ["daemon", "sidecar"]
 		development:   "stable"

--- a/website/cue/reference/components/sources/demo_logs.cue
+++ b/website/cue/reference/components/sources/demo_logs.cue
@@ -10,7 +10,7 @@ components: sources: demo_logs: {
 		"""
 
 	classes: {
-		delivery:      "at_least_once"
+		delivery: "at_least_once"
 		deployment_roles: ["daemon", "sidecar"]
 		development:   "stable"
 		egress_method: "stream"

--- a/website/cue/reference/components/sources/dnstap.cue
+++ b/website/cue/reference/components/sources/dnstap.cue
@@ -4,7 +4,7 @@ components: sources: dnstap: {
 	title: "Dnstap"
 
 	classes: {
-		delivery:      "best_effort"
+		delivery: "best_effort"
 		deployment_roles: ["daemon"]
 		development:   "beta"
 		egress_method: "stream"

--- a/website/cue/reference/components/sources/dnstap.cue
+++ b/website/cue/reference/components/sources/dnstap.cue
@@ -4,7 +4,6 @@ components: sources: dnstap: {
 	title: "Dnstap"
 
 	classes: {
-		commonly_used: false
 		delivery:      "best_effort"
 		deployment_roles: ["daemon"]
 		development:   "beta"

--- a/website/cue/reference/components/sources/docker_logs.cue
+++ b/website/cue/reference/components/sources/docker_logs.cue
@@ -5,7 +5,6 @@ components: sources: docker_logs: {
 	alias: "docker"
 
 	classes: {
-		commonly_used: false
 		delivery:      "best_effort"
 		deployment_roles: ["daemon"]
 		development:   "stable"

--- a/website/cue/reference/components/sources/docker_logs.cue
+++ b/website/cue/reference/components/sources/docker_logs.cue
@@ -5,7 +5,7 @@ components: sources: docker_logs: {
 	alias: "docker"
 
 	classes: {
-		delivery:      "best_effort"
+		delivery: "best_effort"
 		deployment_roles: ["daemon"]
 		development:   "stable"
 		egress_method: "stream"

--- a/website/cue/reference/components/sources/eventstoredb_metrics.cue
+++ b/website/cue/reference/components/sources/eventstoredb_metrics.cue
@@ -4,7 +4,7 @@ components: sources: eventstoredb_metrics: {
 	title: "EventStoreDB Metrics"
 
 	classes: {
-		delivery:      "at_least_once"
+		delivery: "at_least_once"
 		deployment_roles: ["daemon", "sidecar"]
 		development:   "beta"
 		egress_method: "batch"

--- a/website/cue/reference/components/sources/eventstoredb_metrics.cue
+++ b/website/cue/reference/components/sources/eventstoredb_metrics.cue
@@ -4,7 +4,6 @@ components: sources: eventstoredb_metrics: {
 	title: "EventStoreDB Metrics"
 
 	classes: {
-		commonly_used: false
 		delivery:      "at_least_once"
 		deployment_roles: ["daemon", "sidecar"]
 		development:   "beta"

--- a/website/cue/reference/components/sources/exec.cue
+++ b/website/cue/reference/components/sources/exec.cue
@@ -4,7 +4,7 @@ components: sources: exec: {
 	title: "Exec"
 
 	classes: {
-		delivery:      "at_least_once"
+		delivery: "at_least_once"
 		deployment_roles: ["sidecar"]
 		development:   "stable"
 		egress_method: "stream"

--- a/website/cue/reference/components/sources/exec.cue
+++ b/website/cue/reference/components/sources/exec.cue
@@ -4,7 +4,6 @@ components: sources: exec: {
 	title: "Exec"
 
 	classes: {
-		commonly_used: false
 		delivery:      "at_least_once"
 		deployment_roles: ["sidecar"]
 		development:   "stable"

--- a/website/cue/reference/components/sources/file.cue
+++ b/website/cue/reference/components/sources/file.cue
@@ -6,7 +6,7 @@ components: sources: file: {
 	title: "File"
 
 	classes: {
-		delivery:      "best_effort"
+		delivery: "best_effort"
 		deployment_roles: ["daemon", "sidecar"]
 		development:   "stable"
 		egress_method: "stream"

--- a/website/cue/reference/components/sources/file.cue
+++ b/website/cue/reference/components/sources/file.cue
@@ -6,7 +6,6 @@ components: sources: file: {
 	title: "File"
 
 	classes: {
-		commonly_used: true
 		delivery:      "best_effort"
 		deployment_roles: ["daemon", "sidecar"]
 		development:   "stable"

--- a/website/cue/reference/components/sources/file_descriptor.cue
+++ b/website/cue/reference/components/sources/file_descriptor.cue
@@ -4,7 +4,7 @@ components: sources: file_descriptor: {
 	title: "File Descriptor"
 
 	classes: {
-		delivery:      "at_least_once"
+		delivery: "at_least_once"
 		deployment_roles: ["sidecar"]
 		development:   "stable"
 		egress_method: "stream"

--- a/website/cue/reference/components/sources/file_descriptor.cue
+++ b/website/cue/reference/components/sources/file_descriptor.cue
@@ -4,7 +4,6 @@ components: sources: file_descriptor: {
 	title: "File Descriptor"
 
 	classes: {
-		commonly_used: false
 		delivery:      "at_least_once"
 		deployment_roles: ["sidecar"]
 		development:   "stable"

--- a/website/cue/reference/components/sources/fluent.cue
+++ b/website/cue/reference/components/sources/fluent.cue
@@ -6,7 +6,7 @@ components: sources: fluent: {
 	title: "Fluent"
 
 	classes: {
-		delivery:      "best_effort"
+		delivery: "best_effort"
 		deployment_roles: ["sidecar", "aggregator"]
 		development:   "beta"
 		egress_method: "stream"

--- a/website/cue/reference/components/sources/fluent.cue
+++ b/website/cue/reference/components/sources/fluent.cue
@@ -6,7 +6,6 @@ components: sources: fluent: {
 	title: "Fluent"
 
 	classes: {
-		commonly_used: true
 		delivery:      "best_effort"
 		deployment_roles: ["sidecar", "aggregator"]
 		development:   "beta"

--- a/website/cue/reference/components/sources/gcp_pubsub.cue
+++ b/website/cue/reference/components/sources/gcp_pubsub.cue
@@ -26,7 +26,6 @@ components: sources: gcp_pubsub: {
 	}
 
 	classes: {
-		commonly_used: true
 		deployment_roles: ["aggregator"]
 		delivery:      "at_least_once"
 		development:   "beta"

--- a/website/cue/reference/components/sources/heroku_logs.cue
+++ b/website/cue/reference/components/sources/heroku_logs.cue
@@ -12,7 +12,7 @@ components: sources: heroku_logs: {
 	alias: "logplex"
 
 	classes: {
-		delivery:      "at_least_once"
+		delivery: "at_least_once"
 		deployment_roles: ["aggregator"]
 		development:   "stable"
 		egress_method: "batch"

--- a/website/cue/reference/components/sources/heroku_logs.cue
+++ b/website/cue/reference/components/sources/heroku_logs.cue
@@ -12,7 +12,6 @@ components: sources: heroku_logs: {
 	alias: "logplex"
 
 	classes: {
-		commonly_used: false
 		delivery:      "at_least_once"
 		deployment_roles: ["aggregator"]
 		development:   "stable"

--- a/website/cue/reference/components/sources/host_metrics.cue
+++ b/website/cue/reference/components/sources/host_metrics.cue
@@ -10,7 +10,7 @@ components: sources: host_metrics: {
 		"""
 
 	classes: {
-		delivery:      "at_least_once"
+		delivery: "at_least_once"
 		deployment_roles: ["daemon"]
 		development:   "stable"
 		egress_method: "batch"

--- a/website/cue/reference/components/sources/host_metrics.cue
+++ b/website/cue/reference/components/sources/host_metrics.cue
@@ -10,7 +10,6 @@ components: sources: host_metrics: {
 		"""
 
 	classes: {
-		commonly_used: false
 		delivery:      "at_least_once"
 		deployment_roles: ["daemon"]
 		development:   "stable"

--- a/website/cue/reference/components/sources/http_client.cue
+++ b/website/cue/reference/components/sources/http_client.cue
@@ -4,7 +4,6 @@ components: sources: http_client: {
 	title: "HTTP Client"
 
 	classes: {
-		commonly_used: false
 		delivery:      "at_least_once"
 		deployment_roles: ["daemon", "sidecar", "aggregator"]
 		development:   "beta"

--- a/website/cue/reference/components/sources/http_client.cue
+++ b/website/cue/reference/components/sources/http_client.cue
@@ -4,7 +4,7 @@ components: sources: http_client: {
 	title: "HTTP Client"
 
 	classes: {
-		delivery:      "at_least_once"
+		delivery: "at_least_once"
 		deployment_roles: ["daemon", "sidecar", "aggregator"]
 		development:   "beta"
 		egress_method: "batch"

--- a/website/cue/reference/components/sources/http_server.cue
+++ b/website/cue/reference/components/sources/http_server.cue
@@ -7,7 +7,7 @@ components: sources: http_server: {
 	alias: "http"
 
 	classes: {
-		delivery:      "at_least_once"
+		delivery: "at_least_once"
 		deployment_roles: ["aggregator", "sidecar"]
 		development:   "stable"
 		egress_method: "batch"

--- a/website/cue/reference/components/sources/http_server.cue
+++ b/website/cue/reference/components/sources/http_server.cue
@@ -7,7 +7,6 @@ components: sources: http_server: {
 	alias: "http"
 
 	classes: {
-		commonly_used: false
 		delivery:      "at_least_once"
 		deployment_roles: ["aggregator", "sidecar"]
 		development:   "stable"

--- a/website/cue/reference/components/sources/internal_logs.cue
+++ b/website/cue/reference/components/sources/internal_logs.cue
@@ -5,7 +5,7 @@ components: sources: internal_logs: {
 	description: "The internal logs source exposes all log and trace messages emitted by the running Vector instance."
 
 	classes: {
-		delivery:      "at_least_once"
+		delivery: "at_least_once"
 		deployment_roles: ["aggregator", "daemon", "sidecar"]
 		development:   "stable"
 		egress_method: "stream"

--- a/website/cue/reference/components/sources/internal_logs.cue
+++ b/website/cue/reference/components/sources/internal_logs.cue
@@ -5,7 +5,6 @@ components: sources: internal_logs: {
 	description: "The internal logs source exposes all log and trace messages emitted by the running Vector instance."
 
 	classes: {
-		commonly_used: true
 		delivery:      "at_least_once"
 		deployment_roles: ["aggregator", "daemon", "sidecar"]
 		development:   "stable"

--- a/website/cue/reference/components/sources/internal_metrics.cue
+++ b/website/cue/reference/components/sources/internal_metrics.cue
@@ -9,7 +9,6 @@ components: sources: internal_metrics: {
 		"""
 
 	classes: {
-		commonly_used: true
 		delivery:      "at_least_once"
 		deployment_roles: ["aggregator", "daemon", "sidecar"]
 		development:   "stable"

--- a/website/cue/reference/components/sources/internal_metrics.cue
+++ b/website/cue/reference/components/sources/internal_metrics.cue
@@ -9,7 +9,7 @@ components: sources: internal_metrics: {
 		"""
 
 	classes: {
-		delivery:      "at_least_once"
+		delivery: "at_least_once"
 		deployment_roles: ["aggregator", "daemon", "sidecar"]
 		development:   "stable"
 		egress_method: "batch"

--- a/website/cue/reference/components/sources/journald.cue
+++ b/website/cue/reference/components/sources/journald.cue
@@ -4,7 +4,7 @@ components: sources: journald: {
 	title: "Journald"
 
 	classes: {
-		delivery:      "at_least_once"
+		delivery: "at_least_once"
 		deployment_roles: ["daemon"]
 		development:   "stable"
 		egress_method: "batch"

--- a/website/cue/reference/components/sources/journald.cue
+++ b/website/cue/reference/components/sources/journald.cue
@@ -4,7 +4,6 @@ components: sources: journald: {
 	title: "Journald"
 
 	classes: {
-		commonly_used: true
 		delivery:      "at_least_once"
 		deployment_roles: ["daemon"]
 		development:   "stable"

--- a/website/cue/reference/components/sources/kafka.cue
+++ b/website/cue/reference/components/sources/kafka.cue
@@ -25,7 +25,6 @@ components: sources: kafka: {
 	}
 
 	classes: {
-		commonly_used: true
 		deployment_roles: ["aggregator"]
 		delivery:      "at_least_once"
 		development:   "stable"

--- a/website/cue/reference/components/sources/kubernetes_logs.cue
+++ b/website/cue/reference/components/sources/kubernetes_logs.cue
@@ -11,7 +11,6 @@ components: sources: kubernetes_logs: {
 		"""
 
 	classes: {
-		commonly_used: true
 		delivery:      "best_effort"
 		deployment_roles: ["daemon"]
 		development:   "stable"

--- a/website/cue/reference/components/sources/kubernetes_logs.cue
+++ b/website/cue/reference/components/sources/kubernetes_logs.cue
@@ -11,7 +11,7 @@ components: sources: kubernetes_logs: {
 		"""
 
 	classes: {
-		delivery:      "best_effort"
+		delivery: "best_effort"
 		deployment_roles: ["daemon"]
 		development:   "stable"
 		egress_method: "stream"

--- a/website/cue/reference/components/sources/logstash.cue
+++ b/website/cue/reference/components/sources/logstash.cue
@@ -6,7 +6,6 @@ components: sources: logstash: {
 	title: "Logstash"
 
 	classes: {
-		commonly_used: true
 		delivery:      "best_effort"
 		deployment_roles: ["sidecar", "aggregator"]
 		development:   "stable"

--- a/website/cue/reference/components/sources/logstash.cue
+++ b/website/cue/reference/components/sources/logstash.cue
@@ -6,7 +6,7 @@ components: sources: logstash: {
 	title: "Logstash"
 
 	classes: {
-		delivery:      "best_effort"
+		delivery: "best_effort"
 		deployment_roles: ["sidecar", "aggregator"]
 		development:   "stable"
 		egress_method: "stream"

--- a/website/cue/reference/components/sources/mongodb_metrics.cue
+++ b/website/cue/reference/components/sources/mongodb_metrics.cue
@@ -4,7 +4,7 @@ components: sources: mongodb_metrics: {
 	title: "MongoDB Metrics"
 
 	classes: {
-		delivery:      "at_least_once"
+		delivery: "at_least_once"
 		deployment_roles: ["daemon", "sidecar"]
 		development:   "stable"
 		egress_method: "batch"

--- a/website/cue/reference/components/sources/mongodb_metrics.cue
+++ b/website/cue/reference/components/sources/mongodb_metrics.cue
@@ -4,7 +4,6 @@ components: sources: mongodb_metrics: {
 	title: "MongoDB Metrics"
 
 	classes: {
-		commonly_used: false
 		delivery:      "at_least_once"
 		deployment_roles: ["daemon", "sidecar"]
 		development:   "stable"

--- a/website/cue/reference/components/sources/mqtt.cue
+++ b/website/cue/reference/components/sources/mqtt.cue
@@ -28,7 +28,6 @@ components: sources: mqtt: {
 	}
 
 	classes: {
-		commonly_used: false
 		deployment_roles: ["aggregator"]
 		delivery:      "best_effort"
 		development:   "beta"

--- a/website/cue/reference/components/sources/nats.cue
+++ b/website/cue/reference/components/sources/nats.cue
@@ -25,7 +25,6 @@ components: sources: nats: {
 	}
 
 	classes: {
-		commonly_used: true
 		deployment_roles: ["aggregator"]
 		delivery:      "best_effort"
 		development:   "stable"

--- a/website/cue/reference/components/sources/nginx_metrics.cue
+++ b/website/cue/reference/components/sources/nginx_metrics.cue
@@ -4,7 +4,6 @@ components: sources: nginx_metrics: {
 	title: "Nginx Metrics"
 
 	classes: {
-		commonly_used: false
 		delivery:      "at_least_once"
 		deployment_roles: ["daemon", "sidecar"]
 		development:   "stable"

--- a/website/cue/reference/components/sources/nginx_metrics.cue
+++ b/website/cue/reference/components/sources/nginx_metrics.cue
@@ -4,7 +4,7 @@ components: sources: nginx_metrics: {
 	title: "Nginx Metrics"
 
 	classes: {
-		delivery:      "at_least_once"
+		delivery: "at_least_once"
 		deployment_roles: ["daemon", "sidecar"]
 		development:   "stable"
 		egress_method: "batch"

--- a/website/cue/reference/components/sources/okta.cue
+++ b/website/cue/reference/components/sources/okta.cue
@@ -5,7 +5,6 @@ components: sources: okta: {
 	title: "Okta"
 
 	classes: {
-		commonly_used: true
 		delivery:      "best_effort"
 		deployment_roles: ["aggregator"]
 		development:   "beta"

--- a/website/cue/reference/components/sources/okta.cue
+++ b/website/cue/reference/components/sources/okta.cue
@@ -5,7 +5,7 @@ components: sources: okta: {
 	title: "Okta"
 
 	classes: {
-		delivery:      "best_effort"
+		delivery: "best_effort"
 		deployment_roles: ["aggregator"]
 		development:   "beta"
 		egress_method: "stream"

--- a/website/cue/reference/components/sources/opentelemetry.cue
+++ b/website/cue/reference/components/sources/opentelemetry.cue
@@ -7,7 +7,6 @@ components: sources: opentelemetry: {
 	title: "OpenTelemetry"
 
 	classes: {
-		commonly_used: false
 		delivery:      "at_least_once"
 		deployment_roles: ["daemon", "aggregator"]
 		development:   "beta"

--- a/website/cue/reference/components/sources/opentelemetry.cue
+++ b/website/cue/reference/components/sources/opentelemetry.cue
@@ -7,7 +7,7 @@ components: sources: opentelemetry: {
 	title: "OpenTelemetry"
 
 	classes: {
-		delivery:      "at_least_once"
+		delivery: "at_least_once"
 		deployment_roles: ["daemon", "aggregator"]
 		development:   "beta"
 		egress_method: "stream"

--- a/website/cue/reference/components/sources/postgresql_metrics.cue
+++ b/website/cue/reference/components/sources/postgresql_metrics.cue
@@ -9,7 +9,6 @@ components: sources: postgresql_metrics: {
 		"""
 
 	classes: {
-		commonly_used: false
 		delivery:      "at_least_once"
 		deployment_roles: ["daemon", "sidecar"]
 		development:   "stable"

--- a/website/cue/reference/components/sources/postgresql_metrics.cue
+++ b/website/cue/reference/components/sources/postgresql_metrics.cue
@@ -9,7 +9,7 @@ components: sources: postgresql_metrics: {
 		"""
 
 	classes: {
-		delivery:      "at_least_once"
+		delivery: "at_least_once"
 		deployment_roles: ["daemon", "sidecar"]
 		development:   "stable"
 		egress_method: "batch"

--- a/website/cue/reference/components/sources/prometheus_pushgateway.cue
+++ b/website/cue/reference/components/sources/prometheus_pushgateway.cue
@@ -4,7 +4,6 @@ components: sources: prometheus_pushgateway: {
 	title: "Prometheus Pushgateway"
 
 	classes: {
-		commonly_used: false
 		delivery:      "at_least_once"
 		deployment_roles: ["daemon", "sidecar"]
 		development:   "beta"

--- a/website/cue/reference/components/sources/prometheus_pushgateway.cue
+++ b/website/cue/reference/components/sources/prometheus_pushgateway.cue
@@ -4,7 +4,7 @@ components: sources: prometheus_pushgateway: {
 	title: "Prometheus Pushgateway"
 
 	classes: {
-		delivery:      "at_least_once"
+		delivery: "at_least_once"
 		deployment_roles: ["daemon", "sidecar"]
 		development:   "beta"
 		egress_method: "batch"

--- a/website/cue/reference/components/sources/prometheus_remote_write.cue
+++ b/website/cue/reference/components/sources/prometheus_remote_write.cue
@@ -4,7 +4,6 @@ components: sources: prometheus_remote_write: {
 	title: "Prometheus Remote Write"
 
 	classes: {
-		commonly_used: false
 		delivery:      "at_least_once"
 		deployment_roles: ["daemon", "sidecar"]
 		development:   "beta"

--- a/website/cue/reference/components/sources/prometheus_remote_write.cue
+++ b/website/cue/reference/components/sources/prometheus_remote_write.cue
@@ -4,7 +4,7 @@ components: sources: prometheus_remote_write: {
 	title: "Prometheus Remote Write"
 
 	classes: {
-		delivery:      "at_least_once"
+		delivery: "at_least_once"
 		deployment_roles: ["daemon", "sidecar"]
 		development:   "beta"
 		egress_method: "batch"

--- a/website/cue/reference/components/sources/prometheus_scrape.cue
+++ b/website/cue/reference/components/sources/prometheus_scrape.cue
@@ -5,7 +5,6 @@ components: sources: prometheus_scrape: {
 	alias: "prometheus"
 
 	classes: {
-		commonly_used: false
 		delivery:      "at_least_once"
 		deployment_roles: ["daemon", "sidecar"]
 		development:   "stable"

--- a/website/cue/reference/components/sources/prometheus_scrape.cue
+++ b/website/cue/reference/components/sources/prometheus_scrape.cue
@@ -5,7 +5,7 @@ components: sources: prometheus_scrape: {
 	alias: "prometheus"
 
 	classes: {
-		delivery:      "at_least_once"
+		delivery: "at_least_once"
 		deployment_roles: ["daemon", "sidecar"]
 		development:   "stable"
 		egress_method: "batch"

--- a/website/cue/reference/components/sources/pulsar.cue
+++ b/website/cue/reference/components/sources/pulsar.cue
@@ -4,7 +4,6 @@ components: sources: pulsar: {
 	title: "Apache Pulsar"
 
 	classes: {
-		commonly_used: false
 		delivery:      "at_least_once"
 		deployment_roles: ["aggregator"]
 		development:   "beta"

--- a/website/cue/reference/components/sources/pulsar.cue
+++ b/website/cue/reference/components/sources/pulsar.cue
@@ -4,7 +4,7 @@ components: sources: pulsar: {
 	title: "Apache Pulsar"
 
 	classes: {
-		delivery:      "at_least_once"
+		delivery: "at_least_once"
 		deployment_roles: ["aggregator"]
 		development:   "beta"
 		egress_method: "stream"

--- a/website/cue/reference/components/sources/redis.cue
+++ b/website/cue/reference/components/sources/redis.cue
@@ -29,7 +29,6 @@ components: sources: redis: {
 	}
 
 	classes: {
-		commonly_used: false
 		delivery:      "best_effort"
 		deployment_roles: ["aggregator"]
 		development:   "stable"

--- a/website/cue/reference/components/sources/redis.cue
+++ b/website/cue/reference/components/sources/redis.cue
@@ -29,7 +29,7 @@ components: sources: redis: {
 	}
 
 	classes: {
-		delivery:      "best_effort"
+		delivery: "best_effort"
 		deployment_roles: ["aggregator"]
 		development:   "stable"
 		egress_method: "stream"

--- a/website/cue/reference/components/sources/socket.cue
+++ b/website/cue/reference/components/sources/socket.cue
@@ -6,7 +6,6 @@ components: sources: socket: {
 	title: "Socket"
 
 	classes: {
-		commonly_used: true
 		delivery:      "best_effort"
 		deployment_roles: ["aggregator", "sidecar"]
 		development:   "stable"

--- a/website/cue/reference/components/sources/socket.cue
+++ b/website/cue/reference/components/sources/socket.cue
@@ -6,7 +6,7 @@ components: sources: socket: {
 	title: "Socket"
 
 	classes: {
-		delivery:      "best_effort"
+		delivery: "best_effort"
 		deployment_roles: ["aggregator", "sidecar"]
 		development:   "stable"
 		egress_method: "stream"

--- a/website/cue/reference/components/sources/splunk_hec.cue
+++ b/website/cue/reference/components/sources/splunk_hec.cue
@@ -10,7 +10,7 @@ components: sources: splunk_hec: {
 		"""
 
 	classes: {
-		delivery:      "at_least_once"
+		delivery: "at_least_once"
 		deployment_roles: ["aggregator"]
 		development:   "stable"
 		egress_method: "batch"

--- a/website/cue/reference/components/sources/splunk_hec.cue
+++ b/website/cue/reference/components/sources/splunk_hec.cue
@@ -10,7 +10,6 @@ components: sources: splunk_hec: {
 		"""
 
 	classes: {
-		commonly_used: false
 		delivery:      "at_least_once"
 		deployment_roles: ["aggregator"]
 		development:   "stable"

--- a/website/cue/reference/components/sources/static_metrics.cue
+++ b/website/cue/reference/components/sources/static_metrics.cue
@@ -9,7 +9,7 @@ components: sources: static_metrics: {
 		"""
 
 	classes: {
-		delivery:      "at_least_once"
+		delivery: "at_least_once"
 		deployment_roles: ["aggregator", "daemon", "sidecar"]
 		development:   "stable"
 		egress_method: "batch"

--- a/website/cue/reference/components/sources/static_metrics.cue
+++ b/website/cue/reference/components/sources/static_metrics.cue
@@ -9,7 +9,6 @@ components: sources: static_metrics: {
 		"""
 
 	classes: {
-		commonly_used: true
 		delivery:      "at_least_once"
 		deployment_roles: ["aggregator", "daemon", "sidecar"]
 		development:   "stable"

--- a/website/cue/reference/components/sources/statsd.cue
+++ b/website/cue/reference/components/sources/statsd.cue
@@ -6,7 +6,7 @@ components: sources: statsd: {
 	title: "StatsD"
 
 	classes: {
-		delivery:      "best_effort"
+		delivery: "best_effort"
 		deployment_roles: ["aggregator"]
 		development:   "stable"
 		egress_method: "stream"

--- a/website/cue/reference/components/sources/statsd.cue
+++ b/website/cue/reference/components/sources/statsd.cue
@@ -6,7 +6,6 @@ components: sources: statsd: {
 	title: "StatsD"
 
 	classes: {
-		commonly_used: false
 		delivery:      "best_effort"
 		deployment_roles: ["aggregator"]
 		development:   "stable"

--- a/website/cue/reference/components/sources/stdin.cue
+++ b/website/cue/reference/components/sources/stdin.cue
@@ -4,7 +4,6 @@ components: sources: stdin: {
 	title: "STDIN"
 
 	classes: {
-		commonly_used: false
 		delivery:      "at_least_once"
 		deployment_roles: ["sidecar"]
 		development:   "stable"

--- a/website/cue/reference/components/sources/stdin.cue
+++ b/website/cue/reference/components/sources/stdin.cue
@@ -4,7 +4,7 @@ components: sources: stdin: {
 	title: "STDIN"
 
 	classes: {
-		delivery:      "at_least_once"
+		delivery: "at_least_once"
 		deployment_roles: ["sidecar"]
 		development:   "stable"
 		egress_method: "stream"

--- a/website/cue/reference/components/sources/vector.cue
+++ b/website/cue/reference/components/sources/vector.cue
@@ -10,7 +10,6 @@ components: sources: vector: {
 		"""
 
 	classes: {
-		commonly_used: false
 		delivery:      "at_least_once"
 		deployment_roles: ["aggregator"]
 		development:   "stable"

--- a/website/cue/reference/components/sources/vector.cue
+++ b/website/cue/reference/components/sources/vector.cue
@@ -10,7 +10,7 @@ components: sources: vector: {
 		"""
 
 	classes: {
-		delivery:      "at_least_once"
+		delivery: "at_least_once"
 		deployment_roles: ["aggregator"]
 		development:   "stable"
 		egress_method: "stream"

--- a/website/cue/reference/components/sources/websocket.cue
+++ b/website/cue/reference/components/sources/websocket.cue
@@ -4,7 +4,7 @@ components: sources: websocket: {
 	title: "WebSocket"
 
 	classes: {
-		delivery:      "best_effort"
+		delivery: "best_effort"
 		deployment_roles: ["aggregator"]
 		development:   "beta"
 		egress_method: "stream"

--- a/website/cue/reference/components/sources/websocket.cue
+++ b/website/cue/reference/components/sources/websocket.cue
@@ -4,7 +4,6 @@ components: sources: websocket: {
 	title: "WebSocket"
 
 	classes: {
-		commonly_used: false
 		delivery:      "best_effort"
 		deployment_roles: ["aggregator"]
 		development:   "beta"

--- a/website/cue/reference/components/sources/windows_event_log.cue
+++ b/website/cue/reference/components/sources/windows_event_log.cue
@@ -9,7 +9,7 @@ components: sources: windows_event_log: {
 		"""
 
 	classes: {
-		delivery:      "at_least_once"
+		delivery: "at_least_once"
 		deployment_roles: ["daemon"]
 		development:   "beta"
 		egress_method: "stream"

--- a/website/cue/reference/components/sources/windows_event_log.cue
+++ b/website/cue/reference/components/sources/windows_event_log.cue
@@ -9,7 +9,6 @@ components: sources: windows_event_log: {
 		"""
 
 	classes: {
-		commonly_used: false
 		delivery:      "at_least_once"
 		deployment_roles: ["daemon"]
 		development:   "beta"

--- a/website/cue/reference/components/transforms/aggregate.cue
+++ b/website/cue/reference/components/transforms/aggregate.cue
@@ -10,7 +10,6 @@ components: transforms: aggregate: {
 		"""
 
 	classes: {
-		commonly_used: false
 		development:   "stable"
 		egress_method: "stream"
 		stateful:      true

--- a/website/cue/reference/components/transforms/aws_ec2_metadata.cue
+++ b/website/cue/reference/components/transforms/aws_ec2_metadata.cue
@@ -8,7 +8,6 @@ components: transforms: aws_ec2_metadata: {
 		"""
 
 	classes: {
-		commonly_used: false
 		development:   "stable"
 		egress_method: "stream"
 		stateful:      false

--- a/website/cue/reference/components/transforms/dedupe.cue
+++ b/website/cue/reference/components/transforms/dedupe.cue
@@ -8,7 +8,6 @@ components: transforms: dedupe: {
 		"""
 
 	classes: {
-		commonly_used: false
 		development:   "stable"
 		egress_method: "stream"
 		stateful:      true

--- a/website/cue/reference/components/transforms/delay.cue
+++ b/website/cue/reference/components/transforms/delay.cue
@@ -8,7 +8,6 @@ components: transforms: delay: {
 		"""
 
 	classes: {
-		commonly_used: false
 		development:   "beta"
 		egress_method: "stream"
 		stateful:      true

--- a/website/cue/reference/components/transforms/exclusive_route.cue
+++ b/website/cue/reference/components/transforms/exclusive_route.cue
@@ -12,7 +12,6 @@ components: transforms: exclusive_route: {
 		"""
 
 	classes: {
-		commonly_used: false
 		development:   "beta"
 		egress_method: "stream"
 		stateful:      false

--- a/website/cue/reference/components/transforms/filter.cue
+++ b/website/cue/reference/components/transforms/filter.cue
@@ -8,7 +8,6 @@ components: transforms: filter: {
 		"""
 
 	classes: {
-		commonly_used: true
 		development:   "stable"
 		egress_method: "stream"
 		stateful:      false

--- a/website/cue/reference/components/transforms/incremental_to_absolute.cue
+++ b/website/cue/reference/components/transforms/incremental_to_absolute.cue
@@ -8,7 +8,6 @@ components: transforms: incremental_to_absolute: {
 		"""
 
 	classes: {
-		commonly_used: false
 		development:   "beta"
 		egress_method: "stream"
 		stateful:      true

--- a/website/cue/reference/components/transforms/log_to_metric.cue
+++ b/website/cue/reference/components/transforms/log_to_metric.cue
@@ -8,7 +8,6 @@ components: transforms: log_to_metric: {
 		"""
 
 	classes: {
-		commonly_used: false
 		development:   "stable"
 		egress_method: "batch"
 		stateful:      false

--- a/website/cue/reference/components/transforms/lua.cue
+++ b/website/cue/reference/components/transforms/lua.cue
@@ -8,7 +8,6 @@ components: transforms: lua: {
 		"""
 
 	classes: {
-		commonly_used: false
 		development:   "stable"
 		egress_method: "stream"
 		stateful:      true

--- a/website/cue/reference/components/transforms/metric_to_log.cue
+++ b/website/cue/reference/components/transforms/metric_to_log.cue
@@ -9,7 +9,6 @@ components: transforms: metric_to_log: {
 		"""
 
 	classes: {
-		commonly_used: true
 		development:   "stable"
 		egress_method: "stream"
 		stateful:      false

--- a/website/cue/reference/components/transforms/reduce.cue
+++ b/website/cue/reference/components/transforms/reduce.cue
@@ -9,7 +9,6 @@ components: transforms: reduce: {
 		"""
 
 	classes: {
-		commonly_used: false
 		development:   "stable"
 		egress_method: "stream"
 		stateful:      true

--- a/website/cue/reference/components/transforms/remap.cue
+++ b/website/cue/reference/components/transforms/remap.cue
@@ -12,7 +12,6 @@ components: transforms: "remap": {
 		"""
 
 	classes: {
-		commonly_used: true
 		development:   "stable"
 		egress_method: "stream"
 		stateful:      false

--- a/website/cue/reference/components/transforms/route.cue
+++ b/website/cue/reference/components/transforms/route.cue
@@ -12,7 +12,6 @@ components: transforms: route: {
 		"""
 
 	classes: {
-		commonly_used: false
 		development:   "stable"
 		egress_method: "stream"
 		stateful:      false

--- a/website/cue/reference/components/transforms/sample.cue
+++ b/website/cue/reference/components/transforms/sample.cue
@@ -8,7 +8,6 @@ components: transforms: sample: {
 		"""
 
 	classes: {
-		commonly_used: false
 		development:   "stable"
 		egress_method: "stream"
 		stateful:      false

--- a/website/cue/reference/components/transforms/tag_cardinality_limit.cue
+++ b/website/cue/reference/components/transforms/tag_cardinality_limit.cue
@@ -16,7 +16,6 @@ components: transforms: tag_cardinality_limit: {
 		"""
 
 	classes: {
-		commonly_used: false
 		development:   "beta"
 		egress_method: "stream"
 		stateful:      true

--- a/website/cue/reference/components/transforms/throttle.cue
+++ b/website/cue/reference/components/transforms/throttle.cue
@@ -8,7 +8,6 @@ components: transforms: throttle: {
 		"""
 
 	classes: {
-		commonly_used: false
 		development:   "stable"
 		egress_method: "stream"
 		stateful:      true

--- a/website/cue/reference/components/transforms/trace_to_log.cue
+++ b/website/cue/reference/components/transforms/trace_to_log.cue
@@ -11,7 +11,6 @@ components: transforms: trace_to_log: {
 		"""
 
 	classes: {
-		commonly_used: false
 		development:   "beta"
 		egress_method: "stream"
 		stateful:      false

--- a/website/cue/reference/components/transforms/window.cue
+++ b/website/cue/reference/components/transforms/window.cue
@@ -9,7 +9,6 @@ components: transforms: window: {
 		"""
 
 	classes: {
-		commonly_used: false
 		development:   "beta"
 		egress_method: "stream"
 		stateful:      true


### PR DESCRIPTION
## Summary

Removes the `commonly_used` field from all component CUE definitions across sources, sinks, and transforms.

## Vector configuration

NA

## How did you test this PR?

NA

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

NA