### PR TITLE
fix(ci): split docs review label workflow to fix fork PR permissions

### DIFF
--- a/.github/workflows/check_docs_review.yml
+++ b/.github/workflows/check_docs_review.yml
@@ -1,0 +1,50 @@
+name: Check Docs Review
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  contents: read
+
+env:
+  LABEL_NAME: "docs review on hold"
+
+jobs:
+  check:
+    if: github.event.review.state == 'approved'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Check association and label
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const association = context.payload.review.author_association;
+            core.info(`Author association: ${association}`);
+
+            const allowed = ['MEMBER', 'OWNER'];
+            if (!allowed.includes(association)) {
+              core.info(`Association "${association}" not in allowed list, skipping`);
+              return;
+            }
+
+            const labelName = process.env.LABEL_NAME;
+            const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+            });
+            if (!labels.some(l => l.name === labelName)) {
+              core.info(`Label "${labelName}" not found, skipping`);
+              return;
+            }
+
+            require('fs').writeFileSync('pr-number', String(context.payload.pull_request.number));
+
+      - name: Upload PR number
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: docs-review-pr
+          path: pr-number
+          if-no-files-found: ignore

--- a/.github/workflows/remove_docs_review_label.yml
+++ b/.github/workflows/remove_docs_review_label.yml
@@ -1,53 +1,52 @@
-# Removes the docs review label once a maintainer approves the PR.
-# Currently dedicated to the docs review flow. If a second use case appears, promote
-# this into a reusable workflow (`workflow_call`) with the label as an input.
 name: Remove Docs Review Label
 
-permissions:
-  issues: write
-  pull-requests: write
-
 on:
-  pull_request_review:
-    types: [submitted]
+  workflow_run:
+    workflows: ["Check Docs Review"]
+    types:
+      - completed
+
+permissions:
+  contents: read
 
 env:
   LABEL_NAME: "docs review on hold"
 
 jobs:
   remove_label:
-    if: github.event.review.state == 'approved'
+    if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-24.04
     timeout-minutes: 5
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
-      - name: Check association, label, and remove
+      - name: Download PR number
+        id: download
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: docs-review-pr
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      - name: Remove label
+        if: steps.download.outcome == 'success'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
-            const association = context.payload.review.author_association;
-            core.info(`Author association: ${association}`);
-
-            const allowed = ['MEMBER', 'OWNER'];
-            if (!allowed.includes(association)) {
-              core.info(`Association "${association}" not in allowed list, skipping`);
+            const fs = require('fs');
+            const prNumber = parseInt(fs.readFileSync('pr-number', 'utf8').trim(), 10);
+            if (isNaN(prNumber)) {
+              core.setFailed('Invalid PR number');
               return;
             }
 
             const labelName = process.env.LABEL_NAME;
-            const { data: labels } = await github.rest.issues.listLabelsOnIssue({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-            });
-            const hasLabel = labels.some(l => l.name === labelName);
-            if (!hasLabel) {
-              core.info(`Label "${labelName}" not found, skipping`);
-              return;
-            }
             await github.rest.issues.removeLabel({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
+              issue_number: prNumber,
               name: labelName,
             });
-            core.info(`Removed "${labelName}" label`);
+            core.info(`Removed "${labelName}" label from PR #${prNumber}`);


### PR DESCRIPTION
## Summary

The `Remove Docs Review Label` workflow was failing with `Resource not accessible by integration` when triggered by a review on a fork PR. `pull_request_review` events from forks run with a read-only token, so the label removal write call fails even with `issues: write` declared.

Splits the workflow into two:
- `check_docs_review.yml` — runs on `pull_request_review`, checks reviewer association and label presence, uploads PR number as an artifact (read-only operations only)
- `remove_docs_review_label.yml` — runs on `workflow_run`, always has full base-repo token permissions, downloads the artifact and removes the label

## Vector configuration

NA

## How did you test this PR?

Reproduced the failure on #25574. Pattern is identical to the existing `check_generated_vrl_docs` / `check_generated_vrl_docs_comment` workflow pair already in this repo.

Tested the workflow split in vectordotdev/ci-sandbox#29.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: #25574