### PR TITLE
feat(releasing): include shell completions in deb, rpm, and archive packages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,9 @@ assets = [
   ["licenses/*", "/usr/share/vector/licenses/", "644"],
   ["NOTICE", "/usr/share/vector/NOTICE", "644"],
   ["LICENSE-3rdparty.csv", "/usr/share/vector/LICENSE-3rdparty.csv", "644"],
+  ["target/completion/bash/vector", "/usr/share/bash-completion/completions/vector", "644"],
+  ["target/completion/zsh/_vector", "/usr/share/zsh/vendor-completions/_vector", "644"],
+  ["target/completion/fish/vector.fish", "/usr/share/fish/vendor_completions.d/vector.fish", "644"],
 ]
 license-file = ["target/debian-license.txt"]
 extended-description-file = "target/debian-extended-description.txt"

--- a/changelog.d/24513_shell_completion_packaging.enhancement.md
+++ b/changelog.d/24513_shell_completion_packaging.enhancement.md
@@ -1,0 +1,3 @@
+Shell completion scripts for bash, zsh, and fish are now included in `.deb`, `.rpm`, and archive (`.tar.gz`) packages. After installing vector, completions are automatically available at the standard system paths for each shell.
+
+authors: thomasqueirozb

--- a/distribution/rpm/vector.spec
+++ b/distribution/rpm/vector.spec
@@ -65,6 +65,18 @@ cp -a %{_builddir}/licenses/. %{buildroot}%{_datadir}/%{_name}/licenses
 cp -a %{_builddir}/NOTICE %{buildroot}%{_datadir}/%{_name}/NOTICE
 cp -a %{_builddir}/LICENSE-3rdparty.csv %{buildroot}%{_datadir}/%{_name}/LICENSE-3rdparty.csv
 
+# Generate shell completions; fall back to empty files if the binary cannot run
+# (e.g. cross-compiled for a different architecture without QEMU/binfmt support).
+mkdir -p %{buildroot}%{_datadir}/bash-completion/completions
+mkdir -p %{buildroot}%{_datadir}/zsh/site-functions
+mkdir -p %{buildroot}%{_datadir}/fish/vendor_completions.d
+%{buildroot}%{_bindir}/vector completion bash > %{buildroot}%{_datadir}/bash-completion/completions/vector 2>/dev/null || \
+  touch %{buildroot}%{_datadir}/bash-completion/completions/vector
+%{buildroot}%{_bindir}/vector completion zsh  > %{buildroot}%{_datadir}/zsh/site-functions/_vector 2>/dev/null || \
+  touch %{buildroot}%{_datadir}/zsh/site-functions/_vector
+%{buildroot}%{_bindir}/vector completion fish > %{buildroot}%{_datadir}/fish/vendor_completions.d/vector.fish 2>/dev/null || \
+  touch %{buildroot}%{_datadir}/fish/vendor_completions.d/vector.fish
+
 %post
 getent passwd %{_username} > /dev/null || \
   useradd --shell /sbin/nologin --system --home-dir %{_sharedstatedir}/%{_name} --user-group \
