### PR TITLE
chore(ci): replace semantic PR title action with custom script

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -60,9 +60,9 @@ Changes to CI, website, playground and similar are generally not considered user
 
   <type>(<scope>)!: <description>
 
-  * `type` = chore, enhancement, feat, fix, docs, revert
+  * `type` = chore, enhancement, feat, fix, docs, revert, perf
   * `!` = OPTIONAL: signals a breaking change
-  * `scope` = Optional but appreciated; free-form (e.g. component name, subsystem)
+  * `scope` = Optional but appreciated; letters, digits, spaces, hyphens, underscores (e.g. `kafka source`, `amazon-linux`)
   * `description` = short description of the change
 
 Examples:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -62,7 +62,7 @@ Changes to CI, website, playground and similar are generally not considered user
 
   * `type` = chore, enhancement, feat, fix, docs, revert
   * `!` = OPTIONAL: signals a breaking change
-  * `scope` = Optional when `type` is "chore" or "docs", available scopes https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L31
+  * `scope` = Optional but appreciated; free-form (e.g. component name, subsystem)
   * `description` = short description of the change
 
 Examples:

--- a/.github/workflows/semantic.yml
+++ b/.github/workflows/semantic.yml
@@ -19,7 +19,7 @@ jobs:
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          pattern='^(feat|fix|docs|chore|revert|enhancement)(\([^)]+\))?!?: .+'
+          pattern='^(feat|fix|docs|chore|revert|enhancement)(\([a-zA-Z0-9_, ]+\))?!?: .+'
           if ! echo "$PR_TITLE" | grep -qP "$pattern"; then
             echo "PR title does not follow Conventional Commits format."
             echo "Expected: <type>(<optional scope>): <description>"

--- a/.github/workflows/semantic.yml
+++ b/.github/workflows/semantic.yml
@@ -19,7 +19,7 @@ jobs:
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          pattern='^(feat|fix|docs|chore|revert|enhancement)(\([a-zA-Z0-9_, ]+\))?!?: .+'
+          pattern='^(feat|fix|docs|chore|revert|enhancement|perf)(\([a-zA-Z0-9_, -]+\))?!?: .+'
           if ! echo "$PR_TITLE" | grep -qP "$pattern"; then
             echo "PR title does not follow Conventional Commits format."
             echo "Expected: <type>(<optional scope>): <description>"

--- a/.github/workflows/semantic.yml
+++ b/.github/workflows/semantic.yml
@@ -1,11 +1,9 @@
-# This is a GitHub Action that ensures that the PR titles match the Conventional Commits spec.
+# Validates PR titles against the Conventional Commits spec.
 # See: https://www.conventionalcommits.org/en/v1.0.0/
 
-name: "PR Title Semantic Check"
+name: "PR Title Check"
 
 on:
-  pull_request_target:
-    types: [opened, edited, synchronize]
   pull_request:
     types: [opened, edited, synchronize]
 
@@ -13,270 +11,20 @@ permissions:
   contents: read
 
 jobs:
-  main:
-    permissions:
-      pull-requests: read # for amannn/action-semantic-pull-request to analyze PRs
-      statuses: write # for amannn/action-semantic-pull-request to mark status of analyzed PR
-    name: Check Semantic PR
+  check:
+    name: Check PR Title
     runs-on: ubuntu-24.04
     steps:
