### PR TITLE
fix(databricks_zerobus sink): return pool-resolved DescriptorProto to fix nested-type ingestion

### DIFF
--- a/changelog.d/databricks-zerobus-descriptor-fqn.fix.md
+++ b/changelog.d/databricks-zerobus-descriptor-fqn.fix.md
@@ -1,0 +1,8 @@
+Fixed the Databricks Zerobus sink sending unresolved (relative) protobuf type
+names to the Databricks ingestion server when schemas contain nested struct
+fields. The server rejected such descriptors with
+"Proto not self-contained for field '…' with type name '…'". The sink now
+sends the pool-resolved descriptor with fully-qualified type names, matching
+the behavior expected by SDK ≥ 2.0.1.
+
+authors: gwenaskell

--- a/src/sinks/databricks_zerobus/unity_catalog_schema.rs
+++ b/src/sinks/databricks_zerobus/unity_catalog_schema.rs
@@ -377,7 +377,34 @@ pub fn generate_descriptor_from_schema(
         );
     }
 
-    Ok((message_descriptor, sdk_message_proto))
+    // Return the pool-resolved DescriptorProto rather than the raw SDK proto.
+    //
+    // `sdk_message_proto` (from `descriptor_from_uc_schema`) contains relative
+    // type names for nested-message fields (e.g. `type_name: "Metadata"`).
+    // After `DescriptorPool::from_file_descriptor_set` the pool resolves those
+    // to fully-qualified names (e.g. `type_name: ".catalog.Row.Metadata"`).
+    // `message_descriptor.descriptor_proto()` exposes the resolved form.
+    //
+    // SDK ≥ 2.0.1 passes the `DescriptorProto` straight to the Databricks
+    // server, which rejects unresolved relative type names with
+    // "Proto not self-contained for field '…' with type name '…'".
+    // Re-encoding through the wire format bridges prost-types 0.13 → 0.14.
+    let resolved_013 = message_descriptor.descriptor_proto().clone();
+    let resolved_encoded =
+        <prost_reflect::prost_types::DescriptorProto as prost_reflect::prost::Message>::encode_to_vec(
+            &resolved_013,
+        );
+    let resolved_014 = <prost_types_014::DescriptorProto as prost_014::Message>::decode(
+        resolved_encoded.as_slice(),
+    )
+    .map_err(|e| ZerobusSinkError::ConfigError {
+        message: format!(
+            "Failed to re-encode resolved DescriptorProto to prost-types 0.14: {}",
+            e
+        ),
+    })?;
+
+    Ok((message_descriptor, resolved_014))
 }
 
 /// Default prefix for package name segments that start with a non-letter.
@@ -509,6 +536,47 @@ mod tests {
             proto_text.contains("message Field008"),
             "Proto should have Field008 nested message"
         );
+    }
+
+    /// Regression test: the DescriptorProto returned by
+    /// `generate_descriptor_from_schema` must have fully-qualified (absolute)
+    /// type names for all message-type fields.
+    ///
+    /// Before the fix, the raw SDK `DescriptorProto` was returned with relative
+    /// type names (e.g. `"Metadata"`). The Databricks server rejects those with
+    /// "Proto not self-contained for field '…' with type name '…'".
+    /// After the fix, the pool-resolved form is returned, where type names are
+    /// absolute FQNs starting with `.` (e.g. `".test_catalog.Row.Metadata"`).
+    #[test]
+    fn test_returned_descriptor_proto_has_fqn_type_names() {
+        let json = include_str!("tests/fixtures/nested_structs_complete_schema.json");
+        let schema: UnityCatalogTableSchema =
+            serde_json::from_str(json).expect("Failed to parse nested_structs_complete schema");
+
+        let (_descriptor, sdk_proto) =
+            generate_descriptor_from_schema(&schema).expect("Failed to generate descriptor");
+
+        fn check_fqn_recursive(desc_proto: &prost_types_014::DescriptorProto) {
+            for field in &desc_proto.field {
+                if let Some(type_name) = &field.type_name
+                    && !type_name.is_empty()
+                {
+                    assert!(
+                        type_name.starts_with('.'),
+                        "field '{}' has relative type_name '{}'; expected a fully-qualified \
+                             name starting with '.' — this indicates the raw (unresolved) SDK \
+                             DescriptorProto was returned instead of the pool-resolved one",
+                        field.name.as_deref().unwrap_or("<unknown>"),
+                        type_name,
+                    );
+                }
+            }
+            for nested in &desc_proto.nested_type {
+                check_fqn_recursive(nested);
+            }
+        }
+
+        check_fqn_recursive(&sdk_proto);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The Databricks Zerobus sink was broken for tables with nested struct fields after bumping the `databricks-zerobus-ingest-sdk` from 1.2.0 (private git) to 2.0.1 (crates.io) in #25438.

**Root cause:** `generate_descriptor_from_schema` returned `sdk_message_proto` — the raw `DescriptorProto` from `descriptor_from_uc_schema` — which contains **relative type names** for nested-message fields (e.g. `type_name: "Metadata"`). SDK ≥ 2.0.1 now serialises this proto and sends it straight to the Databricks ingestion server, which rejects it:

> "Proto not self-contained for field 'metadata' with type name 'Metadata'"

**Why it worked before (SDK 1.2.0):** The old `service.rs` derived the `DescriptorProto` from `descriptor.descriptor_proto()` — the form stored _after_ the `DescriptorPool` resolved all relative names to fully-qualified names (FQNs). SDK 1.2.0 also apparently did its own resolution internally.

**Fix:** After building the `DescriptorPool` (which resolves all type references), return `message_descriptor.descriptor_proto()` re-encoded to prost-types 0.14, instead of the raw `sdk_message_proto`. This is the same wire-format round-trip pattern (prost 0.13 ↔ 0.14) already used earlier in the same function.

The `service.rs` call-site is unchanged — it still passes the cached `DescriptorProto` to `compiled_proto()` on each stream rebuild.

## Vector configuration

No configuration changes — this is an internal fix for schema descriptor serialisation.

## How did you test this PR?

- Added a regression test `test_returned_descriptor_proto_has_fqn_type_names` that calls `generate_descriptor_from_schema` with the existing `nested_structs_complete_schema.json` fixture and asserts that every message-type field in the returned `DescriptorProto` has an absolute (`.`-prefixed) FQN type name. The test fails on the unfixed code and passes after the fix.
- Ran `cargo clippy --features sinks-databricks-zerobus -p vector -- -D warnings` — no warnings or errors.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).

Added `changelog.d/databricks-zerobus-descriptor-fqn.fix.md`.

## References

<!-- Related to the SDK 2.0.1 bump in this branch -->

Made with [Cursor](https://cursor.com)