### PR TITLE
docs(config): document verbatim substitution of structural characters in env var interpolation

### DIFF
--- a/changelog.d/config_interpolation_double_quote.security.md
+++ b/changelog.d/config_interpolation_double_quote.security.md
@@ -1,3 +1,0 @@
-Documented that environment variable interpolation substitutes values verbatim before config parsing. Values containing structural characters such as `"`, `{`, `}`, `[`, or `]` may affect the parsed config structure. Newline characters remain the only rejected values.
-
-authors: pront

--- a/changelog.d/config_interpolation_double_quote.security.md
+++ b/changelog.d/config_interpolation_double_quote.security.md
@@ -1,0 +1,3 @@
+Documented that environment variable interpolation substitutes values verbatim before config parsing. Values containing structural characters such as `"`, `{`, `}`, `[`, or `]` may affect the parsed config structure. Newline characters remain the only rejected values.
+
+authors: pront

--- a/website/content/en/docs/reference/environment_variables.md
+++ b/website/content/en/docs/reference/environment_variables.md
@@ -62,6 +62,10 @@ environment variable example.
 Vector prevents security issues related to environment variable interpolation by rejecting environment variables that contain newline
 characters. This also prevents injection of multi-line configuration blocks.
 
+Vector does not validate or escape other characters in interpolated values. Values containing config-structural characters such as
+`"`, `{`, `}`, `[`, or `]` are substituted verbatim before the config file is parsed, and may affect the resulting parsed structure.
+Operators are responsible for controlling the content of interpolated environment variables.
+
 If you need to inject multi-line configuration blocks, use a config pre-processing step with a tool like `envsubst`.
 This approach gives you more control over the configuration and allows you to inspect the result before passing it to Vector:
 


### PR DESCRIPTION
## Summary

Environment variable values are substituted into raw config text before parsing. Only newline characters are currently rejected. Other structural characters — `"`, `{`, `}`, `[`, `]` — pass through unchanged and can affect the parsed config structure if placed in the wrong context.

This PR documents that behavior explicitly in the [Security Restrictions](https://vector.dev/docs/reference/environment_variables/#security-restrictions) section so operators have clear expectations. No behavior change.

## Vector configuration

No change.

## How did you test this PR?

Docs-only change. Existing unit tests in `src/config/vars.rs` are unchanged and continue to pass.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [x] Yes. Changelog fragment added.