### PR TITLE
docs(file sink): enhance note on `path` templates

### DIFF
--- a/src/sinks/file/mod.rs
+++ b/src/sinks/file/mod.rs
@@ -58,7 +58,7 @@ pub struct FileSinkConfig {
     ))]
     #[configurable(metadata(docs::examples = "/tmp/vector-%Y-%m-%d.log.zst"))]
     #[configurable(metadata(
-        docs::warnings = "The rendered path can resolve to any location on the filesystem. Vector will write to it if the process has permission."
+        docs::warnings = "The rendered path is not sanitized. If event fields used in the template originate from untrusted sources, the resulting path may resolve outside the intended directory. Operators are responsible for ensuring that fields used in path templates come from trusted sources."
     ))]
     pub path: Template,
 

--- a/src/sinks/file/mod.rs
+++ b/src/sinks/file/mod.rs
@@ -58,7 +58,7 @@ pub struct FileSinkConfig {
     ))]
     #[configurable(metadata(docs::examples = "/tmp/vector-%Y-%m-%d.log.zst"))]
     #[configurable(metadata(
-        docs::warnings = "The rendered path is resolved as-is and not sanitized in any way. Operators should ensure that the Vector process can only write to the desired locations."
+        docs::warnings = "The rendered path is resolved as-is and is not sanitized. Operators should ensure that the Vector process can only write to the desired locations."
     ))]
     pub path: Template,
 

--- a/src/sinks/file/mod.rs
+++ b/src/sinks/file/mod.rs
@@ -58,7 +58,7 @@ pub struct FileSinkConfig {
     ))]
     #[configurable(metadata(docs::examples = "/tmp/vector-%Y-%m-%d.log.zst"))]
     #[configurable(metadata(
-        docs::warnings = "The rendered path is not sanitized. If event fields used in the template originate from untrusted sources, the resulting path may resolve outside the intended directory. Operators are responsible for ensuring that fields used in path templates come from trusted sources."
+        docs::warnings = "The rendered path is resolved as-is and not sanitized in any way. If event fields used in the template originate from untrusted sources, the resulting path may resolve outside the intended directory. Operators should ensure that the Vector process can only write to the desired locations, for example by using filesystem permissions or similar OS-level controls."
     ))]
     pub path: Template,
 

--- a/src/sinks/file/mod.rs
+++ b/src/sinks/file/mod.rs
@@ -58,7 +58,7 @@ pub struct FileSinkConfig {
     ))]
     #[configurable(metadata(docs::examples = "/tmp/vector-%Y-%m-%d.log.zst"))]
     #[configurable(metadata(
-        docs::warnings = "The rendered path is resolved as-is and not sanitized in any way. If event fields used in the template originate from untrusted sources, the resulting path may resolve outside the intended directory. Operators should ensure that the Vector process can only write to the desired locations, for example by using filesystem permissions or similar OS-level controls."
+        docs::warnings = "The rendered path is resolved as-is and not sanitized in any way. Operators should ensure that the Vector process can only write to the desired locations."
     ))]
     pub path: Template,
 

