### PR TITLE
docs(schemas): improve log_namespace docs and warn on log_schema

### DIFF
--- a/lib/vector-core/src/config/global_options.rs
+++ b/lib/vector-core/src/config/global_options.rs
@@ -84,7 +84,11 @@ pub struct GlobalOptions {
     /// This is used if a component does not have its own specific log schema. All events use a log
     /// schema, whether or not the default is used, to assign event fields on incoming events.
     #[serde(default, skip_serializing_if = "crate::serde::is_default")]
-    #[configurable(metadata(docs::common = false, docs::required = false))]
+    #[configurable(metadata(
+        docs::common = false,
+        docs::required = false,
+        docs::warnings = "These settings are ignored when `schema.log_namespace` is set to `true`."
+    ))]
     pub log_schema: LogSchema,
 
     /// Telemetry options.

--- a/src/config/schema.rs
+++ b/src/config/schema.rs
@@ -30,6 +30,8 @@ pub struct Options {
 
     /// Controls how metadata is stored in log events.
     ///
+    /// This feature is in beta and behavior may change.
+    ///
     /// When set to `false` (legacy mode), metadata fields like `host`, `timestamp`, and `source_type`
     /// are stored as top-level fields alongside your log data.
     ///
@@ -39,6 +41,7 @@ pub struct Options {
     /// See the [Log Namespacing guide](/guides/level-up/log_namespace/) for detailed information
     /// about when to use Vector namespace mode and how to migrate from legacy mode.
     #[configurable(metadata(
+        status = "beta",
         docs::warnings = "Enabling log namespacing currently does not work when disk buffers are used. Avoid combining `schema.log_namespace = true` with disk buffers until [#18574](https://github.com/vectordotdev/vector/issues/18574) is resolved."
     ))]
     pub log_namespace: Option<bool>,

--- a/website/content/en/guides/level-up/log_namespace.md
+++ b/website/content/en/guides/level-up/log_namespace.md
@@ -23,6 +23,12 @@ If you encounter any issues please [report them here](https://github.com/vectord
 
 {{< /requirement >}}
 
+{{< warning >}}
+Enabling log namespacing does not work when disk buffers are used. Avoid combining
+`schema.log_namespace: true` with disk buffers until
+[#18574](https://github.com/vectordotdev/vector/issues/18574) is resolved.
+{{< /warning >}}
+
 ## Background
 
 Vector traditionally stored metadata (like `host`, `timestamp`, and `source_type`) as top-level

--- a/website/cue/reference/generated/configuration.cue
+++ b/website/cue/reference/generated/configuration.cue
@@ -433,6 +433,8 @@ generated: configuration: {
 					description: """
 						Controls how metadata is stored in log events.
 
+						This feature is in beta and behavior may change.
+
 						When set to `false` (legacy mode), metadata fields like `host`, `timestamp`, and `source_type`
 						are stored as top-level fields alongside your log data.
 
@@ -1498,7 +1500,8 @@ generated: configuration: {
 				"""
 			common:   false
 			required: false
-			group:    "schema"
+			warnings: ["These settings are ignored when `schema.log_namespace` is set to `true`."]
+			group: "schema"
 		}
 		metrics_storage_refresh_period: {
 			type: float: {}


### PR DESCRIPTION
## Summary

Docs improvements for `schema.log_namespace` and the related `log_schema`:

- Adds a `{{< warning >}}` callout in the log namespace guide for the disk buffer incompatibility.
- Adds a beta note in the `log_namespace` field description on the reference page.
- Marks the `log_namespace` field with `status = "beta"` in Rust metadata.
- Adds a warning on `log_schema` noting it is ignored when `schema.log_namespace = true`.

### Future work

`#[configurable(metadata(status = "beta"))]` does not currently render a visible marker for fields. A follow-up could surface this in the generated docs.

## Tests
<img width="798" height="344" alt="Screenshot 2026-06-02 at 11 24 08 AM" src="https://github.com/user-attachments/assets/76b639c2-5f0f-4edf-b5aa-149f65eb313c" />

<img width="677" height="447" alt="Screenshot 2026-06-02 at 11 24 40 AM" src="https://github.com/user-attachments/assets/92101358-f490-4d35-aabb-6d78d2e78f66" />

<img width="719" height="265" alt="Screenshot 2026-06-02 at 11 25 59 AM" src="https://github.com/user-attachments/assets/1724ac1a-fd23-4770-96ba-4b4e09189a9b" />

## Change Type

- [x] Non-functional (chore, refactoring, docs)

## Is this a breaking change?

- [x] No

## Does this PR include user facing changes?

- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: https://github.com/vectordotdev/vector/issues/21360
- Related: https://github.com/vectordotdev/vector/issues/18574