### PR TITLE
chore(ci): cache openssl and rdkafka C build artifacts

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -161,6 +161,36 @@ runs:
         restore-keys: |
           ${{ runner.os }}-cargo-
 
+    - name: Cache C build artifacts (openssl, rdkafka)
+      if: ${{ (inputs.cargo-cache == 'true' || env.NEEDS_RUST == 'true') && github.ref == 'refs/heads/master' }}
+      uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+      with:
+        path: |
+          target/debug/build/openssl-sys-*/
+          target/debug/build/openssl-src-*/
+          target/debug/build/rdkafka-sys-*/
+          target/debug/.fingerprint/openssl-sys-*/
+          target/debug/.fingerprint/openssl-src-*/
+          target/debug/.fingerprint/rdkafka-sys-*/
+        key: ${{ runner.os }}-cbuild-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-cbuild-
+
+    - name: Restore C build artifacts (openssl, rdkafka)
+      if: ${{ (inputs.cargo-cache == 'true' || env.NEEDS_RUST == 'true') && github.ref != 'refs/heads/master' }}
+      uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+      with:
+        path: |
+          target/debug/build/openssl-sys-*/
+          target/debug/build/openssl-src-*/
+          target/debug/build/rdkafka-sys-*/
+          target/debug/.fingerprint/openssl-sys-*/
+          target/debug/.fingerprint/openssl-src-*/
+          target/debug/.fingerprint/rdkafka-sys-*/
+        key: ${{ runner.os }}-cbuild-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-cbuild-
+
     - name: Install mold
       if: ${{ runner.os == 'Linux' && env.DISABLE_MOLD != 'true' && inputs.mold == 'true' }}
       shell: bash


### PR DESCRIPTION
## Summary

\`openssl-sys\` (vendored) and \`rdkafka-sys\` (\`cmake_build\`) are the two heaviest C/C++ compilations in Vector CI builds — 5–10 min and 2–5 min respectively on a cold \`target/\` directory. Every clean build (cache miss or new \`Cargo.lock\` hash) pays this cost in full.

Cache \`target/debug/build/<crate>-*/\` and the corresponding \`target/debug/.fingerprint/<crate>-*/\` entries. The \`build/\` directory contains the compiled \`.a\` libraries and generated bindings; the \`.fingerprint/\` entries tell Cargo the build script output is still valid so it skips re-running the C compilation entirely. Without fingerprints, Cargo re-runs the build script even when \`out/\` is present.

Key: \`${{ runner.os }}-cbuild-${{ hashFiles('**/Cargo.lock') }}\` — invalidates automatically when either crate version changes. Same master-only save pattern as the registry cache (introduced in #25643) to prevent cross-ref duplication.

Estimated cache size: ~150–300 MB. Estimated savings: 7–15 min per clean build.

## Vector configuration

N/A

## How did you test this PR?

Not yet validated end-to-end — drafted for review of approach before wiring up sandbox validation.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the \`no-changelog\` label to this PR.