### PR TITLE
chore(ci): only save cargo registry cache from master

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -134,9 +134,24 @@ runs:
       run: echo "::add-matcher::.github/matchers/rust.json"
       shell: bash
 
+    # Two steps so that the actions/cache post-step (which saves the cache) runs
+    # directly from this composite, not a nested one — nested composites break
+    # post-step input resolution (actions/runner#3514, #2030).
     - name: Cache Cargo registry, index, and git DB
-      if: ${{ inputs.cargo-cache == 'true' || env.NEEDS_RUST == 'true' }}
+      if: ${{ (inputs.cargo-cache == 'true' || env.NEEDS_RUST == 'true') && github.ref == 'refs/heads/master' }}
       uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+      with:
+        path: |
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-
+
+    - name: Restore Cargo registry, index, and git DB
+      if: ${{ (inputs.cargo-cache == 'true' || env.NEEDS_RUST == 'true') && github.ref != 'refs/heads/master' }}
+      uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
       with:
         path: |
           ~/.cargo/registry/index/


### PR DESCRIPTION
## Summary

The cargo registry cache (~411 MB per entry) was being saved independently for every Git ref that ran CI. The cache key is \`${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}\`, so when multiple PRs share the same \`Cargo.lock\`, each writes an identical blob under its own ref scope. A single hash was stored 5–6 times across PR branches, merge-queue branches, and master. With 51 total entries the repo was at GitHub's 10 GB cache limit, causing active LRU eviction.

**Fix:** split the single \`actions/cache\` step into two adjacent steps directly in \`setup/action.yml\`:

- On \`refs/heads/master\`: uses the full \`actions/cache\` — its automatic post-step fires after all job steps complete and saves a populated registry
- On all other refs: uses \`actions/cache/restore\` only — no post-step, no cache written back

Both steps stay directly in \`setup/action.yml\` (not a nested composite) due to a known runner limitation where \`actions/cache\`'s post-step loses its \`path\` input when invoked from a composite-within-composite (actions/runner#3514, #2030).

## Vector configuration

N/A

## How did you test this PR?

Audited the live cache state via the GitHub Actions cache API: 51 entries, ~10 GB total, with the same \`Cargo.lock\` hash appearing on 5+ refs simultaneously.

Validated end-to-end in [vectordotdev/ci-sandbox](https://github.com/vectordotdev/ci-sandbox) with a Rust binary (with real crate dependencies) before applying here:

1. **PR branch run** ([#32](https://github.com/vectordotdev/ci-sandbox/pull/32), [#33](https://github.com/vectordotdev/ci-sandbox/pull/33)): \`actions/cache/restore\` ran, no post-step registered, no cache entry written to the PR ref
2. **master run** (post-merge): \`actions/cache\` post-step fired after the build and wrote \`Linux-cargo-<hash>\` — confirmed via \`Cache saved with key:\` in the logs
3. **Follow-up PR run** ([#33](https://github.com/vectordotdev/ci-sandbox/pull/33), same \`Cargo.lock\`): exact cache hit on the key master saved — \`Cache restored from key: Linux-cargo-<hash>\` in under 1 second, no write-back

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the \`no-changelog\` label to this PR.