### PR TITLE
docs(external docs): Document VECTOR_LOG target filters

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -118,6 +118,7 @@ DEBHELPER
 debian
 DECT
 demuxing
+deser
 dfs
 discriminants
 distro

--- a/website/content/en/docs/administration/monitoring.md
+++ b/website/content/en/docs/administration/monitoring.md
@@ -86,6 +86,23 @@ command-line flags or the `VECTOR_LOG` environment variable. The table below det
 | `-qqq` flag | Disables logging |
 | `VECTOR_LOG=<level>` environment variable | Set the log level. Must be one of `trace`, `debug`, `info`, `warn`, `error`, `off`. |
 
+#### Targeted filters
+
+`VECTOR_LOG` can also use comma-separated [`tracing_subscriber` target filters][tracing_subscriber_targets] when you only
+need additional detail from part of Vector. Start with a global level, then add more specific module targets:
+
+```shell
+VECTOR_LOG=info,vector::sources::file=debug,vector::sinks::aws_s3=trace vector --config=/etc/vector/vector.yaml
+```
+
+This keeps most internal logs at `info`, emits `debug` logs from the file source implementation, and emits `trace` logs
+from the AWS S3 sink implementation. Targeted filters are useful when you know which component type is failing but do
+not want to run the whole process at `debug` or `trace`.
+
+For component-level investigation, capture Vector logs with the [`internal_logs`][internal_logs] source. Internal log
+events include metadata such as `metadata.target`, `metadata.module_path`, and `metadata.level`, which you can filter or
+route in your topology after they enter the pipeline.
+
 #### Stack traces
 
 You can enable full error backtraces by setting the `RUST_BACKTRACE=full` environment variable. More on this in the
@@ -147,6 +164,7 @@ IO and disrupting the service. The trade-off is that repetitive logs aren't logg
 [stderr]: https://en.wikipedia.org/wiki/Standard_streams#Standard_error_(stderr)
 [topology]: /docs/introduction/concepts/#topology
 [transform]: /transforms
+[tracing_subscriber_targets]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/targets/struct.Targets.html
 [troubleshooting]: /guides/level-up/troubleshooting
 [vrl]: /docs/reference/vrl
 [debugging_guide]: /guides/developer/debugging#visualizing-and-querying-internal-metrics

--- a/website/content/en/guides/level-up/troubleshooting.md
+++ b/website/content/en/guides/level-up/troubleshooting.md
@@ -109,6 +109,17 @@ vector --verbose --config=/etc/vector/vector.yaml
 {{< /tab >}}
 {{< /tabs >}}
 
+If full debug logging is too noisy, use `VECTOR_LOG` target filters to focus on the module that owns the failing
+component:
+
+```shell
+VECTOR_LOG=info,vector::sources::file=debug,vector::sinks::aws_s3=trace vector --config=/etc/vector/vector.yaml
+```
+
+The first directive sets the default level for the process. Later directives increase or decrease verbosity for
+specific Vector modules. This is often enough to inspect a failing source or sink without enabling `trace` logs
+globally. For more detail, see [Monitoring and observing Vector][monitoring].
+
 ## 5. Get help
 
 At this point, we recommend reaching out to the community for help.
@@ -123,4 +134,5 @@ At this point, we recommend reaching out to the community for help.
 [urls.new_feature_request]: https://github.com/vectordotdev/vector/issues/new?assignees=&labels=type%3A+feature&template=feature.yml
 [urls.vector_chat]: https://chat.vector.dev
 [urls.vector_issues]: https://github.com/vectordotdev/vector/issues
+[monitoring]: /docs/administration/monitoring/#targeted-filters
 [Vector tap]: /guides/level-up/vector-tap-guide

--- a/website/cue/reference/cli.cue
+++ b/website/cue/reference/cli.cue
@@ -618,7 +618,14 @@ cli: {
 			type: string: default: null
 		}
 		VECTOR_LOG: {
-			description: "Vector's log level. Each log level includes messages from higher priority levels."
+			description: """
+				Vector's log level. Each log level includes messages from higher priority levels.
+
+				`VECTOR_LOG` also accepts comma-separated `tracing_subscriber` target filters. Start with a
+				global level, then add module-specific directives to increase or decrease verbosity for part
+				of Vector. For example, `VECTOR_LOG=info,vector::sources::file=debug,vector::sinks::aws_s3=trace`
+				keeps most logs at `info` while enabling more detail for the file source and AWS S3 sink.
+				"""
 			type: string: {
 				default: "INFO"
 				enum: {


### PR DESCRIPTION
## Summary

Documents how to use `VECTOR_LOG` target filters to narrow internal logging to specific Vector modules, and links the troubleshooting guide to the new targeted logging guidance.

## Vector configuration

No Vector runtime configuration was required. Example commands added to the docs:

```shell
VECTOR_LOG=info,vector::sources::file=debug,vector::sinks::aws_s3=trace vector --config=/etc/vector/vector.yaml
```

## How did you test this PR?

- Ran `git diff --check`
- Reviewed the current `src/app.rs` and `src/trace.rs` logging path to confirm `VECTOR_LOG` is parsed as `tracing_subscriber::filter::Targets`

I could not run the full CUE/docs checks locally because `cue`/`vdev` are not installed in this environment.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our guidelines.
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Closes: #970