### PR TITLE
fix(metrics): correct CUE metric catalog discrepancies

### DIFF
--- a/website/cue/reference/components/sinks.cue
+++ b/website/cue/reference/components/sinks.cue
@@ -667,9 +667,9 @@ components: sinks: [Name=string]: {
 		buffer_size_events:                   components.sources.internal_metrics.output.metrics.buffer_size_events
 		buffer_events:                        components.sources.internal_metrics.output.metrics.buffer_events
 		buffer_received_events_total:         components.sources.internal_metrics.output.metrics.buffer_received_events_total
-		buffer_received_event_bytes_total:    components.sources.internal_metrics.output.metrics.buffer_received_event_bytes_total
+		buffer_received_bytes_total:          components.sources.internal_metrics.output.metrics.buffer_received_bytes_total
 		buffer_sent_events_total:             components.sources.internal_metrics.output.metrics.buffer_sent_events_total
-		buffer_sent_event_bytes_total:        components.sources.internal_metrics.output.metrics.buffer_sent_event_bytes_total
+		buffer_sent_bytes_total:              components.sources.internal_metrics.output.metrics.buffer_sent_bytes_total
 		component_discarded_events_total:     components.sources.internal_metrics.output.metrics.component_discarded_events_total
 		component_errors_total:               components.sources.internal_metrics.output.metrics.component_errors_total
 		component_received_events_count:      components.sources.internal_metrics.output.metrics.component_received_events_count

--- a/website/cue/reference/components/sinks/loki.cue
+++ b/website/cue/reference/components/sinks/loki.cue
@@ -157,7 +157,5 @@ components: sinks: loki: {
 		}
 	}
 
-	telemetry: metrics: {
-		streams_total: components.sources.internal_metrics.output.metrics.streams_total
-	}
+	telemetry: metrics: {}
 }

--- a/website/cue/reference/components/sinks/nats.cue
+++ b/website/cue/reference/components/sinks/nats.cue
@@ -62,7 +62,5 @@ components: sinks: nats: {
 
 	how_it_works: components._nats.how_it_works
 
-	telemetry: metrics: {
-		send_errors_total: components.sources.internal_metrics.output.metrics.send_errors_total
-	}
+	telemetry: metrics: {}
 }

--- a/website/cue/reference/components/sinks/redis.cue
+++ b/website/cue/reference/components/sinks/redis.cue
@@ -80,7 +80,5 @@ components: sinks: redis: {
 		}
 	}
 
-	telemetry: metrics: {
-		send_errors_total: components.sources.internal_metrics.output.metrics.send_errors_total
-	}
+	telemetry: metrics: {}
 }

--- a/website/cue/reference/components/sinks/vector.cue
+++ b/website/cue/reference/components/sinks/vector.cue
@@ -79,7 +79,5 @@ components: sinks: vector: {
 
 	how_it_works: components.sinks.vector.how_it_works
 
-	telemetry: metrics: {
-		protobuf_decode_errors_total: components.sources.internal_metrics.output.metrics.protobuf_decode_errors_total
-	}
+	telemetry: metrics: {}
 }

