### PR TITLE
chore(deps): update VRL to use perf/smol-str-keystring branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10765,11 +10765,11 @@ dependencies = [
 
 [[package]]
 name = "smol_str"
-version = "0.2.2"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
+checksum = "4aaa7368fcf4852a4c2dd92df0cace6a71f2091ca0a23391ce7f3a31833f1523"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -13483,7 +13483,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 [[package]]
 name = "vrl"
 version = "0.33.1"
-source = "git+https://github.com/vectordotdev/vrl.git?branch=perf%2Fsmol-str-keystring#0b5556b7993c064dcd0da3e510b5f8f3dde0ff82"
+source = "git+https://github.com/vectordotdev/vrl.git?branch=perf%2Fsmol-str-keystring#46f61ee8232d1ca9f8455788959f123e0c439b2b"
 dependencies = [
  "aes",
  "aes-siv",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13483,7 +13483,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 [[package]]
 name = "vrl"
 version = "0.33.1"
-source = "git+https://github.com/vectordotdev/vrl.git?branch=perf%2Fsmol-str-keystring#d9b72fee50f19abab556b3aa4f08c0c6f3776adf"
+source = "git+https://github.com/vectordotdev/vrl.git?branch=perf%2Fsmol-str-keystring#0b5556b7993c064dcd0da3e510b5f8f3dde0ff82"
 dependencies = [
  "aes",
  "aes-siv",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10764,6 +10764,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "smol_str"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "smpl_jwt"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13474,7 +13483,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 [[package]]
 name = "vrl"
 version = "0.33.1"
-source = "git+https://github.com/vectordotdev/vrl.git?branch=main#74e3e74582aa6b4445c1a94004bb3f14276d07df"
+source = "git+https://github.com/vectordotdev/vrl.git?branch=perf%2Fsmol-str-keystring#d9b72fee50f19abab556b3aa4f08c0c6f3776adf"
 dependencies = [
  "aes",
  "aes-siv",
@@ -13565,6 +13574,7 @@ dependencies = [
  "sha2 0.10.9",
  "sha3",
  "simdutf8",
+ "smol_str",
  "snafu 0.8.9",
  "snap",
  "strip-ansi-escapes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -224,7 +224,7 @@ vector-common-macros = { path = "lib/vector-common-macros" }
 vector-lib = { path = "lib/vector-lib", default-features = false, features = ["vrl"] }
 vector-vrl-category = { path = "lib/vector-vrl/category" }
 vector-vrl-functions = { path = "lib/vector-vrl/functions", default-features = false }
-vrl = { git = "https://github.com/vectordotdev/vrl.git", branch = "main", default-features = false, features = ["arbitrary", "cli", "test", "test_framework", "stdlib-base"] }
+vrl = { git = "https://github.com/vectordotdev/vrl.git", branch = "perf/smol-str-keystring", default-features = false, features = ["arbitrary", "cli", "test", "test_framework", "stdlib-base"] }
 mock_instant = { version = "0.6" }
 serial_test = { version = "3.4" }
 strum = { version = "0.28", features = ["derive"] }

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -729,6 +729,7 @@ sketches-ddsketch,https://github.com/mheffner/rust-sketches-ddsketch,Apache-2.0,
 slab,https://github.com/tokio-rs/slab,MIT,Carl Lerche <me@carllerche.com>
 smallvec,https://github.com/servo/rust-smallvec,MIT OR Apache-2.0,The Servo Project Developers
 smol,https://github.com/smol-rs/smol,Apache-2.0 OR MIT,Stjepan Glavina <stjepang@gmail.com>
+smol_str,https://github.com/rust-analyzer/smol_str,MIT OR Apache-2.0,Aleksey Kladov <aleksey.kladov@gmail.com>
 smpl_jwt,https://github.com/durch/rust-jwt,MIT,Drazen Urch <github@drazenur.ch>
 snafu,https://github.com/shepmaster/snafu,MIT OR Apache-2.0,Jake Goulding <jake.goulding@gmail.com>
 snafu-derive,https://github.com/shepmaster/snafu,MIT OR Apache-2.0,Jake Goulding <jake.goulding@gmail.com>

--- a/src/sources/fluent/message.rs
+++ b/src/sources/fluent/message.rs
@@ -54,7 +54,7 @@ pub(super) struct FluentMessageOptions {
 pub(super) struct FluentEntry(pub(super) FluentTimestamp, pub(super) FluentRecord);
 
 /// Fluent record is just key/value pairs.
-pub(super) type FluentRecord = BTreeMap<String, FluentValue>;
+pub(super) type FluentRecord = BTreeMap<KeyString, FluentValue>;
 
 /// Fluent message tag.
 pub(super) type FluentTag = String;


### PR DESCRIPTION
## Summary
Updated VRL dependency to use the `perf/smol-str-keystring` branch which includes performance improvements.

## Vector configuration
NA

## How did you test this PR?

`/ci-run-regression`

https://github.com/vectordotdev/vector/actions/runs/27721823285?pr=25647

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [x] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?
- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References
Related to https://github.com/vectordotdev/vrl/pull/1825