### PR TITLE
chore(ci): upload JUnit test results on Windows

### DIFF
--- a/.github/workflows/unit_windows.yml
+++ b/.github/workflows/unit_windows.yml
@@ -26,3 +26,8 @@ jobs:
           python-version: "3.10"
       - run: .\scripts\environment\bootstrap-windows-2025.ps1
       - run: make test
+
+      - name: Upload test results to Datadog
+        if: always()
+        run: scripts/upload-test-results.sh
+        shell: bash


### PR DESCRIPTION
## Summary

Upload `cargo-nextest` JUnit results to Datadog from the Windows unit test job, achieving parity with Linux/macOS. Windows runners support bash via Git Bash, so the existing `scripts/upload-test-results.sh` works with `shell: bash`.

## Vector configuration

NA

## How did you test this PR?

`/ci-run-unit-windows`
## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Closes: #11762