### PR TITLE
feat(nats source): expose NATS message headers via headers_key

### DIFF
--- a/changelog.d/24937_nats_source_headers.feature.md
+++ b/changelog.d/24937_nats_source_headers.feature.md
@@ -1,0 +1,3 @@
+The `nats` source can now expose NATS message headers on each event. Set the new `headers_key` option to the field where headers should be written (for example `headers_key: headers`). Each header name maps to an array of its string values, since NATS headers can be multi-valued. By default `headers_key` is unset and no headers are exposed, preserving backwards compatibility.
+
+authors: Simon Dugas

--- a/src/sources/nats/config.rs
+++ b/src/sources/nats/config.rs
@@ -9,7 +9,7 @@ use vector_lib::{
     configurable::configurable_component,
     lookup::{lookup_v2::OptionalValuePath, owned_value_path},
 };
-use vrl::value::Kind;
+use vrl::value::{Kind, kind::Collection};
 
 use crate::{
     codecs::DecodingConfig,
@@ -156,6 +156,15 @@ pub struct NatsSourceConfig {
     #[serde(default = "default_subject_key_field")]
     pub subject_key_field: OptionalValuePath,
 
+    /// Enables exposing NATS message headers on each event under the named key.
+    ///
+    /// By default this is unset and no headers are exposed, preserving backwards
+    /// compatibility. When set, the message headers are inserted as an object
+    /// mapping each header name to an array of its string values.
+    #[serde(default)]
+    #[configurable(metadata(docs::examples = "headers"))]
+    pub headers_key: OptionalValuePath,
+
     /// The buffer capacity of the underlying NATS subscriber.
     ///
     /// This value determines how many messages the NATS subscriber buffers
@@ -258,7 +267,7 @@ impl SourceConfig for NatsSourceConfig {
             .clone()
             .path
             .map(LegacyKey::InsertIfEmpty);
-        let schema_definition = self
+        let mut schema_definition = self
             .decoding
             .schema_definition(log_namespace)
             .with_standard_vector_source_metadata()
@@ -269,6 +278,19 @@ impl SourceConfig for NatsSourceConfig {
                 Kind::bytes(),
                 None,
             );
+
+        if let Some(headers_key) = self.headers_key.path.clone() {
+            schema_definition = schema_definition.with_source_metadata(
+                NatsSourceConfig::NAME,
+                Some(LegacyKey::Overwrite(headers_key)),
+                &owned_value_path!("headers"),
+                Kind::object(
+                    Collection::empty()
+                        .with_unknown(Kind::array(Collection::empty().with_unknown(Kind::bytes()))),
+                ),
+                None,
+            );
+        }
 
         vec![SourceOutput::new_maybe_logs(
             self.decoding.output_type(),
@@ -369,6 +391,81 @@ mod tests {
                     None,
                 )
                 .with_metadata_field(&owned_value_path!("nats", "subject"), Kind::bytes(), None);
+
+        assert_eq!(definitions, Some(expected_definition));
+    }
+
+    #[test]
+    fn output_schema_definition_vector_namespace_with_headers() {
+        let config = NatsSourceConfig {
+            log_namespace: Some(true),
+            subject_key_field: default_subject_key_field(),
+            headers_key: OptionalValuePath::new("headers"),
+            ..Default::default()
+        };
+
+        let definitions = config
+            .outputs(LogNamespace::Vector)
+            .remove(0)
+            .schema_definition(true);
+
+        let expected_definition =
+            Definition::new_with_default_metadata(Kind::bytes(), [LogNamespace::Vector])
+                .with_meaning(OwnedTargetPath::event_root(), "message")
+                .with_metadata_field(
+                    &owned_value_path!("vector", "source_type"),
+                    Kind::bytes(),
+                    None,
+                )
+                .with_metadata_field(
+                    &owned_value_path!("vector", "ingest_timestamp"),
+                    Kind::timestamp(),
+                    None,
+                )
+                .with_metadata_field(&owned_value_path!("nats", "subject"), Kind::bytes(), None)
+                .with_metadata_field(
+                    &owned_value_path!("nats", "headers"),
+                    Kind::object(Collection::empty().with_unknown(Kind::array(
+                        Collection::empty().with_unknown(Kind::bytes()),
+                    ))),
+                    None,
+                );
+
+        assert_eq!(definitions, Some(expected_definition));
+    }
+
+    #[test]
+    fn output_schema_definition_legacy_namespace_with_headers() {
+        let config = NatsSourceConfig {
+            subject_key_field: default_subject_key_field(),
+            headers_key: OptionalValuePath::new("headers"),
+            ..Default::default()
+        };
+        let definitions = config
+            .outputs(LogNamespace::Legacy)
+            .remove(0)
+            .schema_definition(true);
+
+        let expected_definition = Definition::new_with_default_metadata(
+            Kind::object(Collection::empty()),
+            [LogNamespace::Legacy],
+        )
+        .with_event_field(
+            &owned_value_path!("message"),
+            Kind::bytes(),
+            Some("message"),
+        )
+        .with_event_field(&owned_value_path!("timestamp"), Kind::timestamp(), None)
+        .with_event_field(&owned_value_path!("source_type"), Kind::bytes(), None)
+        .with_event_field(&owned_value_path!("subject"), Kind::bytes(), None)
+        .with_event_field(
+            &owned_value_path!("headers"),
+            Kind::object(
+                Collection::empty()
+                    .with_unknown(Kind::array(Collection::empty().with_unknown(Kind::bytes()))),
+            ),
+            None,
+        );
 
         assert_eq!(definitions, Some(expected_definition));
     }

--- a/src/sources/nats/integration_tests.rs
+++ b/src/sources/nats/integration_tests.rs
@@ -131,6 +131,98 @@ async fn publish_and_check(conf: NatsSourceConfig) -> Result<(), BuildError> {
     Ok(())
 }
 
+/// Publishes a message with NATS headers and returns the resulting event's log.
+async fn publish_with_headers_and_collect(
+    conf: NatsSourceConfig,
+    headers: async_nats::HeaderMap,
+) -> Result<vector_lib::event::LogEvent, BuildError> {
+    let subject = conf.subject.clone();
+    let (nc, sub) = create_subscription(&conf).await?;
+    let nc_pub = nc.clone();
+    let msg = "my message with headers";
+
+    let events = assert_source_compliance(&SOURCE_TAGS, async move {
+        let (tx, rx) = SourceSender::new_test();
+        let decoder = DecodingConfig::new(
+            conf.framing.clone(),
+            conf.decoding.clone(),
+            LogNamespace::Legacy,
+        )
+        .build()
+        .unwrap();
+        tokio::spawn(run_nats_core(
+            conf.clone(),
+            nc,
+            sub,
+            decoder,
+            LogNamespace::Legacy,
+            ShutdownSignal::noop(),
+            tx,
+        ));
+        nc_pub
+            .publish_with_headers(subject, headers, Bytes::from_static(msg.as_bytes()))
+            .await
+            .unwrap();
+
+        collect_n(rx, 1).await
+    })
+    .await;
+
+    Ok(events.into_iter().next().unwrap().into_log())
+}
+
+#[tokio::test]
+async fn nats_headers_enabled() {
+    let subject = format!("test-{}", random_string(10));
+    let url =
+        std::env::var("NATS_ADDRESS").unwrap_or_else(|_| String::from("nats://localhost:4222"));
+
+    let mut conf = generate_source_config(&url, &subject);
+    conf.headers_key = vector_lib::lookup::lookup_v2::OptionalValuePath::new("headers");
+
+    let mut headers = async_nats::HeaderMap::new();
+    headers.insert("X-My-Custom-Header", "A");
+    headers.insert("X-My-Custom-Timestamp", "1771517040123456000");
+
+    let log = publish_with_headers_and_collect(conf, headers)
+        .await
+        .expect("publish_with_headers_and_collect failed");
+
+    let mut expected = vrl::value::ObjectMap::new();
+    expected.insert(
+        "X-My-Custom-Header".into(),
+        vec![vector_lib::event::Value::from("A")].into(),
+    );
+    expected.insert(
+        "X-My-Custom-Timestamp".into(),
+        vec![vector_lib::event::Value::from("1771517040123456000")].into(),
+    );
+
+    assert_eq!(log["headers"], vector_lib::event::Value::Object(expected));
+}
+
+#[tokio::test]
+async fn nats_headers_disabled_by_default() {
+    let subject = format!("test-{}", random_string(10));
+    let url =
+        std::env::var("NATS_ADDRESS").unwrap_or_else(|_| String::from("nats://localhost:4222"));
+
+    // No headers_key set: headers must not be exposed.
+    let conf = generate_source_config(&url, &subject);
+
+    let mut headers = async_nats::HeaderMap::new();
+    headers.insert("X-My-Custom-Header", "A");
+
+    let log = publish_with_headers_and_collect(conf, headers)
+        .await
+        .expect("publish_with_headers_and_collect failed");
+
+    assert!(
+        log.get("headers").is_none(),
+        "headers should not be present when headers_key is unset, got: {log:?}"
+    );
+}
+
 #[tokio::test]
 async fn nats_no_auth() {
     let subject = format!("test-{}", random_string(10));

--- a/src/sources/nats/source.rs
+++ b/src/sources/nats/source.rs
@@ -1,4 +1,5 @@
 use async_nats::jetstream::consumer::pull::Stream as PullConsumerStream;
+use bytes::Bytes;
 use chrono::Utc;
 use futures::StreamExt;
 use snafu::ResultExt;
@@ -12,6 +13,7 @@ use vector_lib::{
     },
     lookup::owned_value_path,
 };
+use vrl::value::{ObjectMap, Value};
 
 use crate::{
     SourceSender,
@@ -21,6 +23,22 @@ use crate::{
     shutdown::ShutdownSignal,
     sources::nats::config::{BuildError, NatsSourceConfig, SubscribeSnafu},
 };
+
+/// Converts a NATS [`HeaderMap`] into a [`Value`] suitable for insertion into an event.
+///
+/// Each header name maps to an array of its string values, since NATS headers
+/// can be multi-valued.
+fn headers_to_value(headers: &async_nats::HeaderMap) -> Value {
+    let mut map = ObjectMap::new();
+    for (name, values) in headers.iter() {
+        let values = values
+            .iter()
+            .map(|value| Value::from(Bytes::copy_from_slice(value.as_str().as_bytes())))
+            .collect::<Vec<_>>();
+        map.insert(name.to_string().into(), Value::Array(values));
+    }
+    Value::Object(map)
+}
 
 /// The outcome of processing a single NATS message.
 pub enum ProcessingStatus {
@@ -76,6 +94,18 @@ pub async fn process_message(
                             &owned_value_path!("subject"),
                             msg.subject.as_str(),
                         );
+
+                        if let Some(headers_key) = config.headers_key.path.as_ref()
+                            && let Some(headers) = msg.headers.as_ref()
+                        {
+                            log_namespace.insert_source_metadata(
+                                NatsSourceConfig::NAME,
+                                log,
+                                Some(LegacyKey::Overwrite(headers_key)),
+                                &owned_value_path!("headers"),
+                                headers_to_value(headers),
+                            );
+                        }
                     }
                     event
                 });
@@ -219,4 +249,56 @@ pub async fn create_subscription(
     let subscription = subscription.context(SubscribeSnafu)?;
 
     Ok((nc, subscription))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn headers_to_value_maps_names_to_arrays_of_values() {
+        let mut headers = async_nats::HeaderMap::new();
+        headers.insert("X-My-Custom-Header", "A");
+        headers.insert("X-My-Custom-Timestamp", "1771517040123456000");
+
+        let value = headers_to_value(&headers);
+
+        let mut expected = ObjectMap::new();
+        expected.insert(
+            "X-My-Custom-Header".into(),
+            Value::Array(vec![Value::from("A")]),
+        );
+        expected.insert(
+            "X-My-Custom-Timestamp".into(),
+            Value::Array(vec![Value::from("1771517040123456000")]),
+        );
+
+        assert_eq!(value, Value::Object(expected));
+    }
+
+    #[test]
+    fn headers_to_value_collects_multiple_values_per_name() {
+        let mut headers = async_nats::HeaderMap::new();
+        headers.append("X-Multi", "one");
+        headers.append("X-Multi", "two");
+
+        let value = headers_to_value(&headers);
+
+        let object = value.as_object().expect("headers should be an object");
+        let values = object
+            .get("X-Multi")
+            .and_then(|v| v.as_array())
+            .expect("X-Multi should be an array");
+
+        assert_eq!(values.len(), 2);
+        assert!(values.contains(&Value::from("one")));
+        assert!(values.contains(&Value::from("two")));
+    }
+
+    #[test]
+    fn headers_to_value_empty_map_is_empty_object() {
+        let headers = async_nats::HeaderMap::new();
+        let value = headers_to_value(&headers);
+        assert_eq!(value, Value::Object(ObjectMap::new()));
+    }
 }

--- a/website/cue/reference/components/sources/generated/nats.cue
+++ b/website/cue/reference/components/sources/generated/nats.cue
@@ -598,6 +598,20 @@ generated: components: sources: nats: configuration: {
 			}
 		}
 	}
+	headers_key: {
+		description: """
+			Enables exposing NATS message headers on each event under the named key.
+
+			By default this is unset and no headers are exposed, preserving backwards
+			compatibility. When set, the message headers are inserted as an object
+			mapping each header name to an array of its string values.
+			"""
+		required: false
+		type: string: {
+			default: ""
+			examples: ["headers"]
+		}
+	}
 	jetstream: {
 		description: "Configuration for NATS JetStream."
 		required:    false


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

Add an optional `headers_key` configuration field to the `nats` source. When set, NATS message headers are inserted into each event under the configured key as an object mapping each header name to an array of its string values (NATS headers can be multi-valued). The field is unset by default, so no headers are exposed unless explicitly configured, preserving backwards compatibility.

## Vector configuration
<!-- Include Vector configuration(s) you used to test and debug your changes. -->

```
# Vector config exercising the new `headers_key` option on the NATS source.
#
# The NATS source subscribes to `demo.>` on the core NATS protocol.
# Setting `headers_key: headers` causes each message's NATS headers to be
# inserted into the event under `.headers`, where each header name maps to an
# array of its string values.
#
# The remap transform then pulls the custom headers into top-level fields so
# they are easy to eyeball in the console output, and demonstrates accessing
# headers from VRL (the goal of issue #24937).

sources:
  nats_in:
    type: nats
    url: nats://nats:4222
    subject: "demo.>"
    connection_name: vector-headers-test
    # The feature under test: expose NATS headers under `.headers`.
    headers_key: headers
    decoding:
      codec: bytes

transforms:
  surface_headers:
    type: remap
    inputs:
      - nats_in
    source: |
      # `.headers."X-My-Custom-Header"` is an array of strings.
      # Use [0] for the (typical) single-valued case.
      .custom_header = .headers."X-My-Custom-Header" || []
      .custom_timestamp = .headers."X-My-Custom-Timestamp" || []
      # Keep the raw headers object visible too.

sinks:
  console_out:
    type: console
    inputs:
      - surface_headers
    encoding:
      codec: json
      json:
        pretty: true
```

## How did you test this PR?
<!-- Please describe how you tested your changes. Also include any information about your setup. -->

On top of existing automated tests, I loaded the above configuration in a docker compose setup to confirm the headers are being added.

```
# Docker Compose harness to manually test the NATS source `headers_key` feature.
#
# Usage (see README.md for detail):
#   cd /tmp/nats-headers-test
#   docker compose up --build -d nats vector
#   docker compose logs -f vector        # watch decoded events
#   docker compose run --rm publisher     # publish a message with headers
#
# The `vector` service builds Vector from your local checkout. Adjust
# VECTOR_SRC below if your repo lives elsewhere.

services:
  nats:
    # Alpine variant ships a shell + wget so the healthcheck can run.
    image: nats:2.10-alpine
    # -js enables JetStream so you can also test the JetStream path if desired.
    command: ["-js", "-m", "8222"]
    ports:
      - "4222:4222"   # client
      - "8222:8222"   # monitoring
    healthcheck:
      test: ["CMD", "wget", "--spider", "-q", "http://localhost:8222/healthz"]
      interval: 2s
      timeout: 3s
      retries: 15

  vector:
    build:
      # Primary build context is the Vector repo root so the local source is
      # compiled.
      context: ${VECTOR_SRC:-/Users/<user>/source/vector}
      dockerfile: /tmp/nats-headers-test/Dockerfile.vector
      additional_contexts:
        harness: /tmp/nats-headers-test
    depends_on:
      nats:
        condition: service_healthy
    # To iterate on vector.yaml, edit it then re-run:
    #   docker compose up -d --build vector

  # One-shot publisher: sends a message carrying custom NATS headers.
  # Gated behind a profile so `docker compose up` does not start it; invoke
  # explicitly with: docker compose run --rm publisher
  # (or just use ./publish.sh, which is more convenient).
  publisher:
    image: natsio/nats-box:latest
    profiles: ["tools"]
    depends_on:
      nats:
        condition: service_healthy
    entrypoint: ["/bin/sh", "-c"]
    command:
      - |
        nats --server nats://nats:4222 pub demo.event \
          --header "X-My-Custom-Header:A" \
          --header "X-My-Custom-Timestamp:1771517040123456000" \
          '{"id":"abc123","proto":"tcp","service":"http"}'

```

Sample Output
```
$ cd /tmp/nats-headers-test && docker compose logs vector
vector-1  | 2026-06-19T18:20:11.271466Z  INFO vector::app: Log level is enabled. level="info"
vector-1  | 2026-06-19T18:20:11.274485Z  INFO vector::app: Loading configs. paths=["/etc/vector/vector.yaml"]
vector-1  | 2026-06-19T18:20:11.283810Z  INFO source{component_kind="source" component_id=nats_in component_type=nats}: async_nats::connector: connected successfully server=4222 max_payload=1048576
vector-1  | 2026-06-19T18:20:11.284181Z  INFO async_nats: event: connected
vector-1  | 2026-06-19T18:20:11.285257Z  INFO vector::topology::running: Running healthchecks.
vector-1  | 2026-06-19T18:20:11.285334Z  INFO vector::topology::builder: Healthcheck passed.
vector-1  | 2026-06-19T18:20:11.285370Z  INFO vector: Vector has started. debug="false" version="0.57.0" arch="aarch64" revision=""
vector-1  | {
vector-1  |   "custom_header": [
vector-1  |     "A"
vector-1  |   ],
vector-1  |   "custom_timestamp": [
vector-1  |     "1771517040123456000"
vector-1  |   ],
vector-1  |   "headers": {
vector-1  |     "X-My-Custom-Header": [
vector-1  |       "A"
vector-1  |     ],
vector-1  |     "X-My-Custom-Timestamp": [
vector-1  |       "1771517040123456000"
vector-1  |     ]
vector-1  |   },
vector-1  |   "message": "{\"id\":\"abc123\",\"proto\":\"tcp\"}",
vector-1  |   "source_type": "nats",
vector-1  |   "subject": "demo.event",
vector-1  |   "timestamp": "2026-06-19T18:22:04.159653960Z"
vector-1  | }
```

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References
- Closes: #24937
<!--
- Related: #<issue/PR number or link>
-->

## Notes

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details on the [dd-rust-license-tool](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert, perf
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional but appreciated; letters, digits, spaces, hyphens, underscores (e.g. `kafka source`, `amazon-linux`)
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