--- a/website/cue/reference/components/sinks/file.cue
+++ b/website/cue/reference/components/sinks/file.cue
@@ -58,6 +58,18 @@ components: sinks: file: {
 	}
 
 	how_it_works: {
+		path_template_trust: {
+			title: "Path Templates and Untrusted Input"
+			body: """
+				The `path` option supports Vector's template syntax, allowing event fields to be
+				interpolated into the output path. Vector does not sanitize or restrict the rendered
+				path. If the interpolated fields originate from untrusted sources (for example, a
+				field set by a remote client), the resulting path may resolve outside the intended
+				directory. Operators are responsible for ensuring that fields used in path templates
+				come from trusted sources.
+				"""
+		}
+
 		dir_and_file_creation: {
 			title: "File & Directory Creation"
 			body: """

--- a/website/cue/reference/components/sinks/file.cue
+++ b/website/cue/reference/components/sinks/file.cue
@@ -58,18 +58,6 @@ components: sinks: file: {
 	}
 
 	how_it_works: {
-		path_template_trust: {
-			title: "Path Templates and Untrusted Input"
-			body: """
-				The `path` option supports Vector's template syntax, allowing event fields to be
-				interpolated into the output path. Vector does not sanitize or restrict the rendered
-				path. If the interpolated fields originate from untrusted sources (for example, a
-				field set by a remote client), the resulting path may resolve outside the intended
-				directory. Operators are responsible for ensuring that fields used in path templates
-				come from trusted sources.
-				"""
-		}
-
 		dir_and_file_creation: {
 			title: "File & Directory Creation"
 			body: """

--- a/website/cue/reference/components/sinks/generated/file.cue
+++ b/website/cue/reference/components/sinks/generated/file.cue
@@ -590,7 +590,7 @@ generated: components: sinks: file: configuration: {
 			examples: ["/tmp/vector-%Y-%m-%d.log", "/tmp/application-{{ application_id }}-%Y-%m-%d.log", "/tmp/vector-%Y-%m-%d.log.zst"]
 			syntax: "template"
 		}
-		warnings: ["The rendered path can resolve to any location on the filesystem. Vector will write to it if the process has permission."]
+		warnings: ["The rendered path is not sanitized. If event fields used in the template originate from untrusted sources, the resulting path may resolve outside the intended directory. Operators are responsible for ensuring that fields used in path templates come from trusted sources."]
 	}
 	timezone: {
 		description: """

--- a/website/cue/reference/components/sinks/generated/file.cue
+++ b/website/cue/reference/components/sinks/generated/file.cue
@@ -590,7 +590,7 @@ generated: components: sinks: file: configuration: {
 			examples: ["/tmp/vector-%Y-%m-%d.log", "/tmp/application-{{ application_id }}-%Y-%m-%d.log", "/tmp/vector-%Y-%m-%d.log.zst"]
 			syntax: "template"
 		}
-		warnings: ["The rendered path is resolved as-is and not sanitized in any way. Operators should ensure that the Vector process can only write to the desired locations."]
+		warnings: ["The rendered path is resolved as-is and is not sanitized. Operators should ensure that the Vector process can only write to the desired locations."]
 	}
 	timezone: {
 		description: """

--- a/website/cue/reference/components/sinks/generated/file.cue
+++ b/website/cue/reference/components/sinks/generated/file.cue
@@ -590,7 +590,7 @@ generated: components: sinks: file: configuration: {
 			examples: ["/tmp/vector-%Y-%m-%d.log", "/tmp/application-{{ application_id }}-%Y-%m-%d.log", "/tmp/vector-%Y-%m-%d.log.zst"]
 			syntax: "template"
 		}
-		warnings: ["The rendered path is not sanitized. If event fields used in the template originate from untrusted sources, the resulting path may resolve outside the intended directory. Operators are responsible for ensuring that fields used in path templates come from trusted sources."]
+		warnings: ["The rendered path is resolved as-is and not sanitized in any way. If event fields used in the template originate from untrusted sources, the resulting path may resolve outside the intended directory. Operators should ensure that the Vector process can only write to the desired locations, for example by using filesystem permissions or similar OS-level controls."]
 	}
 	timezone: {
 		description: """

--- a/website/cue/reference/components/sinks/generated/file.cue
+++ b/website/cue/reference/components/sinks/generated/file.cue
@@ -590,7 +590,7 @@ generated: components: sinks: file: configuration: {
 			examples: ["/tmp/vector-%Y-%m-%d.log", "/tmp/application-{{ application_id }}-%Y-%m-%d.log", "/tmp/vector-%Y-%m-%d.log.zst"]
 			syntax: "template"
 		}
-		warnings: ["The rendered path is resolved as-is and not sanitized in any way. If event fields used in the template originate from untrusted sources, the resulting path may resolve outside the intended directory. Operators should ensure that the Vector process can only write to the desired locations, for example by using filesystem permissions or similar OS-level controls."]
+		warnings: ["The rendered path is resolved as-is and not sanitized in any way. Operators should ensure that the Vector process can only write to the desired locations."]
 	}
 	timezone: {
 		description: """


### PR DESCRIPTION
## Summary

The `file` sink `path` option supports template syntax, allowing event fields to be interpolated into the output path. Vector does not sanitize or restrict the rendered path. This is intentional and enables common patterns like routing output by host or application.

Adds a `how_it_works` entry stating this explicitly, so operators using untrusted field values in path templates understand the implication.

## Vector configuration

No change.

## How did you test this PR?

Docs-only change.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.