### PR TITLE
chore(ci): Update OTLP experiments' lading configs

### DIFF
--- a/regression/cases/otlp_grpc_to_blackhole/lading/lading.yaml
+++ b/regression/cases/otlp_grpc_to_blackhole/lading/lading.yaml
@@ -33,7 +33,7 @@ generator:
           109,
           113,
           127,
-          131,
+          131
         ]
       target_uri: "http://127.0.0.1:4317/opentelemetry.proto.collector.logs.v1.LogsService/Export"
       bytes_per_second: "100 Mb"

--- a/regression/cases/otlp_grpc_to_blackhole/lading/lading.yaml
+++ b/regression/cases/otlp_grpc_to_blackhole/lading/lading.yaml
@@ -33,13 +33,15 @@ generator:
           109,
           113,
           127,
-          131
+          131,
         ]
       target_uri: "http://127.0.0.1:4317/opentelemetry.proto.collector.logs.v1.LogsService/Export"
       bytes_per_second: "100 Mb"
       parallel_connections: 5
       maximum_prebuild_cache_size_bytes: "8 Mb"
-      variant: "opentelemetry_logs"
+      maximum_block_size: "8 Mb"
+      variant:
+        opentelemetry_logs: {}
 
 blackhole:
   - tcp:

--- a/regression/cases/otlp_http_to_blackhole/lading/lading.yaml
+++ b/regression/cases/otlp_http_to_blackhole/lading/lading.yaml
@@ -40,10 +40,12 @@ generator:
       target_uri: "http://127.0.0.1:4318/v1/logs"
       bytes_per_second: "100 Mb"
       parallel_connections: 5
+      maximum_block_size: "8 Mb"
       method:
         post:
           maximum_prebuild_cache_size_bytes: "8 Mb"
-          variant: "opentelemetry_logs"
+          variant:
+            opentelemetry_logs: {}
 
 blackhole:
   - tcp:


### PR DESCRIPTION
## Summary

Update both OTLP experiments with lading configs compatible with lading 0.31.2.

## How did you test this PR?

`smp local smoketest --experiment-dir ./regression --case otlp_grpc_to_blackhole --target-image timberio/vector:0.56.0-debian`

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

Related, crashing experiments in the latest Regression Detector run:  https://github.com/vectordotdev/vector/actions/runs/27125618999/attempts/1.
