### PR TITLE
enhancement(file source): skip redundant file fingerprinting for already-watched files

### DIFF
--- a/lib/file-source/src/file_server.rs
+++ b/lib/file-source/src/file_server.rs
@@ -185,7 +185,29 @@ where
                 for (_file_id, watcher) in &mut fp_map {
                     watcher.set_file_findable(false); // assume not findable until found
                 }
+
+                // Reverse lookup: path → fingerprint, to skip fingerprinting files we're already watching
+                let watched_paths: HashMap<PathBuf, (FileFingerprint, u64)> = fp_map
+                    .iter()
+                    .map(|(fp, watcher)| (watcher.path.clone(), (*fp, watcher.get_file_position())))
+                    .collect();
+
                 for path in self.paths_provider.paths().into_iter() {
+                    // Fast path: skip fingerprinting if we're already watching this path
+                    // and the file hasn't been truncated (size >= our read position).
+                    if let Some((file_id, file_position)) = watched_paths.get(&path)
+                        && let Ok(metadata) = fs::metadata(&path).await
+                        && metadata.len() >= *file_position
+                        && let Some(watcher) = fp_map.get_mut(file_id)
+                    {
+                        watcher.set_file_findable(true);
+                        trace!(
+                            message = "Continue watching file.",
+                            path = ?path,
+                        );
+                        continue;
+                    }
+
                     if let Some(file_id) = self
                         .fingerprinter
                         .fingerprint_or_emit(&path, &mut known_small_files, &self.emitter)

--- a/lib/file-source/src/file_server.rs
+++ b/lib/file-source/src/file_server.rs
@@ -9,7 +9,7 @@ use std::{
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
 use file_source_common::{
-    FileFingerprint, FileSourceInternalEvents, Fingerprinter, ReadFrom,
+    FileFingerprint, FileSourceInternalEvents, Fingerprinter, PortableFileExt, ReadFrom,
     checkpointer::{Checkpointer, CheckpointsView},
 };
 use futures::{
@@ -186,17 +186,24 @@ where
                     watcher.set_file_findable(false); // assume not findable until found
                 }
 
-                // Reverse lookup: path → fingerprint, to skip fingerprinting files we're already watching
-                let watched_paths: HashMap<PathBuf, (FileFingerprint, u64)> = fp_map
+                // Reverse lookup: path → (fingerprint, file_position, devno, inode)
+                // to skip fingerprinting files we're already watching.
+                let watched_paths: HashMap<PathBuf, (FileFingerprint, u64, u64, u64)> = fp_map
                     .iter()
-                    .map(|(fp, watcher)| (watcher.path.clone(), (*fp, watcher.get_file_position())))
+                    .map(|(fp, watcher)| {
+                        let (devno, inode) = watcher.get_inode();
+                        (watcher.path.clone(), (*fp, watcher.get_file_position(), devno, inode))
+                    })
                     .collect();
 
                 for path in self.paths_provider.paths().into_iter() {
-                    // Fast path: skip fingerprinting if we're already watching this path
-                    // and the file hasn't been truncated (size >= our read position).
-                    if let Some((file_id, file_position)) = watched_paths.get(&path)
+                    // Fast path: skip fingerprinting if we're already watching this path,
+                    // the file hasn't been replaced (same inode), and hasn't been
+                    // truncated (size >= our read position).
+                    if let Some((file_id, file_position, devno, inode)) = watched_paths.get(&path)
                         && let Ok(metadata) = fs::metadata(&path).await
+                        && metadata.portable_dev() == *devno
+                        && metadata.portable_ino() == *inode
                         && metadata.len() >= *file_position
                         && let Some(watcher) = fp_map.get_mut(file_id)
                     {

--- a/lib/file-source/src/file_watcher/mod.rs
+++ b/lib/file-source/src/file_watcher/mod.rs
@@ -230,6 +230,10 @@ impl FileWatcher {
         self.file_position
     }
 
+    pub fn get_inode(&self) -> (u64, u64) {
+        (self.devno, self.inode)
+    }
+
     /// Read a single line from the underlying file
     ///
     /// This function will attempt to read a new line from its file, blocking,


### PR DESCRIPTION
## Summary
- Skip fingerprinting files that are already being watched during glob cycles
- Reduces disk I/O syscalls by ~79% (open/read/lseek) for stable file sets
- Detects file truncation via metadata check (1 stat() call) to preserve correctness

Every glob cycle (default 60s), `FileServer` fingerprints **every** file returned by the paths provider, even files already tracked in `fp_map`. Each fingerprint involves ~6 syscalls (open, seek etc).

On large Kubernetes clusters with 500+ pods, this causes thousands of unnecessary read syscalls per minute, saturating disk I/O and disrupting other node services (e.g., etcd on control plane nodes).

  ## Changes 
Before the glob loop, build a reverse lookup (`path → fingerprint`) from `fp_map`. When glob returns a path, check the reverse map first. If the path is already tracked, skip fingerprinting entirely — no file I/O needed.

To handle file truncation (same path, different content), we do one `stat()` call to compare the current file size against our read position. If the file is smaller than where we last read (`metadata.len() < file_position`), it was truncated — fall through to full fingerprinting so Vector detects the change and re-reads from the beginning. If `stat()` fails (file deleted, permissions error), we also fall through to full fingerprinting.

  ## Measured Impact (500 files, 35s trace, `glob_minimum_cooldown_ms = 10000 (10s)`)
  | Syscall  | Before |  After  | Reduction |
  |---------|--------|-------|-----------|
  | open      | 1,503   | 5         | 99.7%       |
  | lseek      | 3,000  | 0         | 100%        |
  | read       | 4,500.  | 2,500 | 44%         |
  | **total** | **12,033** | **2,555** | **78.8%** |


<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

## Vector configuration
<!-- Include Vector configuration(s) you used to test and debug your changes. -->

## How did you test this PR?
<!-- Please describe how you tested your changes. Also include any information about your setup. -->
Exsited test passed - no regression 

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [x] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Closes: #<issue/PR number or link>
-->
<!--
- Related: #<issue/PR number or link>
-->

## Notes

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details on the [dd-rust-license-tool](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert, perf
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional but appreciated; letters, digits, spaces, hyphens, underscores (e.g. `kafka source`, `amazon-linux`)
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
