### PR TITLE
chore(dev): bump rust toolchain to 1.95 and fix clippy lints

### DIFF
--- a/lib/codecs/tests/native.rs
+++ b/lib/codecs/tests/native.rs
@@ -202,7 +202,7 @@ fn rebuild_proto_fixtures() {
 fn fixtures_match(suffix: &str) {
     let json_entries = list_fixtures("json", suffix);
     let proto_entries = list_fixtures("proto", suffix);
-    for (json_path, proto_path) in json_entries.into_iter().zip(proto_entries.into_iter()) {
+    for (json_path, proto_path) in json_entries.into_iter().zip(proto_entries) {
         // Make sure we're looking at the matching files for each format
         assert_eq!(
             json_path.file_stem().unwrap(),
@@ -220,7 +220,7 @@ fn decoding_matches(suffix: &str) {
     let json_entries = list_fixtures("json", suffix);
     let proto_entries = list_fixtures("proto", suffix);
 
-    for (json_path, proto_path) in json_entries.into_iter().zip(proto_entries.into_iter()) {
+    for (json_path, proto_path) in json_entries.into_iter().zip(proto_entries) {
         let (_, json_event) = load_deserialize(&json_path, &json_deserializer);
 
         let (_, proto_event) = load_deserialize(&proto_path, &proto_deserializer);

--- a/lib/vector-buffers/src/variants/disk_v2/common.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/common.rs
@@ -339,7 +339,7 @@ where
         if max_record_size <= MINIMUM_MAX_RECORD_SIZE {
             return Err(BuildError::InvalidParameter {
                 param_name: "max_record_size",
-                reason: format!("must be greater than or equal to {MINIMUM_MAX_RECORD_SIZE} bytes",),
+                reason: format!("must be greater than or equal to {MINIMUM_MAX_RECORD_SIZE} bytes"),
             });
         }
 

--- a/lib/vector-buffers/src/variants/disk_v2/ledger.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/ledger.rs
@@ -471,7 +471,7 @@ where
         );
 
         trace!(
-            unacked_reader_file_id_offset = result.map(|n| n - 1).unwrap_or(0),
+            unacked_reader_file_id_offset = result.map_or(0, |n| n - 1),
             acked_reader_file_id_offset = new_reader_file_id,
             "Incremented acknowledged reader file ID offset with corresponding unacknowledged decrement."
         );

--- a/lib/vector-config/src/schema/visitors/merge.rs
+++ b/lib/vector-config/src/schema/visitors/merge.rs
@@ -262,7 +262,7 @@ where
     K: Clone + Eq + Ord,
     V: Clone + Mergeable,
 {
-    destination.merge(source);
+    Mergeable::merge(destination, source);
 }
 
 fn merge_optional<T: Clone>(destination: &mut Option<T>, source: Option<&T>) {

--- a/lib/vector-core/src/config/global_options.rs
+++ b/lib/vector-core/src/config/global_options.rs
@@ -217,9 +217,8 @@ impl GlobalOptions {
         if !data_dir.exists() {
             return Err(DataDirError::DoesNotExist { data_dir }.into());
         }
-        let readonly = std::fs::metadata(&data_dir)
-            .map(|meta| meta.permissions().readonly())
-            .unwrap_or(true);
+        let readonly =
+            std::fs::metadata(&data_dir).map_or(true, |meta| meta.permissions().readonly());
         if readonly {
             return Err(DataDirError::NotWritable { data_dir }.into());
         }

--- a/lib/vector-core/src/config/mod.rs
+++ b/lib/vector-core/src/config/mod.rs
@@ -197,7 +197,7 @@ fn fmt_helper(
     data_type: DataType,
 ) -> fmt::Result {
     match maybe_port {
-        Some(port) => write!(f, "port: \"{port}\",",),
+        Some(port) => write!(f, "port: \"{port}\","),
         None => write!(f, "port: None,"),
     }?;
     write!(f, " types: {data_type}")

--- a/lib/vector-core/src/event/lua/metric.rs
+++ b/lib/vector-core/src/event/lua/metric.rs
@@ -163,7 +163,7 @@ impl IntoLua for LuaMetric {
             }
             MetricValue::Set { values } => {
                 let set = lua.create_table()?;
-                set.raw_set("values", lua.create_sequence_from(values.into_iter())?)?;
+                set.raw_set("values", lua.create_sequence_from(values)?)?;
                 tbl.raw_set("set", set)?;
             }
             MetricValue::Distribution { samples, statistic } => {

--- a/lib/vector-core/src/event/metadata.rs
+++ b/lib/vector-core/src/event/metadata.rs
@@ -381,10 +381,8 @@ impl EventMetadata {
 
         // Keep the earliest `last_transform_timestamp` for accurate latency measurement.
         match (self.last_transform_timestamp, other_timestamp) {
-            (Some(self_ts), Some(other_ts)) => {
-                if other_ts < self_ts {
-                    self.last_transform_timestamp = Some(other_ts);
-                }
+            (Some(self_ts), Some(other_ts)) if other_ts < self_ts => {
+                self.last_transform_timestamp = Some(other_ts);
             }
             (None, Some(other_ts)) => {
                 self.last_transform_timestamp = Some(other_ts);

--- a/lib/vector-core/src/event/metric/mod.rs
+++ b/lib/vector-core/src/event/metric/mod.rs
@@ -334,8 +334,8 @@ impl Metric {
     /// Returns `true` if `name` tag is present, and matches the provided `value`
     pub fn tag_matches(&self, name: &str, value: &str) -> bool {
         self.tags()
-            .filter(|t| t.get(name).filter(|v| *v == value).is_some())
-            .is_some()
+            .as_ref()
+            .is_some_and(|t| t.get(name).as_ref().is_some_and(|v| *v == value))
     }
 
     /// Returns the string value of a tag, if it exists

--- a/lib/vector-core/src/metrics/ddsketch.rs
+++ b/lib/vector-core/src/metrics/ddsketch.rs
@@ -407,7 +407,7 @@ impl AgentDDSketch {
 
     fn insert_key_counts(&mut self, mut counts: Vec<(i16, u32)>) {
         // Counts need to be sorted by key.
-        counts.sort_unstable_by(|(k1, _), (k2, _)| k1.cmp(k2));
+        counts.sort_unstable_by_key(|(k1, _)| *k1);
 
         let mut temp = Vec::new();
 

--- a/lib/vector-core/src/source_sender/output.rs
+++ b/lib/vector-core/src/source_sender/output.rs
@@ -248,7 +248,7 @@ impl Output {
     {
         let mut stream = events.ready_chunks(CHUNK_SIZE);
         while let Some(events) = stream.next().await {
-            self.send_batch(events.into_iter()).await?;
+            self.send_batch(events).await?;
         }
         Ok(())
     }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.92"
+channel = "1.95"
 profile = "default"

--- a/src/config/unit_test/mod.rs
+++ b/src/config/unit_test/mod.rs
@@ -442,7 +442,7 @@ async fn build_unit_test(
         .enrichment_tables
         .iter()
         .filter_map(|(key, c)| c.as_sink(key).map(|(_, sink)| sink.inputs))
-        .for_each(|i| valid_components.extend(i.into_iter()));
+        .for_each(|i| valid_components.extend(i));
 
     // Remove all transforms that are not relevant to the current test
     config_builder.transforms = config_builder

--- a/src/http.rs
+++ b/src/http.rs
@@ -561,27 +561,27 @@ where
         Box::pin(async move {
             let mut response = future.await?;
             match version {
-                Version::HTTP_09 | Version::HTTP_10 | Version::HTTP_11 => {
-                    if start_reference.elapsed() >= max_connection_age {
-                        debug!(
-                            message = "Closing connection due to max connection age.",
-                            ?max_connection_age,
-                            connection_age = ?start_reference.elapsed(),
-                            ?peer_addr,
-                        );
-                        // Tell the client to close this connection.
-                        // Hyper will automatically close the connection after the response is sent.
-                        response.headers_mut().insert(
-                            hyper::header::CONNECTION,
-                            hyper::header::HeaderValue::from_static("close"),
-                        );
-                    }
+                Version::HTTP_09 | Version::HTTP_10 | Version::HTTP_11
+                    if start_reference.elapsed() >= max_connection_age =>
+                {
+                    debug!(
+                        message = "Closing connection due to max connection age.",
+                        ?max_connection_age,
+                        connection_age = ?start_reference.elapsed(),
+                        ?peer_addr,
+                    );
+                    // Tell the client to close this connection.
+                    // Hyper will automatically close the connection after the response is sent.
+                    response.headers_mut().insert(
+                        hyper::header::CONNECTION,
+                        hyper::header::HeaderValue::from_static("close"),
+                    );
                 }
+                Version::HTTP_09 | Version::HTTP_10 | Version::HTTP_11 => (),
                 // TODO need to send GOAWAY frame
                 Version::HTTP_2 => (),
                 // TODO need to send GOAWAY frame
                 Version::HTTP_3 => (),
-                _ => (),
             }
             Ok(response)
         })

--- a/src/http.rs
+++ b/src/http.rs
@@ -582,6 +582,7 @@ where
                 Version::HTTP_2 => (),
                 // TODO need to send GOAWAY frame
                 Version::HTTP_3 => (),
+                _ => (),
             }
             Ok(response)
         })

--- a/src/sinks/http/encoder.rs
+++ b/src/sinks/http/encoder.rs
@@ -75,12 +75,10 @@ impl SinkEncoder<Vec<Event>> for HttpEncoder {
         }
 
         match (self.encoder.serializer(), self.encoder.framer()) {
-            (Json(_), NewlineDelimited(_)) => {
-                if !body.is_empty() {
-                    // Remove trailing newline for backwards-compatibility
-                    // with Vector `0.20.x`.
-                    body.truncate(body.len() - 1);
-                }
+            (Json(_), NewlineDelimited(_)) if !body.is_empty() => {
+                // Remove trailing newline for backwards-compatibility
+                // with Vector `0.20.x`.
+                body.truncate(body.len() - 1);
             }
             (Json(_), CharacterDelimited(CharacterDelimitedEncoder { delimiter: b',' })) => {
                 if !body.is_empty() {

--- a/src/sinks/websocket/sink.rs
+++ b/src/sinks/websocket/sink.rs
@@ -407,14 +407,12 @@ mod tests {
                                     let hdr = req.headers().get("Authorization");
                                     if let Some(h) = hdr {
                                         match a {
-                                            Auth::Bearer { token } => {
-                                                if format!("Bearer {}", token.inner())
-                                                    != h.to_str().unwrap()
-                                                {
-                                                    return Err(
-                                                        http::Response::<Option<String>>::new(None),
-                                                    );
-                                                }
+                                            Auth::Bearer { token }
+                                                if format!("Bearer {}", token.inner()) != h.to_str().unwrap() =>
+                                            {
+                                                return Err(
+                                                    http::Response::<Option<String>>::new(None),
+                                                );
                                             }
                                             Auth::Basic {
                                                 user: _user,

--- a/src/sinks/websocket/sink.rs
+++ b/src/sinks/websocket/sink.rs
@@ -414,6 +414,7 @@ mod tests {
                                                     http::Response::<Option<String>>::new(None),
                                                 );
                                             }
+                                            Auth::Bearer { .. } => {}
                                             Auth::Basic {
                                                 user: _user,
                                                 password: _password,

--- a/src/sources/datadog_agent/tests.rs
+++ b/src/sources/datadog_agent/tests.rs
@@ -118,7 +118,7 @@ fn test_decode_log_body() {
 
         let events = decode_log_body(body, api_key, &source).unwrap();
         assert_eq!(events.len(), msgs.len());
-        for (msg, event) in msgs.into_iter().zip(events.into_iter()) {
+        for (msg, event) in msgs.into_iter().zip(events) {
             let log = event.as_log();
             assert_eq!(log["message"], msg.message.into());
             assert_eq!(log["status"], msg.status.into());

--- a/src/sources/util/framestream.rs
+++ b/src/sources/util/framestream.rs
@@ -1304,7 +1304,7 @@ mod test {
         sock_sink: &mut S,
         frames: Vec<Result<Bytes, std::io::Error>>,
     ) {
-        let mut stream = stream::iter(frames.into_iter());
+        let mut stream = stream::iter(frames);
         //send and send_all consume the sink
         _ = sock_sink.send_all(&mut stream).await;
     }

--- a/src/test_util/mod.rs
+++ b/src/test_util/mod.rs
@@ -152,7 +152,7 @@ pub async fn send_encodable<I, E: From<std::io::Error> + std::fmt::Debug>(
 
     let mut sink = FramedWrite::new(stream, encoder);
 
-    let mut lines = stream::iter(lines.into_iter()).map(Ok);
+    let mut lines = stream::iter(lines).map(Ok);
     sink.send_all(&mut lines).await.unwrap();
 
     let stream = sink.get_mut();

--- a/src/topology/running.rs
+++ b/src/topology/running.rs
@@ -154,7 +154,7 @@ impl RunningTopology {
 
         // We need to give some time to the sources to gracefully shutdown, so
         // we will merge them with other tasks.
-        for (key, task) in self.tasks.into_iter().chain(self.source_tasks.into_iter()) {
+        for (key, task) in self.tasks.into_iter().chain(self.source_tasks) {
             let task = task.map(map_closure).shared();
 
             wait_handles.push(task.clone());
@@ -549,8 +549,8 @@ impl RunningTopology {
                     .map(|(key, value)| ((false, key), value)),
             ),
         )
-        .into_iter()
-        .flat_map(|(_, components)| components)
+        .into_values()
+        .flatten()
         .collect::<HashSet<_>>();
         // Existing conflicting sinks
         let conflicting_sinks = conflicts

--- a/vdev/src/commands/build/component_docs/schema.rs
+++ b/vdev/src/commands/build/component_docs/schema.rs
@@ -180,10 +180,8 @@ fn push_const_variants(result: &mut Vec<Value>, value: Value) {
                 }
             }
         }
-        obj @ Value::Object(_) => {
-            if !result.contains(&obj) {
-                result.push(obj);
-            }
+        obj @ Value::Object(_) if !result.contains(&obj) => {
+            result.push(obj);
         }
         _ => {}
     }

--- a/vdev/src/commands/check/events.rs
+++ b/vdev/src/commands/check/events.rs
@@ -717,10 +717,8 @@ impl<'ast> Visit<'ast> for Scanner<'_> {
                 event.skip.validity_check |= raw_block.contains("## skip check-validity-events ##");
 
                 match trait_name {
-                    "InternalEvent" => {
-                        if !registers_inside {
-                            event.internal_impl = true;
-                        }
+                    "InternalEvent" if !registers_inside => {
+                        event.internal_impl = true;
                     }
                     "RegisterInternalEvent" => {
                         event.register_impl = Some(event_name.clone());


### PR DESCRIPTION
## Summary

Bumps the Rust toolchain from 1.92 to 1.95 and resolves the resulting Clippy lint failures across the codebase. All changes are semantically equivalent idiom improvements (redundant `into_iter()`, `map_or`, `is_some_and`, match guards, `sort_unstable_by_key`, etc.).

## Vector configuration

NA

## How did you test this PR?

Verified with `make check-clippy` after the toolchain bump.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

NA