--- a/website/cue/reference/components/sources/internal_metrics.cue
+++ b/website/cue/reference/components/sources/internal_metrics.cue
@@ -57,7 +57,7 @@ components: sources: internal_metrics: {
 			description:       "The number of active endpoints this component is sending data to."
 			type:              "gauge"
 			default_namespace: "vector"
-			tags:              _internal_metrics_tags
+			tags:              _component_tags
 		}
 		active_clients: {
 			description:       "Number of clients attached to a component."

--- a/website/cue/reference/components/sources/internal_metrics.cue
+++ b/website/cue/reference/components/sources/internal_metrics.cue
@@ -328,7 +328,7 @@ components: sources: internal_metrics: {
 			default_namespace: "vector"
 			tags:              _component_tags
 		}
-		buffer_received_event_bytes_total: {
+		buffer_received_bytes_total: {
 			description:       "The number of bytes received by this buffer."
 			type:              "counter"
 			default_namespace: "vector"
@@ -346,7 +346,7 @@ components: sources: internal_metrics: {
 			default_namespace: "vector"
 			tags:              _component_tags
 		}
-		buffer_sent_event_bytes_total: {
+		buffer_sent_bytes_total: {
 			description:       "The number of bytes sent by this buffer."
 			type:              "counter"
 			default_namespace: "vector"

--- a/website/cue/reference/components/sources/internal_metrics.cue
+++ b/website/cue/reference/components/sources/internal_metrics.cue
@@ -1185,11 +1185,11 @@ components: sources: internal_metrics: {
 			description: "The specific error code emitted for a buffer read failure."
 			required:    true
 			enum: {
-				"deser_failed":               "The buffer record could not be deserialized."
-				"checksum_mismatch":          "The buffer record checksum did not match the expected value."
-				"decode_failed":              "The buffer record could not be decoded."
+				"deser_failed":                "The buffer record could not be deserialized."
+				"checksum_mismatch":           "The buffer record checksum did not match the expected value."
+				"decode_failed":               "The buffer record could not be decoded."
 				"incompatible_record_version": "The buffer record version is incompatible with this reader."
-				"partial_write":              "The buffer contained a partially written record."
+				"partial_write":               "The buffer contained a partially written record."
 			}
 		}
 		_buffer_stage: {

--- a/website/cue/reference/components/sources/internal_metrics.cue
+++ b/website/cue/reference/components/sources/internal_metrics.cue
@@ -1207,6 +1207,7 @@ components: sources: internal_metrics: {
 				"match_failed":                "The match operation failed."
 				"out_of_order":                "The event was out of order."
 				"parse_failed":                "The parsing operation failed."
+				"reader_failed":               "The buffer reader failed."
 				"read_failed":                 "The file read operation failed."
 				"render_error":                "The rendering operation failed."
 				"stream_closed":               "The downstream was closed, forwarding the event(s) failed."

--- a/website/cue/reference/components/sources/internal_metrics.cue
+++ b/website/cue/reference/components/sources/internal_metrics.cue
@@ -53,6 +53,12 @@ components: sources: internal_metrics: {
 		}
 
 		// Instance-level "process" metrics
+		active_endpoints: {
+			description:       "The number of active endpoints this component is sending data to."
+			type:              "gauge"
+			default_namespace: "vector"
+			tags:              _internal_metrics_tags
+		}
 		active_clients: {
 			description:       "Number of clients attached to a component."
 			type:              "gauge"
@@ -164,6 +170,24 @@ components: sources: internal_metrics: {
 			default_namespace: "vector"
 			tags:              _component_tags
 		}
+		adaptive_concurrency_back_pressure: {
+			description:       "A histogram of whether back-pressure was applied during the current window."
+			type:              "histogram"
+			default_namespace: "vector"
+			tags:              _component_tags
+		}
+		adaptive_concurrency_past_rtt_mean: {
+			description:       "The mean round-trip time (RTT) from the past window."
+			type:              "histogram"
+			default_namespace: "vector"
+			tags:              _component_tags
+		}
+		adaptive_concurrency_reached_limit: {
+			description:       "A histogram of whether the concurrency limit was reached during the current window."
+			type:              "histogram"
+			default_namespace: "vector"
+			tags:              _component_tags
+		}
 		checkpoints_total: {
 			description:       "The total number of files checkpointed."
 			type:              "counter"
@@ -250,6 +274,18 @@ components: sources: internal_metrics: {
 			default_namespace: "vector"
 			tags:              _component_tags
 		}
+		k8s_event_namespace_annotation_failures_total: {
+			description:       "The total number of failures to annotate a Kubernetes event with namespace metadata."
+			type:              "counter"
+			default_namespace: "vector"
+			tags:              _component_tags
+		}
+		k8s_event_node_annotation_failures_total: {
+			description:       "The total number of failures to annotate a Kubernetes event with node metadata."
+			type:              "counter"
+			default_namespace: "vector"
+			tags:              _component_tags
+		}
 		events_discarded_total: {
 			description:       "The total number of events discarded by this component."
 			type:              "counter"
@@ -313,6 +349,22 @@ components: sources: internal_metrics: {
 			type:              "counter"
 			default_namespace: "vector"
 			tags:              _component_tags
+		}
+		buffer_discarded_bytes_total: {
+			description:       "The number of bytes dropped by this non-blocking buffer."
+			type:              "counter"
+			default_namespace: "vector"
+			tags:              _component_tags
+		}
+		buffer_errors_total: {
+			description:       "The total number of errors encountered by this buffer."
+			type:              "counter"
+			default_namespace: "vector"
+			tags: _component_tags & {
+				error_code: _error_code
+				error_type: _error_type
+				stage:      _stage
+			}
 		}
 		buffer_received_bytes_total: {
 			description:       "The number of bytes received by this buffer."
@@ -676,6 +728,28 @@ components: sources: internal_metrics: {
 			default_namespace: "vector"
 			tags:              _component_tags
 		}
+		http_client_errors_total: {
+			description:       "The total number of HTTP request errors."
+			type:              "counter"
+			default_namespace: "vector"
+			tags: _component_tags & {
+				error_kind: {
+					description: "The type of error returned by the HTTP client."
+					required:    true
+				}
+			}
+		}
+		http_client_error_rtt_seconds: {
+			description:       "The round-trip time (RTT) of failed HTTP requests."
+			type:              "histogram"
+			default_namespace: "vector"
+			tags: _component_tags & {
+				error_kind: {
+					description: "The type of error returned by the HTTP client."
+					required:    true
+				}
+			}
+		}
 		http_requests_total: {
 			description:       "The total number of HTTP requests issued by this component."
 			type:              "counter"
@@ -840,6 +914,12 @@ components: sources: internal_metrics: {
 					required:    true
 				}
 			}
+		}
+		sqs_message_defer_succeeded_total: {
+			description:       "The total number of SQS messages successfully deferred."
+			type:              "counter"
+			default_namespace: "vector"
+			tags:              _component_tags
 		}
 		sqs_message_delete_succeeded_total: {
 			description:       "The total number of successful deletions of SQS messages."

--- a/website/cue/reference/components/sources/internal_metrics.cue
+++ b/website/cue/reference/components/sources/internal_metrics.cue
@@ -1006,18 +1006,18 @@ components: sources: internal_metrics: {
 			}
 		}
 		transform_buffer_max_byte_size: {
-			description:       "The maximum number of bytes the buffer that feeds into a transform can hold."
-			type:              "gauge"
-			default_namespace: "vector"
-			tags:              _component_tags
+			description:        "The maximum number of bytes the buffer that feeds into a transform can hold."
+			type:               "gauge"
+			default_namespace:  "vector"
+			tags:               _component_tags
 			deprecated:         true
 			deprecated_message: "This metric has been deprecated in favor of [`transform_buffer_max_size_bytes`](#transform_buffer_max_size_bytes)."
 		}
 		transform_buffer_max_event_size: {
-			description:       "The maximum number of events the buffer that feeds into a transform can hold."
-			type:              "gauge"
-			default_namespace: "vector"
-			tags:              _component_tags
+			description:        "The maximum number of events the buffer that feeds into a transform can hold."
+			type:               "gauge"
+			default_namespace:  "vector"
+			tags:               _component_tags
 			deprecated:         true
 			deprecated_message: "This metric has been deprecated in favor of [`transform_buffer_max_size_events`](#transform_buffer_max_size_events)."
 		}

--- a/website/cue/reference/components/sources/internal_metrics.cue
+++ b/website/cue/reference/components/sources/internal_metrics.cue
@@ -371,7 +371,7 @@ components: sources: internal_metrics: {
 			type:              "counter"
 			default_namespace: "vector"
 			tags: _component_tags & {
-				error_code: _error_code
+				error_code: _buffer_error_code
 				error_type: _error_type
 				stage:      _stage
 			}
@@ -1180,6 +1180,17 @@ components: sources: internal_metrics: {
 		_buffer_id: {
 			description: "The unique identifier of the buffer."
 			required:    true
+		}
+		_buffer_error_code: {
+			description: "The specific error code emitted for a buffer read failure."
+			required:    true
+			enum: {
+				"deser_failed":               "The buffer record could not be deserialized."
+				"checksum_mismatch":          "The buffer record checksum did not match the expected value."
+				"decode_failed":              "The buffer record could not be decoded."
+				"incompatible_record_version": "The buffer record version is incompatible with this reader."
+				"partial_write":              "The buffer contained a partially written record."
+			}
 		}
 		_buffer_stage: {
 			description: "The numbered stage within the buffer pipeline."

--- a/website/cue/reference/components/sources/internal_metrics.cue
+++ b/website/cue/reference/components/sources/internal_metrics.cue
@@ -665,7 +665,7 @@ components: sources: internal_metrics: {
 		}
 		open_files: {
 			description:       "The total number of open files."
-			type:              "counter"
+			type:              "gauge"
 			default_namespace: "vector"
 			tags:              _component_tags
 		}
@@ -997,9 +997,7 @@ components: sources: internal_metrics: {
 			description:       "The maximum number of bytes the buffer that feeds into a transform can hold."
 			type:              "gauge"
 			default_namespace: "vector"
-			tags: _component_tags & {
-				output: _output
-			}
+			tags:              _component_tags
 			deprecated:         true
 			deprecated_message: "This metric has been deprecated in favor of [`transform_buffer_max_size_bytes`](#transform_buffer_max_size_bytes)."
 		}
@@ -1007,9 +1005,7 @@ components: sources: internal_metrics: {
 			description:       "The maximum number of events the buffer that feeds into a transform can hold."
 			type:              "gauge"
 			default_namespace: "vector"
-			tags: _component_tags & {
-				output: _output
-			}
+			tags:              _component_tags
 			deprecated:         true
 			deprecated_message: "This metric has been deprecated in favor of [`transform_buffer_max_size_events`](#transform_buffer_max_size_events)."
 		}
@@ -1017,41 +1013,31 @@ components: sources: internal_metrics: {
 			description:       "The maximum number of bytes the buffer that feeds into a transform can hold."
 			type:              "gauge"
 			default_namespace: "vector"
-			tags: _component_tags & {
-				output: _output
-			}
+			tags:              _component_tags
 		}
 		transform_buffer_max_size_events: {
 			description:       "The maximum number of events the buffer that feeds into a transform can hold."
 			type:              "gauge"
 			default_namespace: "vector"
-			tags: _component_tags & {
-				output: _output
-			}
+			tags:              _component_tags
 		}
 		transform_buffer_utilization: {
 			description:       "The utilization level of the buffer that feeds into a transform."
 			type:              "histogram"
 			default_namespace: "vector"
-			tags: _component_tags & {
-				output: _output
-			}
+			tags:              _component_tags
 		}
 		transform_buffer_utilization_level: {
 			description:       "The current utilization level of the buffer that feeds into a transform."
 			type:              "gauge"
 			default_namespace: "vector"
-			tags: _component_tags & {
-				output: _output
-			}
+			tags:              _component_tags
 		}
 		transform_buffer_utilization_mean: {
 			description:       "The mean utilization level of the buffer that feeds into a transform. This value is smoothed over time using an exponentially weighted moving average (EWMA)."
 			type:              "gauge"
 			default_namespace: "vector"
-			tags: _component_tags & {
-				output: _output
-			}
+			tags:              _component_tags
 		}
 		uptime_seconds: {
 			description:       "The total number of seconds the Vector instance has been up."

--- a/website/cue/reference/components/sources/internal_metrics.cue
+++ b/website/cue/reference/components/sources/internal_metrics.cue
@@ -320,10 +320,7 @@ components: sources: internal_metrics: {
 			description:        "The number of bytes currently in the buffer."
 			type:               "gauge"
 			default_namespace:  "vector"
-			tags: _component_tags & {
-				buffer_id: _buffer_id
-				stage:     _buffer_stage
-			}
+			tags:               _buffer_tags
 			deprecated:         true
 			deprecated_message: "This metric has been deprecated in favor of [`buffer_size_bytes`](#buffer_size_bytes)."
 		}
@@ -331,10 +328,7 @@ components: sources: internal_metrics: {
 			description:        "The number of events currently in the buffer."
 			type:               "gauge"
 			default_namespace:  "vector"
-			tags: _component_tags & {
-				buffer_id: _buffer_id
-				stage:     _buffer_stage
-			}
+			tags:               _buffer_tags
 			deprecated:         true
 			deprecated_message: "This metric has been deprecated in favor of [`buffer_size_events`](#buffer_size_events)."
 		}
@@ -342,27 +336,19 @@ components: sources: internal_metrics: {
 			description:       "The number of bytes currently in the buffer."
 			type:              "gauge"
 			default_namespace: "vector"
-			tags: _component_tags & {
-				buffer_id: _buffer_id
-				stage:     _buffer_stage
-			}
+			tags:              _buffer_tags
 		}
 		buffer_size_events: {
 			description:       "The number of events currently in the buffer."
 			type:              "gauge"
 			default_namespace: "vector"
-			tags: _component_tags & {
-				buffer_id: _buffer_id
-				stage:     _buffer_stage
-			}
+			tags:              _buffer_tags
 		}
 		buffer_discarded_events_total: {
 			description:       "The number of events dropped by this non-blocking buffer."
 			type:              "counter"
 			default_namespace: "vector"
-			tags: _component_tags & {
-				buffer_id: _buffer_id
-				stage:     _buffer_stage
+			tags: _buffer_tags & {
 				intentional: {
 					description: "True if the events were discarded intentionally, like a `filter` transform, or false if due to an error."
 					required:    true
@@ -373,9 +359,7 @@ components: sources: internal_metrics: {
 			description:       "The number of bytes dropped by this non-blocking buffer."
 			type:              "counter"
 			default_namespace: "vector"
-			tags: _component_tags & {
-				buffer_id: _buffer_id
-				stage:     _buffer_stage
+			tags: _buffer_tags & {
 				intentional: {
 					description: "True if the events were discarded intentionally, like a `filter` transform, or false if due to an error."
 					required:    true
@@ -396,19 +380,13 @@ components: sources: internal_metrics: {
 			description:       "The number of bytes received by this buffer."
 			type:              "counter"
 			default_namespace: "vector"
-			tags: _component_tags & {
-				buffer_id: _buffer_id
-				stage:     _buffer_stage
-			}
+			tags:              _buffer_tags
 		}
 		buffer_received_events_total: {
 			description:       "The number of events received by this buffer."
 			type:              "counter"
 			default_namespace: "vector"
-			tags: _component_tags & {
-				buffer_id: _buffer_id
-				stage:     _buffer_stage
-			}
+			tags:              _buffer_tags
 		}
 		buffer_send_duration_seconds: {
 			description:       "The duration spent sending a payload to this buffer."
@@ -422,19 +400,13 @@ components: sources: internal_metrics: {
 			description:       "The number of bytes sent by this buffer."
 			type:              "counter"
 			default_namespace: "vector"
-			tags: _component_tags & {
-				buffer_id: _buffer_id
-				stage:     _buffer_stage
-			}
+			tags:              _buffer_tags
 		}
 		buffer_sent_events_total: {
 			description:       "The number of events sent by this buffer."
 			type:              "counter"
 			default_namespace: "vector"
-			tags: _component_tags & {
-				buffer_id: _buffer_id
-				stage:     _buffer_stage
-			}
+			tags:              _buffer_tags
 		}
 		component_discarded_events_total: {
 			description:       "The number of events dropped by this component."
@@ -1200,6 +1172,10 @@ components: sources: internal_metrics: {
 			description: "The Vector component type."
 			required:    true
 			examples: ["file", "http", "honeycomb", "splunk_hec"]
+		}
+		_buffer_tags: _component_tags & {
+			buffer_id: _buffer_id
+			stage:     _buffer_stage
 		}
 		_buffer_id: {
 			description: "The unique identifier of the buffer."

--- a/website/cue/reference/components/sources/internal_metrics.cue
+++ b/website/cue/reference/components/sources/internal_metrics.cue
@@ -202,20 +202,6 @@ components: sources: internal_metrics: {
 			default_namespace: "vector"
 			tags:              _component_tags
 		}
-		connection_read_errors_total: {
-			description:       "The total number of errors reading datagram."
-			type:              "counter"
-			default_namespace: "vector"
-			tags: _component_tags & {
-				mode: {
-					description: ""
-					required:    true
-					enum: {
-						udp: "User Datagram Protocol"
-					}
-				}
-			}
-		}
 		container_processed_events_total: {
 			description:       "The total number of container events processed."
 			type:              "counter"
@@ -725,12 +711,6 @@ components: sources: internal_metrics: {
 				status: _status
 			}
 		}
-		invalid_record_total: {
-			description:       "The total number of invalid records that have been discarded."
-			type:              "counter"
-			default_namespace: "vector"
-			tags:              _component_tags
-		}
 		lua_memory_used_bytes: {
 			description:       "The total memory currently being used by the Lua runtime."
 			type:              "gauge"
@@ -754,18 +734,6 @@ components: sources: internal_metrics: {
 			type:              "gauge"
 			default_namespace: "vector"
 			tags:              _internal_metrics_tags
-		}
-		protobuf_decode_errors_total: {
-			description:       "The total number of [Protocol Buffers](\(urls.protobuf)) errors thrown during communication between Vector instances."
-			type:              "counter"
-			default_namespace: "vector"
-			tags:              _component_tags
-		}
-		send_errors_total: {
-			description:       "The total number of errors sending messages."
-			type:              "counter"
-			default_namespace: "vector"
-			tags:              _component_tags
 		}
 		source_lag_time_seconds: {
 			description:       "The difference between the timestamp recorded in each event and the time when it was ingested, expressed as fractional seconds."
@@ -851,12 +819,6 @@ components: sources: internal_metrics: {
 			default_namespace: "vector"
 			tags:              _component_tags
 		}
-		streams_total: {
-			description:       "The total number of streams."
-			type:              "counter"
-			default_namespace: "vector"
-			tags:              _component_tags
-		}
 		s3_object_processing_failed_duration_seconds: {
 			description:       "The time taken to process an S3 object that failed, in seconds."
 			type:              "histogram"
@@ -924,12 +886,6 @@ components: sources: internal_metrics: {
 			default_namespace: "vector"
 			tags:              _component_tags
 		}
-		stdin_reads_failed_total: {
-			description:       "The total number of errors reading from stdin."
-			type:              "counter"
-			default_namespace: "vector"
-			tags:              _component_tags
-		}
 		tag_value_limit_exceeded_total: {
 			description: """
 				The total number of events discarded because the tag has been rejected after
@@ -956,12 +912,6 @@ components: sources: internal_metrics: {
 					required: false
 				}
 			}
-		}
-		timestamp_parse_errors_total: {
-			description:       "The total number of errors encountered parsing [RFC 3339](\(urls.rfc_3339)) timestamps."
-			type:              "counter"
-			default_namespace: "vector"
-			tags:              _component_tags
 		}
 		transform_buffer_max_byte_size: {
 			description:       "The maximum number of bytes the buffer that feeds into a transform can hold."
@@ -1028,20 +978,6 @@ components: sources: internal_metrics: {
 			type:              "gauge"
 			default_namespace: "vector"
 			tags:              _internal_metrics_tags
-		}
-		utf8_convert_errors_total: {
-			description:       "The total number of errors converting bytes to a UTF-8 string in UDP mode."
-			type:              "counter"
-			default_namespace: "vector"
-			tags: _component_tags & {
-				mode: {
-					description: "The connection mode used by the component."
-					required:    true
-					enum: {
-						udp: "User Datagram Protocol"
-					}
-				}
-			}
 		}
 		utilization: {
 			description:       "A ratio from 0 to 1 of the load on a component. A value of 0 would indicate a completely idle component that is simply waiting for input. A value of 1 would indicate a that is never idle. This value is updated every 5 seconds."
@@ -1123,22 +1059,6 @@ components: sources: internal_metrics: {
 			description: """
 				The total number of times the Windows service has been uninstalled.
 				"""
-			type:              "counter"
-			default_namespace: "vector"
-			tags:              _internal_metrics_tags
-		}
-
-		// config metrics
-		config_reload_rejected: {
-			description:       "Number of configuration reload attempts that were rejected."
-			type:              "counter"
-			default_namespace: "vector"
-			tags: _internal_metrics_tags & {
-				reason: _reason
-			}
-		}
-		config_reloaded: {
-			description:       "Number of times a new configuration was loaded successfully."
 			type:              "counter"
 			default_namespace: "vector"
 			tags:              _internal_metrics_tags

--- a/website/cue/reference/components/sources/internal_metrics.cue
+++ b/website/cue/reference/components/sources/internal_metrics.cue
@@ -320,7 +320,10 @@ components: sources: internal_metrics: {
 			description:        "The number of bytes currently in the buffer."
 			type:               "gauge"
 			default_namespace:  "vector"
-			tags:               _component_tags
+			tags: _component_tags & {
+				buffer_id: _buffer_id
+				stage:     _buffer_stage
+			}
 			deprecated:         true
 			deprecated_message: "This metric has been deprecated in favor of [`buffer_size_bytes`](#buffer_size_bytes)."
 		}
@@ -328,7 +331,10 @@ components: sources: internal_metrics: {
 			description:        "The number of events currently in the buffer."
 			type:               "gauge"
 			default_namespace:  "vector"
-			tags:               _component_tags
+			tags: _component_tags & {
+				buffer_id: _buffer_id
+				stage:     _buffer_stage
+			}
 			deprecated:         true
 			deprecated_message: "This metric has been deprecated in favor of [`buffer_size_events`](#buffer_size_events)."
 		}
@@ -336,25 +342,45 @@ components: sources: internal_metrics: {
 			description:       "The number of bytes currently in the buffer."
 			type:              "gauge"
 			default_namespace: "vector"
-			tags:              _component_tags
+			tags: _component_tags & {
+				buffer_id: _buffer_id
+				stage:     _buffer_stage
+			}
 		}
 		buffer_size_events: {
 			description:       "The number of events currently in the buffer."
 			type:              "gauge"
 			default_namespace: "vector"
-			tags:              _component_tags
+			tags: _component_tags & {
+				buffer_id: _buffer_id
+				stage:     _buffer_stage
+			}
 		}
 		buffer_discarded_events_total: {
 			description:       "The number of events dropped by this non-blocking buffer."
 			type:              "counter"
 			default_namespace: "vector"
-			tags:              _component_tags
+			tags: _component_tags & {
+				buffer_id: _buffer_id
+				stage:     _buffer_stage
+				intentional: {
+					description: "True if the events were discarded intentionally, like a `filter` transform, or false if due to an error."
+					required:    true
+				}
+			}
 		}
 		buffer_discarded_bytes_total: {
 			description:       "The number of bytes dropped by this non-blocking buffer."
 			type:              "counter"
 			default_namespace: "vector"
-			tags:              _component_tags
+			tags: _component_tags & {
+				buffer_id: _buffer_id
+				stage:     _buffer_stage
+				intentional: {
+					description: "True if the events were discarded intentionally, like a `filter` transform, or false if due to an error."
+					required:    true
+				}
+			}
 		}
 		buffer_errors_total: {
 			description:       "The total number of errors encountered by this buffer."
@@ -370,31 +396,45 @@ components: sources: internal_metrics: {
 			description:       "The number of bytes received by this buffer."
 			type:              "counter"
 			default_namespace: "vector"
-			tags:              _component_tags
+			tags: _component_tags & {
+				buffer_id: _buffer_id
+				stage:     _buffer_stage
+			}
 		}
 		buffer_received_events_total: {
 			description:       "The number of events received by this buffer."
 			type:              "counter"
 			default_namespace: "vector"
-			tags:              _component_tags
+			tags: _component_tags & {
+				buffer_id: _buffer_id
+				stage:     _buffer_stage
+			}
 		}
 		buffer_send_duration_seconds: {
 			description:       "The duration spent sending a payload to this buffer."
 			type:              "histogram"
 			default_namespace: "vector"
-			tags:              _component_tags
+			tags: _component_tags & {
+				stage: _buffer_stage
+			}
 		}
 		buffer_sent_bytes_total: {
 			description:       "The number of bytes sent by this buffer."
 			type:              "counter"
 			default_namespace: "vector"
-			tags:              _component_tags
+			tags: _component_tags & {
+				buffer_id: _buffer_id
+				stage:     _buffer_stage
+			}
 		}
 		buffer_sent_events_total: {
 			description:       "The number of events sent by this buffer."
 			type:              "counter"
 			default_namespace: "vector"
-			tags:              _component_tags
+			tags: _component_tags & {
+				buffer_id: _buffer_id
+				stage:     _buffer_stage
+			}
 		}
 		component_discarded_events_total: {
 			description:       "The number of events dropped by this component."
@@ -1160,6 +1200,14 @@ components: sources: internal_metrics: {
 			description: "The Vector component type."
 			required:    true
 			examples: ["file", "http", "honeycomb", "splunk_hec"]
+		}
+		_buffer_id: {
+			description: "The unique identifier of the buffer."
+			required:    true
+		}
+		_buffer_stage: {
+			description: "The numbered stage within the buffer pipeline."
+			required:    true
 		}
 		_endpoint: {
 			description: "The absolute path of originating file."

--- a/website/cue/reference/components/sources/stdin.cue
+++ b/website/cue/reference/components/sources/stdin.cue
@@ -91,7 +91,5 @@ components: sources: stdin: {
 		}
 	}
 
-	telemetry: metrics: {
-		stdin_reads_failed_total: components.sources.internal_metrics.output.metrics.stdin_reads_failed_total
-	}
+	telemetry: metrics: {}
 }

--- a/website/cue/reference/components/sources/syslog.cue
+++ b/website/cue/reference/components/sources/syslog.cue
@@ -211,8 +211,6 @@ components: sources: syslog: {
 	}
 
 	telemetry: metrics: {
-		connection_read_errors_total: components.sources.internal_metrics.output.metrics.connection_read_errors_total
-		utf8_convert_errors_total:    components.sources.internal_metrics.output.metrics.utf8_convert_errors_total
-		component_received_bytes:     components.sources.internal_metrics.output.metrics.component_received_bytes
+		component_received_bytes: components.sources.internal_metrics.output.metrics.component_received_bytes
 	}
 }

--- a/website/cue/reference/components/sources/vector.cue
+++ b/website/cue/reference/components/sources/vector.cue
@@ -105,6 +105,5 @@ components: sources: vector: {
 		grpc_server_handler_duration_seconds: components.sources.internal_metrics.output.metrics.grpc_server_handler_duration_seconds
 		grpc_server_messages_received_total:  components.sources.internal_metrics.output.metrics.grpc_server_messages_received_total
 		grpc_server_messages_sent_total:      components.sources.internal_metrics.output.metrics.grpc_server_messages_sent_total
-		protobuf_decode_errors_total:         components.sources.internal_metrics.output.metrics.protobuf_decode_errors_total
 	}
 }


### PR DESCRIPTION
## Summary

Fixes multiple discrepancies in the CUE metric catalog (`website/cue/reference/components/sources/internal_metrics.cue`).

Four separate commits, one per issue class:

**1 – Wrong metric names (HIGH)**
- `buffer_received_event_bytes_total` → `buffer_received_bytes_total`
- `buffer_sent_event_bytes_total` → `buffer_sent_bytes_total`

These names are fixed in `lib/vector-common/src/internal_event/metric_name.rs` as `BufferReceivedBytesTotal`/`BufferSentBytesTotal`. Users querying the old names got no data.

**2 – Stale metrics (no longer emitted)**

Removed 10 metrics absent from `metric_name.rs` and all emit sites:
`connection_read_errors_total`, `utf8_convert_errors_total`, `stdin_reads_failed_total`, `protobuf_decode_errors_total` (sinks/vector + sources/vector), `send_errors_total` (nats, redis), `streams_total` (loki), `invalid_record_total`, `timestamp_parse_errors_total`, `config_reload_rejected`, `config_reloaded`.

**3 – Emitted metrics missing from documentation**

Added 11 metrics present in `metric_name.rs` but absent from the catalog:
- Buffer: `buffer_discarded_bytes_total`, `buffer_errors_total`
- Adaptive concurrency: `adaptive_concurrency_back_pressure`, `adaptive_concurrency_past_rtt_mean`, `adaptive_concurrency_reached_limit`
- HTTP client: `http_client_errors_total`, `http_client_error_rtt_seconds`
- Infrastructure: `active_endpoints`, `sqs_message_defer_succeeded_total`, `k8s_event_namespace_annotation_failures_total`, `k8s_event_node_annotation_failures_total`

**4 – Metric metadata corrections**
- `open_files`: documented as `counter` but emitted as `gauge!(GaugeName::OpenFiles)` in `src/internal_events/file.rs`
- `transform_buffer_*` (7 metrics): documented with an `output` tag that is never present — `src/topology/builder.rs` always constructs transform channel metrics with `ChannelMetricMetadata::new(Transform, None)`

## Vector configuration

N/A — documentation-only change.

## How did you test this PR?

Cross-referenced all changes against:
- `lib/vector-common/src/internal_event/metric_name.rs` (canonical metric registry)
- Individual `emit!()` / `counter!()` / `gauge!()` call sites in `src/internal_events/` and `lib/vector-buffers/src/internal_events.rs`
- `src/topology/builder.rs` for transform buffer tag behavior

## Change Type

- [x] Non-functional (chore, refactoring, docs)

## Is this a breaking change?

- [x] No

## Does this PR include user facing changes?

- [x] No. A maintainer will apply the `no-changelog` label to this PR.