-      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+      - name: Validate conventional commit format
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          requireScope: true
-          types: |
-            chore
-            enhancement
-            feat
-            fix
-            docs
-            revert
-
-          scopes: |
-            administration
-            api
-            api top
-            api tap
-            ARC
-            architecture
-            auth
-            buffers
-            ci
-            cli
-            codecs
-            compression
-            config
-            config provider
-            core
-            data model
-            delivery
-            deployment
-            deprecations
-            deps
-            dev
-            durability
-            enriching
-            enrichment tables
-            enterprise
-            exceptions
-            external
-            external docs
-            filtering
-            feature flags
-            healthchecks
-            internal
-            internal docs
-            logs
-            metrics
-            networking
-            new sink
-            new source
-            new transform
-            observability
-            parsing
-            performance
-            platforms
-            privacy
-            processing
-            releasing
-            reliability
-            reload
-            replay
-            schemas
-            security
-            setup
-            shutdown
-            sinks
-            soak tests
-            sources
-            startup
-            templating
-            tests
-            topology
-            traces
-            transforms
-            unit tests
-            vdev
-            vrl
-
-            amazon-linux platform
-            apt platform
-            arm platform
-            arm64 platform
-            centos platform
-            debian platform
-            docker platform
-            dpkg platform
-            helm platform
-            heroku platform
-            homebrew platform
-            kubernetes platform
-            macos platform
-            msi platform
-            nix platform
-            nixos platform
-            raspbian platform
-            rhel platform
-            rpm platform
-            ubuntu platform
-            windows platform
-            x86_64 platform
-            yum platform
-
-            aws service
-            azure service
-            confluent service
-            datadog service
-            elastic service
-            gcp service
-            grafana service
-            heroku service
-            honeycomb service
-            humio service
-            influxdata service
-            logdna service
-            new relic service
-            papertrail service
-            sematext service
-            service providers
-            splunk service
-            yandex service
-
-            apache_metrics source
-            aws_ecs_metrics source
-            aws_kinesis_firehose source
-            aws_s3 source
-            aws_sqs source
-            datadog_agent source
-            demo_logs source
-            dnstap source
-            docker_logs source
-            exec source
-            file source
-            file_descriptor source
-            fluent source
-            gcp_pubsub source
-            heroku_logs source
-            host_metrics source
-            http_client source
-            http_server source
-            http_scrape source
-            internal_logs source
-            internal_metrics source
-            journald source
-            kafka source
-            kubernetes_logs source
-            logstash source
-            mongodb_metrics source
-            mqtt source
-            nats source
-            new source
-            nginx_metrics source
-            okta source
-            opentelemetry source
-            postgresql_metrics source
-            prometheus_remote_write source
-            prometheus_scrape source
-            redis source
-            socket source
-            splunk_hec source
-            static_metrics source
-            statsd source
-            stdin source
-            syslog source
-            vector source
-            websocket source
-
-            aggregate transform
-            aws_ec2_metadata transform
-            dedupe transform
-            exclusive_route transform
-            filter transform
-            geoip transform
-            log_to_metric transform
-            lua transform
-            metric_to_log transform
-            new transform
-            pipelines transform
-            reduce transform
-            remap transform
-            route transform
-            sample transform
-            tag_cardinality_limit transform
-            throttle transform
-
-            amqp sink
-            apex sink
-            aws_cloudwatch_logs sink
-            aws_cloudwatch_metrics sink
-            aws_kinesis_firehose sink
-            aws_kinesis_streams sink
-            aws_s3 sink
-            aws_sqs sink
-            axiom sink
-            azure_blob sink
-            azure_logs_ingestion sink
-            azure_monitor_logs sink
-            blackhole sink
-            clickhouse sink
-            console sink
-            databricks_zerobus sink
-            datadog_archives sink
-            datadog_common sink
-            datadog_events sink
-            datadog_logs sink
-            datadog_metrics sink
-            doris sink
-            elasticsearch sink
-            file sink
-            gcp_chronicle sink
-            gcp_cloud_storage sink
-            gcp_pubsub sink
-            gcp_stackdriver_logs sink
-            gcp_stackdriver_metrics sink
-            greptimedb_logs sink
-            greptimedb_metrics sink
-            honeycomb sink
-            http sink
-            humio_logs sink
-            humio_metrics sink
-            influxdb_logs sink
-            influxdb_metrics sink
-            kafka sink
-            logdna sink
-            loki sink
-            mqtt sink
-            nats sink
-            new sink
-            new_relic sink
-            new_relic_logs sink
-            opentelemetry sink
-            papertrail sink
-            postgres sink
-            prometheus_exporter sink
-            prometheus_remote_write sink
-            pulsar sink
-            redis sink
-            sematext_logs sink
-            sematext_metrics sink
-            socket sink
-            splunk_hec sink
-            statsd sink
-            vector sink
-            websocket sink
-            websocket_server sink
-
-            blog website
-            css website
-            guides website
-            highlights website
-            javascript website
-            search website
-            template website
-            website
-            website deps
-
-            vrl playground
-
-            opentelemetry lib
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          pattern='^(feat|fix|docs|chore|revert|enhancement)(\([^)]+\))?: .+'
+          if ! echo "$PR_TITLE" | grep -qP "$pattern"; then
+            echo "PR title does not follow Conventional Commits format."
+            echo "Expected: <type>(<optional scope>): <description>"
+            echo "Valid types: feat, fix, docs, chore, revert, enhancement"
+            echo "Got: $PR_TITLE"
+            exit 1
+          fi
+          echo "OK: $PR_TITLE"

--- a/.github/workflows/semantic.yml
+++ b/.github/workflows/semantic.yml
@@ -19,7 +19,7 @@ jobs:
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          pattern='^(feat|fix|docs|chore|revert|enhancement)(\([^)]+\))?: .+'
+          pattern='^(feat|fix|docs|chore|revert|enhancement)(\([^)]+\))?!?: .+'
           if ! echo "$PR_TITLE" | grep -qP "$pattern"; then
             echo "PR title does not follow Conventional Commits format."
             echo "Expected: <type>(<optional scope>): <description>"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -175,7 +175,7 @@ branches, this means that only the pull request title must conform to this
 format. Vector performs a pull request check to verify the pull request title
 in case you forget.
 
-A scope is optional but appreciated — use it to identify the component or subsystem (e.g. `feat(kafka source): ...`).
+A scope is optional but appreciated. Use it to identify the component or subsystem affected, for example `feat(kafka source): ...` or `fix(loki sink): ...`.
 
 The following are all good examples of pull request titles:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -175,8 +175,7 @@ branches, this means that only the pull request title must conform to this
 format. Vector performs a pull request check to verify the pull request title
 in case you forget.
 
