### PR TITLE
fix(aws_cloudwatch_logs sink): Parse string and integer `.timestamp` values

### DIFF
--- a/changelog.d/15346_cloudwatch_logs_parse_timestamp.fix.md
+++ b/changelog.d/15346_cloudwatch_logs_parse_timestamp.fix.md
@@ -1,0 +1,3 @@
+The `aws_cloudwatch_logs` sink now parses string- and integer-encoded `.timestamp` values instead of silently replacing them with the current time. Integer values are interpreted as Unix seconds. If the value cannot be parsed, the sink falls back to the current time and emits a warning.
+
+authors: shivansh-mathur

--- a/src/sinks/aws_cloudwatch_logs/config.rs
+++ b/src/sinks/aws_cloudwatch_logs/config.rs
@@ -223,6 +223,7 @@ impl SinkConfig for CloudwatchLogsSinkConfig {
                 stream_template: self.stream_name.clone(),
                 transformer,
                 encoder,
+                timezone: cx.globals.timezone(),
             },
 
             service: svc,

--- a/src/sinks/aws_cloudwatch_logs/request_builder.rs
+++ b/src/sinks/aws_cloudwatch_logs/request_builder.rs
@@ -16,6 +16,7 @@ use crate::{
     internal_events::AwsCloudwatchLogsMessageSizeError,
     sinks::{aws_cloudwatch_logs::CloudwatchKey, util::metadata::RequestMetadataBuilder},
     template::Template,
+    types::Conversion,
 };
 
 // Estimated maximum size of InputLogEvent is 50 bytes with an empty message
