### PR TITLE
chore(vdev): bump version to 0.3.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12791,7 +12791,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vdev"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "anyhow",
  "cfg-if",

--- a/vdev/Cargo.toml
+++ b/vdev/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vdev"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2024"
 authors = ["Vector Contributors <vector@datadoghq.com>"]
 license = "MPL-2.0"


### PR DESCRIPTION
## Summary

Cuts a vdev release that ships the changes accumulated since v0.3.3:

- **`vdev deprecation show / enact / generate / check`** (#25638) — the deprecation.d fragment management commands. Required so the CI workflow in #25442 (which calls `vdev deprecation check`) finds the subcommand on the installed binary.
- **`vdev release` tooling fixes** (#25629) — drop scope parsing, dry-run warning, fix `insert_block_after_changelog` positioning.

## Release-flow notes

This is the first release on the new install flow from #25456 (\`--manifest-path\`, no \`VDEV_VERSION\` pin in \`prepare.sh\`, source-compile fallback when the binary isn't available). The flow is:

1. Merge this PR.
2. Tag the merge commit \`vdev-v0.3.4\`.
3. \`vdev_publish.yml\` builds and uploads the prebuilt binaries.
4. Subsequent CI runs install \`0.3.4\` via binstall automatically — no follow-up PR to bump anything in \`prepare.sh\`.

## Vector configuration

NA

## How did you test this PR?

- \`cargo build -p vdev\` and \`cargo test -p vdev\` (72 tests pass) at the bumped version.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the \`no-changelog\` label to this PR.

## References

- Bundles changes from: #25638, #25629
- Uses the install flow from: #25456