### PR TITLE
feat(databricks_zerobus sink): add user_agent config option

### DIFF
--- a/changelog.d/25561_databricks_zerobus_user_agent.enhancement.md
+++ b/changelog.d/25561_databricks_zerobus_user_agent.enhancement.md
@@ -1,0 +1,3 @@
+The `databricks_zerobus` sink now supports a `user_agent` option whose value is appended to the `user-agent` header sent to Databricks. The header always identifies Vector (`Vector/<version>`); when set, the configured value is appended after it.
+
+authors: flaviocruz

--- a/src/sinks/databricks_zerobus/config.rs
+++ b/src/sinks/databricks_zerobus/config.rs
@@ -449,7 +449,10 @@ mod tests {
             "expected Vector/<version> prefix, got {suffix:?}"
         );
         // No user value configured, so nothing is appended.
-        assert!(!suffix.contains(' '), "unexpected appended value in {suffix:?}");
+        assert!(
+            !suffix.contains(' '),
+            "unexpected appended value in {suffix:?}"
+        );
     }
 
     #[test]
@@ -473,6 +476,9 @@ mod tests {
         config.user_agent = Some(String::new());
         let suffix = config.user_agent_suffix();
         // An empty string is treated the same as no value: no trailing space.
-        assert!(!suffix.contains(' '), "empty user_agent should be ignored, got {suffix:?}");
+        assert!(
+            !suffix.contains(' '),
+            "empty user_agent should be ignored, got {suffix:?}"
+        );
     }
 }

--- a/src/sinks/databricks_zerobus/config.rs
+++ b/src/sinks/databricks_zerobus/config.rs
@@ -109,6 +109,14 @@ pub struct ZerobusSinkConfig {
     #[configurable(derived)]
     pub auth: DatabricksAuthentication,
 
+    /// Custom identifier appended to the `user-agent` header sent to Databricks.
+    ///
+    /// The header always includes `Vector/<version>`; when set, this value is
+    /// appended after it (e.g. `my-service/1.2`).
+    #[serde(default)]
+    #[configurable(metadata(docs::examples = "my-service/1.2"))]
+    pub user_agent: Option<String>,
+
     #[configurable(derived)]
     #[serde(default)]
     pub stream_options: ZerobusStreamOptions,
@@ -140,6 +148,7 @@ impl GenerateConfig for ZerobusSinkConfig {
                 client_id: SensitiveString::from("${DATABRICKS_CLIENT_ID}".to_string()),
                 client_secret: SensitiveString::from("${DATABRICKS_CLIENT_SECRET}".to_string()),
             },
+            user_agent: None,
             stream_options: ZerobusStreamOptions::default(),
             batch: BatchConfig::default(),
             request: TowerRequestConfig::default(),
@@ -246,6 +255,17 @@ impl ZerobusSinkConfig {
 
         Ok(())
     }
+
+    /// The user-agent suffix to hand the Zerobus SDK: `Vector/<version>`
+    /// alone, or with the user's configured `user_agent` appended. The SDK
+    /// prepends its own `zerobus-sdk-rs/<version>` prefix to this value.
+    pub fn user_agent_suffix(&self) -> String {
+        let vector = format!("Vector/{}", crate::vector_version());
+        match self.user_agent.as_deref().filter(|s| !s.is_empty()) {
+            Some(ua) => format!("{vector} {ua}"),
+            None => vector,
+        }
+    }
 }
 
 // Default value functions
@@ -271,6 +291,7 @@ mod tests {
                 client_id: SensitiveString::from("test-client-id".to_string()),
                 client_secret: SensitiveString::from("test-client-secret".to_string()),
             },
+            user_agent: None,
             stream_options: ZerobusStreamOptions::default(),
             batch: Default::default(),
             request: Default::default(),
