### PR TITLE
fix(topology): serialize enrichment table registry loads

### DIFF
--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -12,7 +12,7 @@ use metrics::Counter;
 use stream_cancel::{StreamExt as StreamCancelExt, Trigger, Tripwire};
 use tokio::{
     select,
-    sync::{mpsc::UnboundedSender, oneshot},
+    sync::{Mutex as AsyncMutex, mpsc::UnboundedSender, oneshot},
     time::timeout,
 };
 use tracing::{Instrument, Span};
@@ -66,6 +66,9 @@ use crate::{
 
 static ENRICHMENT_TABLES: LazyLock<vector_lib::enrichment::TableRegistry> =
     LazyLock::new(vector_lib::enrichment::TableRegistry::default);
+// `TableRegistry::load` and `finish_load` are separate operations on a process-global registry.
+// Keep topology builds and enrichment-table reloads from interleaving that transition.
+static ENRICHMENT_TABLES_LOAD_LOCK: LazyLock<AsyncMutex<()>> = LazyLock::new(AsyncMutex::default);
 static METRICS_STORAGE: LazyLock<MetricsStorage> = LazyLock::new(MetricsStorage::default);
 
 pub(crate) static SOURCE_SENDER_BUFFER_SIZE: LazyLock<usize> =
@@ -133,6 +136,7 @@ impl<'a> Builder<'a> {
 
     /// Builds the new pieces of the topology found in `self.diff`.
     async fn build(mut self) -> Result<TopologyPieces, Vec<String>> {
+        let _enrichment_tables_load_guard = ENRICHMENT_TABLES_LOAD_LOCK.lock().await;
         let enrichment_tables = self.load_enrichment_tables().await;
         let source_tasks = self.build_sources(enrichment_tables).await;
         self.build_transforms(enrichment_tables).await;
@@ -1003,6 +1007,7 @@ async fn run_source_output_pump(
 }
 
 pub async fn reload_enrichment_tables(config: &Config) {
+    let _enrichment_tables_load_guard = ENRICHMENT_TABLES_LOAD_LOCK.lock().await;
     let mut enrichment_tables = HashMap::new();
     // Build enrichment tables
     'tables: for (name, table_outer) in config.enrichment_tables.iter() {


### PR DESCRIPTION
## Summary

Serialize access to the process-global `ENRICHMENT_TABLES` registry while topology builds or enrichment-table reloads move through `load` / `finish_load`.

This fixes an internal race for concurrent in-process topology builds/reloads. The normal daemon reload path already serializes reload signals through the topology controller, so this is primarily exposed by plain `cargo test` and test harnesses that build topologies concurrently.

## Vector configuration

N/A

## How did you test this PR?

- `make fmt`
- `cargo test -p vector topology::test::reload --no-default-features --features sources-prometheus,sinks-prometheus,sources-internal_metrics,sources-splunk_hec,enrichment-tables-memory`
- Applied this change to #25547 and verified its previously failing reload module now passes under normal parallel `cargo test`
- `make check-clippy`

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: #25547

## Notes

None.
