### PR TITLE
feat(vector sink): add multiple endpoint strategies

### DIFF
--- a/changelog.d/vector_sink_multiple_backends.feature.md
+++ b/changelog.d/vector_sink_multiple_backends.feature.md
@@ -1,0 +1,3 @@
+Add support for configuring multiple endpoints in the `vector` sink via the new `addresses` option, enabling built-in load balancing and failover across downstream Vector instances.
+
+authors: fpytloun

--- a/changelog.d/vector_sink_multiple_backends.feature.md
+++ b/changelog.d/vector_sink_multiple_backends.feature.md
@@ -1,3 +1,3 @@
-Add support for configuring multiple endpoints in the `vector` sink via the new `addresses` option, enabling built-in load balancing and failover across downstream Vector instances.
+Add support for configuring multiple endpoints in the `vector` sink via the new `addresses` option, enabling built-in `load_balance`, `failover`, and `failover_primary` endpoint strategies across downstream Vector instances.
 
 authors: fpytloun

--- a/changelog.d/vector_sink_multiple_backends.feature.md
+++ b/changelog.d/vector_sink_multiple_backends.feature.md
@@ -1,3 +1,3 @@
-Add support for configuring multiple endpoints in the `vector` sink via the new `addresses` option, enabling built-in `load_balance`, `failover`, and `failover_primary` endpoint strategies across downstream Vector instances.
+Add support for configuring multiple endpoints in the `vector` sink via the new `endpoints` option, enabling built-in `load_balance`, `failover`, and `failover_primary` endpoint strategies across downstream Vector instances.
 
 authors: fpytloun

--- a/changelog.d/vector_sink_multiple_backends.feature.md
+++ b/changelog.d/vector_sink_multiple_backends.feature.md
@@ -1,3 +1,3 @@
-Add support for configuring multiple endpoints in the `vector` sink via the new `endpoints` option, enabling built-in `load_balance`, `failover`, and `failover_primary` endpoint strategies across downstream Vector instances. The previous `address` option is now deprecated in favor of `endpoints`.
+Add support for configuring multiple endpoints in the `vector` sink via the new `routing.endpoints` option, enabling built-in `load_balance`, `failover`, and `failover_primary` endpoint strategies across downstream Vector instances. The previous `address` option is now deprecated in favor of `routing.endpoints`.
 
 authors: fpytloun

--- a/changelog.d/vector_sink_multiple_backends.feature.md
+++ b/changelog.d/vector_sink_multiple_backends.feature.md
@@ -1,3 +1,3 @@
-Add support for configuring multiple endpoints in the `vector` sink via the new `endpoints` option, enabling built-in `load_balance`, `failover`, and `failover_primary` endpoint strategies across downstream Vector instances.
+Add support for configuring multiple endpoints in the `vector` sink via the new `endpoints` option, enabling built-in `load_balance`, `failover`, and `failover_primary` endpoint strategies across downstream Vector instances. The previous `address` option is now deprecated in favor of `endpoints`.
 
 authors: fpytloun

