### PR TITLE
docs(rfcs): simplify RFC template and process

### DIFF
--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -78,10 +78,10 @@ more info navigating your solution.
 
 1. Search GitHub for [previous issues](https://github.com/vectordotdev/vector/issues) and
    [RFCs](https://github.com/vectordotdev/vector/tree/master/rfcs) on this topic.
-2. If an RFC issue does not exist, [open one](https://github.com/vectordotdev/vector/issues/new/choose).
-3. Use the issue to obtain consensus that an RFC is necessary.
+2. If you are unsure whether an RFC is the right path forward, consider
+   [opening an issue](https://github.com/vectordotdev/vector/issues/new/choose) first to get community input.
    - The change might be quickly rejected.
-   - The change might be on our long term roadmap and get deferred.
+   - The change might already be planned and get deferred.
    - The change might be blocked by other work.
 
 ### Creating an RFC

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -86,12 +86,11 @@ more info navigating your solution.
 
 ### Creating an RFC
 
-1. Create a new branch
-2. Copy the [`rfcs/_YYYY-MM-DD-issue#-title.md`](rfcs/_YYYY-MM-DD-issue%23-title.md) template with the appropriate
-   name. Be sure to use the issue number you created above. (e.g., `rfcs/2020-02-10-445-internal-observability.md`)
-3. Fill in your RFC, pay attention the bullets and guidelines. Do not omit any sections.
-4. Work with the Vector team to land on a confident solution. Allocate time for code-level spikes if necessary.
-5. Submit your RFC as a pull request and tag reviewers for approval.
+1. Copy the [`rfcs/_YYYY-MM-DD-issue#-title.md`](rfcs/_YYYY-MM-DD-issue%23-title.md) template with the appropriate
+   name. (e.g., `rfcs/2020-02-10-445-internal-observability.md`)
+2. Fill in your RFC, pay attention the bullets and guidelines. Do not omit any sections.
+3. Work with the Vector team to land on a confident solution. Allocate time for code-level spikes if necessary.
+4. Submit your RFC as a pull request and tag reviewers for approval.
 
 ### Getting an RFC accepted
 

--- a/rfcs/_YYYY-MM-DD-issue#-title.md
+++ b/rfcs/_YYYY-MM-DD-issue#-title.md
@@ -5,10 +5,8 @@ One paragraph description of the change.
 ## Context
 
 - Link to any previous issues, RFCs, or briefs (do not repeat that context in this RFC).
-
-## Cross cutting concerns
-
 - Link to any ongoing or future work relevant to this change.
+- List any prior art (from other projects or the broader ecosystem), the good and the bad.
 
 ## Scope
 
@@ -23,7 +21,9 @@ One paragraph description of the change.
 ## Motivation
 
 - What internal or external *pain* are we solving?
-- Do not cover benefits of your change, this is covered in the "Rationale" section.
+- Why is this change worth it?
+- What is the impact of not doing this?
+- How does this position us for success in the future?
 
 ## Proposal
 
@@ -38,25 +38,10 @@ One paragraph description of the change.
 - When possible, demonstrate with pseudo code not text.
 - Be specific. Be opinionated. Avoid ambiguity.
 
-## Rationale
-
-- Why is this change worth it?
-- What is the impact of not doing this?
-- How does this position us for success in the future?
-
-## Drawbacks
-
-- Why should we not do this?
-- What kind on ongoing burden does this place on the team?
-
-## Prior Art
-
-- List prior art, the good and bad.
-- Why can't we simply use or copy them?
-
 ## Alternatives
 
 - What other approaches have been considered and why did you not choose them?
+- What are the drawbacks of the chosen approach?
 - How about not doing this at all?
 
 ## Outstanding Questions


### PR DESCRIPTION
## Summary

The RFC template and process have accumulated sections that either overlap or add friction without adding clarity. This trims redundant sections and softens process requirements that aren't enforced.

## Motivation

The previous template had duplicate concepts split across separate sections (e.g., Motivation vs Rationale, Context vs Cross cutting concerns), making RFCs longer to write and harder to review. The process also required opening a GitHub issue before writing any RFC — a gate that isn't checked and discourages contributors who already have a clear proposal.

## Vector configuration

N/A

## How did you test this PR?

Reviewed both files for clarity and consistency.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.