### PR TITLE
chore(tests): use multi-stage Dockerfile to skip source copy for integration runner

### DIFF
--- a/.github/workflows/ci-integration-review.yml
+++ b/.github/workflows/ci-integration-review.yml
@@ -164,6 +164,7 @@ jobs:
         if: steps.run_condition.outputs.should_run == 'true'
 
       - uses: ./.github/actions/setup
+        if: steps.run_condition.outputs.should_run == 'true'
         with:
           vdev: true
           datadog-ci: true
@@ -222,6 +223,7 @@ jobs:
         if: steps.run_condition.outputs.should_run == 'true'
 
       - uses: ./.github/actions/setup
+        if: steps.run_condition.outputs.should_run == 'true'
         with:
           vdev: true
           datadog-ci: true

--- a/tests/e2e/Dockerfile
+++ b/tests/e2e/Dockerfile
@@ -2,7 +2,7 @@ ARG RUST_VERSION=1
 ARG FEATURES
 ARG BUILD=false
 
-FROM docker.io/rust:${RUST_VERSION}-slim-trixie
+FROM docker.io/rust:${RUST_VERSION}-slim-trixie AS base
 
 COPY scripts/environment/install-debian-build-deps.sh /
 RUN bash /install-debian-build-deps.sh
@@ -19,15 +19,16 @@ COPY rust-toolchain.toml .
 RUN bash /prepare.sh --modules=cargo-nextest,cargo-llvm-cov
 RUN bash /install-protoc.sh
 
+FROM base AS build-false
+
+FROM base AS build-true
 COPY . .
 ARG FEATURES
-ARG BUILD
-
 RUN --mount=type=cache,target=/vector/target \
     --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
-    if [ "$BUILD" = "true" ]; then \
-        /usr/bin/mold -run cargo build --tests --lib --bin vector \
-        --no-default-features --features $FEATURES && \
-        cp target/debug/vector /usr/bin/vector; \
-    fi
+    /usr/bin/mold -run cargo build --tests --lib --bin vector \
+    --no-default-features --features $FEATURES && \
+    cp target/debug/vector /usr/bin/vector
+
+FROM build-${BUILD}

--- a/tests/e2e/Dockerfile
+++ b/tests/e2e/Dockerfile
@@ -31,4 +31,7 @@ RUN --mount=type=cache,target=/vector/target \
     --no-default-features --features $FEATURES && \
     cp target/debug/vector /usr/bin/vector
 
+# BuildKit conditional stage selection: selects build-false (lean, no source) or
+# build-true (full source + compiled binary) based on the BUILD arg.
+# https://www.docker.com/blog/advanced-dockerfiles-faster-builds-and-smaller-images-using-buildkit-and-multistage-builds/
 FROM build-${BUILD}


### PR DESCRIPTION
## Summary

**Dockerfile optimization:** The test runner Dockerfile (`tests/e2e/Dockerfile`) previously ran `COPY . .` unconditionally, regardless of the `BUILD` arg. For integration tests (`BUILD=false`) this baked ~60-70 MB of source into the image even though it is never used at runtime — the container mounts the live source from the host at `/home/vector`. It also meant any source file edit invalidated the Docker layer cache for the integration runner image.

Restructured as a multi-stage build using the [BuildKit conditional stage selection pattern](https://www.docker.com/blog/advanced-dockerfiles-faster-builds-and-smaller-images-using-buildkit-and-multistage-builds/):
- `base` — installs the Rust toolchain, build deps, and test tooling; no source copy
- `build-false` — alias for `base`; used by integration tests
- `build-true` — extends `base` with `COPY . .` and `cargo build`; used by E2E tests
- `FROM build-${BUILD}` — BuildKit selects the correct branch and skips the other entirely

**CI fix:** The `setup` step in both `integration-tests` and `e2e-tests` jobs in `ci-integration-review.yml` was missing `if: steps.run_condition.outputs.should_run == 'true'`. Every other step in those jobs had the guard. When a service wasn't in the triggered run, checkout was skipped but `setup` still ran and failed trying to find the local action. Introduced in #25077.

## Vector configuration

N/A — CI/tooling change only.

## How did you test this PR?

Tested the Dockerfile locally with both `BUILD=false` and `BUILD=true`. With `BUILD=false`, the `build-true` stage (including `COPY . .` and `cargo build`) does not appear in the build output — BuildKit skips it entirely. The `build-test-runner / build` CI job on this PR also passed, confirming `BUILD=false` works correctly in CI.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.