### PR TITLE
chore(ci): wrap apt-get calls with timeout 30m to prevent CI hangs

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -237,7 +237,7 @@ runs:
     - name: Install libsasl2
       if: ${{ inputs.libsasl2 == 'true' }}
       shell: bash
-      run: sudo apt-get update && sudo apt-get install -y libsasl2-dev
+      run: timeout 30m sudo apt-get update && timeout 30m sudo apt-get install -y libsasl2-dev
 
     - name: Cache cargo binaries
       id: cache-cargo-binaries

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Merge coverage reports
         run: |
-          sudo apt-get install -y --no-install-recommends lcov
+          timeout 30m sudo apt-get install -y --no-install-recommends lcov
 
           mapfile -t FILES < <(find coverage-artifacts -name '*.info')
           echo "Merging ${#FILES[@]} coverage file(s)"

--- a/.github/workflows/install-sh.yml
+++ b/.github/workflows/install-sh.yml
@@ -27,6 +27,6 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
 
-      - run: sudo apt-get install --yes bc
+      - run: timeout 30m sudo apt-get install --yes bc
       - run: bash distribution/install.sh -- -y
       - run: ~/.vector/bin/vector --version

--- a/.github/workflows/k8s_e2e.yml
+++ b/.github/workflows/k8s_e2e.yml
@@ -87,7 +87,7 @@ jobs:
           cargo-deb: true
 
       - name: Install packaging dependencies
-        run: sudo apt-get install -y cmark-gfm
+        run: timeout 30m sudo apt-get install -y cmark-gfm
 
       - run: VECTOR_VERSION="$(vdev version)" make package-deb-x86_64-unknown-linux-gnu
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -165,10 +165,10 @@ jobs:
           protoc: true
           libsasl2: true
       - name: Install cross-compilation tools
-        run: sudo apt-get install -y binutils-arm-linux-gnueabihf binutils-aarch64-linux-gnu cmark-gfm
+        run: timeout 30m sudo apt-get install -y binutils-arm-linux-gnueabihf binutils-aarch64-linux-gnu cmark-gfm
       - name: Install rpm
         if: endsWith(matrix.target, '-linux-gnu') || matrix.target == 'armv7-unknown-linux-gnueabihf'
-        run: sudo apt-get install -y rpm
+        run: timeout 30m sudo apt-get install -y rpm
       - name: Build Vector
         run: make package-${{ matrix.target }}-all
       - name: Stage package artifacts for publish
@@ -298,8 +298,8 @@ jobs:
       image: ${{ matrix.container }}
     steps:
       - run: |
-          apt-get -o Acquire::Retries=5 -o Acquire::http::Timeout=30 update && \
-          apt-get -o Acquire::Retries=5 -o Acquire::http::Timeout=30 install -y \
+          timeout 30m apt-get -o Acquire::Retries=5 -o Acquire::http::Timeout=30 update && \
+          timeout 30m apt-get -o Acquire::Retries=5 -o Acquire::http::Timeout=30 install -y \
           ca-certificates \
           curl \
           git \


### PR DESCRIPTION
## Summary

`apt-get` occasionally hangs indefinitely, blocking CI runners for up to 6 hours. Adding `timeout 30m` as a hard wall-clock limit on all `apt-get` invocations across our workflows so they fail fast instead.

`Acquire::http::Timeout` was considered but is not sufficient: it caps each individual HTTP connection in seconds, not the total operation. With retries (`Acquire::Retries=5`) and many packages, a slow mirror can still block for hours within the per-connection budget.

## Vector configuration

NA

## How did you test this PR?

NA

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

NA