-A list of allowed sub-categories is defined in the
-[semantic.yml workflow](https://github.com/vectordotdev/vector/blob/master/.github/workflows/semantic.yml#L21).
+A scope is optional but appreciated — use it to identify the component or subsystem (e.g. `feat(kafka source): ...`).
 
 The following are all good examples of pull request titles:
 

--- a/vdev/src/commands/release/generate_cue.rs
+++ b/vdev/src/commands/release/generate_cue.rs
@@ -355,7 +355,7 @@ struct ConventionalParts {
 impl ConventionalParts {
     fn parse(message: &str) -> Self {
         let re = Regex::new(
-            r"^(?P<type>[a-z]*)(\((?P<scope>[a-zA-Z0-9_, ]*)\))?(?P<breaking>!)?: (?P<desc>.*?)( \(#(?P<pr>[0-9]+)\))?$",
+            r"^(?P<type>[a-z]*)(\((?P<scope>[a-zA-Z0-9_, -]*)\))?(?P<breaking>!)?: (?P<desc>.*?)( \(#(?P<pr>[0-9]+)\))?$",
         )
         .unwrap();
 
@@ -723,7 +723,7 @@ mod tests {
 
     #[test]
     fn commit_validate_scope_is_optional_for_all_types() {
-        for t in &["feat", "enhancement", "fix", "chore", "docs"] {
+        for t in ALLOWED_TYPES {
             let c = Commit {
                 sha: "x".into(),
                 author: "a".into(),

--- a/vdev/src/commands/release/generate_cue.rs
+++ b/vdev/src/commands/release/generate_cue.rs
@@ -722,28 +722,23 @@ mod tests {
     }
 
     #[test]
-    fn commit_validate_requires_scope_for_certain_types() {
-        let mut c = Commit {
-            sha: "x".into(),
-            author: "a".into(),
-            date: "d".into(),
-            description: "no scope".into(),
-            r#type: Some("feat".into()),
-            scopes: vec![],
-            breaking_change: false,
-            pr_number: None,
-            files_count: 0,
-            insertions_count: 0,
-            deletions_count: 0,
-        };
-        assert!(c.validate().is_err());
-        c.scopes = vec!["api".into()];
-        assert!(c.validate().is_ok());
-
-        // chore/docs don't need scopes
-        c.r#type = Some("chore".into());
-        c.scopes = vec![];
-        assert!(c.validate().is_ok());
+    fn commit_validate_scope_is_optional_for_all_types() {
+        for t in &["feat", "enhancement", "fix", "chore", "docs"] {
+            let c = Commit {
+                sha: "x".into(),
+                author: "a".into(),
+                date: "d".into(),
+                description: "no scope".into(),
+                r#type: Some((*t).into()),
+                scopes: vec![],
+                breaking_change: false,
+                pr_number: None,
+                files_count: 0,
+                insertions_count: 0,
+                deletions_count: 0,
+            };
+            assert!(c.validate().is_ok(), "type '{t}' should be valid without a scope");
+        }
     }
 
     #[test]

--- a/vdev/src/commands/release/generate_cue.rs
+++ b/vdev/src/commands/release/generate_cue.rs
@@ -737,7 +737,10 @@ mod tests {
                 insertions_count: 0,
                 deletions_count: 0,
             };
-            assert!(c.validate().is_ok(), "type '{t}' should be valid without a scope");
+            assert!(
+                c.validate().is_ok(),
+                "type '{t}' should be valid without a scope"
+            );
         }
     }
 

--- a/vdev/src/commands/release/generate_cue.rs
+++ b/vdev/src/commands/release/generate_cue.rs
@@ -17,9 +17,6 @@ use crate::utils::{git, paths};
 const RELEASES_DIR: &str = "website/cue/reference/releases";
 const CHANGELOG_DIR: &str = "changelog.d";
 
-/// Conventional-commit types that require a scope.
-const TYPES_REQUIRING_SCOPES: &[&str] = &["feat", "enhancement", "fix"];
-
 /// Allowed conventional-commit types.
 const ALLOWED_TYPES: &[&str] = &[
     "chore",
@@ -229,14 +226,6 @@ impl Commit {
                 self.sha,
                 t,
                 ALLOWED_TYPES
-            );
-        }
-        if TYPES_REQUIRING_SCOPES.contains(&t) && self.scopes.is_empty() {
-            bail!(
-                "Commit {} of type '{}' requires a scope. Description: {}",
-                self.sha,
-                t,
-                self.description
             );
         }
         Ok(())


### PR DESCRIPTION
## Summary

The existing check used a third-party action with a 180-entry hardcoded scope allowlist. This created constant friction: any new component or rename required a PR just to update the list, and contributors got blocked on valid titles that simply didn't match the allowlist.

In practice, we only use the **type** prefix (`feat`, `fix`, etc.) for changelog generation, the scope is informational. This replaces the action with a small inline script that validates the type only, leaving scopes free-form.

Also removes `pull_request_target` in favour of `pull_request` (the former runs with elevated base-branch permissions, which is a security concern for fork PRs).

## Vector configuration

N/A

## How did you test this PR?

Manually verified the regex against valid and invalid title examples.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

## Notes