--- a/src/sinks/util/service/health.rs
+++ b/src/sinks/util/service/health.rs
@@ -48,6 +48,8 @@ pub struct HealthConfig {
 
 impl Default for HealthConfig {
     fn default() -> Self {
+        // Keep Rust defaults aligned with the serde/documented defaults. The
+        // previous derived default produced zero-valued retry durations.
         Self {
             retry_initial_backoff_secs: default_retry_initial_backoff_secs(),
             retry_max_duration_secs: default_retry_max_duration_secs(),

--- a/src/sinks/util/service/health.rs
+++ b/src/sinks/util/service/health.rs
@@ -46,23 +46,21 @@ pub struct HealthConfig {
     pub retry_max_duration_secs: Duration,
 }
 
-impl Default for HealthConfig {
-    fn default() -> Self {
-        // Keep Rust defaults aligned with the serde/documented defaults. The
-        // previous derived default produced zero-valued retry durations.
-        Self {
-            retry_initial_backoff_secs: default_retry_initial_backoff_secs(),
-            retry_max_duration_secs: default_retry_max_duration_secs(),
-        }
-    }
-}
-
 const fn default_retry_initial_backoff_secs() -> u64 {
     RETRY_INITIAL_BACKOFF_SECONDS_DEFAULT
 }
 
 const fn default_retry_max_duration_secs() -> std::time::Duration {
     Duration::from_secs(RETRY_MAX_DURATION_SECONDS_DEFAULT)
+}
+
+impl Default for HealthConfig {
+    fn default() -> Self {
+        Self {
+            retry_initial_backoff_secs: default_retry_initial_backoff_secs(),
+            retry_max_duration_secs: default_retry_max_duration_secs(),
+        }
+    }
 }
 
 impl HealthConfig {
@@ -341,6 +339,7 @@ mod tests {
         assert!(counters.healthy(snapshot).is_ok());
     }
 
+    #[test]
     fn health_config_default_matches_deserialize_defaults() {
         let config = HealthConfig::default();
 

--- a/src/sinks/util/service/health.rs
+++ b/src/sinks/util/service/health.rs
@@ -46,14 +46,6 @@ pub struct HealthConfig {
     pub retry_max_duration_secs: Duration,
 }
 
-const fn default_retry_initial_backoff_secs() -> u64 {
-    RETRY_INITIAL_BACKOFF_SECONDS_DEFAULT
-}
-
-const fn default_retry_max_duration_secs() -> std::time::Duration {
-    Duration::from_secs(RETRY_MAX_DURATION_SECONDS_DEFAULT)
-}
-
 impl Default for HealthConfig {
     fn default() -> Self {
         Self {
@@ -61,6 +53,14 @@ impl Default for HealthConfig {
             retry_max_duration_secs: default_retry_max_duration_secs(),
         }
     }
+}
+
+const fn default_retry_initial_backoff_secs() -> u64 {
+    RETRY_INITIAL_BACKOFF_SECONDS_DEFAULT
+}
+
+const fn default_retry_max_duration_secs() -> std::time::Duration {
+    Duration::from_secs(RETRY_MAX_DURATION_SECONDS_DEFAULT)
 }
 
 impl HealthConfig {
@@ -339,7 +339,6 @@ mod tests {
         assert!(counters.healthy(snapshot).is_ok());
     }
 
-    #[test]
     fn health_config_default_matches_deserialize_defaults() {
         let config = HealthConfig::default();
 

--- a/src/sinks/vector/config.rs
+++ b/src/sinks/vector/config.rs
@@ -56,27 +56,27 @@ pub struct VectorConfig {
     ///
     /// The address _must_ include a port.
     ///
-    /// This option is mutually exclusive with `addresses`. Set exactly one of
-    /// `address` or `addresses`.
+    /// This option is mutually exclusive with `endpoints`. Set exactly one of
+    /// `address` or `endpoints`.
     #[configurable(validation(format = "uri"))]
     #[configurable(metadata(docs::examples = "92.12.333.224:6000"))]
     #[configurable(metadata(docs::examples = "https://somehost:6000"))]
     #[serde(default)]
     address: Option<String>,
 
-    /// The downstream Vector addresses to which to connect.
+    /// The downstream Vector endpoints to which to connect.
     ///
     /// Both IP addresses and hostnames are accepted formats.
     ///
-    /// Each address _must_ include a port.
+    /// Each endpoint _must_ include a port.
     ///
     /// This option is mutually exclusive with `address`. Set exactly one of
-    /// `address` or `addresses`.
+    /// `address` or `endpoints`.
     #[configurable(validation(format = "uri"))]
     #[configurable(metadata(docs::examples = "92.12.333.224:6000"))]
     #[configurable(metadata(docs::examples = "https://somehost:6000"))]
     #[serde(default)]
-    addresses: Vec<String>,
+    endpoints: Vec<String>,
 
     /// Compression algorithm for requests.
     ///
@@ -105,9 +105,9 @@ pub struct VectorConfig {
     #[configurable(derived)]
     pub endpoint_health: Option<HealthConfig>,
 
-    /// Strategy for routing requests across multiple configured addresses.
+    /// Strategy for routing requests across multiple configured endpoints.
     ///
-    /// This option is only used when `addresses` is configured.
+    /// This option is only used when `endpoints` is configured.
     #[serde(default)]
     pub endpoint_strategy: EndpointStrategy,
 
@@ -142,7 +142,7 @@ fn default_config(address: &str) -> VectorConfig {
     VectorConfig {
         version: None,
         address: Some(address.to_owned()),
-        addresses: Vec::new(),
+        endpoints: Vec::new(),
         compression: VectorCompression::None,
         batch: BatchConfig::default(),
         request: TowerRequestConfig::default(),
@@ -253,23 +253,27 @@ impl SinkConfig for VectorConfig {
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum EndpointStrategy {
-    /// Distribute requests across healthy endpoints.
+    /// Distribute requests across healthy endpoints using Vector's existing
+    /// Tower distributed service. Endpoint health is tracked using
+    /// `endpoint_health`, and unhealthy endpoints are backed off and probed
+    /// according to that configuration. This mode does not preserve a single
+    /// active endpoint or prefer the first configured endpoint.
     #[default]
     LoadBalance,
     /// Use one endpoint at a time. When the active endpoint fails, continue
-    /// through the configured addresses from the next endpoint.
+    /// through the configured endpoints from the next endpoint.
     ///
     /// This mode keeps using the last successful endpoint until it fails. Use
     /// `failover_primary` instead when retriable failures should re-check the
-    /// first configured address before trying secondary endpoints.
+    /// first configured endpoint before trying secondary endpoints.
     Failover,
     /// Use one endpoint at a time. When the active endpoint fails, retry from
-    /// the configured address order so the sink can return to its configured
+    /// the configured endpoint order so the sink can return to its configured
     /// primary endpoint.
     ///
     /// This is useful when receiver-side connection recycling, such as
     /// `max_connection_age_secs`, should converge the sink back to the first
-    /// configured address when it is available.
+    /// configured endpoint when it is available.
     FailoverPrimary,
 }
 
@@ -430,12 +434,13 @@ fn failover_next_attempts(
     advance: FailoverAdvance,
     tried: &[usize],
 ) -> usize {
-    if advance.advanced
-        || advance.state == expected_state
-        || failover_state_index(advance.state, endpoints)
-            == failover_state_index(expected_state, endpoints)
-    {
+    if advance.advanced || advance.state == expected_state {
         *attempt += 1;
+    } else if failover_state_index(advance.state, endpoints)
+        == failover_state_index(expected_state, endpoints)
+    {
+        attempts.clear();
+        *attempt = 0;
     } else {
         *attempts = failover_attempt_indices(
             endpoint_strategy,
@@ -497,18 +502,27 @@ fn is_retriable_vector_error(error: &crate::Error) -> bool {
 }
 
 impl VectorConfig {
-    fn uris(&self, tls: bool) -> crate::Result<Vec<Uri>> {
-        match (self.address.as_ref(), self.addresses.as_slice()) {
-            (Some(_), [_first, ..]) => Err(
-                "`address` and `addresses` options are mutually exclusive. Please use `addresses` for multiple Vector endpoints."
+    fn validate_endpoint_options(&self) -> crate::Result<()> {
+        match (self.address.as_ref(), self.endpoints.as_slice()) {
+            (Some(_), [_, ..]) => Err(
+                "`address` and `endpoints` options are mutually exclusive. Please use `endpoints` for multiple Vector endpoints."
                     .into(),
             ),
-            (None, []) => Err("No Vector endpoint configured. Please set `address` or `addresses`.".into()),
-            (Some(address), []) => Ok(vec![with_default_scheme(address, tls)?]),
-            (None, addresses) => addresses
+            (None, []) => Err("No Vector endpoint configured. Please set `address` or `endpoints`.".into()),
+            (Some(_), []) | (None, [_, ..]) => Ok(()),
+        }
+    }
+
+    fn uris(&self, tls: bool) -> crate::Result<Vec<Uri>> {
+        self.validate_endpoint_options()?;
+
+        if let Some(address) = self.address.as_ref() {
+            Ok(vec![with_default_scheme(address, tls)?])
+        } else {
+            self.endpoints
                 .iter()
-                .map(|address| with_default_scheme(address, tls))
-                .collect(),
+                .map(|endpoint| with_default_scheme(endpoint, tls))
+                .collect()
         }
     }
 }
@@ -791,7 +805,7 @@ mod tests {
     }
 
     #[test]
-    fn failover_next_attempts_continues_after_stale_same_endpoint_generation() {
+    fn failover_next_attempts_stops_after_stale_same_endpoint_generation() {
         let mut attempts = failover_ring_attempt_indices(0, 2);
         let mut attempt = 0;
 
@@ -809,8 +823,31 @@ mod tests {
         );
 
         assert_eq!(observed_state, 4);
-        assert_eq!(attempt, 1);
-        assert_eq!(attempts, vec![0, 1]);
+        assert_eq!(attempt, 0);
+        assert!(attempts.is_empty());
+    }
+
+    #[test]
+    fn failover_next_attempts_stops_after_stale_wrapped_generation() {
+        let mut attempts = failover_ring_attempt_indices(0, 3);
+        let mut attempt = 0;
+
+        let observed_state = failover_next_attempts(
+            EndpointStrategy::Failover,
+            3,
+            &mut attempts,
+            &mut attempt,
+            0,
+            FailoverAdvance {
+                state: 6,
+                advanced: false,
+            },
+            &[0],
+        );
+
+        assert_eq!(observed_state, 6);
+        assert_eq!(attempt, 0);
+        assert!(attempts.is_empty());
     }
 
     #[test]

--- a/src/sinks/vector/config.rs
+++ b/src/sinks/vector/config.rs
@@ -1,9 +1,18 @@
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    task::{Context, Poll},
+};
+
+use futures::{FutureExt, TryFutureExt, future::BoxFuture};
 use http::Uri;
 use hyper::client::HttpConnector;
 use hyper_openssl::HttpsConnector;
 use hyper_proxy::ProxyConnector;
 use tonic::body::BoxBody;
-use tower::ServiceBuilder;
+use tower::{Service, ServiceBuilder};
 use vector_lib::configurable::configurable_component;
 
 use super::{
@@ -22,8 +31,9 @@ use crate::{
     sinks::{
         Healthcheck, VectorSink as VectorSinkType,
         util::{
-            BatchConfig, RealtimeEventBasedDefaultBatchSettings, ServiceBuilderExt,
-            TowerRequestConfig, retries::RetryLogic,
+            BatchConfig, RealtimeEventBasedDefaultBatchSettings, TowerRequestConfig,
+            retries::RetryLogic,
+            service::{HealthConfig, HealthLogic, ServiceBuilderExt},
         },
     },
     tls::{MaybeTlsSettings, TlsEnableableConfig},
@@ -45,10 +55,28 @@ pub struct VectorConfig {
     /// Both IP address and hostname are accepted formats.
     ///
     /// The address _must_ include a port.
+    ///
+    /// This option is mutually exclusive with `addresses`. Set exactly one of
+    /// `address` or `addresses`.
     #[configurable(validation(format = "uri"))]
     #[configurable(metadata(docs::examples = "92.12.333.224:6000"))]
     #[configurable(metadata(docs::examples = "https://somehost:6000"))]
-    address: String,
+    #[serde(default)]
+    address: Option<String>,
+
+    /// The downstream Vector addresses to which to connect.
+    ///
+    /// Both IP addresses and hostnames are accepted formats.
+    ///
+    /// Each address _must_ include a port.
+    ///
+    /// This option is mutually exclusive with `address`. Set exactly one of
+    /// `address` or `addresses`.
+    #[configurable(validation(format = "uri"))]
+    #[configurable(metadata(docs::examples = "92.12.333.224:6000"))]
+    #[configurable(metadata(docs::examples = "https://somehost:6000"))]
+    #[serde(default)]
+    addresses: Vec<String>,
 
     /// Compression algorithm for requests.
     ///
@@ -71,6 +99,17 @@ pub struct VectorConfig {
     #[configurable(derived)]
     #[serde(default)]
     pub request: TowerRequestConfig,
+
+    /// Options for determining the health of Vector endpoints.
+    #[serde(default)]
+    #[configurable(derived)]
+    pub endpoint_health: Option<HealthConfig>,
+
+    /// Strategy for routing requests across multiple configured addresses.
+    ///
+    /// This option is only used when `addresses` is configured.
+    #[serde(default)]
+    pub endpoint_strategy: EndpointStrategy,
 
     #[configurable(derived)]
     #[serde(default)]
@@ -102,10 +141,13 @@ impl GenerateConfig for VectorConfig {
 fn default_config(address: &str) -> VectorConfig {
     VectorConfig {
         version: None,
-        address: address.to_owned(),
+        address: Some(address.to_owned()),
+        addresses: Vec::new(),
         compression: VectorCompression::None,
         batch: BatchConfig::default(),
         request: TowerRequestConfig::default(),
+        endpoint_health: None,
+        endpoint_strategy: EndpointStrategy::default(),
         tls: None,
         acknowledgements: Default::default(),
     }
@@ -116,36 +158,74 @@ fn default_config(address: &str) -> VectorConfig {
 impl SinkConfig for VectorConfig {
     async fn build(&self, cx: SinkContext) -> crate::Result<(VectorSinkType, Healthcheck)> {
         let tls = MaybeTlsSettings::from_config(self.tls.as_ref(), false)?;
-        let uri = with_default_scheme(&self.address, tls.is_tls())?;
+        let uris = self.uris(tls.is_tls())?;
 
         let client = new_client(&tls, cx.proxy())?;
 
-        let healthcheck_uri = cx
-            .healthcheck
-            .uri
-            .clone()
-            .map(|uri| uri.uri)
-            .unwrap_or_else(|| uri.clone());
-        let healthcheck_client =
-            VectorService::new(client.clone(), healthcheck_uri, VectorCompression::None);
-        let healthcheck = healthcheck(healthcheck_client, cx.healthcheck);
-        let service = VectorService::new(client, uri, self.compression);
+        let healthcheck = healthchecks(client.clone(), &uris, cx.healthcheck);
         let request_settings = self.request.into_settings();
         let batch_settings = self.batch.into_batcher_settings()?;
 
-        let service = ServiceBuilder::new()
-            .settings(request_settings, VectorGrpcRetryLogic)
-            .service(service);
+        let services = uris
+            .into_iter()
+            .map(|uri| {
+                let endpoint = uri.to_string();
+                let service = VectorService::new(client.clone(), uri, self.compression);
+                (endpoint, service)
+            })
+            .collect::<Vec<_>>();
 
-        let sink = VectorSink {
-            batch_settings,
-            service,
+        let sink = match self.endpoint_strategy {
+            _ if services.len() == 1 => {
+                let service = ServiceBuilder::new()
+                    .settings(request_settings, VectorGrpcRetryLogic)
+                    .service(services.into_iter().next().expect("one service").1);
+
+                VectorSinkType::from_event_streamsink(VectorSink {
+                    batch_settings,
+                    service,
+                })
+            }
+            EndpointStrategy::LoadBalance => {
+                let service = request_settings.distributed_service(
+                    VectorGrpcRetryLogic,
+                    services,
+                    self.endpoint_health.clone().unwrap_or_default(),
+                    VectorGrpcHealthLogic,
+                    1,
+                );
+
+                VectorSinkType::from_event_streamsink(VectorSink {
+                    batch_settings,
+                    service,
+                })
+            }
+            EndpointStrategy::Failover | EndpointStrategy::FailoverPrimary => {
+                let endpoint_timeout = request_settings.timeout;
+                let mut failover_request_settings = request_settings;
+                failover_request_settings.timeout = endpoint_timeout
+                    .checked_mul((services.len() + 1) as u32)
+                    .unwrap_or(endpoint_timeout);
+
+                let service = ServiceBuilder::new()
+                    .settings(failover_request_settings, VectorGrpcRetryLogic)
+                    .service(FailoverVectorService::new(
+                        services
+                            .into_iter()
+                            .map(|(_endpoint, service)| service)
+                            .collect(),
+                        endpoint_timeout,
+                        self.endpoint_strategy,
+                    ));
+
+                VectorSinkType::from_event_streamsink(VectorSink {
+                    batch_settings,
+                    service,
+                })
+            }
         };
 
-        Ok((
-            VectorSinkType::from_event_streamsink(sink),
-            Box::pin(healthcheck),
-        ))
+        Ok((sink, Box::pin(healthcheck)))
     }
 
     fn input(&self) -> Input {
@@ -154,6 +234,207 @@ impl SinkConfig for VectorConfig {
 
     fn acknowledgements(&self) -> &AcknowledgementsConfig {
         &self.acknowledgements
+    }
+}
+
+/// Strategy for routing requests across multiple Vector endpoints.
+#[configurable_component]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum EndpointStrategy {
+    /// Distribute requests across healthy endpoints.
+    #[default]
+    LoadBalance,
+    /// Use one endpoint at a time. When the active endpoint fails, continue
+    /// through the configured addresses from the next endpoint.
+    ///
+    /// This mode keeps using the last successful endpoint until it fails. Use
+    /// `failover_primary` instead when retriable failures should re-check the
+    /// first configured address before trying secondary endpoints.
+    Failover,
+    /// Use one endpoint at a time. When the active endpoint fails, retry from
+    /// the configured address order so the sink can return to its configured
+    /// primary endpoint.
+    ///
+    /// This is useful when receiver-side connection recycling, such as
+    /// `max_connection_age_secs`, should converge the sink back to the first
+    /// configured address when it is available.
+    FailoverPrimary,
+}
+
+#[derive(Clone)]
+struct FailoverVectorService {
+    services: Vec<VectorService>,
+    state: Arc<AtomicUsize>,
+    endpoint_timeout: std::time::Duration,
+    endpoint_strategy: EndpointStrategy,
+}
+
+impl FailoverVectorService {
+    fn new(
+        services: Vec<VectorService>,
+        endpoint_timeout: std::time::Duration,
+        endpoint_strategy: EndpointStrategy,
+    ) -> Self {
+        Self {
+            services,
+            state: Arc::new(AtomicUsize::new(0)),
+            endpoint_timeout,
+            endpoint_strategy,
+        }
+    }
+}
+
+impl Service<VectorRequest> for FailoverVectorService {
+    type Response = VectorResponse;
+    type Error = crate::Error;
+    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, request: VectorRequest) -> Self::Future {
+        let services = self.services.clone();
+        let state = Arc::clone(&self.state);
+        let endpoint_timeout = self.endpoint_timeout;
+        let endpoint_strategy = self.endpoint_strategy;
+
+        Box::pin(async move {
+            let start_state = state.load(Ordering::Acquire);
+            let start = failover_state_index(start_state, services.len());
+            let mut expected_state = start_state;
+            let mut last_error = None;
+            let attempts = match endpoint_strategy {
+                EndpointStrategy::Failover => failover_ring_attempt_indices(start, services.len()),
+                EndpointStrategy::FailoverPrimary => {
+                    failover_primary_attempt_indices(start, services.len())
+                }
+                EndpointStrategy::LoadBalance => {
+                    unreachable!("load balancing uses a different service")
+                }
+            };
+
+            for (attempt, index) in attempts.iter().copied().enumerate() {
+                let mut service = services[index].clone();
+
+                match tokio::time::timeout(endpoint_timeout, service.call(request.clone())).await {
+                    Ok(Ok(response)) => {
+                        return Ok(response);
+                    }
+                    Ok(Err(error)) => {
+                        if !is_retriable_vector_error(&error) {
+                            return Err(error);
+                        }
+
+                        expected_state = failover_advance_if_current(
+                            &state,
+                            expected_state,
+                            index,
+                            attempts.get(attempt + 1).copied(),
+                            services.len(),
+                        );
+                        last_error = Some(error);
+                    }
+                    Err(_elapsed) => {
+                        expected_state = failover_advance_if_current(
+                            &state,
+                            expected_state,
+                            index,
+                            attempts.get(attempt + 1).copied(),
+                            services.len(),
+                        );
+                        last_error = Some(Box::new(VectorSinkError::Request {
+                            source: tonic::Status::deadline_exceeded(
+                                "vector endpoint request timed out",
+                            ),
+                        }) as crate::Error);
+                    }
+                }
+            }
+
+            Err(last_error.expect("failover service should have at least one endpoint"))
+        })
+    }
+}
+
+const fn failover_state_index(state: usize, endpoints: usize) -> usize {
+    state % endpoints
+}
+
+const fn failover_next_state(state: usize, next_index: usize, endpoints: usize) -> usize {
+    let generation = state / endpoints;
+    (generation + 1) * endpoints + next_index
+}
+
+fn failover_primary_attempt_indices(start: usize, endpoints: usize) -> Vec<usize> {
+    std::iter::once(start).chain(0..endpoints).collect()
+}
+
+fn failover_ring_attempt_indices(start: usize, endpoints: usize) -> Vec<usize> {
+    (0..endpoints)
+        .map(|offset| (start + offset) % endpoints)
+        .collect()
+}
+
+fn failover_advance_if_current(
+    state: &AtomicUsize,
+    expected_state: usize,
+    index: usize,
+    next_index: Option<usize>,
+    endpoints: usize,
+) -> usize {
+    let Some(next_index) = next_index else {
+        return state.load(Ordering::Acquire);
+    };
+
+    let mut current_state = expected_state;
+
+    loop {
+        if failover_state_index(current_state, endpoints) != index {
+            let actual_state = state.load(Ordering::Acquire);
+            if actual_state == current_state
+                || failover_state_index(actual_state, endpoints) != index
+            {
+                return actual_state;
+            }
+            current_state = actual_state;
+            continue;
+        }
+
+        let next_state = failover_next_state(current_state, next_index, endpoints);
+        match state.compare_exchange(
+            current_state,
+            next_state,
+            Ordering::AcqRel,
+            Ordering::Acquire,
+        ) {
+            Ok(_) => return next_state,
+            Err(actual) => current_state = actual,
+        }
+    }
+}
+
+fn is_retriable_vector_error(error: &crate::Error) -> bool {
+    error
+        .downcast_ref::<VectorSinkError>()
+        .is_none_or(|error| VectorGrpcRetryLogic.is_retriable_error(error))
+}
+
+impl VectorConfig {
+    fn uris(&self, tls: bool) -> crate::Result<Vec<Uri>> {
+        match (self.address.as_ref(), self.addresses.as_slice()) {
+            (Some(_), [_first, ..]) => Err(
+                "`address` and `addresses` options are mutually exclusive. Please use `addresses` for multiple Vector endpoints."
+                    .into(),
+            ),
+            (None, []) => Err("No Vector endpoint configured. Please set `address` or `addresses`.".into()),
+            (Some(address), []) => Ok(vec![with_default_scheme(address, tls)?]),
+            (None, addresses) => addresses
+                .iter()
+                .map(|address| with_default_scheme(address, tls))
+                .collect(),
+        }
     }
 }
 
@@ -181,6 +462,39 @@ async fn healthcheck(
         },
         Err(source) => Err(Box::new(VectorSinkError::Request { source })),
     }
+}
+
+fn healthchecks(
+    client: hyper::Client<ProxyConnector<HttpsConnector<HttpConnector>>, BoxBody>,
+    uris: &[Uri],
+    options: SinkHealthcheckOptions,
+) -> Healthcheck {
+    if !options.enabled {
+        return Box::pin(futures::future::ok(()));
+    }
+
+    let healthcheck_uris = options
+        .uri
+        .clone()
+        .map(|uri| vec![uri.uri])
+        .unwrap_or_else(|| uris.to_vec());
+
+    Box::pin(
+        futures::future::select_ok(healthcheck_uris.into_iter().map(move |uri| {
+            let service = VectorService::new(client.clone(), uri, VectorCompression::None);
+            let timeout = options.timeout;
+            healthcheck(
+                service,
+                SinkHealthcheckOptions {
+                    enabled: true,
+                    uri: None,
+                    timeout,
+                },
+            )
+            .boxed()
+        }))
+        .map_ok(|((), _)| ()),
+    )
 }
 
 /// grpc doesn't like an address without a scheme, so we default to http or https if one isn't
@@ -254,5 +568,103 @@ impl RetryLogic for VectorGrpcRetryLogic {
             ),
             _ => true,
         }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct VectorGrpcHealthLogic;
+
+impl HealthLogic for VectorGrpcHealthLogic {
+    type Error = crate::Error;
+    type Response = VectorResponse;
+
+    fn is_healthy(&self, response: &Result<Self::Response, Self::Error>) -> Option<bool> {
+        match response {
+            Ok(_) => Some(true),
+            Err(error) if is_retriable_vector_error(error) => Some(false),
+            Err(_) => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn health_logic_ignores_non_retriable_vector_errors() {
+        let response = Err(Box::new(VectorSinkError::Request {
+            source: tonic::Status::data_loss("batch rejected"),
+        }) as crate::Error);
+
+        assert_eq!(VectorGrpcHealthLogic.is_healthy(&response), None);
+    }
+
+    #[test]
+    fn health_logic_marks_retriable_vector_errors_unhealthy() {
+        let response = Err(Box::new(VectorSinkError::Request {
+            source: tonic::Status::unavailable("endpoint unavailable"),
+        }) as crate::Error);
+
+        assert_eq!(VectorGrpcHealthLogic.is_healthy(&response), Some(false));
+    }
+
+    #[test]
+    fn failover_advance_reloads_stale_generation() {
+        let endpoints = 2;
+        let state = AtomicUsize::new(failover_next_state(
+            failover_next_state(0, 1, endpoints),
+            0,
+            endpoints,
+        ));
+
+        let observed = failover_advance_if_current(&state, 0, 0, Some(1), endpoints);
+
+        assert_eq!(observed, 7);
+        assert_eq!(state.load(Ordering::Acquire), 7);
+    }
+
+    #[test]
+    fn failover_advance_reloads_stale_mismatched_state() {
+        let endpoints = 3;
+        let shared_state = failover_next_state(failover_next_state(0, 1, endpoints), 0, endpoints);
+        let stale_state = 1;
+        let state = AtomicUsize::new(shared_state);
+
+        let observed = failover_advance_if_current(&state, stale_state, 0, Some(1), endpoints);
+
+        assert_eq!(observed, 10);
+        assert_eq!(state.load(Ordering::Acquire), 10);
+    }
+
+    #[test]
+    fn failover_primary_attempts_current_then_configured_order() {
+        assert_eq!(failover_primary_attempt_indices(1, 3), vec![1, 0, 1, 2]);
+    }
+
+    #[test]
+    fn failover_attempts_current_then_ring_order() {
+        assert_eq!(failover_ring_attempt_indices(1, 3), vec![1, 2, 0]);
+    }
+
+    #[test]
+    fn failover_advance_ignores_current_non_matching_endpoint() {
+        let endpoints = 3;
+        let state = AtomicUsize::new(5);
+
+        let observed = failover_advance_if_current(&state, 0, 0, Some(1), endpoints);
+
+        assert_eq!(observed, 5);
+        assert_eq!(state.load(Ordering::Acquire), 5);
+    }
+
+    #[test]
+    fn failover_advance_ignores_missing_next_endpoint() {
+        let state = AtomicUsize::new(0);
+
+        let observed = failover_advance_if_current(&state, 0, 0, None, 2);
+
+        assert_eq!(observed, 0);
+        assert_eq!(state.load(Ordering::Acquire), 0);
     }
 }

--- a/src/sinks/vector/config.rs
+++ b/src/sinks/vector/config.rs
@@ -436,24 +436,33 @@ fn failover_next_attempts(
 ) -> usize {
     if advance.advanced || advance.state == expected_state {
         *attempt += 1;
-    } else if failover_state_index(advance.state, endpoints)
-        == failover_state_index(expected_state, endpoints)
-    {
-        attempts.clear();
-        *attempt = 0;
     } else {
-        *attempts = failover_attempt_indices(
+        *attempts = stale_failover_attempt_indices(
             endpoint_strategy,
             failover_state_index(advance.state, endpoints),
             endpoints,
-        )
-        .into_iter()
-        .filter(|index| !tried.contains(index))
-        .collect();
+            tried,
+        );
         *attempt = 0;
     }
 
     advance.state
+}
+
+fn stale_failover_attempt_indices(
+    endpoint_strategy: EndpointStrategy,
+    start: usize,
+    endpoints: usize,
+    tried: &[usize],
+) -> Vec<usize> {
+    let active_endpoint = start;
+    std::iter::once(active_endpoint)
+        .chain(
+            failover_attempt_indices(endpoint_strategy, start, endpoints)
+                .into_iter()
+                .filter(move |index| *index != active_endpoint && !tried.contains(index)),
+        )
+        .collect()
 }
 
 fn failover_advance_if_current(
@@ -805,7 +814,7 @@ mod tests {
     }
 
     #[test]
-    fn failover_next_attempts_stops_after_stale_same_endpoint_generation() {
+    fn failover_next_attempts_restarts_after_stale_same_endpoint_generation() {
         let mut attempts = failover_ring_attempt_indices(0, 2);
         let mut attempt = 0;
 
@@ -824,11 +833,11 @@ mod tests {
 
         assert_eq!(observed_state, 4);
         assert_eq!(attempt, 0);
-        assert!(attempts.is_empty());
+        assert_eq!(attempts, vec![0, 1]);
     }
 
     #[test]
-    fn failover_next_attempts_stops_after_stale_wrapped_generation() {
+    fn failover_next_attempts_restarts_after_stale_wrapped_generation() {
         let mut attempts = failover_ring_attempt_indices(0, 3);
         let mut attempt = 0;
 
@@ -847,7 +856,53 @@ mod tests {
 
         assert_eq!(observed_state, 6);
         assert_eq!(attempt, 0);
-        assert!(attempts.is_empty());
+        assert_eq!(attempts, vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn failover_next_attempts_preserves_failover_primary_after_duplicate_primary_advance() {
+        let mut attempts = failover_primary_attempt_indices(0, 3);
+        let mut attempt = 0;
+
+        let observed_state = failover_next_attempts(
+            EndpointStrategy::FailoverPrimary,
+            3,
+            &mut attempts,
+            &mut attempt,
+            0,
+            FailoverAdvance {
+                state: 3,
+                advanced: false,
+            },
+            &[0],
+        );
+
+        assert_eq!(observed_state, 3);
+        assert_eq!(attempt, 0);
+        assert_eq!(attempts, vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn failover_next_attempts_keeps_shared_active_endpoint_after_stale_wrap() {
+        let mut attempts = failover_ring_attempt_indices(0, 3);
+        let mut attempt = 1;
+
+        let observed_state = failover_next_attempts(
+            EndpointStrategy::Failover,
+            3,
+            &mut attempts,
+            &mut attempt,
+            1,
+            FailoverAdvance {
+                state: 6,
+                advanced: false,
+            },
+            &[0, 1],
+        );
+
+        assert_eq!(observed_state, 6);
+        assert_eq!(attempt, 0);
+        assert_eq!(attempts, vec![0, 2]);
     }
 
     #[test]

--- a/src/sinks/vector/config.rs
+++ b/src/sinks/vector/config.rs
@@ -343,10 +343,10 @@ impl Service<VectorRequest> for FailoverVectorService {
                             &state,
                             expected_state,
                             index,
-                            attempts.get(attempt + 1).copied(),
+                            failover_next_index(endpoint_strategy, attempts.as_slice(), attempt),
                             services.len(),
                         );
-                        expected_state = failover_next_attempts(
+                        let next_attempts = failover_next_attempts(
                             endpoint_strategy,
                             services.len(),
                             attempts.as_mut(),
@@ -355,6 +355,10 @@ impl Service<VectorRequest> for FailoverVectorService {
                             advance,
                             &tried,
                         );
+                        expected_state = next_attempts.state;
+                        if next_attempts.rebuilt {
+                            remaining_attempts = attempts.len();
+                        }
                         last_error = Some(error);
                     }
                     Err(_elapsed) => {
@@ -362,10 +366,10 @@ impl Service<VectorRequest> for FailoverVectorService {
                             &state,
                             expected_state,
                             index,
-                            attempts.get(attempt + 1).copied(),
+                            failover_next_index(endpoint_strategy, attempts.as_slice(), attempt),
                             services.len(),
                         );
-                        expected_state = failover_next_attempts(
+                        let next_attempts = failover_next_attempts(
                             endpoint_strategy,
                             services.len(),
                             attempts.as_mut(),
@@ -374,6 +378,10 @@ impl Service<VectorRequest> for FailoverVectorService {
                             advance,
                             &tried,
                         );
+                        expected_state = next_attempts.state;
+                        if next_attempts.rebuilt {
+                            remaining_attempts = attempts.len();
+                        }
                         last_error = Some(Box::new(VectorSinkError::Request {
                             source: tonic::Status::deadline_exceeded(
                                 "vector endpoint request timed out",
@@ -419,10 +427,30 @@ fn failover_ring_attempt_indices(start: usize, endpoints: usize) -> Vec<usize> {
         .collect()
 }
 
+fn failover_next_index(
+    endpoint_strategy: EndpointStrategy,
+    attempts: &[usize],
+    attempt: usize,
+) -> Option<usize> {
+    attempts
+        .get(attempt + 1)
+        .copied()
+        .or(match endpoint_strategy {
+            EndpointStrategy::FailoverPrimary => Some(0),
+            EndpointStrategy::Failover | EndpointStrategy::LoadBalance => None,
+        })
+}
+
 #[derive(Debug, Eq, PartialEq)]
 struct FailoverAdvance {
     state: usize,
     advanced: bool,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+struct FailoverNextAttempts {
+    state: usize,
+    rebuilt: bool,
 }
 
 fn failover_next_attempts(
@@ -433,9 +461,13 @@ fn failover_next_attempts(
     expected_state: usize,
     advance: FailoverAdvance,
     tried: &[usize],
-) -> usize {
+) -> FailoverNextAttempts {
     if advance.advanced || advance.state == expected_state {
         *attempt += 1;
+        return FailoverNextAttempts {
+            state: advance.state,
+            rebuilt: false,
+        };
     } else {
         *attempts = stale_failover_attempt_indices(
             endpoint_strategy,
@@ -446,7 +478,10 @@ fn failover_next_attempts(
         *attempt = 0;
     }
 
-    advance.state
+    FailoverNextAttempts {
+        state: advance.state,
+        rebuilt: true,
+    }
 }
 
 fn stale_failover_attempt_indices(
@@ -791,11 +826,39 @@ mod tests {
     }
 
     #[test]
+    fn failover_primary_final_attempt_wraps_state_to_primary() {
+        let attempts = failover_primary_attempt_indices(2, 3);
+        let state = AtomicUsize::new(5);
+
+        let observed = failover_advance_if_current(
+            &state,
+            5,
+            2,
+            failover_next_index(
+                EndpointStrategy::FailoverPrimary,
+                &attempts,
+                attempts.len() - 1,
+            ),
+            3,
+        );
+
+        assert_eq!(
+            observed,
+            FailoverAdvance {
+                state: 6,
+                advanced: true,
+            }
+        );
+        assert_eq!(state.load(Ordering::Acquire), 6);
+    }
+
+    #[test]
     fn failover_next_attempts_recomputes_after_concurrent_advance() {
         let mut attempts = failover_ring_attempt_indices(0, 3);
         let mut attempt = 0;
+        let mut remaining_attempts = 2;
 
-        let observed_state = failover_next_attempts(
+        let observed = failover_next_attempts(
             EndpointStrategy::Failover,
             3,
             &mut attempts,
@@ -807,18 +870,24 @@ mod tests {
             },
             &[0],
         );
+        if observed.rebuilt {
+            remaining_attempts = attempts.len();
+        }
 
-        assert_eq!(observed_state, 5);
+        assert_eq!(observed.state, 5);
+        assert!(observed.rebuilt);
         assert_eq!(attempt, 0);
         assert_eq!(attempts, vec![2, 1]);
+        assert_eq!(remaining_attempts, attempts.len());
     }
 
     #[test]
     fn failover_next_attempts_restarts_after_stale_same_endpoint_generation() {
         let mut attempts = failover_ring_attempt_indices(0, 2);
         let mut attempt = 0;
+        let mut remaining_attempts = 1;
 
-        let observed_state = failover_next_attempts(
+        let observed = failover_next_attempts(
             EndpointStrategy::Failover,
             2,
             &mut attempts,
@@ -830,18 +899,24 @@ mod tests {
             },
             &[0],
         );
+        if observed.rebuilt {
+            remaining_attempts = attempts.len();
+        }
 
-        assert_eq!(observed_state, 4);
+        assert_eq!(observed.state, 4);
+        assert!(observed.rebuilt);
         assert_eq!(attempt, 0);
         assert_eq!(attempts, vec![0, 1]);
+        assert_eq!(remaining_attempts, attempts.len());
     }
 
     #[test]
     fn failover_next_attempts_restarts_after_stale_wrapped_generation() {
         let mut attempts = failover_ring_attempt_indices(0, 3);
         let mut attempt = 0;
+        let mut remaining_attempts = 1;
 
-        let observed_state = failover_next_attempts(
+        let observed = failover_next_attempts(
             EndpointStrategy::Failover,
             3,
             &mut attempts,
@@ -853,18 +928,24 @@ mod tests {
             },
             &[0],
         );
+        if observed.rebuilt {
+            remaining_attempts = attempts.len();
+        }
 
-        assert_eq!(observed_state, 6);
+        assert_eq!(observed.state, 6);
+        assert!(observed.rebuilt);
         assert_eq!(attempt, 0);
         assert_eq!(attempts, vec![0, 1, 2]);
+        assert_eq!(remaining_attempts, attempts.len());
     }
 
     #[test]
     fn failover_next_attempts_preserves_failover_primary_after_duplicate_primary_advance() {
         let mut attempts = failover_primary_attempt_indices(0, 3);
         let mut attempt = 0;
+        let mut remaining_attempts = 1;
 
-        let observed_state = failover_next_attempts(
+        let observed = failover_next_attempts(
             EndpointStrategy::FailoverPrimary,
             3,
             &mut attempts,
@@ -876,18 +957,24 @@ mod tests {
             },
             &[0],
         );
+        if observed.rebuilt {
+            remaining_attempts = attempts.len();
+        }
 
-        assert_eq!(observed_state, 3);
+        assert_eq!(observed.state, 3);
+        assert!(observed.rebuilt);
         assert_eq!(attempt, 0);
         assert_eq!(attempts, vec![0, 1, 2]);
+        assert_eq!(remaining_attempts, attempts.len());
     }
 
     #[test]
     fn failover_next_attempts_keeps_shared_active_endpoint_after_stale_wrap() {
         let mut attempts = failover_ring_attempt_indices(0, 3);
         let mut attempt = 1;
+        let mut remaining_attempts = 1;
 
-        let observed_state = failover_next_attempts(
+        let observed = failover_next_attempts(
             EndpointStrategy::Failover,
             3,
             &mut attempts,
@@ -899,18 +986,24 @@ mod tests {
             },
             &[0, 1],
         );
+        if observed.rebuilt {
+            remaining_attempts = attempts.len();
+        }
 
-        assert_eq!(observed_state, 6);
+        assert_eq!(observed.state, 6);
+        assert!(observed.rebuilt);
         assert_eq!(attempt, 0);
         assert_eq!(attempts, vec![0, 2]);
+        assert_eq!(remaining_attempts, attempts.len());
     }
 
     #[test]
     fn failover_next_attempts_continues_after_local_advance() {
         let mut attempts = failover_primary_attempt_indices(1, 3);
         let mut attempt = 0;
+        let remaining_attempts = 3;
 
-        let observed_state = failover_next_attempts(
+        let observed = failover_next_attempts(
             EndpointStrategy::FailoverPrimary,
             3,
             &mut attempts,
@@ -923,8 +1016,10 @@ mod tests {
             &[1],
         );
 
-        assert_eq!(observed_state, 3);
+        assert_eq!(observed.state, 3);
+        assert!(!observed.rebuilt);
         assert_eq!(attempt, 1);
         assert_eq!(attempts, vec![1, 0, 1, 2]);
+        assert_eq!(remaining_attempts, 3);
     }
 }

--- a/src/sinks/vector/config.rs
+++ b/src/sinks/vector/config.rs
@@ -301,22 +301,19 @@ impl Service<VectorRequest> for FailoverVectorService {
         let endpoint_strategy = self.endpoint_strategy;
 
         Box::pin(async move {
-            let start_state = state.load(Ordering::Acquire);
-            let start = failover_state_index(start_state, services.len());
-            let mut expected_state = start_state;
+            let mut expected_state = state.load(Ordering::Acquire);
+            let start = failover_state_index(expected_state, services.len());
             let mut last_error = None;
-            let attempts = match endpoint_strategy {
-                EndpointStrategy::Failover => failover_ring_attempt_indices(start, services.len()),
-                EndpointStrategy::FailoverPrimary => {
-                    failover_primary_attempt_indices(start, services.len())
-                }
-                EndpointStrategy::LoadBalance => {
-                    unreachable!("load balancing uses a different service")
-                }
-            };
+            let mut attempts = failover_attempt_indices(endpoint_strategy, start, services.len());
+            let mut attempt = 0;
+            let mut remaining_attempts = attempts.len();
+            let mut tried = Vec::new();
 
-            for (attempt, index) in attempts.iter().copied().enumerate() {
+            while remaining_attempts > 0 && attempt < attempts.len() {
+                let index = attempts[attempt];
                 let mut service = services[index].clone();
+                tried.push(index);
+                remaining_attempts -= 1;
 
                 match tokio::time::timeout(endpoint_timeout, service.call(request.clone())).await {
                     Ok(Ok(response)) => {
@@ -327,22 +324,40 @@ impl Service<VectorRequest> for FailoverVectorService {
                             return Err(error);
                         }
 
-                        expected_state = failover_advance_if_current(
+                        let advance = failover_advance_if_current(
                             &state,
                             expected_state,
                             index,
                             attempts.get(attempt + 1).copied(),
                             services.len(),
                         );
+                        expected_state = failover_next_attempts(
+                            endpoint_strategy,
+                            services.len(),
+                            attempts.as_mut(),
+                            &mut attempt,
+                            expected_state,
+                            advance,
+                            &tried,
+                        );
                         last_error = Some(error);
                     }
                     Err(_elapsed) => {
-                        expected_state = failover_advance_if_current(
+                        let advance = failover_advance_if_current(
                             &state,
                             expected_state,
                             index,
                             attempts.get(attempt + 1).copied(),
                             services.len(),
+                        );
+                        expected_state = failover_next_attempts(
+                            endpoint_strategy,
+                            services.len(),
+                            attempts.as_mut(),
+                            &mut attempt,
+                            expected_state,
+                            advance,
+                            &tried,
                         );
                         last_error = Some(Box::new(VectorSinkError::Request {
                             source: tonic::Status::deadline_exceeded(
@@ -355,6 +370,18 @@ impl Service<VectorRequest> for FailoverVectorService {
 
             Err(last_error.expect("failover service should have at least one endpoint"))
         })
+    }
+}
+
+fn failover_attempt_indices(
+    endpoint_strategy: EndpointStrategy,
+    start: usize,
+    endpoints: usize,
+) -> Vec<usize> {
+    match endpoint_strategy {
+        EndpointStrategy::Failover => failover_ring_attempt_indices(start, endpoints),
+        EndpointStrategy::FailoverPrimary => failover_primary_attempt_indices(start, endpoints),
+        EndpointStrategy::LoadBalance => unreachable!("load balancing uses a different service"),
     }
 }
 
@@ -377,41 +404,78 @@ fn failover_ring_attempt_indices(start: usize, endpoints: usize) -> Vec<usize> {
         .collect()
 }
 
+#[derive(Debug, Eq, PartialEq)]
+struct FailoverAdvance {
+    state: usize,
+    advanced: bool,
+}
+
+fn failover_next_attempts(
+    endpoint_strategy: EndpointStrategy,
+    endpoints: usize,
+    attempts: &mut Vec<usize>,
+    attempt: &mut usize,
+    expected_state: usize,
+    advance: FailoverAdvance,
+    tried: &[usize],
+) -> usize {
+    if advance.advanced
+        || advance.state == expected_state
+        || failover_state_index(advance.state, endpoints)
+            == failover_state_index(expected_state, endpoints)
+    {
+        *attempt += 1;
+    } else {
+        *attempts = failover_attempt_indices(
+            endpoint_strategy,
+            failover_state_index(advance.state, endpoints),
+            endpoints,
+        )
+        .into_iter()
+        .filter(|index| !tried.contains(index))
+        .collect();
+        *attempt = 0;
+    }
+
+    advance.state
+}
+
 fn failover_advance_if_current(
     state: &AtomicUsize,
     expected_state: usize,
     index: usize,
     next_index: Option<usize>,
     endpoints: usize,
-) -> usize {
+) -> FailoverAdvance {
     let Some(next_index) = next_index else {
-        return state.load(Ordering::Acquire);
+        return FailoverAdvance {
+            state: state.load(Ordering::Acquire),
+            advanced: false,
+        };
     };
 
-    let mut current_state = expected_state;
+    if failover_state_index(expected_state, endpoints) != index {
+        return FailoverAdvance {
+            state: state.load(Ordering::Acquire),
+            advanced: false,
+        };
+    }
 
-    loop {
-        if failover_state_index(current_state, endpoints) != index {
-            let actual_state = state.load(Ordering::Acquire);
-            if actual_state == current_state
-                || failover_state_index(actual_state, endpoints) != index
-            {
-                return actual_state;
-            }
-            current_state = actual_state;
-            continue;
-        }
-
-        let next_state = failover_next_state(current_state, next_index, endpoints);
-        match state.compare_exchange(
-            current_state,
-            next_state,
-            Ordering::AcqRel,
-            Ordering::Acquire,
-        ) {
-            Ok(_) => return next_state,
-            Err(actual) => current_state = actual,
-        }
+    let next_state = failover_next_state(expected_state, next_index, endpoints);
+    match state.compare_exchange(
+        expected_state,
+        next_state,
+        Ordering::AcqRel,
+        Ordering::Acquire,
+    ) {
+        Ok(_) => FailoverAdvance {
+            state: next_state,
+            advanced: true,
+        },
+        Err(actual) => FailoverAdvance {
+            state: actual,
+            advanced: false,
+        },
     }
 }
 
@@ -610,7 +674,7 @@ mod tests {
     }
 
     #[test]
-    fn failover_advance_reloads_stale_generation() {
+    fn failover_advance_ignores_stale_generation() {
         let endpoints = 2;
         let state = AtomicUsize::new(failover_next_state(
             failover_next_state(0, 1, endpoints),
@@ -620,12 +684,18 @@ mod tests {
 
         let observed = failover_advance_if_current(&state, 0, 0, Some(1), endpoints);
 
-        assert_eq!(observed, 7);
-        assert_eq!(state.load(Ordering::Acquire), 7);
+        assert_eq!(
+            observed,
+            FailoverAdvance {
+                state: 4,
+                advanced: false,
+            }
+        );
+        assert_eq!(state.load(Ordering::Acquire), 4);
     }
 
     #[test]
-    fn failover_advance_reloads_stale_mismatched_state() {
+    fn failover_advance_ignores_stale_mismatched_state() {
         let endpoints = 3;
         let shared_state = failover_next_state(failover_next_state(0, 1, endpoints), 0, endpoints);
         let stale_state = 1;
@@ -633,8 +703,14 @@ mod tests {
 
         let observed = failover_advance_if_current(&state, stale_state, 0, Some(1), endpoints);
 
-        assert_eq!(observed, 10);
-        assert_eq!(state.load(Ordering::Acquire), 10);
+        assert_eq!(
+            observed,
+            FailoverAdvance {
+                state: shared_state,
+                advanced: false,
+            }
+        );
+        assert_eq!(state.load(Ordering::Acquire), shared_state);
     }
 
     #[test]
@@ -654,7 +730,13 @@ mod tests {
 
         let observed = failover_advance_if_current(&state, 0, 0, Some(1), endpoints);
 
-        assert_eq!(observed, 5);
+        assert_eq!(
+            observed,
+            FailoverAdvance {
+                state: 5,
+                advanced: false,
+            }
+        );
         assert_eq!(state.load(Ordering::Acquire), 5);
     }
 
@@ -664,7 +746,82 @@ mod tests {
 
         let observed = failover_advance_if_current(&state, 0, 0, None, 2);
 
-        assert_eq!(observed, 0);
+        assert_eq!(
+            observed,
+            FailoverAdvance {
+                state: 0,
+                advanced: false,
+            }
+        );
         assert_eq!(state.load(Ordering::Acquire), 0);
+    }
+
+    #[test]
+    fn failover_next_attempts_recomputes_after_concurrent_advance() {
+        let mut attempts = failover_ring_attempt_indices(0, 3);
+        let mut attempt = 0;
+
+        let observed_state = failover_next_attempts(
+            EndpointStrategy::Failover,
+            3,
+            &mut attempts,
+            &mut attempt,
+            0,
+            FailoverAdvance {
+                state: 5,
+                advanced: false,
+            },
+            &[0],
+        );
+
+        assert_eq!(observed_state, 5);
+        assert_eq!(attempt, 0);
+        assert_eq!(attempts, vec![2, 1]);
+    }
+
+    #[test]
+    fn failover_next_attempts_continues_after_stale_same_endpoint_generation() {
+        let mut attempts = failover_ring_attempt_indices(0, 2);
+        let mut attempt = 0;
+
+        let observed_state = failover_next_attempts(
+            EndpointStrategy::Failover,
+            2,
+            &mut attempts,
+            &mut attempt,
+            0,
+            FailoverAdvance {
+                state: 4,
+                advanced: false,
+            },
+            &[0],
+        );
+
+        assert_eq!(observed_state, 4);
+        assert_eq!(attempt, 1);
+        assert_eq!(attempts, vec![0, 1]);
+    }
+
+    #[test]
+    fn failover_next_attempts_continues_after_local_advance() {
+        let mut attempts = failover_primary_attempt_indices(1, 3);
+        let mut attempt = 0;
+
+        let observed_state = failover_next_attempts(
+            EndpointStrategy::FailoverPrimary,
+            3,
+            &mut attempts,
+            &mut attempt,
+            1,
+            FailoverAdvance {
+                state: 3,
+                advanced: true,
+            },
+            &[1],
+        );
+
+        assert_eq!(observed_state, 3);
+        assert_eq!(attempt, 1);
+        assert_eq!(attempts, vec![1, 0, 1, 2]);
     }
 }

--- a/src/sinks/vector/config.rs
+++ b/src/sinks/vector/config.rs
@@ -202,9 +202,20 @@ impl SinkConfig for VectorConfig {
             }
             EndpointStrategy::Failover | EndpointStrategy::FailoverPrimary => {
                 let endpoint_timeout = request_settings.timeout;
+                let max_endpoint_attempts = match self.endpoint_strategy {
+                    EndpointStrategy::Failover => services.len(),
+                    EndpointStrategy::FailoverPrimary => services.len() + 1,
+                    EndpointStrategy::LoadBalance => {
+                        unreachable!("load balancing uses a different service")
+                    }
+                };
                 let mut failover_request_settings = request_settings;
+                // The outer Tower timeout wraps the whole failover loop. Add one
+                // endpoint timeout of slack so the final endpoint attempt is not
+                // aborted by scheduling overhead after earlier attempts consume
+                // their per-endpoint timeouts.
                 failover_request_settings.timeout = endpoint_timeout
-                    .checked_mul((services.len() + 1) as u32)
+                    .checked_mul((max_endpoint_attempts + 1) as u32)
                     .unwrap_or(endpoint_timeout);
 
                 let service = ServiceBuilder::new()

--- a/src/sinks/vector/config.rs
+++ b/src/sinks/vector/config.rs
@@ -162,7 +162,12 @@ impl SinkConfig for VectorConfig {
 
         let client = new_client(&tls, cx.proxy())?;
 
-        let healthcheck = healthchecks(client.clone(), &uris, cx.healthcheck);
+        let healthcheck = healthchecks(
+            client.clone(),
+            &uris,
+            cx.healthcheck,
+            self.endpoint_strategy,
+        );
         let request_settings = self.request.into_settings();
         let batch_settings = self.batch.into_batcher_settings()?;
 
@@ -601,33 +606,62 @@ fn healthchecks(
     client: hyper::Client<ProxyConnector<HttpsConnector<HttpConnector>>, BoxBody>,
     uris: &[Uri],
     options: SinkHealthcheckOptions,
+    endpoint_strategy: EndpointStrategy,
 ) -> Healthcheck {
     if !options.enabled {
         return Box::pin(futures::future::ok(()));
     }
 
-    let healthcheck_uris = options
+    let healthcheck_uris = healthcheck_uris_for_strategy(uris, &options, endpoint_strategy);
+
+    let healthchecks = healthcheck_uris.into_iter().map(move |uri| {
+        let service = VectorService::new(client.clone(), uri, VectorCompression::None);
+        let timeout = options.timeout;
+        healthcheck(
+            service,
+            SinkHealthcheckOptions {
+                enabled: true,
+                uri: None,
+                timeout,
+            },
+        )
+        .boxed()
+    });
+
+    match endpoint_strategy {
+        // Load balancing can route data to any endpoint, so all endpoints must
+        // pass the startup healthcheck. Otherwise a sink can start with a bad
+        // endpoint that later rejects non-retriable batches.
+        EndpointStrategy::LoadBalance => {
+            Box::pin(futures::future::try_join_all(healthchecks).map_ok(|_| ()))
+        }
+        EndpointStrategy::Failover | EndpointStrategy::FailoverPrimary => {
+            Box::pin(futures::future::select_ok(healthchecks).map_ok(|((), _)| ()))
+        }
+    }
+}
+
+fn requires_all_endpoint_healthchecks(
+    endpoint_strategy: EndpointStrategy,
+    endpoint_count: usize,
+) -> bool {
+    matches!(endpoint_strategy, EndpointStrategy::LoadBalance) && endpoint_count > 1
+}
+
+fn healthcheck_uris_for_strategy(
+    uris: &[Uri],
+    options: &SinkHealthcheckOptions,
+    endpoint_strategy: EndpointStrategy,
+) -> Vec<Uri> {
+    if requires_all_endpoint_healthchecks(endpoint_strategy, uris.len()) {
+        return uris.to_vec();
+    }
+
+    options
         .uri
         .clone()
         .map(|uri| vec![uri.uri])
-        .unwrap_or_else(|| uris.to_vec());
-
-    Box::pin(
-        futures::future::select_ok(healthcheck_uris.into_iter().map(move |uri| {
-            let service = VectorService::new(client.clone(), uri, VectorCompression::None);
-            let timeout = options.timeout;
-            healthcheck(
-                service,
-                SinkHealthcheckOptions {
-                    enabled: true,
-                    uri: None,
-                    timeout,
-                },
-            )
-            .boxed()
-        }))
-        .map_ok(|((), _)| ()),
-    )
+        .unwrap_or_else(|| uris.to_vec())
 }
 
 /// grpc doesn't like an address without a scheme, so we default to http or https if one isn't
@@ -723,6 +757,7 @@ impl HealthLogic for VectorGrpcHealthLogic {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::sinks::util::UriSerde;
 
     #[test]
     fn health_logic_ignores_non_retriable_vector_errors() {
@@ -1021,5 +1056,102 @@ mod tests {
         assert_eq!(attempt, 1);
         assert_eq!(attempts, vec![1, 0, 1, 2]);
         assert_eq!(remaining_attempts, 3);
+    }
+
+    #[test]
+    fn only_load_balancing_requires_all_endpoint_healthchecks() {
+        assert!(requires_all_endpoint_healthchecks(
+            EndpointStrategy::LoadBalance,
+            2
+        ));
+        assert!(!requires_all_endpoint_healthchecks(
+            EndpointStrategy::LoadBalance,
+            1
+        ));
+        assert!(!requires_all_endpoint_healthchecks(
+            EndpointStrategy::Failover,
+            2
+        ));
+        assert!(!requires_all_endpoint_healthchecks(
+            EndpointStrategy::FailoverPrimary,
+            2
+        ));
+    }
+
+    #[test]
+    fn load_balancing_healthchecks_all_configured_endpoints_even_with_override_uri() {
+        let endpoints = vec![
+            "http://endpoint-a.example.com".parse().unwrap(),
+            "http://endpoint-b.example.com".parse().unwrap(),
+        ];
+        let options = SinkHealthcheckOptions {
+            uri: Some("http://health.example.com".parse::<UriSerde>().unwrap()),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            healthcheck_uris_for_strategy(&endpoints, &options, EndpointStrategy::LoadBalance),
+            endpoints
+        );
+    }
+
+    #[test]
+    fn single_endpoint_load_balancing_healthcheck_can_use_override_uri() {
+        let endpoints = vec!["http://endpoint-a.example.com".parse().unwrap()];
+        let override_uri = "http://health.example.com".parse::<UriSerde>().unwrap().uri;
+        let options = SinkHealthcheckOptions {
+            uri: Some(UriSerde {
+                uri: override_uri.clone(),
+                auth: None,
+            }),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            healthcheck_uris_for_strategy(&endpoints, &options, EndpointStrategy::LoadBalance),
+            vec![override_uri]
+        );
+    }
+
+    #[test]
+    fn failover_healthchecks_can_use_override_uri() {
+        let endpoints = vec![
+            "http://endpoint-a.example.com".parse().unwrap(),
+            "http://endpoint-b.example.com".parse().unwrap(),
+        ];
+        let override_uri = "http://health.example.com".parse::<UriSerde>().unwrap().uri;
+        let options = SinkHealthcheckOptions {
+            uri: Some(UriSerde {
+                uri: override_uri.clone(),
+                auth: None,
+            }),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            healthcheck_uris_for_strategy(&endpoints, &options, EndpointStrategy::Failover),
+            vec![override_uri]
+        );
+    }
+
+    #[test]
+    fn failover_primary_healthchecks_can_use_override_uri() {
+        let endpoints = vec![
+            "http://endpoint-a.example.com".parse().unwrap(),
+            "http://endpoint-b.example.com".parse().unwrap(),
+        ];
+        let override_uri = "http://health.example.com".parse::<UriSerde>().unwrap().uri;
+        let options = SinkHealthcheckOptions {
+            uri: Some(UriSerde {
+                uri: override_uri.clone(),
+                auth: None,
+            }),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            healthcheck_uris_for_strategy(&endpoints, &options, EndpointStrategy::FailoverPrimary),
+            vec![override_uri]
+        );
     }
 }

--- a/src/sinks/vector/config.rs
+++ b/src/sinks/vector/config.rs
@@ -12,6 +12,7 @@ use http::Uri;
 use hyper::client::HttpConnector;
 use hyper_openssl::HttpsConnector;
 use hyper_proxy::ProxyConnector;
+use tokio::sync::Semaphore;
 use tonic::body::BoxBody;
 use tower::{Service, ServiceBuilder};
 use vector_lib::configurable::configurable_component;
@@ -34,7 +35,7 @@ use crate::{
         util::{
             BatchConfig, RealtimeEventBasedDefaultBatchSettings, TowerRequestConfig,
             retries::RetryLogic,
-            service::{HealthConfig, HealthLogic, ServiceBuilderExt},
+            service::{HealthConfig, HealthLogic, ServiceBuilderExt, TowerRequestSettings},
         },
     },
     tls::{MaybeTlsSettings, TlsEnableableConfig},
@@ -220,14 +221,11 @@ impl SinkConfig for VectorConfig {
                         unreachable!("load balancing uses a different service")
                     }
                 };
-                let mut failover_request_settings = request_settings;
-                // The outer Tower timeout wraps the whole failover loop. Add one
-                // endpoint timeout of slack so the final endpoint attempt is not
-                // aborted by scheduling overhead after earlier attempts consume
-                // their per-endpoint timeouts.
-                failover_request_settings.timeout = endpoint_timeout
-                    .checked_mul((max_endpoint_attempts + 1) as u32)
-                    .unwrap_or(endpoint_timeout);
+                let failover_request_settings = failover_request_settings(
+                    request_settings,
+                    endpoint_timeout,
+                    max_endpoint_attempts,
+                );
 
                 let service = ServiceBuilder::new()
                     .settings(failover_request_settings, VectorGrpcRetryLogic)
@@ -277,6 +275,9 @@ pub enum EndpointStrategy {
     /// This mode keeps using the last successful endpoint until it fails. Use
     /// `failover_primary` instead when retriable failures should re-check the
     /// first configured endpoint before trying secondary endpoints.
+    ///
+    /// Requests are serialized for this strategy, regardless of the configured
+    /// request concurrency, to preserve one active endpoint at a time.
     Failover,
     /// Use one endpoint at a time. When the active endpoint fails, retry from
     /// the configured endpoint order so the sink can return to its configured
@@ -285,6 +286,9 @@ pub enum EndpointStrategy {
     /// This is useful when receiver-side connection recycling, such as
     /// `max_connection_age_secs`, should converge the sink back to the first
     /// configured endpoint when it is available.
+    ///
+    /// Requests are serialized for this strategy, regardless of the configured
+    /// request concurrency, to preserve one active endpoint at a time.
     FailoverPrimary,
 }
 
@@ -292,6 +296,7 @@ pub enum EndpointStrategy {
 struct FailoverVectorService {
     services: Vec<VectorService>,
     state: Arc<AtomicUsize>,
+    in_flight: Arc<Semaphore>,
     endpoint_timeout: std::time::Duration,
     endpoint_strategy: EndpointStrategy,
 }
@@ -305,6 +310,7 @@ impl FailoverVectorService {
         Self {
             services,
             state: Arc::new(AtomicUsize::new(0)),
+            in_flight: Arc::new(Semaphore::new(1)),
             endpoint_timeout,
             endpoint_strategy,
         }
@@ -323,10 +329,15 @@ impl Service<VectorRequest> for FailoverVectorService {
     fn call(&mut self, request: VectorRequest) -> Self::Future {
         let services = self.services.clone();
         let state = Arc::clone(&self.state);
+        let in_flight = Arc::clone(&self.in_flight);
         let endpoint_timeout = self.endpoint_timeout;
         let endpoint_strategy = self.endpoint_strategy;
 
         Box::pin(async move {
+            let _permit = in_flight
+                .acquire_owned()
+                .await
+                .expect("failover service semaphore should not be closed");
             let mut expected_state = state.load(Ordering::Acquire);
             let start = failover_state_index(expected_state, services.len());
             let mut last_error = None;
@@ -415,6 +426,22 @@ impl Service<VectorRequest> for FailoverVectorService {
             Err(last_error.expect("failover service should have at least one endpoint"))
         })
     }
+}
+
+fn failover_request_settings(
+    mut request_settings: TowerRequestSettings,
+    endpoint_timeout: Duration,
+    max_endpoint_attempts: usize,
+) -> TowerRequestSettings {
+    request_settings.concurrency = Some(1);
+    // The outer Tower timeout wraps the whole failover loop. Add one endpoint
+    // timeout of slack so the final endpoint attempt is not aborted by
+    // scheduling overhead after earlier attempts consume their per-endpoint
+    // timeouts.
+    request_settings.timeout = endpoint_timeout
+        .checked_mul((max_endpoint_attempts + 1) as u32)
+        .unwrap_or(endpoint_timeout);
+    request_settings
 }
 
 fn failover_attempt_indices(
@@ -516,15 +543,13 @@ fn stale_failover_attempt_indices(
     tried: &[usize],
 ) -> Vec<usize> {
     let active_endpoint = start;
+    let filter_tried = endpoint_strategy != EndpointStrategy::FailoverPrimary;
     std::iter::once(active_endpoint)
         .chain(
             failover_attempt_indices(endpoint_strategy, start, endpoints)
                 .into_iter()
                 .filter(move |index| {
-                    *index != active_endpoint
-                        && (!tried.contains(index)
-                            || (endpoint_strategy == EndpointStrategy::FailoverPrimary
-                                && *index == 0))
+                    *index != active_endpoint && (!filter_tried || !tried.contains(index))
                 }),
         )
         .collect()
@@ -653,20 +678,10 @@ fn healthchecks(
         .boxed()
     });
 
-    match endpoint_strategy {
-        // Load balancing can route data to any endpoint, so all endpoints must
-        // pass the startup healthcheck. Otherwise a sink can start with a bad
-        // endpoint that later rejects non-retriable batches.
-        EndpointStrategy::LoadBalance => {
-            Box::pin(futures::future::try_join_all(healthchecks).map_ok(|_| ()))
-        }
-        EndpointStrategy::Failover | EndpointStrategy::FailoverPrimary => {
-            Box::pin(futures::future::select_ok(healthchecks).map_ok(|((), _)| ()))
-        }
-    }
+    Box::pin(futures::future::try_join_all(healthchecks).map_ok(|_| ()))
 }
 
-fn requires_all_endpoint_healthchecks(
+const fn requires_all_endpoint_healthchecks(
     endpoint_strategy: EndpointStrategy,
     endpoint_count: usize,
 ) -> bool {
@@ -694,7 +709,7 @@ fn healthcheck_uris_for_strategy(
     }
 }
 
-fn default_endpoint_health_config() -> HealthConfig {
+const fn default_endpoint_health_config() -> HealthConfig {
     HealthConfig {
         retry_initial_backoff_secs: 1,
         retry_max_duration_secs: Duration::from_secs(60 * 60),
@@ -795,6 +810,42 @@ impl HealthLogic for VectorGrpcHealthLogic {
 mod tests {
     use super::*;
     use crate::sinks::util::UriSerde;
+
+    #[test]
+    fn failover_request_settings_force_serial_concurrency() {
+        let mut settings = TowerRequestConfig::<
+            crate::sinks::util::service::GlobalTowerRequestConfigDefaults,
+        >::default()
+        .into_settings();
+        settings.concurrency = Some(8);
+        settings.timeout = Duration::from_secs(5);
+
+        let settings = failover_request_settings(settings, Duration::from_secs(5), 3);
+
+        assert_eq!(settings.concurrency, Some(1));
+        assert_eq!(settings.timeout, Duration::from_secs(20));
+    }
+
+    #[test]
+    fn failover_service_clones_share_single_in_flight_permit() {
+        let service = FailoverVectorService::new(
+            Vec::new(),
+            Duration::from_secs(1),
+            EndpointStrategy::Failover,
+        );
+        let cloned = service.clone();
+
+        let permit = Arc::clone(&service.in_flight).try_acquire_owned().unwrap();
+
+        assert!(
+            Arc::clone(&cloned.in_flight).try_acquire_owned().is_err(),
+            "cloned failover services must share one request permit"
+        );
+
+        drop(permit);
+
+        assert!(Arc::clone(&cloned.in_flight).try_acquire_owned().is_ok());
+    }
 
     #[test]
     fn health_logic_ignores_non_retriable_vector_errors() {
@@ -1080,7 +1131,7 @@ mod tests {
                 state: 5,
                 advanced: false,
             },
-            &[0],
+            &[0, 1],
         );
         if observed.rebuilt {
             remaining_attempts = attempts.len();

--- a/src/sinks/vector/config.rs
+++ b/src/sinks/vector/config.rs
@@ -4,6 +4,7 @@ use std::{
         atomic::{AtomicUsize, Ordering},
     },
     task::{Context, Poll},
+    time::Duration,
 };
 
 use futures::{FutureExt, TryFutureExt, future::BoxFuture};
@@ -58,7 +59,10 @@ pub struct VectorConfig {
     ///
     /// This option is mutually exclusive with `endpoints`. Set exactly one of
     /// `address` or `endpoints`.
+    ///
+    /// This option has been deprecated, use `endpoints` instead.
     #[configurable(validation(format = "uri"))]
+    #[configurable(deprecated = "This option has been deprecated, use `endpoints` instead.")]
     #[configurable(metadata(docs::examples = "92.12.333.224:6000"))]
     #[configurable(metadata(docs::examples = "https://somehost:6000"))]
     #[serde(default)]
@@ -195,7 +199,9 @@ impl SinkConfig for VectorConfig {
                 let service = request_settings.distributed_service(
                     VectorGrpcRetryLogic,
                     services,
-                    self.endpoint_health.clone().unwrap_or_default(),
+                    self.endpoint_health
+                        .clone()
+                        .unwrap_or_else(default_endpoint_health_config),
                     VectorGrpcHealthLogic,
                     1,
                 );
@@ -662,6 +668,13 @@ fn healthcheck_uris_for_strategy(
         .clone()
         .map(|uri| vec![uri.uri])
         .unwrap_or_else(|| uris.to_vec())
+}
+
+fn default_endpoint_health_config() -> HealthConfig {
+    HealthConfig {
+        retry_initial_backoff_secs: 1,
+        retry_max_duration_secs: Duration::from_secs(60 * 60),
+    }
 }
 
 /// grpc doesn't like an address without a scheme, so we default to http or https if one isn't

--- a/src/sinks/vector/config.rs
+++ b/src/sinks/vector/config.rs
@@ -58,30 +58,26 @@ pub struct VectorConfig {
     ///
     /// The address _must_ include a port.
     ///
-    /// This option is mutually exclusive with `endpoints`. Set exactly one of
-    /// `address` or `endpoints`.
+    /// This option is mutually exclusive with `routing`. Set exactly one of
+    /// `address` or `routing`.
     ///
-    /// This option has been deprecated, use `endpoints` instead.
+    /// This option has been deprecated, use `routing.endpoints` instead.
     #[configurable(validation(format = "uri"))]
-    #[configurable(deprecated = "This option has been deprecated, use `endpoints` instead.")]
+    #[configurable(
+        deprecated = "This option has been deprecated, use `routing.endpoints` instead."
+    )]
     #[configurable(metadata(docs::examples = "92.12.333.224:6000"))]
     #[configurable(metadata(docs::examples = "https://somehost:6000"))]
     #[serde(default)]
     address: Option<String>,
 
-    /// The downstream Vector endpoints to which to connect.
-    ///
-    /// Both IP addresses and hostnames are accepted formats.
-    ///
-    /// Each endpoint _must_ include a port.
+    /// Routing options for sending requests to one or more downstream Vector endpoints.
     ///
     /// This option is mutually exclusive with `address`. Set exactly one of
-    /// `address` or `endpoints`.
-    #[configurable(validation(format = "uri"))]
-    #[configurable(metadata(docs::examples = "92.12.333.224:6000"))]
-    #[configurable(metadata(docs::examples = "https://somehost:6000"))]
+    /// `address` or `routing`.
     #[serde(default)]
-    endpoints: Vec<String>,
+    #[configurable(derived)]
+    routing: Option<RoutingConfig>,
 
     /// Compression algorithm for requests.
     ///
@@ -105,17 +101,6 @@ pub struct VectorConfig {
     #[serde(default)]
     pub request: TowerRequestConfig,
 
-    /// Options for determining the health of Vector endpoints.
-    #[serde(default)]
-    #[configurable(derived)]
-    pub endpoint_health: Option<HealthConfig>,
-
-    /// Strategy for routing requests across multiple configured endpoints.
-    ///
-    /// This option is only used when `endpoints` is configured.
-    #[serde(default)]
-    pub endpoint_strategy: EndpointStrategy,
-
     #[configurable(derived)]
     #[serde(default)]
     tls: Option<TlsEnableableConfig>,
@@ -127,6 +112,43 @@ pub struct VectorConfig {
         skip_serializing_if = "crate::serde::is_default"
     )]
     pub(in crate::sinks::vector) acknowledgements: AcknowledgementsConfig,
+}
+
+/// Routing options for sending requests to downstream Vector endpoints.
+///
+/// Load-balanced sinks healthcheck all configured endpoints on startup.
+/// Failover sinks healthcheck only the initially active endpoint by default,
+/// which is the first configured endpoint, unless `healthcheck.uri` is set.
+#[configurable_component]
+#[derive(Clone, Debug, Default)]
+#[serde(deny_unknown_fields)]
+struct RoutingConfig {
+    /// The downstream Vector endpoints to which to connect.
+    ///
+    /// Both IP addresses and hostnames are accepted formats.
+    ///
+    /// Each endpoint _must_ include a port.
+    #[configurable(validation(format = "uri"))]
+    #[configurable(metadata(docs::examples = "92.12.333.224:6000"))]
+    #[configurable(metadata(docs::examples = "https://somehost:6000"))]
+    #[serde(default)]
+    endpoints: Vec<String>,
+
+    /// Strategy for routing requests across configured endpoints.
+    ///
+    /// When only one endpoint is configured, the sink uses the standard
+    /// single-endpoint service path and strategy-specific routing semantics are
+    /// not applied.
+    #[serde(default)]
+    strategy: EndpointStrategy,
+
+    /// Options for determining the health and backoff behavior of
+    /// load-balanced Vector endpoints.
+    ///
+    /// This option is only used when `strategy` is set to `load_balance`.
+    #[serde(default)]
+    #[configurable(derived)]
+    health: Option<HealthConfig>,
 }
 
 impl VectorConfig {
@@ -147,12 +169,10 @@ fn default_config(address: &str) -> VectorConfig {
     VectorConfig {
         version: None,
         address: Some(address.to_owned()),
-        endpoints: Vec::new(),
+        routing: None,
         compression: VectorCompression::None,
         batch: BatchConfig::default(),
         request: TowerRequestConfig::default(),
-        endpoint_health: None,
-        endpoint_strategy: EndpointStrategy::default(),
         tls: None,
         acknowledgements: Default::default(),
     }
@@ -164,15 +184,14 @@ impl SinkConfig for VectorConfig {
     async fn build(&self, cx: SinkContext) -> crate::Result<(VectorSinkType, Healthcheck)> {
         let tls = MaybeTlsSettings::from_config(self.tls.as_ref(), false)?;
         let uris = self.uris(tls.is_tls())?;
+        let endpoint_strategy = self
+            .routing
+            .as_ref()
+            .map_or_else(EndpointStrategy::default, |routing| routing.strategy);
 
         let client = new_client(&tls, cx.proxy())?;
 
-        let healthcheck = healthchecks(
-            client.clone(),
-            &uris,
-            cx.healthcheck,
-            self.endpoint_strategy,
-        );
+        let healthcheck = healthchecks(client.clone(), &uris, cx.healthcheck, endpoint_strategy);
         let request_settings = self.request.into_settings();
         let batch_settings = self.batch.into_batcher_settings()?;
 
@@ -185,7 +204,7 @@ impl SinkConfig for VectorConfig {
             })
             .collect::<Vec<_>>();
 
-        let sink = match self.endpoint_strategy {
+        let sink = match endpoint_strategy {
             _ if services.len() == 1 => {
                 let service = ServiceBuilder::new()
                     .settings(request_settings, VectorGrpcRetryLogic)
@@ -200,8 +219,9 @@ impl SinkConfig for VectorConfig {
                 let service = request_settings.distributed_service(
                     VectorGrpcRetryLogic,
                     services,
-                    self.endpoint_health
-                        .clone()
+                    self.routing
+                        .as_ref()
+                        .and_then(|routing| routing.health.clone())
                         .unwrap_or_else(default_endpoint_health_config),
                     VectorGrpcHealthLogic,
                     1,
@@ -214,7 +234,7 @@ impl SinkConfig for VectorConfig {
             }
             EndpointStrategy::Failover | EndpointStrategy::FailoverPrimary => {
                 let endpoint_timeout = request_settings.timeout;
-                let max_endpoint_attempts = match self.endpoint_strategy {
+                let max_endpoint_attempts = match endpoint_strategy {
                     EndpointStrategy::Failover => services.len(),
                     EndpointStrategy::FailoverPrimary => services.len() + 1,
                     EndpointStrategy::LoadBalance => {
@@ -235,7 +255,7 @@ impl SinkConfig for VectorConfig {
                             .map(|(_endpoint, service)| service)
                             .collect(),
                         endpoint_timeout,
-                        self.endpoint_strategy,
+                        endpoint_strategy,
                     ));
 
                 VectorSinkType::from_event_streamsink(VectorSink {
@@ -264,7 +284,7 @@ impl SinkConfig for VectorConfig {
 pub enum EndpointStrategy {
     /// Distribute requests across healthy endpoints using Vector's existing
     /// Tower distributed service. Endpoint health is tracked using
-    /// `endpoint_health`, and unhealthy endpoints are backed off and probed
+    /// `routing.health`, and unhealthy endpoints are backed off and probed
     /// according to that configuration. This mode does not preserve a single
     /// active endpoint or prefer the first configured endpoint.
     #[default]
@@ -602,13 +622,18 @@ fn is_retriable_vector_error(error: &crate::Error) -> bool {
 
 impl VectorConfig {
     fn validate_endpoint_options(&self) -> crate::Result<()> {
-        match (self.address.as_ref(), self.endpoints.as_slice()) {
-            (Some(_), [_, ..]) => Err(
-                "`address` and `endpoints` options are mutually exclusive. Please use `endpoints` for multiple Vector endpoints."
+        match (self.address.as_ref(), self.routing.as_ref()) {
+            (Some(_), Some(_)) => Err(
+                "`address` and `routing` options are mutually exclusive. Please use `routing.endpoints` for multiple Vector endpoints."
                     .into(),
             ),
-            (None, []) => Err("No Vector endpoint configured. Please set `address` or `endpoints`.".into()),
-            (Some(_), []) | (None, [_, ..]) => Ok(()),
+            (None, None) => {
+                Err("No Vector endpoint configured. Please set `address` or `routing.endpoints`.".into())
+            }
+            (None, Some(routing)) if routing.endpoints.is_empty() => {
+                Err("`routing.endpoints` must contain at least one endpoint.".into())
+            }
+            (Some(_), None) | (None, Some(_)) => Ok(()),
         }
     }
 
@@ -618,7 +643,10 @@ impl VectorConfig {
         if let Some(address) = self.address.as_ref() {
             Ok(vec![with_default_scheme(address, tls)?])
         } else {
-            self.endpoints
+            self.routing
+                .as_ref()
+                .expect("routing must be present after validation")
+                .endpoints
                 .iter()
                 .map(|endpoint| with_default_scheme(endpoint, tls))
                 .collect()
@@ -863,6 +891,30 @@ mod tests {
         }) as crate::Error);
 
         assert_eq!(VectorGrpcHealthLogic.is_healthy(&response), Some(false));
+    }
+
+    #[test]
+    fn parse_routing_health_config() {
+        let config: VectorConfig = toml::from_str(
+            r#"
+                [routing]
+                endpoints = ["http://127.0.0.1:6000", "http://127.0.0.1:6001"]
+
+                [routing.health]
+                retry_initial_backoff_secs = 2
+                retry_max_duration_secs = 30
+            "#,
+        )
+        .unwrap();
+
+        let health = config
+            .routing
+            .as_ref()
+            .and_then(|routing| routing.health.as_ref())
+            .expect("routing.health should parse");
+
+        assert_eq!(health.retry_initial_backoff_secs, 2);
+        assert_eq!(health.retry_max_duration_secs, Duration::from_secs(30));
     }
 
     #[test]

--- a/src/sinks/vector/config.rs
+++ b/src/sinks/vector/config.rs
@@ -520,7 +520,12 @@ fn stale_failover_attempt_indices(
         .chain(
             failover_attempt_indices(endpoint_strategy, start, endpoints)
                 .into_iter()
-                .filter(move |index| *index != active_endpoint && !tried.contains(index)),
+                .filter(move |index| {
+                    *index != active_endpoint
+                        && (!tried.contains(index)
+                            || (endpoint_strategy == EndpointStrategy::FailoverPrimary
+                                && *index == 0))
+                }),
         )
         .collect()
 }
@@ -1051,6 +1056,35 @@ mod tests {
         assert!(observed.rebuilt);
         assert_eq!(attempt, 0);
         assert_eq!(attempts, vec![0, 1, 2]);
+        assert_eq!(remaining_attempts, attempts.len());
+    }
+
+    #[test]
+    fn failover_primary_stale_rebuild_rechecks_primary_before_secondaries() {
+        let mut attempts = failover_primary_attempt_indices(0, 3);
+        let mut attempt = 0;
+        let mut remaining_attempts = 2;
+
+        let observed = failover_next_attempts(
+            EndpointStrategy::FailoverPrimary,
+            3,
+            &mut attempts,
+            &mut attempt,
+            0,
+            FailoverAdvance {
+                state: 5,
+                advanced: false,
+            },
+            &[0],
+        );
+        if observed.rebuilt {
+            remaining_attempts = attempts.len();
+        }
+
+        assert_eq!(observed.state, 5);
+        assert!(observed.rebuilt);
+        assert_eq!(attempt, 0);
+        assert_eq!(attempts, vec![2, 0, 1]);
         assert_eq!(remaining_attempts, attempts.len());
     }
 

--- a/src/sinks/vector/config.rs
+++ b/src/sinks/vector/config.rs
@@ -354,7 +354,12 @@ impl Service<VectorRequest> for FailoverVectorService {
                             &state,
                             expected_state,
                             index,
-                            failover_next_index(endpoint_strategy, attempts.as_slice(), attempt),
+                            failover_next_index(
+                                endpoint_strategy,
+                                attempts.as_slice(),
+                                attempt,
+                                services.len(),
+                            ),
                             services.len(),
                         );
                         let next_attempts = failover_next_attempts(
@@ -377,7 +382,12 @@ impl Service<VectorRequest> for FailoverVectorService {
                             &state,
                             expected_state,
                             index,
-                            failover_next_index(endpoint_strategy, attempts.as_slice(), attempt),
+                            failover_next_index(
+                                endpoint_strategy,
+                                attempts.as_slice(),
+                                attempt,
+                                services.len(),
+                            ),
                             services.len(),
                         );
                         let next_attempts = failover_next_attempts(
@@ -442,12 +452,16 @@ fn failover_next_index(
     endpoint_strategy: EndpointStrategy,
     attempts: &[usize],
     attempt: usize,
+    endpoint_count: usize,
 ) -> Option<usize> {
     attempts
         .get(attempt + 1)
         .copied()
         .or(match endpoint_strategy {
             EndpointStrategy::FailoverPrimary => Some(0),
+            EndpointStrategy::Failover if endpoint_count > 0 => attempts
+                .get(attempt)
+                .map(|index| (index + 1) % endpoint_count),
             EndpointStrategy::Failover | EndpointStrategy::LoadBalance => None,
         })
 }
@@ -886,6 +900,7 @@ mod tests {
                 EndpointStrategy::FailoverPrimary,
                 &attempts,
                 attempts.len() - 1,
+                3,
             ),
             3,
         );
@@ -898,6 +913,29 @@ mod tests {
             }
         );
         assert_eq!(state.load(Ordering::Acquire), 6);
+    }
+
+    #[test]
+    fn failover_final_attempt_wraps_state_to_next_pass_start() {
+        let attempts = failover_ring_attempt_indices(0, 3);
+        let state = AtomicUsize::new(2);
+
+        let observed = failover_advance_if_current(
+            &state,
+            2,
+            2,
+            failover_next_index(EndpointStrategy::Failover, &attempts, attempts.len() - 1, 3),
+            3,
+        );
+
+        assert_eq!(
+            observed,
+            FailoverAdvance {
+                state: 3,
+                advanced: true,
+            }
+        );
+        assert_eq!(state.load(Ordering::Acquire), 3);
     }
 
     #[test]

--- a/src/sinks/vector/config.rs
+++ b/src/sinks/vector/config.rs
@@ -682,11 +682,16 @@ fn healthcheck_uris_for_strategy(
         return uris.to_vec();
     }
 
-    options
-        .uri
-        .clone()
-        .map(|uri| vec![uri.uri])
-        .unwrap_or_else(|| uris.to_vec())
+    if let Some(uri) = options.uri.clone() {
+        return vec![uri.uri];
+    }
+
+    match endpoint_strategy {
+        EndpointStrategy::Failover | EndpointStrategy::FailoverPrimary => {
+            uris.first().cloned().into_iter().collect()
+        }
+        EndpointStrategy::LoadBalance => uris.to_vec(),
+    }
 }
 
 fn default_endpoint_health_config() -> HealthConfig {
@@ -1220,6 +1225,20 @@ mod tests {
     }
 
     #[test]
+    fn failover_healthchecks_active_endpoint_without_override_uri() {
+        let endpoints = vec![
+            "http://endpoint-a.example.com".parse().unwrap(),
+            "http://endpoint-b.example.com".parse().unwrap(),
+        ];
+        let options = SinkHealthcheckOptions::default();
+
+        assert_eq!(
+            healthcheck_uris_for_strategy(&endpoints, &options, EndpointStrategy::Failover),
+            vec![endpoints[0].clone()]
+        );
+    }
+
+    #[test]
     fn failover_primary_healthchecks_can_use_override_uri() {
         let endpoints = vec![
             "http://endpoint-a.example.com".parse().unwrap(),
@@ -1237,6 +1256,20 @@ mod tests {
         assert_eq!(
             healthcheck_uris_for_strategy(&endpoints, &options, EndpointStrategy::FailoverPrimary),
             vec![override_uri]
+        );
+    }
+
+    #[test]
+    fn failover_primary_healthchecks_primary_without_override_uri() {
+        let endpoints = vec![
+            "http://endpoint-a.example.com".parse().unwrap(),
+            "http://endpoint-b.example.com".parse().unwrap(),
+        ];
+        let options = SinkHealthcheckOptions::default();
+
+        assert_eq!(
+            healthcheck_uris_for_strategy(&endpoints, &options, EndpointStrategy::FailoverPrimary),
+            vec![endpoints[0].clone()]
         );
     }
 }

--- a/src/sinks/vector/mod.rs
+++ b/src/sinks/vector/mod.rs
@@ -92,38 +92,38 @@ mod tests {
 
         assert!(
             err.to_string()
-                .contains("No Vector endpoint configured. Please set `address` or `addresses`."),
+                .contains("No Vector endpoint configured. Please set `address` or `endpoints`."),
             "{err}"
         );
     }
 
     #[tokio::test]
-    async fn build_rejects_address_and_addresses() {
+    async fn build_rejects_address_and_endpoints() {
         let config: VectorConfig = toml::from_str(
             r#"
                 address = "http://127.0.0.1:6000"
-                addresses = ["http://127.0.0.1:6001"]
+                endpoints = ["http://127.0.0.1:6001"]
             "#,
         )
         .unwrap();
 
         let err = match config.build(SinkContext::default()).await {
-            Ok(_) => panic!("address and addresses should be mutually exclusive"),
+            Ok(_) => panic!("address and endpoints should be mutually exclusive"),
             Err(err) => err,
         };
 
         assert!(
             err.to_string()
-                .contains("`address` and `addresses` options are mutually exclusive"),
+                .contains("`address` and `endpoints` options are mutually exclusive"),
             "{err}"
         );
     }
 
     #[test]
-    fn parse_addresses_config() {
+    fn parse_endpoints_config() {
         let config: Result<VectorConfig, _> = toml::from_str(
             r#"
-                addresses = ["http://127.0.0.1:6000", "http://127.0.0.1:6001"]
+                endpoints = ["http://127.0.0.1:6000", "http://127.0.0.1:6001"]
             "#,
         );
 
@@ -134,7 +134,7 @@ mod tests {
     fn parse_failover_endpoint_strategy() {
         let config: Result<VectorConfig, _> = toml::from_str(
             r#"
-                addresses = ["http://127.0.0.1:6000", "http://127.0.0.1:6001"]
+                endpoints = ["http://127.0.0.1:6000", "http://127.0.0.1:6001"]
                 endpoint_strategy = "failover"
             "#,
         );
@@ -146,7 +146,7 @@ mod tests {
     fn parse_failover_primary_endpoint_strategy() {
         let config: Result<VectorConfig, _> = toml::from_str(
             r#"
-                addresses = ["http://127.0.0.1:6000", "http://127.0.0.1:6001"]
+                endpoints = ["http://127.0.0.1:6000", "http://127.0.0.1:6001"]
                 endpoint_strategy = "failover_primary"
             "#,
         );
@@ -242,7 +242,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn deliver_message_to_multiple_addresses() {
+    async fn deliver_message_to_multiple_endpoints() {
         let num_lines = 10;
 
         let (_guard1, addr1) = next_addr();
@@ -250,7 +250,7 @@ mod tests {
 
         let config = format!(
             r#"
-                addresses = ["http://{addr1}/", "http://{addr2}/"]
+                endpoints = ["http://{addr1}/", "http://{addr2}/"]
             "#
         );
         let config: VectorConfig = toml::from_str(&config).unwrap();
@@ -299,7 +299,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn failover_strategy_prefers_first_address() {
+    async fn failover_strategy_prefers_first_endpoint() {
         let num_lines = 10;
 
         let (_guard1, addr1) = next_addr();
@@ -307,7 +307,7 @@ mod tests {
 
         let config = format!(
             r#"
-                addresses = ["http://{addr1}/", "http://{addr2}/"]
+                endpoints = ["http://{addr1}/", "http://{addr2}/"]
                 endpoint_strategy = "failover"
             "#
         );
@@ -351,7 +351,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn failover_strategy_uses_next_address_when_first_fails() {
+    async fn failover_strategy_uses_next_endpoint_when_first_fails() {
         let num_lines = 10;
 
         let (_guard1, addr1) = next_addr();
@@ -359,7 +359,7 @@ mod tests {
 
         let config = format!(
             r#"
-                addresses = ["http://{addr1}/", "http://{addr2}/"]
+                endpoints = ["http://{addr1}/", "http://{addr2}/"]
                 endpoint_strategy = "failover"
             "#
         );
@@ -400,7 +400,7 @@ mod tests {
 
         let config = format!(
             r#"
-                addresses = ["http://{addr1}/", "http://{addr2}/"]
+                endpoints = ["http://{addr1}/", "http://{addr2}/"]
                 endpoint_strategy = "failover_primary"
             "#
         );
@@ -476,7 +476,7 @@ mod tests {
 
         let config = format!(
             r#"
-                addresses = ["http://{addr1}/", "http://{addr2}/", "http://{addr3}/"]
+                endpoints = ["http://{addr1}/", "http://{addr2}/", "http://{addr3}/"]
                 endpoint_strategy = "failover"
                 batch.max_events = 1
                 request.concurrency = 1
@@ -554,7 +554,7 @@ mod tests {
 
         let config = format!(
             r#"
-                addresses = ["http://{addr1}/", "http://{addr2}/", "http://{addr3}/"]
+                endpoints = ["http://{addr1}/", "http://{addr2}/", "http://{addr3}/"]
                 endpoint_strategy = "failover_primary"
                 batch.max_events = 1
                 request.concurrency = 1
@@ -638,7 +638,7 @@ mod tests {
 
         let config = format!(
             r#"
-                addresses = ["http://{addr1}/", "http://{addr2}/"]
+                endpoints = ["http://{addr1}/", "http://{addr2}/"]
                 endpoint_strategy = "failover"
             "#
         );
@@ -679,7 +679,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn failover_strategy_uses_next_address_when_first_times_out() {
+    async fn failover_strategy_uses_next_endpoint_when_first_times_out() {
         let num_lines = 10;
 
         let (_guard1, addr1) = next_addr();
@@ -687,7 +687,7 @@ mod tests {
 
         let config = format!(
             r#"
-                addresses = ["http://{addr1}/", "http://{addr2}/"]
+                endpoints = ["http://{addr1}/", "http://{addr2}/"]
                 endpoint_strategy = "failover"
 
                 [request]
@@ -745,7 +745,7 @@ mod tests {
 
         let config = format!(
             r#"
-                addresses = ["http://{addr}/"]
+                endpoints = ["http://{addr}/"]
                 endpoint_strategy = "failover"
 
                 [request]

--- a/src/sinks/vector/mod.rs
+++ b/src/sinks/vector/mod.rs
@@ -43,8 +43,15 @@ mod tests {
     use bytes::{BufMut, Bytes, BytesMut};
     use futures::{StreamExt, channel::mpsc};
     use http::request::Parts;
-    use hyper::Method;
+    use hyper::{
+        Method, Response, Server,
+        service::{make_service_fn, service_fn},
+    };
     use prost::Message;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
     use vector_lib::{
         config::{Tags, Telemetry, init_telemetry},
         event::{BatchNotifier, BatchStatus},
@@ -72,6 +79,79 @@ mod tests {
     #[test]
     fn generate_config() {
         crate::test_util::test_generate_config::<VectorConfig>();
+    }
+
+    #[tokio::test]
+    async fn build_rejects_missing_address() {
+        let config: VectorConfig = toml::from_str("").unwrap();
+
+        let err = match config.build(SinkContext::default()).await {
+            Ok(_) => panic!("missing address should fail"),
+            Err(err) => err,
+        };
+
+        assert!(
+            err.to_string()
+                .contains("No Vector endpoint configured. Please set `address` or `addresses`."),
+            "{err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn build_rejects_address_and_addresses() {
+        let config: VectorConfig = toml::from_str(
+            r#"
+                address = "http://127.0.0.1:6000"
+                addresses = ["http://127.0.0.1:6001"]
+            "#,
+        )
+        .unwrap();
+
+        let err = match config.build(SinkContext::default()).await {
+            Ok(_) => panic!("address and addresses should be mutually exclusive"),
+            Err(err) => err,
+        };
+
+        assert!(
+            err.to_string()
+                .contains("`address` and `addresses` options are mutually exclusive"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn parse_addresses_config() {
+        let config: Result<VectorConfig, _> = toml::from_str(
+            r#"
+                addresses = ["http://127.0.0.1:6000", "http://127.0.0.1:6001"]
+            "#,
+        );
+
+        assert!(config.is_ok());
+    }
+
+    #[test]
+    fn parse_failover_endpoint_strategy() {
+        let config: Result<VectorConfig, _> = toml::from_str(
+            r#"
+                addresses = ["http://127.0.0.1:6000", "http://127.0.0.1:6001"]
+                endpoint_strategy = "failover"
+            "#,
+        );
+
+        assert!(config.is_ok());
+    }
+
+    #[test]
+    fn parse_failover_primary_endpoint_strategy() {
+        let config: Result<VectorConfig, _> = toml::from_str(
+            r#"
+                addresses = ["http://127.0.0.1:6000", "http://127.0.0.1:6001"]
+                endpoint_strategy = "failover_primary"
+            "#,
+        );
+
+        assert!(config.is_ok());
     }
 
     enum TestType {
@@ -159,6 +239,562 @@ mod tests {
     #[tokio::test]
     async fn deliver_message() {
         run_sink_test(TestType::Normal).await;
+    }
+
+    #[tokio::test]
+    async fn deliver_message_to_multiple_addresses() {
+        let num_lines = 10;
+
+        let (_guard1, addr1) = next_addr();
+        let (_guard2, addr2) = next_addr();
+
+        let config = format!(
+            r#"
+                addresses = ["http://{addr1}/", "http://{addr2}/"]
+            "#
+        );
+        let config: VectorConfig = toml::from_str(&config).unwrap();
+
+        let cx = SinkContext::default();
+
+        let (sink, _) = config.build(cx).await.unwrap();
+        let (rx1, trigger1, server1) = build_test_server_generic(addr1, move || {
+            hyper::Response::builder()
+                .header("grpc-status", "0") // OK
+                .header("content-type", "application/grpc")
+                .body(hyper::Body::from(encode_body(proto::PushEventsResponse {})))
+                .unwrap()
+        });
+        let (rx2, trigger2, server2) = build_test_server_generic(addr2, move || {
+            hyper::Response::builder()
+                .header("grpc-status", "0") // OK
+                .header("content-type", "application/grpc")
+                .body(hyper::Body::from(encode_body(proto::PushEventsResponse {})))
+                .unwrap()
+        });
+
+        tokio::spawn(server1);
+        tokio::spawn(server2);
+
+        let (batch, mut receiver) = BatchNotifier::new_with_receiver();
+        let (mut input_lines, events) = random_lines_with_stream(8, num_lines, Some(batch));
+
+        run_and_assert_sink_compliance(sink, events, &HTTP_SINK_TAGS).await;
+
+        drop(trigger1);
+        drop(trigger2);
+
+        assert_eq!(receiver.try_recv(), Ok(BatchStatus::Delivered));
+
+        let (mut output_lines, mut output_lines2) =
+            futures::future::join(get_received(rx1, |_| {}), get_received(rx2, |_| {})).await;
+
+        output_lines.append(&mut output_lines2);
+
+        input_lines.sort();
+        output_lines.sort();
+
+        assert_eq!(num_lines, output_lines.len());
+        assert_eq!(input_lines, output_lines);
+    }
+
+    #[tokio::test]
+    async fn failover_strategy_prefers_first_address() {
+        let num_lines = 10;
+
+        let (_guard1, addr1) = next_addr();
+        let (_guard2, addr2) = next_addr();
+
+        let config = format!(
+            r#"
+                addresses = ["http://{addr1}/", "http://{addr2}/"]
+                endpoint_strategy = "failover"
+            "#
+        );
+        let config: VectorConfig = toml::from_str(&config).unwrap();
+
+        let (sink, _) = config.build(SinkContext::default()).await.unwrap();
+        let (rx1, trigger1, server1) = build_test_server_generic(addr1, move || {
+            hyper::Response::builder()
+                .header("grpc-status", "0") // OK
+                .header("content-type", "application/grpc")
+                .body(hyper::Body::from(encode_body(proto::PushEventsResponse {})))
+                .unwrap()
+        });
+        let (rx2, trigger2, server2) = build_test_server_generic(addr2, move || {
+            hyper::Response::builder()
+                .header("grpc-status", "0") // OK
+                .header("content-type", "application/grpc")
+                .body(hyper::Body::from(encode_body(proto::PushEventsResponse {})))
+                .unwrap()
+        });
+
+        tokio::spawn(server1);
+        tokio::spawn(server2);
+
+        let (batch, mut receiver) = BatchNotifier::new_with_receiver();
+        let (input_lines, events) = random_lines_with_stream(8, num_lines, Some(batch));
+
+        run_and_assert_sink_compliance(sink, events, &HTTP_SINK_TAGS).await;
+
+        drop(trigger1);
+        drop(trigger2);
+
+        assert_eq!(receiver.try_recv(), Ok(BatchStatus::Delivered));
+
+        let (output_lines, output_lines2) =
+            futures::future::join(get_received(rx1, |_| {}), get_received(rx2, |_| {})).await;
+
+        assert_eq!(num_lines, output_lines.len());
+        assert_eq!(input_lines, output_lines);
+        assert!(output_lines2.is_empty());
+    }
+
+    #[tokio::test]
+    async fn failover_strategy_uses_next_address_when_first_fails() {
+        let num_lines = 10;
+
+        let (_guard1, addr1) = next_addr();
+        let (_guard2, addr2) = next_addr();
+
+        let config = format!(
+            r#"
+                addresses = ["http://{addr1}/", "http://{addr2}/"]
+                endpoint_strategy = "failover"
+            "#
+        );
+        let config: VectorConfig = toml::from_str(&config).unwrap();
+
+        let (sink, _) = config.build(SinkContext::default()).await.unwrap();
+        let (rx2, trigger2, server2) = build_test_server_generic(addr2, move || {
+            hyper::Response::builder()
+                .header("grpc-status", "0") // OK
+                .header("content-type", "application/grpc")
+                .body(hyper::Body::from(encode_body(proto::PushEventsResponse {})))
+                .unwrap()
+        });
+
+        tokio::spawn(server2);
+
+        let (batch, mut receiver) = BatchNotifier::new_with_receiver();
+        let (input_lines, events) = random_lines_with_stream(8, num_lines, Some(batch));
+
+        run_and_assert_sink_compliance(sink, events, &HTTP_SINK_TAGS).await;
+
+        drop(trigger2);
+
+        assert_eq!(receiver.try_recv(), Ok(BatchStatus::Delivered));
+
+        let output_lines = get_received(rx2, |_| {}).await;
+
+        assert_eq!(num_lines, output_lines.len());
+        assert_eq!(input_lines, output_lines);
+    }
+
+    #[tokio::test]
+    async fn failover_primary_strategy_retries_primary_before_secondary() {
+        let num_lines = 10;
+
+        let (_guard1, addr1) = next_addr();
+        let (_guard2, addr2) = next_addr();
+
+        let config = format!(
+            r#"
+                addresses = ["http://{addr1}/", "http://{addr2}/"]
+                endpoint_strategy = "failover_primary"
+            "#
+        );
+        let config: VectorConfig = toml::from_str(&config).unwrap();
+
+        let primary_attempts = Arc::new(AtomicUsize::new(0));
+        let primary_service_attempts = Arc::clone(&primary_attempts);
+        let (rx1, trigger1, server1) = build_test_server_generic(addr1, move || {
+            if primary_service_attempts.fetch_add(1, Ordering::AcqRel) == 0 {
+                hyper::Response::builder()
+                    .header("grpc-status", "14") // unavailable
+                    .header("content-type", "application/grpc")
+                    .body(hyper::Body::empty())
+                    .unwrap()
+            } else {
+                hyper::Response::builder()
+                    .header("grpc-status", "0") // OK
+                    .header("content-type", "application/grpc")
+                    .body(hyper::Body::from(encode_body(proto::PushEventsResponse {})))
+                    .unwrap()
+            }
+        });
+        let (rx2, trigger2, server2) = build_test_server_generic(addr2, move || {
+            hyper::Response::builder()
+                .header("grpc-status", "0") // OK
+                .header("content-type", "application/grpc")
+                .body(hyper::Body::from(encode_body(proto::PushEventsResponse {})))
+                .unwrap()
+        });
+
+        tokio::spawn(server1);
+        tokio::spawn(server2);
+
+        let (sink, _) = config.build(SinkContext::default()).await.unwrap();
+
+        let (batch, mut receiver) = BatchNotifier::new_with_receiver();
+        let (input_lines, events) = random_lines_with_stream(8, num_lines, Some(batch));
+
+        run_and_assert_sink_compliance(sink, events, &HTTP_SINK_TAGS).await;
+
+        drop(trigger1);
+        drop(trigger2);
+
+        assert_eq!(receiver.try_recv(), Ok(BatchStatus::Delivered));
+        assert_eq!(
+            primary_attempts.load(Ordering::Acquire),
+            2,
+            "retriable primary failure should retry configured primary before secondary"
+        );
+
+        let output_lines = get_received(rx1, |_| {}).await;
+        let secondary_output_lines = get_received(rx2, |_| {}).await;
+
+        assert_eq!(num_lines * 2, output_lines.len());
+        assert!(
+            output_lines
+                .chunks(num_lines)
+                .all(|lines| lines == input_lines)
+        );
+        assert!(
+            secondary_output_lines.is_empty(),
+            "secondary must not receive traffic when configured primary succeeds on retry"
+        );
+    }
+
+    #[tokio::test]
+    async fn failover_strategy_continues_in_ring_order_after_active_failure() {
+        let num_lines = 2;
+
+        let (_guard1, addr1) = next_addr();
+        let (_guard2, addr2) = next_addr();
+        let (_guard3, addr3) = next_addr();
+
+        let config = format!(
+            r#"
+                addresses = ["http://{addr1}/", "http://{addr2}/", "http://{addr3}/"]
+                endpoint_strategy = "failover"
+                batch.max_events = 1
+                request.concurrency = 1
+            "#
+        );
+        let config: VectorConfig = toml::from_str(&config).unwrap();
+
+        let primary_attempts = Arc::new(AtomicUsize::new(0));
+        let primary_service_attempts = Arc::clone(&primary_attempts);
+        let (_rx1, trigger1, server1) = build_test_server_generic(addr1, move || {
+            primary_service_attempts.fetch_add(1, Ordering::AcqRel);
+            hyper::Response::builder()
+                .header("grpc-status", "14") // unavailable
+                .header("content-type", "application/grpc")
+                .body(hyper::Body::empty())
+                .unwrap()
+        });
+
+        let active_attempts = Arc::new(AtomicUsize::new(0));
+        let active_service_attempts = Arc::clone(&active_attempts);
+        let (_rx2, trigger2, server2) = build_test_server_generic(addr2, move || {
+            if active_service_attempts.fetch_add(1, Ordering::AcqRel) == 0 {
+                hyper::Response::builder()
+                    .header("grpc-status", "0") // OK
+                    .header("content-type", "application/grpc")
+                    .body(hyper::Body::from(encode_body(proto::PushEventsResponse {})))
+                    .unwrap()
+            } else {
+                hyper::Response::builder()
+                    .header("grpc-status", "14") // unavailable
+                    .header("content-type", "application/grpc")
+                    .body(hyper::Body::empty())
+                    .unwrap()
+            }
+        });
+
+        let next_attempts = Arc::new(AtomicUsize::new(0));
+        let next_service_attempts = Arc::clone(&next_attempts);
+        let (_rx3, trigger3, server3) = build_test_server_generic(addr3, move || {
+            next_service_attempts.fetch_add(1, Ordering::AcqRel);
+            hyper::Response::builder()
+                .header("grpc-status", "0") // OK
+                .header("content-type", "application/grpc")
+                .body(hyper::Body::from(encode_body(proto::PushEventsResponse {})))
+                .unwrap()
+        });
+
+        tokio::spawn(server1);
+        tokio::spawn(server2);
+        tokio::spawn(server3);
+
+        let (sink, _) = config.build(SinkContext::default()).await.unwrap();
+        let (batch, mut receiver) = BatchNotifier::new_with_receiver();
+        let (_input_lines, events) = random_lines_with_stream(8, num_lines, Some(batch));
+
+        run_and_assert_sink_compliance(sink, events, &HTTP_SINK_TAGS).await;
+
+        drop(trigger1);
+        drop(trigger2);
+        drop(trigger3);
+
+        assert_eq!(receiver.try_recv(), Ok(BatchStatus::Delivered));
+        assert_eq!(primary_attempts.load(Ordering::Acquire), 1);
+        assert_eq!(active_attempts.load(Ordering::Acquire), 2);
+        assert_eq!(next_attempts.load(Ordering::Acquire), 1);
+    }
+
+    #[tokio::test]
+    async fn failover_primary_strategy_retries_configured_primary_after_active_failure() {
+        let num_lines = 2;
+
+        let (_guard1, addr1) = next_addr();
+        let (_guard2, addr2) = next_addr();
+        let (_guard3, addr3) = next_addr();
+
+        let config = format!(
+            r#"
+                addresses = ["http://{addr1}/", "http://{addr2}/", "http://{addr3}/"]
+                endpoint_strategy = "failover_primary"
+                batch.max_events = 1
+                request.concurrency = 1
+            "#
+        );
+        let config: VectorConfig = toml::from_str(&config).unwrap();
+
+        let primary_attempts = Arc::new(AtomicUsize::new(0));
+        let primary_service_attempts = Arc::clone(&primary_attempts);
+        let (_rx1, trigger1, server1) = build_test_server_generic(addr1, move || {
+            if primary_service_attempts.fetch_add(1, Ordering::AcqRel) < 2 {
+                hyper::Response::builder()
+                    .header("grpc-status", "14") // unavailable
+                    .header("content-type", "application/grpc")
+                    .body(hyper::Body::empty())
+                    .unwrap()
+            } else {
+                hyper::Response::builder()
+                    .header("grpc-status", "0") // OK
+                    .header("content-type", "application/grpc")
+                    .body(hyper::Body::from(encode_body(proto::PushEventsResponse {})))
+                    .unwrap()
+            }
+        });
+
+        let active_attempts = Arc::new(AtomicUsize::new(0));
+        let active_service_attempts = Arc::clone(&active_attempts);
+        let (_rx2, trigger2, server2) = build_test_server_generic(addr2, move || {
+            if active_service_attempts.fetch_add(1, Ordering::AcqRel) == 0 {
+                hyper::Response::builder()
+                    .header("grpc-status", "0") // OK
+                    .header("content-type", "application/grpc")
+                    .body(hyper::Body::from(encode_body(proto::PushEventsResponse {})))
+                    .unwrap()
+            } else {
+                hyper::Response::builder()
+                    .header("grpc-status", "14") // unavailable
+                    .header("content-type", "application/grpc")
+                    .body(hyper::Body::empty())
+                    .unwrap()
+            }
+        });
+
+        let next_attempts = Arc::new(AtomicUsize::new(0));
+        let next_service_attempts = Arc::clone(&next_attempts);
+        let (_rx3, trigger3, server3) = build_test_server_generic(addr3, move || {
+            next_service_attempts.fetch_add(1, Ordering::AcqRel);
+            hyper::Response::builder()
+                .header("grpc-status", "0") // OK
+                .header("content-type", "application/grpc")
+                .body(hyper::Body::from(encode_body(proto::PushEventsResponse {})))
+                .unwrap()
+        });
+
+        tokio::spawn(server1);
+        tokio::spawn(server2);
+        tokio::spawn(server3);
+
+        let (sink, _) = config.build(SinkContext::default()).await.unwrap();
+        let (batch, mut receiver) = BatchNotifier::new_with_receiver();
+        let (_input_lines, events) = random_lines_with_stream(8, num_lines, Some(batch));
+
+        run_and_assert_sink_compliance(sink, events, &HTTP_SINK_TAGS).await;
+
+        drop(trigger1);
+        drop(trigger2);
+        drop(trigger3);
+
+        assert_eq!(receiver.try_recv(), Ok(BatchStatus::Delivered));
+        assert_eq!(primary_attempts.load(Ordering::Acquire), 3);
+        assert_eq!(active_attempts.load(Ordering::Acquire), 2);
+        assert_eq!(next_attempts.load(Ordering::Acquire), 0);
+    }
+
+    #[tokio::test]
+    async fn failover_strategy_does_not_resend_non_retriable_errors() {
+        let num_lines = 10;
+
+        let (_guard1, addr1) = next_addr();
+        let (_guard2, addr2) = next_addr();
+
+        let config = format!(
+            r#"
+                addresses = ["http://{addr1}/", "http://{addr2}/"]
+                endpoint_strategy = "failover"
+            "#
+        );
+        let config: VectorConfig = toml::from_str(&config).unwrap();
+
+        let (sink, _) = config.build(SinkContext::default()).await.unwrap();
+        let (_rx1, trigger1, server1) = build_test_server_generic(addr1, move || {
+            hyper::Response::builder()
+                .header("grpc-status", "15") // data loss
+                .header("content-type", "application/grpc")
+                .body(tonic::body::empty_body())
+                .unwrap()
+        });
+        let (rx2, trigger2, server2) = build_test_server_generic(addr2, move || {
+            hyper::Response::builder()
+                .header("grpc-status", "0") // OK
+                .header("content-type", "application/grpc")
+                .body(hyper::Body::from(encode_body(proto::PushEventsResponse {})))
+                .unwrap()
+        });
+
+        tokio::spawn(server1);
+        tokio::spawn(server2);
+
+        let (batch, mut receiver) = BatchNotifier::new_with_receiver();
+        let (_, events) = random_lines_with_stream(8, num_lines, Some(batch));
+
+        sink.run(events).await.expect("Running sink failed");
+
+        drop(trigger1);
+        drop(trigger2);
+
+        assert_eq!(receiver.try_recv(), Ok(BatchStatus::Rejected));
+        assert!(
+            get_received(rx2, |_| {}).await.is_empty(),
+            "non-retriable primary rejection must not be resent to secondary endpoint"
+        );
+    }
+
+    #[tokio::test]
+    async fn failover_strategy_uses_next_address_when_first_times_out() {
+        let num_lines = 10;
+
+        let (_guard1, addr1) = next_addr();
+        let (_guard2, addr2) = next_addr();
+
+        let config = format!(
+            r#"
+                addresses = ["http://{addr1}/", "http://{addr2}/"]
+                endpoint_strategy = "failover"
+
+                [request]
+                timeout_secs = 1
+            "#
+        );
+        let config: VectorConfig = toml::from_str(&config).unwrap();
+
+        let hanging_service = make_service_fn(|_| async {
+            Ok::<_, crate::Error>(service_fn(|_req| async {
+                tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+                Ok::<_, crate::Error>(
+                    Response::builder()
+                        .header("grpc-status", "0") // OK
+                        .header("content-type", "application/grpc")
+                        .body(hyper::Body::from(encode_body(proto::PushEventsResponse {})))
+                        .unwrap(),
+                )
+            }))
+        });
+        let hanging_server = tokio::spawn(Server::bind(&addr1).serve(hanging_service));
+
+        let (sink, _) = config.build(SinkContext::default()).await.unwrap();
+        let (rx2, trigger2, server2) = build_test_server_generic(addr2, move || {
+            hyper::Response::builder()
+                .header("grpc-status", "0") // OK
+                .header("content-type", "application/grpc")
+                .body(hyper::Body::from(encode_body(proto::PushEventsResponse {})))
+                .unwrap()
+        });
+
+        tokio::spawn(server2);
+
+        let (batch, mut receiver) = BatchNotifier::new_with_receiver();
+        let (input_lines, events) = random_lines_with_stream(8, num_lines, Some(batch));
+
+        run_and_assert_sink_compliance(sink, events, &HTTP_SINK_TAGS).await;
+
+        hanging_server.abort();
+        drop(trigger2);
+
+        assert_eq!(receiver.try_recv(), Ok(BatchStatus::Delivered));
+
+        let output_lines = get_received(rx2, |_| {}).await;
+
+        assert_eq!(num_lines, output_lines.len());
+        assert_eq!(input_lines, output_lines);
+    }
+
+    #[tokio::test]
+    async fn failover_strategy_retries_after_all_endpoints_time_out() {
+        let num_lines = 10;
+
+        let (_guard, addr) = next_addr();
+
+        let config = format!(
+            r#"
+                addresses = ["http://{addr}/"]
+                endpoint_strategy = "failover"
+
+                [request]
+                timeout_secs = 1
+                retry_initial_backoff_secs = 1
+                retry_max_duration_secs = 5
+            "#
+        );
+        let config: VectorConfig = toml::from_str(&config).unwrap();
+
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let service_attempts = Arc::clone(&attempts);
+        let service = make_service_fn(move |_| {
+            let service_attempts = Arc::clone(&service_attempts);
+            async move {
+                Ok::<_, crate::Error>(service_fn(move |_req| {
+                    let attempt = service_attempts.fetch_add(1, Ordering::AcqRel);
+                    async move {
+                        if attempt == 0 {
+                            tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+                        }
+
+                        Ok::<_, crate::Error>(
+                            Response::builder()
+                                .header("grpc-status", "0") // OK
+                                .header("content-type", "application/grpc")
+                                .body(hyper::Body::from(encode_body(proto::PushEventsResponse {})))
+                                .unwrap(),
+                        )
+                    }
+                }))
+            }
+        });
+        let server = tokio::spawn(Server::bind(&addr).serve(service));
+
+        let (sink, _) = config.build(SinkContext::default()).await.unwrap();
+
+        let (batch, mut receiver) = BatchNotifier::new_with_receiver();
+        let (_input_lines, events) = random_lines_with_stream(8, num_lines, Some(batch));
+
+        run_and_assert_sink_compliance(sink, events, &HTTP_SINK_TAGS).await;
+
+        server.abort();
+
+        assert_eq!(receiver.try_recv(), Ok(BatchStatus::Delivered));
+        assert!(
+            attempts.load(Ordering::Acquire) > 1,
+            "sink should retry after endpoint timeout"
+        );
     }
 
     #[tokio::test]

--- a/src/sinks/vector/mod.rs
+++ b/src/sinks/vector/mod.rs
@@ -91,38 +91,64 @@ mod tests {
         };
 
         assert!(
-            err.to_string()
-                .contains("No Vector endpoint configured. Please set `address` or `endpoints`."),
+            err.to_string().contains(
+                "No Vector endpoint configured. Please set `address` or `routing.endpoints`."
+            ),
             "{err}"
         );
     }
 
     #[tokio::test]
-    async fn build_rejects_address_and_endpoints() {
+    async fn build_rejects_address_and_routing() {
         let config: VectorConfig = toml::from_str(
             r#"
                 address = "http://127.0.0.1:6000"
+
+                [routing]
                 endpoints = ["http://127.0.0.1:6001"]
             "#,
         )
         .unwrap();
 
         let err = match config.build(SinkContext::default()).await {
-            Ok(_) => panic!("address and endpoints should be mutually exclusive"),
+            Ok(_) => panic!("address and routing should be mutually exclusive"),
             Err(err) => err,
         };
 
         assert!(
             err.to_string()
-                .contains("`address` and `endpoints` options are mutually exclusive"),
+                .contains("`address` and `routing` options are mutually exclusive"),
+            "{err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn build_rejects_empty_routing_endpoints() {
+        let config: VectorConfig = toml::from_str(
+            r#"
+                [routing]
+                strategy = "failover"
+            "#,
+        )
+        .unwrap();
+
+        let err = match config.build(SinkContext::default()).await {
+            Ok(_) => panic!("routing without endpoints should fail"),
+            Err(err) => err,
+        };
+
+        assert!(
+            err.to_string()
+                .contains("`routing.endpoints` must contain at least one endpoint"),
             "{err}"
         );
     }
 
     #[test]
-    fn parse_endpoints_config() {
+    fn parse_routing_config() {
         let config: Result<VectorConfig, _> = toml::from_str(
             r#"
+                [routing]
                 endpoints = ["http://127.0.0.1:6000", "http://127.0.0.1:6001"]
             "#,
         );
@@ -134,8 +160,9 @@ mod tests {
     fn parse_failover_endpoint_strategy() {
         let config: Result<VectorConfig, _> = toml::from_str(
             r#"
+                [routing]
                 endpoints = ["http://127.0.0.1:6000", "http://127.0.0.1:6001"]
-                endpoint_strategy = "failover"
+                strategy = "failover"
             "#,
         );
 
@@ -146,8 +173,9 @@ mod tests {
     fn parse_failover_primary_endpoint_strategy() {
         let config: Result<VectorConfig, _> = toml::from_str(
             r#"
+                [routing]
                 endpoints = ["http://127.0.0.1:6000", "http://127.0.0.1:6001"]
-                endpoint_strategy = "failover_primary"
+                strategy = "failover_primary"
             "#,
         );
 
@@ -250,6 +278,7 @@ mod tests {
 
         let config = format!(
             r#"
+                [routing]
                 endpoints = ["http://{addr1}/", "http://{addr2}/"]
             "#
         );
@@ -307,8 +336,9 @@ mod tests {
 
         let config = format!(
             r#"
+                [routing]
                 endpoints = ["http://{addr1}/", "http://{addr2}/"]
-                endpoint_strategy = "failover"
+                strategy = "failover"
             "#
         );
         let config: VectorConfig = toml::from_str(&config).unwrap();
@@ -359,8 +389,9 @@ mod tests {
 
         let config = format!(
             r#"
+                [routing]
                 endpoints = ["http://{addr1}/", "http://{addr2}/"]
-                endpoint_strategy = "failover"
+                strategy = "failover"
             "#
         );
         let config: VectorConfig = toml::from_str(&config).unwrap();
@@ -400,8 +431,9 @@ mod tests {
 
         let config = format!(
             r#"
+                [routing]
                 endpoints = ["http://{addr1}/", "http://{addr2}/"]
-                endpoint_strategy = "failover_primary"
+                strategy = "failover_primary"
             "#
         );
         let config: VectorConfig = toml::from_str(&config).unwrap();
@@ -476,10 +508,12 @@ mod tests {
 
         let config = format!(
             r#"
-                endpoints = ["http://{addr1}/", "http://{addr2}/", "http://{addr3}/"]
-                endpoint_strategy = "failover"
                 batch.max_events = 1
                 request.concurrency = 1
+
+                [routing]
+                endpoints = ["http://{addr1}/", "http://{addr2}/", "http://{addr3}/"]
+                strategy = "failover"
             "#
         );
         let config: VectorConfig = toml::from_str(&config).unwrap();
@@ -554,10 +588,12 @@ mod tests {
 
         let config = format!(
             r#"
-                endpoints = ["http://{addr1}/", "http://{addr2}/", "http://{addr3}/"]
-                endpoint_strategy = "failover_primary"
                 batch.max_events = 1
                 request.concurrency = 1
+
+                [routing]
+                endpoints = ["http://{addr1}/", "http://{addr2}/", "http://{addr3}/"]
+                strategy = "failover_primary"
             "#
         );
         let config: VectorConfig = toml::from_str(&config).unwrap();
@@ -638,8 +674,9 @@ mod tests {
 
         let config = format!(
             r#"
+                [routing]
                 endpoints = ["http://{addr1}/", "http://{addr2}/"]
-                endpoint_strategy = "failover"
+                strategy = "failover"
             "#
         );
         let config: VectorConfig = toml::from_str(&config).unwrap();
@@ -687,11 +724,12 @@ mod tests {
 
         let config = format!(
             r#"
-                endpoints = ["http://{addr1}/", "http://{addr2}/"]
-                endpoint_strategy = "failover"
-
                 [request]
                 timeout_secs = 1
+
+                [routing]
+                endpoints = ["http://{addr1}/", "http://{addr2}/"]
+                strategy = "failover"
             "#
         );
         let config: VectorConfig = toml::from_str(&config).unwrap();
@@ -745,13 +783,14 @@ mod tests {
 
         let config = format!(
             r#"
-                endpoints = ["http://{addr}/"]
-                endpoint_strategy = "failover"
-
                 [request]
                 timeout_secs = 1
                 retry_initial_backoff_secs = 1
                 retry_max_duration_secs = 5
+
+                [routing]
+                endpoints = ["http://{addr}/"]
+                strategy = "failover"
             "#
         );
         let config: VectorConfig = toml::from_str(&config).unwrap();

--- a/website/cue/reference/components/sinks/generated/vector.cue
+++ b/website/cue/reference/components/sinks/generated/vector.cue
@@ -34,9 +34,29 @@ generated: components: sinks: vector: configuration: {
 			Both IP address and hostname are accepted formats.
 
 			The address _must_ include a port.
+
+			This option is mutually exclusive with `addresses`. Set exactly one of
+			`address` or `addresses`.
 			"""
-		required: true
+		required: false
 		type: string: examples: ["92.12.333.224:6000", "https://somehost:6000"]
+	}
+	addresses: {
+		description: """
+			The downstream Vector addresses to which to connect.
+
+			Both IP addresses and hostnames are accepted formats.
+
+			Each address _must_ include a port.
+
+			This option is mutually exclusive with `address`. Set exactly one of
+			`address` or `addresses`.
+			"""
+		required: false
+		type: array: {
+			default: []
+			items: type: string: examples: ["92.12.333.224:6000", "https://somehost:6000"]
+		}
 	}
 	batch: {
 		description: "Event batching behavior."
@@ -95,6 +115,59 @@ generated: components: sinks: vector: configuration: {
 
 					[zstd]: https://facebook.github.io/zstd/
 					"""
+			}
+		}
+	}
+	endpoint_health: {
+		description: "Options for determining the health of Vector endpoints."
+		required:    false
+		type: object: options: {
+			retry_initial_backoff_secs: {
+				description: "Initial delay between attempts to reactivate endpoints once they become unhealthy."
+				required:    false
+				type: uint: {
+					default: 1
+					unit:    "seconds"
+				}
+			}
+			retry_max_duration_secs: {
+				description: "Maximum delay between attempts to reactivate endpoints once they become unhealthy."
+				required:    false
+				type: uint: {
+					default: 3600
+					unit:    "seconds"
+				}
+			}
+		}
+	}
+	endpoint_strategy: {
+		description: """
+			Strategy for routing requests across multiple configured addresses.
+
+			This option is only used when `addresses` is configured.
+			"""
+		required: false
+		type: string: {
+			default: "load_balance"
+			enum: {
+				failover: """
+					Use one endpoint at a time. When the active endpoint fails, continue
+					through the configured addresses from the next endpoint.
+
+					This mode keeps using the last successful endpoint until it fails. Use
+					`failover_primary` instead when retriable failures should re-check the
+					first configured address before trying secondary endpoints.
+					"""
+				failover_primary: """
+					Use one endpoint at a time. When the active endpoint fails, retry from
+					the configured address order so the sink can return to its configured
+					primary endpoint.
+
+					This is useful when receiver-side connection recycling, such as
+					`max_connection_age_secs`, should converge the sink back to the first
+					configured address when it is available.
+					"""
+				load_balance: "Distribute requests across healthy endpoints."
 			}
 		}
 	}

--- a/website/cue/reference/components/sinks/generated/vector.cue
+++ b/website/cue/reference/components/sinks/generated/vector.cue
@@ -35,28 +35,11 @@ generated: components: sinks: vector: configuration: {
 
 			The address _must_ include a port.
 
-			This option is mutually exclusive with `addresses`. Set exactly one of
-			`address` or `addresses`.
+			This option is mutually exclusive with `endpoints`. Set exactly one of
+			`address` or `endpoints`.
 			"""
 		required: false
 		type: string: examples: ["92.12.333.224:6000", "https://somehost:6000"]
-	}
-	addresses: {
-		description: """
-			The downstream Vector addresses to which to connect.
-
-			Both IP addresses and hostnames are accepted formats.
-
-			Each address _must_ include a port.
-
-			This option is mutually exclusive with `address`. Set exactly one of
-			`address` or `addresses`.
-			"""
-		required: false
-		type: array: {
-			default: []
-			items: type: string: examples: ["92.12.333.224:6000", "https://somehost:6000"]
-		}
 	}
 	batch: {
 		description: "Event batching behavior."
@@ -142,9 +125,9 @@ generated: components: sinks: vector: configuration: {
 	}
 	endpoint_strategy: {
 		description: """
-			Strategy for routing requests across multiple configured addresses.
+			Strategy for routing requests across multiple configured endpoints.
 
-			This option is only used when `addresses` is configured.
+			This option is only used when `endpoints` is configured.
 			"""
 		required: false
 		type: string: {
@@ -152,23 +135,46 @@ generated: components: sinks: vector: configuration: {
 			enum: {
 				failover: """
 					Use one endpoint at a time. When the active endpoint fails, continue
-					through the configured addresses from the next endpoint.
+					through the configured endpoints from the next endpoint.
 
 					This mode keeps using the last successful endpoint until it fails. Use
 					`failover_primary` instead when retriable failures should re-check the
-					first configured address before trying secondary endpoints.
+					first configured endpoint before trying secondary endpoints.
 					"""
 				failover_primary: """
 					Use one endpoint at a time. When the active endpoint fails, retry from
-					the configured address order so the sink can return to its configured
+					the configured endpoint order so the sink can return to its configured
 					primary endpoint.
 
 					This is useful when receiver-side connection recycling, such as
 					`max_connection_age_secs`, should converge the sink back to the first
-					configured address when it is available.
+					configured endpoint when it is available.
 					"""
-				load_balance: "Distribute requests across healthy endpoints."
+				load_balance: """
+					Distribute requests across healthy endpoints using Vector's existing
+					Tower distributed service. Endpoint health is tracked using
+					`endpoint_health`, and unhealthy endpoints are backed off and probed
+					according to that configuration. This mode does not preserve a single
+					active endpoint or prefer the first configured endpoint.
+					"""
 			}
+		}
+	}
+	endpoints: {
+		description: """
+			The downstream Vector endpoints to which to connect.
+
+			Both IP addresses and hostnames are accepted formats.
+
+			Each endpoint _must_ include a port.
+
+			This option is mutually exclusive with `address`. Set exactly one of
+			`address` or `endpoints`.
+			"""
+		required: false
+		type: array: {
+			default: []
+			items: type: string: examples: ["92.12.333.224:6000", "https://somehost:6000"]
 		}
 	}
 	request: {

--- a/website/cue/reference/components/sinks/generated/vector.cue
+++ b/website/cue/reference/components/sinks/generated/vector.cue
@@ -29,7 +29,7 @@ generated: components: sinks: vector: configuration: {
 	}
 	address: {
 		deprecated:         true
-		deprecated_message: "This option has been deprecated, use `endpoints` instead."
+		deprecated_message: "This option has been deprecated, use `routing.endpoints` instead."
 		description: """
 			The downstream Vector address to which to connect.
 
@@ -37,10 +37,10 @@ generated: components: sinks: vector: configuration: {
 
 			The address _must_ include a port.
 
-			This option is mutually exclusive with `endpoints`. Set exactly one of
-			`address` or `endpoints`.
+			This option is mutually exclusive with `routing`. Set exactly one of
+			`address` or `routing`.
 
-			This option has been deprecated, use `endpoints` instead.
+			This option has been deprecated, use `routing.endpoints` instead.
 			"""
 		required: false
 		type: string: examples: ["92.12.333.224:6000", "https://somehost:6000"]
@@ -103,88 +103,6 @@ generated: components: sinks: vector: configuration: {
 					[zstd]: https://facebook.github.io/zstd/
 					"""
 			}
-		}
-	}
-	endpoint_health: {
-		description: "Options for determining the health of Vector endpoints."
-		required:    false
-		type: object: options: {
-			retry_initial_backoff_secs: {
-				description: "Initial delay between attempts to reactivate endpoints once they become unhealthy."
-				required:    false
-				type: uint: {
-					default: 1
-					unit:    "seconds"
-				}
-			}
-			retry_max_duration_secs: {
-				description: "Maximum delay between attempts to reactivate endpoints once they become unhealthy."
-				required:    false
-				type: uint: {
-					default: 3600
-					unit:    "seconds"
-				}
-			}
-		}
-	}
-	endpoint_strategy: {
-		description: """
-			Strategy for routing requests across multiple configured endpoints.
-
-			This option is only used when `endpoints` is configured.
-			"""
-		required: false
-		type: string: {
-			default: "load_balance"
-			enum: {
-				failover: """
-					Use one endpoint at a time. When the active endpoint fails, continue
-					through the configured endpoints from the next endpoint.
-
-					This mode keeps using the last successful endpoint until it fails. Use
-					`failover_primary` instead when retriable failures should re-check the
-					first configured endpoint before trying secondary endpoints.
-
-					Requests are serialized for this strategy, regardless of the configured
-					request concurrency, to preserve one active endpoint at a time.
-					"""
-				failover_primary: """
-					Use one endpoint at a time. When the active endpoint fails, retry from
-					the configured endpoint order so the sink can return to its configured
-					primary endpoint.
-
-					This is useful when receiver-side connection recycling, such as
-					`max_connection_age_secs`, should converge the sink back to the first
-					configured endpoint when it is available.
-
-					Requests are serialized for this strategy, regardless of the configured
-					request concurrency, to preserve one active endpoint at a time.
-					"""
-				load_balance: """
-					Distribute requests across healthy endpoints using Vector's existing
-					Tower distributed service. Endpoint health is tracked using
-					`endpoint_health`, and unhealthy endpoints are backed off and probed
-					according to that configuration. This mode does not preserve a single
-					active endpoint or prefer the first configured endpoint.
-					"""
-			}
-		}
-	}
-	endpoints: {
-		description: """
-			The downstream Vector endpoints to which to connect.
-
-			Both IP addresses and hostnames are accepted formats.
-
-			Each endpoint _must_ include a port.
-
-			This option is mutually exclusive with `address`. Set exactly one of
-			`address` or `endpoints`.
-			"""
-		required: false
-		type: array: {
-			default: []
-			items: type: string: examples: ["92.12.333.224:6000", "https://somehost:6000"]
 		}
 	}
 	request: {
@@ -369,6 +287,103 @@ generated: components: sinks: vector: configuration: {
 				type: uint: {
 					default: 60
 					unit:    "seconds"
+				}
+			}
+		}
+	}
+	routing: {
+		description: """
+			Routing options for sending requests to one or more downstream Vector endpoints.
+
+			This option is mutually exclusive with `address`. Set exactly one of
+			`address` or `routing`.
+			"""
+		required: false
+		type: object: options: {
+			endpoints: {
+				description: """
+					The downstream Vector endpoints to which to connect.
+
+					Both IP addresses and hostnames are accepted formats.
+
+					Each endpoint _must_ include a port.
+					"""
+				required: false
+				type: array: {
+					default: []
+					items: type: string: examples: ["92.12.333.224:6000", "https://somehost:6000"]
+				}
+			}
+			health: {
+				description: """
+					Options for determining the health and backoff behavior of
+					load-balanced Vector endpoints.
+
+					This option is only used when `strategy` is set to `load_balance`.
+					"""
+				required: false
+				type: object: options: {
+					retry_initial_backoff_secs: {
+						description: "Initial delay between attempts to reactivate endpoints once they become unhealthy."
+						required:    false
+						type: uint: {
+							default: 1
+							unit:    "seconds"
+						}
+					}
+					retry_max_duration_secs: {
+						description: "Maximum delay between attempts to reactivate endpoints once they become unhealthy."
+						required:    false
+						type: uint: {
+							default: 3600
+							unit:    "seconds"
+						}
+					}
+				}
+			}
+			strategy: {
+				description: """
+					Strategy for routing requests across configured endpoints.
+
+					When only one endpoint is configured, the sink uses the standard
+					single-endpoint service path and strategy-specific routing semantics are
+					not applied.
+					"""
+				required: false
+				type: string: {
+					default: "load_balance"
+					enum: {
+						failover: """
+															Use one endpoint at a time. When the active endpoint fails, continue
+															through the configured endpoints from the next endpoint.
+
+															This mode keeps using the last successful endpoint until it fails. Use
+															`failover_primary` instead when retriable failures should re-check the
+															first configured endpoint before trying secondary endpoints.
+
+															Requests are serialized for this strategy, regardless of the configured
+															request concurrency, to preserve one active endpoint at a time.
+															"""
+						failover_primary: """
+															Use one endpoint at a time. When the active endpoint fails, retry from
+															the configured endpoint order so the sink can return to its configured
+															primary endpoint.
+
+															This is useful when receiver-side connection recycling, such as
+															`max_connection_age_secs`, should converge the sink back to the first
+															configured endpoint when it is available.
+
+															Requests are serialized for this strategy, regardless of the configured
+															request concurrency, to preserve one active endpoint at a time.
+															"""
+						load_balance: """
+															Distribute requests across healthy endpoints using Vector's existing
+															Tower distributed service. Endpoint health is tracked using
+															`routing.health`, and unhealthy endpoints are backed off and probed
+															according to that configuration. This mode does not preserve a single
+															active endpoint or prefer the first configured endpoint.
+															"""
+					}
 				}
 			}
 		}

--- a/website/cue/reference/components/sinks/generated/vector.cue
+++ b/website/cue/reference/components/sinks/generated/vector.cue
@@ -28,6 +28,8 @@ generated: components: sinks: vector: configuration: {
 		}
 	}
 	address: {
+		deprecated:         true
+		deprecated_message: "This option has been deprecated, use `endpoints` instead."
 		description: """
 			The downstream Vector address to which to connect.
 
@@ -37,6 +39,8 @@ generated: components: sinks: vector: configuration: {
 
 			This option is mutually exclusive with `endpoints`. Set exactly one of
 			`address` or `endpoints`.
+
+			This option has been deprecated, use `endpoints` instead.
 			"""
 		required: false
 		type: string: examples: ["92.12.333.224:6000", "https://somehost:6000"]
@@ -140,6 +144,9 @@ generated: components: sinks: vector: configuration: {
 					This mode keeps using the last successful endpoint until it fails. Use
 					`failover_primary` instead when retriable failures should re-check the
 					first configured endpoint before trying secondary endpoints.
+
+					Requests are serialized for this strategy, regardless of the configured
+					request concurrency, to preserve one active endpoint at a time.
 					"""
 				failover_primary: """
 					Use one endpoint at a time. When the active endpoint fails, retry from
@@ -149,6 +156,9 @@ generated: components: sinks: vector: configuration: {
 					This is useful when receiver-side connection recycling, such as
 					`max_connection_age_secs`, should converge the sink back to the first
 					configured endpoint when it is available.
+
+					Requests are serialized for this strategy, regardless of the configured
+					request concurrency, to preserve one active endpoint at a time.
 					"""
 				load_balance: """
 					Distribute requests across healthy endpoints using Vector's existing


### PR DESCRIPTION
## Summary

Adds multi-endpoint support to the `vector` sink:

- `addresses = [...]` configures multiple downstream Vector endpoints
- `endpoint_strategy = "load_balance"` is the default and uses the existing distributed service / endpoint-health path
- `endpoint_strategy = "failover"` uses ordered, non-preemptive failover for stateful downstream Vector aggregators
- keeps existing `address = "..."` behavior unchanged
- updates generated component docs and adds a changelog fragment

The failover strategy starts with the first configured endpoint, moves to the next endpoint on request failure or per-endpoint timeout, and keeps using the successful endpoint until it fails. Hosts can use different address ordering to spread primary ownership without requiring random failover semantics.

## Validation

- `make generate-component-docs`
- `cargo fmt --all -- --check`
- `cargo test --no-default-features --features sinks-vector --lib sinks::vector::tests::`
- `cargo test --no-default-features --features sinks-vector --lib sinks::vector::test::generate_config`
- `cargo clippy --no-default-features --features sinks-vector --lib -- -D warnings -A clippy::manual_option_zip`
- `./scripts/check_changelog_fragments.sh`
- Docker Compose E2E:
  - `load_balance` delivered events to both downstream Vector servers
  - `failover` delivered only to the first endpoint while healthy, then moved to the second endpoint after the first was stopped with bounded `request.timeout_secs`