@@ -55,6 +56,7 @@ pub struct CloudwatchRequestBuilder {
     pub stream_template: Template,
     pub transformer: Transformer,
     pub encoder: Encoder<()>,
+    pub timezone: vector_lib::TimeZone,
 }
 
 impl CloudwatchRequestBuilder {
@@ -86,7 +88,21 @@ impl CloudwatchRequestBuilder {
 
         let timestamp = match event.as_mut_log().remove_timestamp() {
             Some(Value::Timestamp(ts)) => ts.timestamp_millis(),
-            _ => Utc::now().timestamp_millis(),
+            Some(value) => {
+                // See issue #15346: parse non-Timestamp `.timestamp` values before falling back.
+                match Conversion::Timestamp(self.timezone).convert::<Value>(value.coerce_to_bytes())
+                {
+                    Ok(Value::Timestamp(ts)) => ts.timestamp_millis(),
+                    Ok(_) => {
+                        unreachable!("Conversion::Timestamp always produces a Value::Timestamp")
+                    }
+                    Err(error) => {
+                        warn!(message = "Unable to parse timestamp, using current time instead.", %error, internal_log_rate_limit = true);
+                        Utc::now().timestamp_millis()
+                    }
+                }
+            }
+            None => Utc::now().timestamp_millis(),
         };
 
         let finalizers = event.take_finalizers();
@@ -139,10 +155,11 @@ impl ByteSizeOf for CloudwatchRequest {
 
 #[cfg(test)]
 mod tests {
-    use chrono::Utc;
+    use chrono::{DateTime, Utc};
     use vector_lib::{config::log_schema, event::LogEvent};
 
     use super::{CloudwatchRequestBuilder, MAX_MESSAGE_SIZE};
+    use crate::event::Value;
 
     #[test]
     fn test() {
@@ -151,6 +168,7 @@ mod tests {
             stream_template: "stream".try_into().unwrap(),
             transformer: Default::default(),
             encoder: Default::default(),
+            timezone: Default::default(),
         };
         let timestamp = Utc::now();
         let message = "event message";
@@ -169,6 +187,7 @@ mod tests {
             stream_template: "stream".try_into().unwrap(),
             transformer: Default::default(),
             encoder: Default::default(),
+            timezone: Default::default(),
         };
 
         let timestamp = Utc::now();
@@ -178,5 +197,78 @@ mod tests {
 
         let request = request_builder.build(event.into());
         assert!(request.is_none(), "Expected None for oversized log event");
+    }
+
+    #[test]
+    fn test_string_timestamp_is_parsed() {
+        let mut request_builder = CloudwatchRequestBuilder {
+            group_template: "group".try_into().unwrap(),
+            stream_template: "stream".try_into().unwrap(),
+            transformer: Default::default(),
+            encoder: Default::default(),
+            timezone: Default::default(),
+        };
+        let message = "event message";
+        let mut event = LogEvent::from(message);
+        event.insert(
+            log_schema().timestamp_key_target_path().unwrap(),
+            Value::Bytes("2022-11-24T21:06:29.000Z".into()),
+        );
+
+        let request = request_builder.build(event.into()).unwrap();
+        let expected = DateTime::parse_from_rfc3339("2022-11-24T21:06:29.000Z")
+            .unwrap()
+            .timestamp_millis();
+        assert_eq!(request.timestamp, expected);
+    }
+
+    #[test]
+    fn test_integer_timestamp_is_parsed_as_unix_seconds() {
+        let mut request_builder = CloudwatchRequestBuilder {
+            group_template: "group".try_into().unwrap(),
+            stream_template: "stream".try_into().unwrap(),
+            transformer: Default::default(),
+            encoder: Default::default(),
+            timezone: Default::default(),
+        };
+        let message = "event message";
+        let mut event = LogEvent::from(message);
+        // Integer timestamps are interpreted as Unix seconds.
+        event.insert(
+            log_schema().timestamp_key_target_path().unwrap(),
+            Value::Integer(1669324389),
+        );
+
+        let request = request_builder.build(event.into()).unwrap();
+        assert_eq!(request.timestamp, 1669324389 * 1000);
+    }
+
+    #[test]
+    fn test_unparseable_timestamp_falls_back_to_now() {
+        let mut request_builder = CloudwatchRequestBuilder {
+            group_template: "group".try_into().unwrap(),
+            stream_template: "stream".try_into().unwrap(),
+            transformer: Default::default(),
+            encoder: Default::default(),
+            timezone: Default::default(),
+        };
+        let message = "event message";
+        let mut event = LogEvent::from(message);
+        event.insert(
+            log_schema().timestamp_key_target_path().unwrap(),
+            Value::Bytes("not-a-timestamp".into()),
+        );
+
+        let before = Utc::now().timestamp_millis();
+        let request = request_builder.build(event.into()).unwrap();
+        let after = Utc::now().timestamp_millis();
+
+        assert!(
+            request.timestamp >= before && request.timestamp <= after,
+            "Expected timestamp to fall back to current time, got {} (window: {}..{})",
+            request.timestamp,
+            before,
+            after
+        );
     }
 }


### PR DESCRIPTION
## Summary

The `aws_cloudwatch_logs` sink uses `.timestamp` to set the CloudWatch event time, but only accepted a
`Value::Timestamp`. A string timestamp (e.g. `"2022-11-24T21:06:29.000Z"` from `remap`/JSON) silently fell back to
`Utc::now()`, dropping the real time.

This parses string and integer-seconds `.timestamp` values via the existing `Conversion::Timestamp` (as used by
`metric_to_log`/`logstash`), and emits a rate-limited warning when a value still can't be parsed. Fixes #15346.

## Vector configuration

```yaml
sources:
  demo:
    type: demo_logs
    format: shuffle
    lines:
      - '{"message": "audit event", "timestamp": "2022-11-24T21:06:29.000Z"}'

transforms:
  parse:
    type: remap
    inputs: ["demo"]
    source: |
      . = parse_json!(.message)

sinks:
  cloudwatch:
    type: aws_cloudwatch_logs
    inputs: ["parse"]
    group_name: "vector-test"
    stream_name: "vector-test"
    region: "us-east-1"
    encoding:
      codec: json
```

Before this change the CloudWatch event is stored at submission time; after it, at `2022-11-24T21:06:29.000Z` — no
`parse_timestamp!` workaround required.

## How did you test this PR?

Added unit tests on `CloudwatchRequestBuilder::build`: string timestamp parsed correctly, integer parsed as Unix
seconds, unparseable value falls back to `now()`. Ran `make fmt`, `make check-clippy`, and the sink's
`request_builder` tests.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

Intentional, more-correct behavior: a string `.timestamp` that was becoming `now()` is now preserved. The message
body is unchanged (the field was already removed before). Integer values are read as Unix **seconds**.

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

Changelog fragment added: `changelog.d/15346_cloudwatch_logs_parse_timestamp.fix.md`

## References

- Closes: #15346

## Notes

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details on the [dd-rust-license-tool](https://crates.io/crates/dd-rust-license-tool).