### PR TITLE
chore(website): Remove component aliases except for mezmo and greptimedb

### DIFF
--- a/website/cue/reference/components/sinks/prometheus_exporter.cue
+++ b/website/cue/reference/components/sinks/prometheus_exporter.cue
@@ -4,7 +4,6 @@ components: sinks: prometheus_exporter: {
 	_port: 9598
 
 	title: "Prometheus Exporter"
-	alias: "prometheus"
 
 	classes: {
 		delivery:      "best_effort"

--- a/website/cue/reference/components/sinks/splunk_hec_logs.cue
+++ b/website/cue/reference/components/sinks/splunk_hec_logs.cue
@@ -2,7 +2,6 @@ package metadata
 
 components: sinks: splunk_hec_logs: {
 	title: "Splunk HEC logs"
-	alias: "splunk_hec"
 
 	classes: {
 		delivery:      "at_least_once"

--- a/website/cue/reference/components/sources/demo_logs.cue
+++ b/website/cue/reference/components/sources/demo_logs.cue
@@ -3,8 +3,6 @@ package metadata
 components: sources: demo_logs: {
 	title: "Demo Logs"
 
-	alias: "generator"
-
 	description: """
 		Generates fakes events useful for testing and demoing.
 		"""

--- a/website/cue/reference/components/sources/docker_logs.cue
+++ b/website/cue/reference/components/sources/docker_logs.cue
@@ -2,7 +2,6 @@ package metadata
 
 components: sources: docker_logs: {
 	title: "Docker"
-	alias: "docker"
 
 	classes: {
 		delivery: "best_effort"

--- a/website/cue/reference/components/sources/heroku_logs.cue
+++ b/website/cue/reference/components/sources/heroku_logs.cue
@@ -9,8 +9,6 @@ components: sources: heroku_logs: {
 		Receives log data from Heroku log drains via Heroku's logplex system.
 		"""
 
-	alias: "logplex"
-
 	classes: {
 		delivery: "at_least_once"
 		deployment_roles: ["aggregator"]

--- a/website/cue/reference/components/sources/http_server.cue
+++ b/website/cue/reference/components/sources/http_server.cue
@@ -4,7 +4,6 @@ components: sources: http_server: {
 	_port: 80
 
 	title: "HTTP Server"
-	alias: "http"
 
 	classes: {
 		delivery: "at_least_once"

--- a/website/cue/reference/components/sources/prometheus_scrape.cue
+++ b/website/cue/reference/components/sources/prometheus_scrape.cue
@@ -2,7 +2,6 @@ package metadata
 
 components: sources: prometheus_scrape: {
 	title: "Prometheus Scrape"
-	alias: "prometheus"
 
 	classes: {
 		delivery: "at_least_once"


### PR DESCRIPTION
## Summary
This PR removes alias definitions from component CUE files, keeping only the aliases for mezmo (logdna) and greptimedb components as requested.

Aliases were originally added to components at various dates:
- `docker_logs` (`docker`) - November 24, 2020
- `prometheus_scrape` (`prometheus`) - November 27, 2020
- `heroku_logs` (`logplex`) - December 27, 2020
- `prometheus_exporter` (`prometheus`) - November 27, 2020
- `demo_logs` (`generator`) - November 15, 2021
- `http_server` (`http`) - October 12, 2022
- `splunk_hec_logs` (`splunk_hec`) - September 9, 2021
- `mezmo` (`logdna`) - March 9, 2023
- `greptimedb_metrics` (`greptimedb`) - September 10, 2024

This change removes all aliases except for mezmo and greptimedb, which are fairly recent compared to others.

## Vector configuration
NA

## How did you test this PR?
NA

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

NA