### PR TITLE
chore(deps): ignore RUSTSEC-2026-0173 (proc-macro-error2 unmaintained via mlua_derive)

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -48,4 +48,5 @@ ignore = [
   { id = "RUSTSEC-2026-0099", reason = "rustls-webpki 0.102/0.101 is vulnerable - tonic upgrade (https://github.com/vectordotdev/vector/issues/19179)" },
   { id = "RUSTSEC-2024-0436", reason = "paste crate is unmaintained - transitive dependency via parquet v56.2.0, no safe upgrade available" },
   { id = "RUSTSEC-2026-0104", reason = "rustls-webpki 0.102/0.101 CRL parsing panic - tonic upgrade (https://github.com/vectordotdev/vector/issues/19179); 0.103 already patched to 0.103.13" },
+  { id = "RUSTSEC-2026-0173", reason = "proc-macro-error2 is unmaintained - transitive dep via mlua_derive v0.11.0; unblocked when mlua upgrades its derive macro" },
 ]


### PR DESCRIPTION
## Summary

`proc-macro-error2` is flagged as unmaintained by RUSTSEC-2026-0173. It enters the dependency tree via `mlua_derive v0.11.0`, which is a proc-macro helper bundled with `mlua v0.11.6`. There is no newer stable `mlua 0.11.x` release that drops this dependency.

This PR adds an ignore entry to `deny.toml` to unblock CI, with a note pointing at the upstream blocker so it's easy to remove when mlua ships a fix.

## Vector configuration

N/A

## How did you test this PR?

`cargo deny check advisories` passes cleanly.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.