### PR TITLE
fix(vdev): release tooling fixes from #25442

### DIFF
--- a/vdev/src/commands/release/generate_cue.rs
+++ b/vdev/src/commands/release/generate_cue.rs
@@ -196,7 +196,6 @@ struct Commit {
     date: String,
     description: String,
     r#type: Option<String>,
-    scopes: Vec<String>,
     breaking_change: bool,
     pr_number: Option<u64>,
     files_count: u64,
@@ -232,7 +231,6 @@ impl Commit {
     }
 
     fn render_cue(&self) -> String {
-        let scopes_json = serde_json::to_string(&self.scopes).expect("scopes serialise");
         let pr_number = match self.pr_number {
             Some(n) => n.to_string(),
             None => "null".to_string(),
@@ -242,11 +240,10 @@ impl Commit {
             None => "null".to_string(),
         };
         format!(
-            "{{sha: {sha}, date: {date}, description: {description}, pr_number: {pr_number}, scopes: {scopes}, type: {type_field}, breaking_change: {breaking}, author: {author}, files_count: {files}, insertions_count: {ins}, deletions_count: {del}}}",
+            "{{sha: {sha}, date: {date}, description: {description}, pr_number: {pr_number}, type: {type_field}, breaking_change: {breaking}, author: {author}, files_count: {files}, insertions_count: {ins}, deletions_count: {del}}}",
             sha = json!(self.sha),
             date = json!(self.date),
             description = json!(self.description),
-            scopes = scopes_json,
             type_field = type_json,
             breaking = self.breaking_change,
             author = json!(self.author),
@@ -291,7 +288,6 @@ fn fetch_commits_since(last_version: &Version) -> Result<Vec<Commit>> {
             date,
             description: conv.description,
             r#type: conv.r#type,
-            scopes: conv.scopes,
             breaking_change: conv.breaking_change,
             pr_number: conv.pr_number,
             files_count: files,
@@ -346,7 +342,6 @@ fn commit_stats(sha: &str) -> Result<(u64, u64, u64)> {
 #[derive(Debug)]
 struct ConventionalParts {
     r#type: Option<String>,
-    scopes: Vec<String>,
     breaking_change: bool,
     description: String,
     pr_number: Option<u64>,
@@ -355,7 +350,7 @@ struct ConventionalParts {
 impl ConventionalParts {
     fn parse(message: &str) -> Self {
         let re = Regex::new(
-            r"^(?P<type>[a-z]*)(\((?P<scope>[a-zA-Z0-9_, -]*)\))?(?P<breaking>!)?: (?P<desc>.*?)( \(#(?P<pr>[0-9]+)\))?$",
+            r"^(?P<type>[a-z]*)(\([a-zA-Z0-9_, -]*\))?(?P<breaking>!)?: (?P<desc>.*?)( \(#(?P<pr>[0-9]+)\))?$",
         )
         .unwrap();
 
@@ -364,16 +359,6 @@ impl ConventionalParts {
                 .name("type")
                 .map(|m| m.as_str().to_string())
                 .filter(|s| !s.is_empty());
-            let scopes: Vec<String> = caps
-                .name("scope")
-                .map(|m| {
-                    m.as_str()
-                        .split(',')
-                        .map(|s| s.trim().to_string())
-                        .filter(|s| !s.is_empty())
-                        .collect()
-                })
-                .unwrap_or_default();
             let breaking_change = caps.name("breaking").is_some();
             let description = caps
                 .name("desc")
@@ -382,7 +367,6 @@ impl ConventionalParts {
             let pr_number = caps.name("pr").and_then(|m| m.as_str().parse::<u64>().ok());
             ConventionalParts {
                 r#type,
-                scopes,
                 breaking_change,
                 description,
                 pr_number,
@@ -390,7 +374,6 @@ impl ConventionalParts {
         } else {
             ConventionalParts {
                 r#type: None,
-                scopes: Vec::new(),
                 breaking_change: false,
                 description: message.to_string(),
                 pr_number: None,
@@ -568,7 +551,6 @@ mod tests {
     fn parse_conventional_basic() {
         let p = ConventionalParts::parse("feat(kafka source): add new metric (#123)");
         assert_eq!(p.r#type.as_deref(), Some("feat"));
-        assert_eq!(p.scopes, vec!["kafka source".to_string()]);
         assert!(!p.breaking_change);
         assert_eq!(p.description, "add new metric");
         assert_eq!(p.pr_number, Some(123));
@@ -584,21 +566,42 @@ mod tests {
     }
 
     #[test]
-    fn parse_conventional_multi_scope() {
-        let p = ConventionalParts::parse("fix(a, b): wip");
-        assert_eq!(p.scopes, vec!["a".to_string(), "b".to_string()]);
-        assert_eq!(p.pr_number, None);
+    fn parse_conventional_with_scope() {
+        // Scopes are accepted in the commit subject but no longer stored.
+        let p = ConventionalParts::parse("fix(ARC): tweak retry policy (#456)");
+        assert_eq!(p.r#type.as_deref(), Some("fix"));
+        assert_eq!(p.description, "tweak retry policy");
+        assert_eq!(p.pr_number, Some(456));
     }
 
     #[test]
-    fn parse_conventional_uppercase_scope() {
-        // The semantic-PR workflow allows uppercase scopes like `ARC`, so the
-        // release-generation parser must accept them too.
-        let p = ConventionalParts::parse("fix(ARC): tweak retry policy (#456)");
-        assert_eq!(p.r#type.as_deref(), Some("fix"));
-        assert_eq!(p.scopes, vec!["ARC".to_string()]);
-        assert_eq!(p.description, "tweak retry policy");
-        assert_eq!(p.pr_number, Some(456));
+    fn scoped_subject_parses_and_validates() {
+        // End-to-end: a scoped conventional subject must flow through both
+        // parsing and Commit::validate without error after the scope drop.
+        let subjects = [
+            "feat(kafka source): add new metric (#123)",
+            "fix(loki sink): handle empty labels (#9)",
+            "chore(deps): bump tokio (#1)",
+            "enhancement(api, config): tweak schema (#42)",
+        ];
+        for subject in subjects {
+            let p = ConventionalParts::parse(subject);
+            assert!(p.r#type.is_some(), "parse failed for: {subject}");
+            let c = Commit {
+                sha: "x".into(),
+                author: "a".into(),
+                date: "d".into(),
+                description: p.description,
+                r#type: p.r#type,
+                breaking_change: p.breaking_change,
+                pr_number: p.pr_number,
+                files_count: 0,
+                insertions_count: 0,
+                deletions_count: 0,
+            };
+            c.validate()
+                .unwrap_or_else(|e| panic!("validate failed for {subject}: {e}"));
+        }
     }
 
     #[test]
@@ -694,7 +697,6 @@ mod tests {
             date: "2026-05-06 12:00:00 UTC".into(),
             description: "do stuff".into(),
             r#type: Some("feat".into()),
-            scopes: vec!["kafka source".into()],
             breaking_change: false,
             pr_number: Some(42),
             files_count: 1,
@@ -711,11 +713,9 @@ mod tests {
         assert!(out.contains("\t\t\t\tAdds a thing.\n"));
         assert!(out.contains("\t\t\t\tMulti-line.\n"));
         assert!(out.contains("contributors: [\"alice\"]"));
-        // contributors line must NOT appear for the fix entry
         assert!(out.contains("\t\t\ttype: \"fix\"\n"));
-        // Commit struct rendered inline.
         assert!(out.contains("sha: \"abc123\""));
-        assert!(out.contains("scopes: [\"kafka source\"]"));
+        assert!(!out.contains("scopes:"));
         assert!(out.contains("pr_number: 42"));
         assert!(out.contains("files_count: 1"));
     }
@@ -729,7 +729,6 @@ mod tests {
                 date: "d".into(),
                 description: "no scope".into(),
                 r#type: Some((*t).into()),
-                scopes: vec![],
                 breaking_change: false,
                 pr_number: None,
                 files_count: 0,
@@ -751,7 +750,6 @@ mod tests {
             date: "d".into(),
             description: "x".into(),
             r#type: Some("nope".into()),
-            scopes: vec!["a".into()],
             breaking_change: false,
             pr_number: None,
             files_count: 0,
@@ -771,7 +769,6 @@ mod tests {
             date: "d".into(),
             description: "Merge branch 'foo'".into(),
             r#type: None,
-            scopes: Vec::new(),
             breaking_change: false,
             pr_number: None,
             files_count: 0,

--- a/vdev/src/commands/release/prepare.rs
+++ b/vdev/src/commands/release/prepare.rs
@@ -119,9 +119,26 @@ impl Prepare {
     /// Steps 1 & 2
     fn create_release_branches(&self) -> Result<()> {
         debug!("create_release_branches");
-        // Step 1: Create a new release branch
-        git::run_and_check_output(&["fetch"])?;
-        git::checkout_main_branch()?;
+
+        if self.dry_run {
+            // In dry-run mode the branches (and the commit range fed to
+            // generate_cue) are based on whatever is currently checked out.
+            // Surface that explicitly so a stale or feature branch doesn't
+            // silently land unrelated commits in the generated release CUE.
+            let head = git::run_and_check_output(&["rev-parse", "--abbrev-ref", "HEAD"])
+                .unwrap_or_else(|_| "<unknown>".to_string());
+            let last = &self.latest_vector_version;
+            warn!(
+                "dry-run: using HEAD ({}) as the release base; \
+                 commits in the generated CUE will be `git log v{last}...HEAD`. \
+                 Verify this matches what you'd expect from master.",
+                head.trim()
+            );
+        } else {
+            // Step 1: Sync with remote and start from master.
+            git::run_and_check_output(&["fetch"])?;
+            git::checkout_main_branch()?;
+        }
 
         git::checkout_or_create_branch(self.release_branch.as_str())?;
         if !self.dry_run {
@@ -442,12 +459,17 @@ fn format_vrl_changelog_block(changelog: &str) -> String {
 fn insert_block_after_changelog(original: &str, block: &str) -> String {
     let mut result = Vec::new();
     let mut inserted = false;
+    let mut in_changelog = false;
 
     for line in original.lines() {
         result.push(line.to_string());
 
-        // Insert *after* the line containing only the closing `]` (end of changelog array)
-        if !inserted && line.trim() == "]" {
+        if line.trim_start().starts_with("changelog:") {
+            in_changelog = true;
+        }
+
+        // Insert after the closing `]` of the changelog array specifically.
+        if !inserted && in_changelog && line.trim() == "]" {
             result.push(String::new()); // empty line before
             result.push(block.to_string());
             inserted = true;


### PR DESCRIPTION
## Summary

Small release tooling fixes, partially extracted from #25442.

**Fix dry-run branch creation in `vdev release prepare`**

`--dry-run` previously still called `git fetch` and `checkout_main_branch`, requiring a clean remote checkout. Those steps are now skipped in dry-run mode so the command works from any local branch.

**Fix `insert_block_after_changelog` inserting at the wrong position**

When a CUE release file contains a nested array that closes before the `changelog:` array, the old code inserted the VRL changelog block at the first `]` it encountered. Now tracks entry into the `changelog:` block before looking for the closing `]`.

**Drop scope parsing from the release CUE generator**

Scopes were used by older release page layouts (pre-~0.30) to render blue badges on vector.dev. The current release page template does not render them. Removes the `scopes` field from `ConventionalParts` and `Commit`, simplifies the regex, and drops `scopes` from the CUE output. The CUE schema retains the field (defaulting to `[]`) so existing release files continue to validate.

## Vector configuration

NA

## How did you test this PR?

- `cargo test -p vdev`

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: #25442