### PR TITLE
chore(codecs): Use simdutf for converting bytes to string

### DIFF
--- a/lib/codecs/src/decoding/format/json.rs
+++ b/lib/codecs/src/decoding/format/json.rs
@@ -8,7 +8,7 @@ use vector_core::{
     event::Event,
     schema,
 };
-use vrl::value::Kind;
+use vrl::value::{Kind, value::simdutf_bytes_utf8_lossy};
 
 use super::{Deserializer, default_lossy};
 
@@ -108,7 +108,7 @@ impl Deserializer for JsonDeserializer {
         }
 
         let json: serde_json::Value = match self.lossy {
-            true => serde_json::from_str(&String::from_utf8_lossy(&bytes)),
+            true => serde_json::from_str(&simdutf_bytes_utf8_lossy(&bytes)),
             false => serde_json::from_slice(&bytes),
         }
         .map_err(|error| format!("Error parsing JSON: {error:?}"))?;

--- a/lib/codecs/src/decoding/format/native_json.rs
+++ b/lib/codecs/src/decoding/format/native_json.rs
@@ -7,7 +7,7 @@ use vector_core::{
     event::Event,
     schema,
 };
-use vrl::value::{Kind, kind::Collection};
+use vrl::value::{Kind, kind::Collection, value::simdutf_bytes_utf8_lossy};
 
 use super::{Deserializer, default_lossy};
 
@@ -96,7 +96,7 @@ impl Deserializer for NativeJsonDeserializer {
         }
 
         let json: serde_json::Value = match self.lossy {
-            true => serde_json::from_str(&String::from_utf8_lossy(&bytes)),
+            true => serde_json::from_str(&simdutf_bytes_utf8_lossy(&bytes)),
             false => serde_json::from_slice(&bytes),
         }
         .map_err(|error| format!("Error parsing JSON: {error:?}"))?;

--- a/src/sinks/elasticsearch/retry.rs
+++ b/src/sinks/elasticsearch/retry.rs
@@ -1,5 +1,6 @@
 use http::StatusCode;
 use serde::Deserialize;
+use vrl::prelude::value::simdutf_bytes_utf8_lossy;
 use vector_lib::{EstimatedJsonEncodedSizeOf, json_size::JsonSize};
 
 use crate::{
@@ -119,16 +120,16 @@ impl RetryLogic for ElasticsearchRetryLogic {
                 format!(
                     "{}: {}",
                     status,
-                    String::from_utf8_lossy(response.http_response.body())
+                    simdutf_bytes_utf8_lossy(response.http_response.body())
                 )
                 .into(),
             ),
             _ if status.is_client_error() => {
-                let body = String::from_utf8_lossy(response.http_response.body());
+                let body = simdutf_bytes_utf8_lossy(response.http_response.body());
                 RetryAction::DontRetry(format!("client-side error, {status}: {body}").into())
             }
             _ if status.is_success() => {
-                let body = String::from_utf8_lossy(response.http_response.body());
+                let body = simdutf_bytes_utf8_lossy(response.http_response.body());
 
                 if body.contains("\"errors\":true") {
                     match EsResultResponse::parse(&body) {

--- a/src/sources/journald.rs
+++ b/src/sources/journald.rs
@@ -39,7 +39,7 @@ use vector_lib::{
 };
 use vrl::{
     event_path,
-    value::{Kind, Value, kind::Collection},
+    value::{Kind, Value, kind::Collection, value::simdutf_bytes_utf8_lossy},
 };
 
 use crate::{
@@ -954,7 +954,7 @@ fn fixup_unit(unit: &str) -> String {
 }
 
 fn decode_record(line: &[u8], remap: bool) -> Result<Record, JsonError> {
-    let mut record = serde_json::from_str::<JsonValue>(&String::from_utf8_lossy(line))?;
+    let mut record = serde_json::from_str::<JsonValue>(&simdutf_bytes_utf8_lossy(line))?;
     // journalctl will output non-ASCII values using an array
     // of integers. Look for those values and re-parse them.
     if let Some(record) = record.as_object_mut() {
@@ -988,7 +988,7 @@ fn decode_array_as_bytes(array: &[JsonValue]) -> Option<JsonValue> {
             })
         })
         .collect::<Option<Vec<u8>>>()
-        .map(|array| String::from_utf8_lossy(&array).into())
+        .map(|array| simdutf_bytes_utf8_lossy(&array).into())
 }
 
 fn remap_priority(priority: &mut JsonValue) {


### PR DESCRIPTION
## Summary
Speed up decoding json, elasticsearch sink and journald source by using simdutf8 crate for faster checking if string is UTF-8 valid by utilizing SIMD instructions. simdutf8 is already used in vrl, so I just reuse method that internally uses VRL.

According to crate docs this library is:

> x86-64: Up to 23 times faster than the std library on valid non-ASCII, up to four times faster on ASCII
> aarch64: Up to eleven times faster than the std library on valid non-ASCII, up to four times faster on ASCII (Apple Silicon)

## How did you test this PR?

Standard vector tests

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [x] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

Just performance improvement.

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.