### PR TITLE
fix(vdev): use CUE raw string for VRL changelog in release prepare

### DIFF
--- a/vdev/src/commands/release/prepare.rs
+++ b/vdev/src/commands/release/prepare.rs
@@ -433,8 +433,8 @@ fn format_vrl_changelog_block(changelog: &str) -> String {
         .collect::<Vec<_>>()
         .join("\n");
 
-    let opening = "\tvrl_changelog: \"\"\"";
-    let closing = format!("{double_tab}\"\"\"");
+    let opening = "\tvrl_changelog: #\"\"\"";
+    let closing = format!("{double_tab}\"\"\"#");
 
     format!("{opening}\n{body}\n{closing}")
 }
@@ -547,11 +547,11 @@ mod tests {
         let vrl_changelog_block = format_vrl_changelog_block(vrl_changelog);
 
         let expected = concat!(
-            "\tvrl_changelog: \"\"\"\n",
+            "\tvrl_changelog: #\"\"\"\n",
             "\t\t#### [0.2.0]\n",
             "\t\t- Feature\n",
             "\t\t- Fix\n",
-            "\t\t\"\"\""
+            "\t\t\"\"\"#"
         );
 
         assert_eq!(vrl_changelog_block, expected);


### PR DESCRIPTION
## Summary

`cargo vdev release prepare` fails when the VRL changelog contains backslash-brace sequences (e.g. `\{`) because CUE interprets them as invalid escape sequences in a regular multiline string. The fix uses a CUE raw string (`#"""..."""#`) for the `vrl_changelog` field, matching the existing pattern used for Vector changelog `description` entries.

## Vector configuration

NA

## How did you test this PR?

Unit tests in `vdev/src/commands/release/prepare.rs` updated and passing. Ran a release dry-run also which passed

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

NA