### PR TITLE
fix(statsd source): prevent panic on multi-byte UTF-8 gauge value prefix

### DIFF
--- a/changelog.d/statsd_gauge_utf8_panic.fix.md
+++ b/changelog.d/statsd_gauge_utf8_panic.fix.md
@@ -1,3 +1,3 @@
-Fixed a panic in the statsd source gauge parser triggered by a multi-byte UTF-8 character in the metric value position. A single malformed UDP datagram could crash the entire Vector process. The invalid value now returns a parse error instead.
+Fixed a potential panic in the `statsd` source when a gauge metric value begins with a multi-byte UTF-8 character. The invalid value now returns a parse error instead.
 
 authors: pront

--- a/changelog.d/statsd_gauge_utf8_panic.fix.md
+++ b/changelog.d/statsd_gauge_utf8_panic.fix.md
@@ -1,0 +1,3 @@
+Fixed a panic in the statsd source gauge parser triggered by a multi-byte UTF-8 character in the metric value position. A single malformed UDP datagram could crash the entire Vector process. The invalid value now returns a parse error instead.
+
+authors: pront

--- a/src/sources/statsd/parser.rs
+++ b/src/sources/statsd/parser.rs
@@ -106,7 +106,9 @@ impl Parser {
                 {
                     parts[0].parse()?
                 } else {
-                    parts[0][1..].parse()?
+                    let mut chars = parts[0].chars();
+                    chars.next();
+                    chars.as_str().parse()?
                 };
 
                 match parse_direction(parts[0])? {
@@ -444,6 +446,15 @@ mod test {
                 MetricValue::Gauge { value: 10.0 },
             )),
         );
+    }
+
+    #[test]
+    fn gauge_multibyte_utf8_prefix_is_error_not_panic() {
+        // A multi-byte UTF-8 character as the value prefix must return a parse
+        // error, not panic with "byte index 1 is not a char boundary".
+        let input = std::str::from_utf8(b"m:\xc3\xa9|g").unwrap();
+        assert!(parse(input).is_err());
+        assert!(parse("m:é|g").is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The statsd gauge parser sliced the metric value at byte index 1 to strip a sign prefix (`+`/`-`). If the first character is a multi-byte UTF-8 codepoint, byte index 1 falls inside the character and Rust panics with `byte index 1 is not a char boundary`.

Fix: use `chars()` to advance past the first character and take `as_str()` for the remainder. Invalid prefixes already produce a `ParseError` via `parse_direction()`; this change prevents the crash before that point.

## Vector configuration

```yaml
sources:
  statsd_in:
    type: statsd
    address: 0.0.0.0:8125
    mode: udp
```

## How did you test this PR?

Added a regression test `gauge_multibyte_utf8_prefix_is_error_not_panic` covering both the raw byte sequence and the Unicode literal. All 16 statsd parser unit tests pass.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [x] Yes. Changelog fragment added.