@@ -417,5 +438,41 @@ mod tests {
             .expect("batch settings should build");
 
         assert_eq!(settings.size_limit, 10_000_000);
+    }
+
+    #[test]
+    fn test_user_agent_suffix_without_user_value() {
+        let config = create_test_config();
+        let suffix = config.user_agent_suffix();
+        assert!(
+            suffix.starts_with("Vector/"),
+            "expected Vector/<version> prefix, got {suffix:?}"
+        );
+        // No user value configured, so nothing is appended.
+        assert!(!suffix.contains(' '), "unexpected appended value in {suffix:?}");
+    }
+
+    #[test]
+    fn test_user_agent_suffix_with_user_value() {
+        let mut config = create_test_config();
+        config.user_agent = Some("my-service/1.2".to_string());
+        let suffix = config.user_agent_suffix();
+        assert!(
+            suffix.starts_with("Vector/"),
+            "expected Vector/<version> prefix, got {suffix:?}"
+        );
+        assert!(
+            suffix.ends_with(" my-service/1.2"),
+            "expected user value appended, got {suffix:?}"
+        );
+    }
+
+    #[test]
+    fn test_user_agent_suffix_empty_user_value_ignored() {
+        let mut config = create_test_config();
+        config.user_agent = Some(String::new());
+        let suffix = config.user_agent_suffix();
+        // An empty string is treated the same as no value: no trailing space.
+        assert!(!suffix.contains(' '), "empty user_agent should be ignored, got {suffix:?}");
     }
 }

--- a/src/sinks/databricks_zerobus/service.rs
+++ b/src/sinks/databricks_zerobus/service.rs
@@ -298,7 +298,8 @@ impl ZerobusService {
     ) -> Result<Self, ZerobusSinkError> {
         let mut builder = ZerobusSdk::builder()
             .endpoint(&config.ingestion_endpoint)
-            .unity_catalog_url(&config.unity_catalog_endpoint);
+            .unity_catalog_url(&config.unity_catalog_endpoint)
+            .application_name(config.user_agent_suffix());
         builder = builder.connector_factory(build_connector_factory(proxy)?);
         let sdk = builder.build().map_err(|e| ZerobusSinkError::ConfigError {
             message: format!("Failed to create Zerobus SDK: {}", e),
@@ -691,6 +692,7 @@ mod tests {
                 client_id: SensitiveString::from("id".to_string()),
                 client_secret: SensitiveString::from("secret".to_string()),
             },
+            user_agent: None,
             stream_options: ZerobusStreamOptions::default(),
             batch: Default::default(),
             request: Default::default(),

--- a/website/cue/reference/components/sinks/generated/databricks_zerobus.cue
+++ b/website/cue/reference/components/sinks/generated/databricks_zerobus.cue
@@ -320,4 +320,14 @@ generated: components: sinks: databricks_zerobus: configuration: {
 		required: true
 		type: string: examples: ["https://dbc-e2f0eb31-2b0e.staging.cloud.databricks.com", "https://your-workspace.cloud.databricks.com"]
 	}
+	user_agent: {
+		description: """
+			Custom identifier appended to the `user-agent` header sent to Databricks.
+
+			The header always includes `Vector/<version>`; when set, this value is
+			appended after it (e.g. `my-service/1.2`).
+			"""
+		required: false
+		type: string: examples: ["my-service/1.2"]
+	}
 }


### PR DESCRIPTION

## Summary

Add an optional `user_agent` config field whose value is appended to the `user-agent` header sent to Databricks via the Zerobus SDK's `application_name`. The header always identifies Vector (`Vector/<version>`), preserving the SDK's own `zerobus-sdk-rs/<version>` prefix; the configured value is appended after it when set.
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

## Vector configuration

```
  sinks:
    zb:
      type: databricks_zerobus
      inputs: [demo]
      ingestion_endpoint: "https://ingest.dev.databricks.com"
      unity_catalog_endpoint: "https://workspace.cloud.databricks.com"
      table_name: "main.default.my_table"
      user_agent: "My Application"
      auth:
        strategy: oauth
        client_id: "${DATABRICKS_CLIENT_ID}"
        client_secret: "${DATABRICKS_CLIENT_SECRET}"
```

## How did you test this PR?
Unit tests.

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Closes: #<issue/PR number or link>
-->
<!--
- Related: #<issue/PR number or link>
-->

## Notes

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details on the [dd-rust-license-tool](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
