### PR TITLE
docs(website): Fix typo in aggregator documentation

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -118,6 +118,7 @@ DEBHELPER
 debian
 DECT
 demuxing
+deser
 dfs
 discriminants
 distro

--- a/website/content/en/docs/setup/going-to-prod/arch/aggregator.md
+++ b/website/content/en/docs/setup/going-to-prod/arch/aggregator.md
@@ -98,7 +98,7 @@ Partitioning, or “topics” in Kafka terminology, refers to separating data in
 
 ### Global Aggregation
 
-Because Vector can deployed anywhere in your infrastructure, it offers a unique approach to global aggregation. Aggregation can be tiered, allowing local aggregators to reduce data before forwarding to your global aggregators.
+Because Vector can be deployed anywhere in your infrastructure, it offers a unique approach to global aggregation. Aggregation can be tiered, allowing local aggregators to reduce data before forwarding to your global aggregators.
 
 ![Aggregator](/img/going-to-prod/global-aggregation.png)
 


### PR DESCRIPTION
## Summary
- Fix a small grammar typo in the aggregator documentation.

## Testing
- Not run; documentation-only change.