### PR TITLE
docs(agents): add Git Conventions section

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -264,6 +264,11 @@ cargo install dd-rust-license-tool --locked
 make build-licenses
 ```
 
+## Git Conventions
+
+- **Commit messages:** Do NOT include co-authoring information from coding agents (i.e. avoid "Co-Authored-By: Claude" attribution)
+- **Pull requests:** Do NOT add "Generated with Claude Code" or similar footers — keep PR descriptions focused on the technical changes
+
 ## Creating Pull Requests
 
 Before opening a PR, read [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md) and use it as the reference for the PR body structure and title.


### PR DESCRIPTION
## Summary

Adds a Git Conventions section to `AGENTS.md` instructing coding agents not to include AI attribution in commits or PR descriptions.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.