@@ -93,6 +105,9 @@ rm -rf %{buildroot}
 %doc %{_datadir}/%{_name}/licenses/*
 %doc %{_datadir}/%{_name}/LICENSE-3rdparty.csv
 %license LICENSE
+%{_datadir}/bash-completion/completions/vector
+%{_datadir}/zsh/site-functions/_vector
+%{_datadir}/fish/vendor_completions.d/vector.fish
 
 %changelog
 * Fri Jun 21 2019 Vector Devs <vector@datadoghq.com> - 0.3.0

--- a/scripts/package-archive.sh
+++ b/scripts/package-archive.sh
@@ -95,6 +95,19 @@ cp -av LICENSE-3rdparty.csv "$ARCHIVE_DIR"
 mkdir -p "$ARCHIVE_DIR/bin"
 cp -av "$TARGET_DIR/release/vector" "$ARCHIVE_DIR/bin"
 
+# Generate shell completions (only if the binary is executable on this host)
+VECTOR_BIN="$ARCHIVE_DIR/bin/vector"
+if "$VECTOR_BIN" --version >/dev/null 2>&1; then
+  mkdir -p "$ARCHIVE_DIR/completion/bash" \
+           "$ARCHIVE_DIR/completion/zsh" \
+           "$ARCHIVE_DIR/completion/fish"
+  "$VECTOR_BIN" completion bash > "$ARCHIVE_DIR/completion/bash/vector"
+  "$VECTOR_BIN" completion zsh  > "$ARCHIVE_DIR/completion/zsh/_vector"
+  "$VECTOR_BIN" completion fish > "$ARCHIVE_DIR/completion/fish/vector.fish"
+else
+  echo "Skipping shell completion generation (binary not executable on this host)"
+fi
+
 # Copy the entire config dir to /config
 
 cp -rv config "$ARCHIVE_DIR/config"

--- a/scripts/package-deb.sh
+++ b/scripts/package-deb.sh
@@ -49,6 +49,21 @@ rm -rf "$td"
 df -h
 
 #
+# Generate shell completions
+#
+
+mkdir -p "$PROJECT_ROOT/target/completion/bash" \
+         "$PROJECT_ROOT/target/completion/zsh" \
+         "$PROJECT_ROOT/target/completion/fish"
+VECTOR_BIN="$PROJECT_ROOT/target/$TARGET/$PROFILE/vector"
+"$VECTOR_BIN" completion bash > "$PROJECT_ROOT/target/completion/bash/vector"   2>/dev/null || \
+  touch "$PROJECT_ROOT/target/completion/bash/vector"
+"$VECTOR_BIN" completion zsh  > "$PROJECT_ROOT/target/completion/zsh/_vector"   2>/dev/null || \
+  touch "$PROJECT_ROOT/target/completion/zsh/_vector"
+"$VECTOR_BIN" completion fish > "$PROJECT_ROOT/target/completion/fish/vector.fish" 2>/dev/null || \
+  touch "$PROJECT_ROOT/target/completion/fish/vector.fish"
+
+#
 # Package
 #
 

--- a/scripts/verify-install.sh
+++ b/scripts/verify-install.sh
@@ -28,6 +28,17 @@ vector --version || (echo "vector --version failed" && exit 1)
 test -f /etc/default/vector || (echo "/etc/default/vector doesn't exist" && exit 1)
 test ! -e /etc/vector/vector.yaml || (echo "/etc/vector/vector.yaml should not be installed by default" && exit 1)
 test -f /usr/share/vector/examples/vector.yaml || (echo "/usr/share/vector/examples/vector.yaml doesn't exist" && exit 1)
+test -f /usr/share/bash-completion/completions/vector || (echo "bash completion missing" && exit 1)
+test -f /usr/share/fish/vendor_completions.d/vector.fish || (echo "fish completion missing" && exit 1)
+
+case "$package" in
+  *.deb)
+    test -f /usr/share/zsh/vendor-completions/_vector || (echo "zsh completion missing" && exit 1)
+    ;;
+  *.rpm)
+    test -f /usr/share/zsh/site-functions/_vector || (echo "zsh completion missing" && exit 1)
+    ;;
+esac
 
 mkdir -p /etc/vector
 echo "FOO=bar" > /etc/default/vector


### PR DESCRIPTION
## Summary

Add shell completions for bash, zsh, and fish to `.deb`, `.rpm`, and `.tar.gz` archive packages. Completions are generated at package build time using `vector completion <shell>` and installed to the standard system paths for each shell.

For cross-compiled builds where the binary cannot run on the host, completion files are created as empty stubs so packaging does not fail.

> [!NOTE]  
> Changes are also needed in `https://github.com/vectordotdev/homebrew-brew`
```diff
diff --git a/Formula/vector.rb b/Formula/vector.rb
index 755cb63..bfe0c49 100644
--- a/Formula/vector.rb
+++ b/Formula/vector.rb
@@ -19,6 +19,9 @@ class Vector < Formula
 
   def install
     bin.install "bin/vector"
+    bash_completion.install "completion/bash/vector"
+    zsh_completion.install "completion/zsh/_vector"
+    fish_completion.install "completion/fish/vector.fish"
 
     # Set up Vector for local development
     inreplace "config/vector.yaml" do |s|
```

## Vector configuration

NA

## How did you test this PR?

Reviewed the packaging scripts and spec file changes. The `verify-install.sh` script now checks for the presence of completion files after installation.

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Closes: #24513