### PR TITLE
chore(ci): update SMP CLI to 0.27.0

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -116,7 +116,7 @@ jobs:
       - name: Set SMP version
         id: experimental-meta
         run: |
-          export SMP_CRATE_VERSION="0.26.1"
+          export SMP_CRATE_VERSION="0.27.0"
           echo "smp crate version: ${SMP_CRATE_VERSION}"
           echo "SMP_CRATE_VERSION=${SMP_CRATE_VERSION}" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
Bumps the SMP CLI version from 0.26.1 to 0.27.0 in the regression workflow.

No breaking changes. Notable CLI changes are: all commands now signal success/failure via exit codes, there's a `--output json` flag for machines to use, and the CLI has a real 'local run' capability for getting ballpark results. The [full release notes](https://github.com/DataDog/single-machine-performance/releases/tag/v0.27.0) cover the CLI and backend changes for this version.