### PR TITLE
docs(codecs): fix duplicated word in Avro decoder doc comment

### DIFF
--- a/lib/codecs/src/decoding/mod.rs
+++ b/lib/codecs/src/decoding/mod.rs
@@ -311,7 +311,7 @@ pub enum DeserializerConfig {
     /// [influxdb]: https://docs.influxdata.com/influxdb/cloud/reference/syntax/line-protocol
     Influxdb(InfluxdbDeserializerConfig),
 
-    /// Decodes the raw bytes as as an [Apache Avro][apache_avro] message.
+    /// Decodes the raw bytes as an [Apache Avro][apache_avro] message.
     ///
     /// [apache_avro]: https://avro.apache.org/
     Avro {

--- a/website/cue/reference/components/sinks/generated/websocket_server.cue
+++ b/website/cue/reference/components/sinks/generated/websocket_server.cue
@@ -617,7 +617,7 @@ generated: components: sinks: websocket_server: configuration: {
 									default: "bytes"
 									enum: {
 										avro: """
-																							Decodes the raw bytes as as an [Apache Avro][apache_avro] message.
+																							Decodes the raw bytes as an [Apache Avro][apache_avro] message.
 
 																							[apache_avro]: https://avro.apache.org/
 																							"""

--- a/website/cue/reference/components/sources/generated/amqp.cue
+++ b/website/cue/reference/components/sources/generated/amqp.cue
@@ -85,7 +85,7 @@ generated: components: sources: amqp: configuration: {
 					default: "bytes"
 					enum: {
 						avro: """
-															Decodes the raw bytes as as an [Apache Avro][apache_avro] message.
+															Decodes the raw bytes as an [Apache Avro][apache_avro] message.
 
 															[apache_avro]: https://avro.apache.org/
 															"""

--- a/website/cue/reference/components/sources/generated/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sources/generated/aws_kinesis_firehose.cue
@@ -88,7 +88,7 @@ generated: components: sources: aws_kinesis_firehose: configuration: {
 					default: "bytes"
 					enum: {
 						avro: """
-															Decodes the raw bytes as as an [Apache Avro][apache_avro] message.
+															Decodes the raw bytes as an [Apache Avro][apache_avro] message.
 
 															[apache_avro]: https://avro.apache.org/
 															"""

--- a/website/cue/reference/components/sources/generated/aws_s3.cue
+++ b/website/cue/reference/components/sources/generated/aws_s3.cue
@@ -203,7 +203,7 @@ generated: components: sources: aws_s3: configuration: {
 					default: "bytes"
 					enum: {
 						avro: """
-															Decodes the raw bytes as as an [Apache Avro][apache_avro] message.
+															Decodes the raw bytes as an [Apache Avro][apache_avro] message.
 
 															[apache_avro]: https://avro.apache.org/
 															"""

--- a/website/cue/reference/components/sources/generated/aws_sqs.cue
+++ b/website/cue/reference/components/sources/generated/aws_sqs.cue
@@ -198,7 +198,7 @@ generated: components: sources: aws_sqs: configuration: {
 					default: "bytes"
 					enum: {
 						avro: """
-															Decodes the raw bytes as as an [Apache Avro][apache_avro] message.
+															Decodes the raw bytes as an [Apache Avro][apache_avro] message.
 
 															[apache_avro]: https://avro.apache.org/
 															"""

--- a/website/cue/reference/components/sources/generated/datadog_agent.cue
+++ b/website/cue/reference/components/sources/generated/datadog_agent.cue
@@ -70,7 +70,7 @@ generated: components: sources: datadog_agent: configuration: {
 					default: "bytes"
 					enum: {
 						avro: """
-															Decodes the raw bytes as as an [Apache Avro][apache_avro] message.
+															Decodes the raw bytes as an [Apache Avro][apache_avro] message.
 
 															[apache_avro]: https://avro.apache.org/
 															"""

--- a/website/cue/reference/components/sources/generated/demo_logs.cue
+++ b/website/cue/reference/components/sources/generated/demo_logs.cue
@@ -49,7 +49,7 @@ generated: components: sources: demo_logs: configuration: {
 					default: "bytes"
 					enum: {
 						avro: """
-															Decodes the raw bytes as as an [Apache Avro][apache_avro] message.
+															Decodes the raw bytes as an [Apache Avro][apache_avro] message.
 
 															[apache_avro]: https://avro.apache.org/
 															"""

--- a/website/cue/reference/components/sources/generated/exec.cue
+++ b/website/cue/reference/components/sources/generated/exec.cue
@@ -50,7 +50,7 @@ generated: components: sources: exec: configuration: {
 					default: "bytes"
 					enum: {
 						avro: """
-															Decodes the raw bytes as as an [Apache Avro][apache_avro] message.
+															Decodes the raw bytes as an [Apache Avro][apache_avro] message.
 
 															[apache_avro]: https://avro.apache.org/
 															"""

--- a/website/cue/reference/components/sources/generated/file_descriptor.cue
+++ b/website/cue/reference/components/sources/generated/file_descriptor.cue
@@ -40,7 +40,7 @@ generated: components: sources: file_descriptor: configuration: {
 					default: "bytes"
 					enum: {
 						avro: """
-															Decodes the raw bytes as as an [Apache Avro][apache_avro] message.
+															Decodes the raw bytes as an [Apache Avro][apache_avro] message.
 
 															[apache_avro]: https://avro.apache.org/
 															"""

--- a/website/cue/reference/components/sources/generated/gcp_pubsub.cue
+++ b/website/cue/reference/components/sources/generated/gcp_pubsub.cue
@@ -116,7 +116,7 @@ generated: components: sources: gcp_pubsub: configuration: {
 					default: "bytes"
 					enum: {
 						avro: """
-															Decodes the raw bytes as as an [Apache Avro][apache_avro] message.
+															Decodes the raw bytes as an [Apache Avro][apache_avro] message.
 
 															[apache_avro]: https://avro.apache.org/
 															"""

--- a/website/cue/reference/components/sources/generated/heroku_logs.cue
+++ b/website/cue/reference/components/sources/generated/heroku_logs.cue
@@ -113,7 +113,7 @@ generated: components: sources: heroku_logs: configuration: {
 					default: "bytes"
 					enum: {
 						avro: """
-															Decodes the raw bytes as as an [Apache Avro][apache_avro] message.
+															Decodes the raw bytes as an [Apache Avro][apache_avro] message.
 
 															[apache_avro]: https://avro.apache.org/
 															"""

--- a/website/cue/reference/components/sources/generated/http.cue
+++ b/website/cue/reference/components/sources/generated/http.cue
@@ -119,7 +119,7 @@ generated: components: sources: http: configuration: {
 				required:    true
 				type: string: enum: {
 					avro: """
-						Decodes the raw bytes as as an [Apache Avro][apache_avro] message.
+						Decodes the raw bytes as an [Apache Avro][apache_avro] message.
 
 						[apache_avro]: https://avro.apache.org/
 						"""

--- a/website/cue/reference/components/sources/generated/http_client.cue
+++ b/website/cue/reference/components/sources/generated/http_client.cue
@@ -251,7 +251,7 @@ generated: components: sources: http_client: configuration: {
 					default: "bytes"
 					enum: {
 						avro: """
-															Decodes the raw bytes as as an [Apache Avro][apache_avro] message.
+															Decodes the raw bytes as an [Apache Avro][apache_avro] message.
 
 															[apache_avro]: https://avro.apache.org/
 															"""

--- a/website/cue/reference/components/sources/generated/http_server.cue
+++ b/website/cue/reference/components/sources/generated/http_server.cue
@@ -119,7 +119,7 @@ generated: components: sources: http_server: configuration: {
 				required:    true
 				type: string: enum: {
 					avro: """
-						Decodes the raw bytes as as an [Apache Avro][apache_avro] message.
+						Decodes the raw bytes as an [Apache Avro][apache_avro] message.
 
 						[apache_avro]: https://avro.apache.org/
 						"""

--- a/website/cue/reference/components/sources/generated/kafka.cue
+++ b/website/cue/reference/components/sources/generated/kafka.cue
@@ -94,7 +94,7 @@ generated: components: sources: kafka: configuration: {
 					default: "bytes"
 					enum: {
 						avro: """
-															Decodes the raw bytes as as an [Apache Avro][apache_avro] message.
+															Decodes the raw bytes as an [Apache Avro][apache_avro] message.
 
 															[apache_avro]: https://avro.apache.org/
 															"""

--- a/website/cue/reference/components/sources/generated/mqtt.cue
+++ b/website/cue/reference/components/sources/generated/mqtt.cue
@@ -45,7 +45,7 @@ generated: components: sources: mqtt: configuration: {
 					default: "bytes"
 					enum: {
 						avro: """
-															Decodes the raw bytes as as an [Apache Avro][apache_avro] message.
+															Decodes the raw bytes as an [Apache Avro][apache_avro] message.
 
 															[apache_avro]: https://avro.apache.org/
 															"""

--- a/website/cue/reference/components/sources/generated/nats.cue
+++ b/website/cue/reference/components/sources/generated/nats.cue
@@ -137,7 +137,7 @@ generated: components: sources: nats: configuration: {
 					default: "bytes"
 					enum: {
 						avro: """
-															Decodes the raw bytes as as an [Apache Avro][apache_avro] message.
+															Decodes the raw bytes as an [Apache Avro][apache_avro] message.
 
 															[apache_avro]: https://avro.apache.org/
 															"""

--- a/website/cue/reference/components/sources/generated/pulsar.cue
+++ b/website/cue/reference/components/sources/generated/pulsar.cue
@@ -143,7 +143,7 @@ generated: components: sources: pulsar: configuration: {
 					default: "bytes"
 					enum: {
 						avro: """
-															Decodes the raw bytes as as an [Apache Avro][apache_avro] message.
+															Decodes the raw bytes as an [Apache Avro][apache_avro] message.
 
 															[apache_avro]: https://avro.apache.org/
 															"""

--- a/website/cue/reference/components/sources/generated/redis.cue
+++ b/website/cue/reference/components/sources/generated/redis.cue
@@ -55,7 +55,7 @@ generated: components: sources: redis: configuration: {
 					default: "bytes"
 					enum: {
 						avro: """
-															Decodes the raw bytes as as an [Apache Avro][apache_avro] message.
+															Decodes the raw bytes as an [Apache Avro][apache_avro] message.
 
 															[apache_avro]: https://avro.apache.org/
 															"""

--- a/website/cue/reference/components/sources/generated/socket.cue
+++ b/website/cue/reference/components/sources/generated/socket.cue
@@ -57,7 +57,7 @@ generated: components: sources: socket: configuration: {
 					default: "bytes"
 					enum: {
 						avro: """
-															Decodes the raw bytes as as an [Apache Avro][apache_avro] message.
+															Decodes the raw bytes as an [Apache Avro][apache_avro] message.
 
 															[apache_avro]: https://avro.apache.org/
 															"""

--- a/website/cue/reference/components/sources/generated/splunk_hec.cue
+++ b/website/cue/reference/components/sources/generated/splunk_hec.cue
@@ -128,7 +128,7 @@ generated: components: sources: splunk_hec: configuration: {
 						required:    true
 						type: string: enum: {
 							avro: """
-																			Decodes the raw bytes as as an [Apache Avro][apache_avro] message.
+																			Decodes the raw bytes as an [Apache Avro][apache_avro] message.
 
 																			[apache_avro]: https://avro.apache.org/
 																			"""
@@ -672,7 +672,7 @@ generated: components: sources: splunk_hec: configuration: {
 						required:    true
 						type: string: enum: {
 							avro: """
-																			Decodes the raw bytes as as an [Apache Avro][apache_avro] message.
+																			Decodes the raw bytes as an [Apache Avro][apache_avro] message.
 
 																			[apache_avro]: https://avro.apache.org/
 																			"""

--- a/website/cue/reference/components/sources/generated/stdin.cue
+++ b/website/cue/reference/components/sources/generated/stdin.cue
@@ -40,7 +40,7 @@ generated: components: sources: stdin: configuration: {
 					default: "bytes"
 					enum: {
 						avro: """
-															Decodes the raw bytes as as an [Apache Avro][apache_avro] message.
+															Decodes the raw bytes as an [Apache Avro][apache_avro] message.
 
 															[apache_avro]: https://avro.apache.org/
 															"""

--- a/website/cue/reference/components/sources/generated/websocket.cue
+++ b/website/cue/reference/components/sources/generated/websocket.cue
@@ -227,7 +227,7 @@ generated: components: sources: websocket: configuration: {
 					default: "bytes"
 					enum: {
 						avro: """
-															Decodes the raw bytes as as an [Apache Avro][apache_avro] message.
+															Decodes the raw bytes as an [Apache Avro][apache_avro] message.
 
 															[apache_avro]: https://avro.apache.org/
 															"""


### PR DESCRIPTION
The Avro decoder doc comment read "Decodes the raw bytes as as an [Apache Avro] message" — removed the duplicated "as", matching the sibling decoder comments.
