### PR TITLE
chore(clippy): add workspace lints string_slice, await_holding_lock, let_underscore_must_use

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,8 +47,8 @@ lto = "fat"
 [profile.bench]
 debug = true
 
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tokio_unstable)'] }
+[lints]
+workspace = true
 
 [package.metadata.deb]
 name = "vector"
@@ -135,6 +135,15 @@ members = [
   "tests/antithesis/harness",
   "vdev",
 ]
+
+[workspace.lints.rust]
+# 'cfg(tokio_unstable)' used in vector; 'cfg(ddsketch_extended)' used in vector-core
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tokio_unstable)', 'cfg(ddsketch_extended)'] }
+
+[workspace.lints.clippy]
+string_slice = "warn"
+await_holding_lock = "warn"
+let_underscore_must_use = "warn"
 
 [workspace.dependencies]
 antithesis-instrumentation = { version = "0.1", default-features = false, features = [] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ default-run = "vector"
 autobenches = false # our benchmarks are not runnable on their own either way
 # Minimum supported rust version
 # See docs/DEVELOPING.md for policy
-rust-version = "1.92"
+rust-version = "1.95"
 
 [[bin]]
 name = "vector"

--- a/lib/codecs/Cargo.toml
+++ b/lib/codecs/Cargo.toml
@@ -5,8 +5,8 @@ authors = ["Vector Contributors <vector@datadoghq.com>"]
 edition = "2024"
 publish = false
 
-[lints.clippy]
-unwrap-used = "deny"
+[lints]
+workspace = true
 
 [[bin]]
 name = "generate-avro-fixtures"

--- a/lib/codecs/src/encoding/format/parquet.rs
+++ b/lib/codecs/src/encoding/format/parquet.rs
@@ -1,3 +1,6 @@
+// Derivative's Debug impl generates 'let _ = field.fmt(f)' which triggers this lint.
+#![allow(clippy::let_underscore_must_use)]
+
 //! Parquet batch format codec for batched event encoding
 //!
 //! Provides Apache Parquet format encoding with schema file support and auto-inference.

--- a/lib/codecs/src/encoding/format/syslog.rs
+++ b/lib/codecs/src/encoding/format/syslog.rs
@@ -4,7 +4,6 @@ use lookup::lookup_v2::ConfigTargetPath;
 use serde_json;
 use std::borrow::Cow;
 use std::collections::BTreeMap;
-use std::fmt::Write;
 use std::str::FromStr;
 use strum::{EnumString, FromRepr, VariantNames};
 use tokio_util::codec::Encoder;
@@ -321,7 +320,7 @@ impl SyslogMessage {
     fn encode(&self, rfc: &SyslogRFC) -> String {
         let mut result = String::with_capacity(256);
 
-        write!(result, "{}", self.pri.encode()).ok();
+        result.push_str(&self.pri.encode().to_string());
 
         if *rfc == SyslogRFC::Rfc5424 {
             result.push_str(SYSLOG_V1);
@@ -330,7 +329,7 @@ impl SyslogMessage {
 
         match rfc {
             SyslogRFC::Rfc3164 => {
-                write!(result, "{} ", self.timestamp.format("%b %e %H:%M:%S")).ok();
+                result.push_str(&format!("{} ", self.timestamp.format("%b %e %H:%M:%S")));
             }
             SyslogRFC::Rfc5424 => {
                 result.push_str(

--- a/lib/codecs/src/encoding/format/syslog.rs
+++ b/lib/codecs/src/encoding/format/syslog.rs
@@ -235,8 +235,9 @@ where
         None => Cow::Borrowed(s), // All valid, zero allocation
         Some((first_invalid_idx, _)) => {
             let mut result = String::with_capacity(s.len());
-            result.push_str(&s[..first_invalid_idx]); // Copy valid prefix
-            for c in s[first_invalid_idx..].chars() {
+            let (valid_prefix, remainder) = s.split_at(first_invalid_idx);
+            result.push_str(valid_prefix);
+            for c in remainder.chars() {
                 result.push(if is_valid(c) { c } else { '_' });
             }
 
@@ -320,7 +321,7 @@ impl SyslogMessage {
     fn encode(&self, rfc: &SyslogRFC) -> String {
         let mut result = String::with_capacity(256);
 
-        let _ = write!(result, "{}", self.pri.encode());
+        write!(result, "{}", self.pri.encode()).ok();
 
         if *rfc == SyslogRFC::Rfc5424 {
             result.push_str(SYSLOG_V1);
@@ -329,7 +330,7 @@ impl SyslogMessage {
 
         match rfc {
             SyslogRFC::Rfc3164 => {
-                let _ = write!(result, "{} ", self.timestamp.format("%b %e %H:%M:%S"));
+                write!(result, "{} ", self.timestamp.format("%b %e %H:%M:%S")).ok();
             }
             SyslogRFC::Rfc5424 => {
                 result.push_str(
@@ -435,12 +436,12 @@ impl StructuredData {
             self.elements
                 .iter()
                 .fold(String::new(), |mut acc, (sd_id, sd_params)| {
-                    let _ = write!(acc, "[{sd_id}");
+                    acc.push_str(&format!("[{sd_id}"));
                     for (key, value) in sd_params {
                         let esc_val = escape_sd_value(value);
-                        let _ = write!(acc, " {key}=\"{esc_val}\"");
+                        acc.push_str(&format!(" {key}=\"{esc_val}\""));
                     }
-                    let _ = write!(acc, "]");
+                    acc.push(']');
                     acc
                 })
         }

--- a/lib/codecs/src/lib.rs
+++ b/lib/codecs/src/lib.rs
@@ -3,6 +3,7 @@
 
 #![deny(missing_docs)]
 #![deny(warnings)]
+#![deny(clippy::unwrap_used)]
 
 mod common;
 mod decoder_framed_read;

--- a/lib/dnsmsg-parser/Cargo.toml
+++ b/lib/dnsmsg-parser/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2024"
 publish = false
 license = "MIT"
 
-[lints.clippy]
-unwrap-used = "forbid"
+[lints]
+workspace = true
 
 [dependencies]
 data-encoding = "2.10"

--- a/lib/dnsmsg-parser/src/lib.rs
+++ b/lib/dnsmsg-parser/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(warnings)]
+#![deny(clippy::unwrap_used)]
 #![warn(
     missing_debug_implementations,
     rust_2018_idioms,

--- a/lib/docs-renderer/Cargo.toml
+++ b/lib/docs-renderer/Cargo.toml
@@ -5,6 +5,9 @@ authors = ["Vector Contributors <vector@datadoghq.com>"]
 edition = "2024"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 serde.workspace = true

--- a/lib/fakedata/Cargo.toml
+++ b/lib/fakedata/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2024"
 publish = false
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 chrono.workspace = true
 rand.workspace = true

--- a/lib/file-source-common/Cargo.toml
+++ b/lib/file-source-common/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2024"
 publish = false
 license = "MIT"
 
+[lints]
+workspace = true
+
 [target.'cfg(windows)'.dependencies]
 libc.workspace = true
 winapi = { version = "0.3", features = ["winioctl"] }

--- a/lib/file-source/Cargo.toml
+++ b/lib/file-source/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2024"
 publish = false
 license = "MIT"
 
+[lints]
+workspace = true
+
 [target.'cfg(windows)'.dependencies]
 libc.workspace = true
 winapi = { version = "0.3", features = ["winioctl"] }

--- a/lib/k8s-e2e-tests/Cargo.toml
+++ b/lib/k8s-e2e-tests/Cargo.toml
@@ -7,6 +7,9 @@ description = "End-to-end tests of Vector in the Kubernetes environment"
 publish = false
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 futures.workspace = true
 k8s-openapi = { version = "0.27.0", default-features = false, features = ["v1_31"] }

--- a/lib/k8s-test-framework/Cargo.toml
+++ b/lib/k8s-test-framework/Cargo.toml
@@ -7,6 +7,9 @@ description = "Kubernetes Test Framework used to test Vector in Kubernetes"
 publish = false
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 k8s-openapi = { version = "0.27.0", default-features = false, features = ["v1_31"] }
 serde_json.workspace = true

--- a/lib/loki-logproto/Cargo.toml
+++ b/lib/loki-logproto/Cargo.toml
@@ -7,6 +7,9 @@ publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[lints]
+workspace = true
+
 [dependencies]
 prost.workspace = true
 prost-types.workspace = true

--- a/lib/opentelemetry-proto/Cargo.toml
+++ b/lib/opentelemetry-proto/Cargo.toml
@@ -5,6 +5,9 @@ authors = ["Vector Contributors <vector@datadoghq.com>"]
 edition = "2024"
 publish = false
 
+[lints]
+workspace = true
+
 [build-dependencies]
 prost-build.workspace = true
 tonic-build.workspace = true

--- a/lib/prometheus-parser/Cargo.toml
+++ b/lib/prometheus-parser/Cargo.toml
@@ -8,6 +8,9 @@ license = "MPL-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[lints]
+workspace = true
+
 [dependencies]
 indexmap.workspace = true
 nom.workspace = true

--- a/lib/prometheus-parser/src/lib.rs
+++ b/lib/prometheus-parser/src/lib.rs
@@ -157,6 +157,10 @@ impl GroupKind {
         prefix_len: usize,
         metric: Metric,
     ) -> Result<Option<Metric>, ParserError> {
+        #[expect(
+            clippy::string_slice,
+            reason = "prefix_len is always self.name.len(), a valid UTF-8 boundary"
+        )]
         let suffix = &metric.name[prefix_len..];
         let mut key = GroupKey {
             timestamp: metric.timestamp,
@@ -328,15 +332,23 @@ struct MetricGroupSet(IndexMap<String, GroupKind>);
 
 impl MetricGroupSet {
     fn get_group<'a>(&'a mut self, name: &str) -> (usize, &'a String, &'a mut GroupKind) {
-        let len = name.len();
         let name = if self.0.contains_key(name) {
             name
-        } else if name.ends_with("_bucket") && self.0.contains_key(&name[..len - 7]) {
-            &name[..len - 7]
-        } else if name.ends_with("_sum") && self.0.contains_key(&name[..len - 4]) {
-            &name[..len - 4]
-        } else if name.ends_with("_count") && self.0.contains_key(&name[..len - 6]) {
-            &name[..len - 6]
+        } else if let Some(base) = name
+            .strip_suffix("_bucket")
+            .filter(|b| self.0.contains_key(*b))
+        {
+            base
+        } else if let Some(base) = name
+            .strip_suffix("_sum")
+            .filter(|b| self.0.contains_key(*b))
+        {
+            base
+        } else if let Some(base) = name
+            .strip_suffix("_count")
+            .filter(|b| self.0.contains_key(*b))
+        {
+            base
         } else {
             self.0
                 .insert(name.into(), GroupKind::new(MetricKind::Untyped));

--- a/lib/tracing-limit/Cargo.toml
+++ b/lib/tracing-limit/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2024"
 publish = false
 license = "MPL-2.0"
 
-[lints.clippy]
-unwrap-used = "forbid"
+[lints]
+workspace = true
 
 [dependencies]
 tracing-core = { version = "0.1", default-features = false }

--- a/lib/tracing-limit/src/lib.rs
+++ b/lib/tracing-limit/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(warnings)]
+#![deny(clippy::unwrap_used)]
 //! Rate limiting for tracing events.
 //!
 //! This crate provides a tracing-subscriber layer that rate limits log events to prevent

--- a/lib/vector-api-client/Cargo.toml
+++ b/lib/vector-api-client/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2024"
 publish = false
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 # gRPC
 tonic.workspace = true

--- a/lib/vector-buffers/Cargo.toml
+++ b/lib/vector-buffers/Cargo.toml
@@ -5,8 +5,8 @@ authors = ["Vector Contributors <vector@datadoghq.com>"]
 edition = "2024"
 publish = false
 
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tokio_unstable)'] }
+[lints]
+workspace = true
 
 [dependencies]
 async-recursion = "1.1.1"

--- a/lib/vector-buffers/src/topology/channel/sender.rs
+++ b/lib/vector-buffers/src/topology/channel/sender.rs
@@ -1,3 +1,6 @@
+// Derivative's Debug impl generates 'let _ = field.fmt(f)' which triggers this lint.
+#![allow(clippy::let_underscore_must_use)]
+
 use std::{sync::Arc, time::Instant};
 
 use async_recursion::async_recursion;

--- a/lib/vector-common-macros/Cargo.toml
+++ b/lib/vector-common-macros/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2024"
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [lib]
 proc-macro = true
 

--- a/lib/vector-common/Cargo.toml
+++ b/lib/vector-common/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2024"
 publish = false
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [features]
 default = [
   "btreemap",

--- a/lib/vector-common/src/event_test_util.rs
+++ b/lib/vector-common/src/event_test_util.rs
@@ -73,9 +73,9 @@ pub fn record_internal_event(event: &str) {
     // Remove leading '&'
     let event = event.strip_prefix('&').unwrap_or(event);
     // Remove trailing '{fields…}'
-    let event = event.find('{').map_or(event, |par| &event[..par]);
+    let event = event.split_once('{').map_or(event, |(before, _)| before);
     // Remove trailing '::from…'
-    let event = event.find(':').map_or(event, |colon| &event[..colon]);
+    let event = event.split_once(':').map_or(event, |(before, _)| before);
 
     EVENTS_RECORDED.with(|er| er.borrow_mut().insert(event.trim().into()));
 }

--- a/lib/vector-config-common/Cargo.toml
+++ b/lib/vector-config-common/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2024"
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 convert_case.workspace = true
 darling.workspace = true

--- a/lib/vector-config-common/src/schema/generator.rs
+++ b/lib/vector-config-common/src/schema/generator.rs
@@ -117,12 +117,9 @@ impl SchemaGenerator {
                 ..
             }) => {
                 let definitions_path = &self.settings().definitions_path;
-                if schema_ref.starts_with(definitions_path) {
-                    let name = &schema_ref[definitions_path.len()..];
-                    self.definitions.get(name)
-                } else {
-                    None
-                }
+                schema_ref
+                    .strip_prefix(definitions_path.as_str())
+                    .and_then(|name| self.definitions.get(name))
             }
             _ => None,
         }

--- a/lib/vector-config-macros/Cargo.toml
+++ b/lib/vector-config-macros/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 edition = "2024"
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [lib]
 proc-macro = true
 

--- a/lib/vector-config/Cargo.toml
+++ b/lib/vector-config/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2024"
 publish = false
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [[test]]
 name = "integration"
 path = "tests/integration/lib.rs"

--- a/lib/vector-config/tests/integration/smoke.rs
+++ b/lib/vector-config/tests/integration/smoke.rs
@@ -288,16 +288,13 @@ impl TryFrom<String> for SocketListenAddr {
             Err(_) => {
                 let fd: usize = match input.as_str() {
                     "systemd" => Ok(0),
-                    s if s.starts_with("systemd#") => s
+                    s => s
                         .strip_prefix("systemd#")
-                        .unwrap()
+                        .ok_or_else(|| "unable to parse".to_string())?
                         .parse::<usize>()
                         .map_err(|_| "failed to parse usize".to_string())?
                         .checked_sub(1)
                         .ok_or_else(|| "systemd indices start at 1".to_string()),
-
-                    // otherwise fail
-                    _ => Err("unable to parse".to_string()),
                 }?;
 
                 Ok(fd.into())

--- a/lib/vector-config/tests/integration/smoke.rs
+++ b/lib/vector-config/tests/integration/smoke.rs
@@ -288,7 +288,9 @@ impl TryFrom<String> for SocketListenAddr {
             Err(_) => {
                 let fd: usize = match input.as_str() {
                     "systemd" => Ok(0),
-                    s if s.starts_with("systemd#") => s[8..]
+                    s if s.starts_with("systemd#") => s
+                        .strip_prefix("systemd#")
+                        .unwrap()
                         .parse::<usize>()
                         .map_err(|_| "failed to parse usize".to_string())?
                         .checked_sub(1)

--- a/lib/vector-core/Cargo.toml
+++ b/lib/vector-core/Cargo.toml
@@ -5,8 +5,8 @@ authors = ["Vector Contributors <vector@datadoghq.com>"]
 edition = "2024"
 publish = false
 
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(ddsketch_extended)'] }
+[lints]
+workspace = true
 
 [dependencies]
 async-trait.workspace = true

--- a/lib/vector-core/src/event/util/log/all_fields.rs
+++ b/lib/vector-core/src/event/util/log/all_fields.rs
@@ -259,7 +259,11 @@ mod test {
         .map(|(k, v)| (k.into(), v))
         .collect();
         // Compare without the leading `"` char so that the order is the same as the collected fields.
-        expected.sort_by(|(a, _), (b, _)| a[1..].cmp(&b[1..]));
+        expected.sort_by(|(a, _), (b, _)| {
+            a.strip_prefix('"')
+                .unwrap_or(a)
+                .cmp(b.strip_prefix('"').unwrap_or(b))
+        });
 
         assert_eq!(collected, expected);
     }

--- a/lib/vector-core/src/event/vrl_target.rs
+++ b/lib/vector-core/src/event/vrl_target.rs
@@ -303,7 +303,7 @@ impl Target for VrlTarget {
                                 metric.remove_tags();
                                 for (field, value) in &value {
                                     set_metric_tag_values(
-                                        field[..].into(),
+                                        field.as_str().into(),
                                         value,
                                         metric,
                                         *multi_value_tags,

--- a/lib/vector-core/src/fanout.rs
+++ b/lib/vector-core/src/fanout.rs
@@ -877,7 +877,7 @@ mod tests {
         let (mut fanout, _, _receivers) = fanout_from_senders(&[2, 2]);
         let empty: EventArray = Vec::<LogEvent>::new().into();
 
-        let _ = fanout.send(empty, None).await;
+        _ = fanout.send(empty, None).await;
     }
 
     #[tokio::test]

--- a/lib/vector-lib/Cargo.toml
+++ b/lib/vector-lib/Cargo.toml
@@ -5,6 +5,9 @@ authors = ["Vector Contributors <vector@datadoghq.com>"]
 edition = "2024"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 codecs = { path = "../codecs", default-features = false }
 enrichment = { path = "../vector-vrl/enrichment" }

--- a/lib/vector-lookup/Cargo.toml
+++ b/lib/vector-lookup/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2024"
 publish = false
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }

--- a/lib/vector-stream/Cargo.toml
+++ b/lib/vector-stream/Cargo.toml
@@ -5,6 +5,9 @@ authors = ["Vector Contributors <vector@datadoghq.com>"]
 edition = "2024"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 async-stream.workspace = true
 futures.workspace = true

--- a/lib/vector-tap/Cargo.toml
+++ b/lib/vector-tap/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2024"
 publish = false
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [features]
 api = [
     "dep:bytes",

--- a/lib/vector-top/Cargo.toml
+++ b/lib/vector-top/Cargo.toml
@@ -5,6 +5,9 @@ authors = ["Vector Contributors <vector@datadoghq.com>"]
 edition = "2024"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 clap.workspace = true
 chrono.workspace = true

--- a/lib/vector-top/src/input.rs
+++ b/lib/vector-top/src/input.rs
@@ -38,71 +38,79 @@ async fn handle_top_input<B: Backend>(
             return true;
         }
         KeyCode::Up | KeyCode::Char('k') => {
-            let _ = event_tx
+            event_tx
                 .send(UiEventType::Scroll(-1, terminal.size().unwrap_or_default()))
-                .await;
+                .await
+                .ok();
         }
         KeyCode::Down | KeyCode::Char('j') => {
-            let _ = event_tx
+            event_tx
                 .send(UiEventType::Scroll(1, terminal.size().unwrap_or_default()))
-                .await;
+                .await
+                .ok();
         }
         KeyCode::End | KeyCode::Char('G') => {
-            let _ = event_tx
+            event_tx
                 .send(UiEventType::Scroll(
                     isize::MAX,
                     terminal.size().unwrap_or_default(),
                 ))
-                .await;
+                .await
+                .ok();
         }
         KeyCode::Home | KeyCode::Char('g') => {
-            let _ = event_tx
+            event_tx
                 .send(UiEventType::Scroll(
                     isize::MIN,
                     terminal.size().unwrap_or_default(),
                 ))
-                .await;
+                .await
+                .ok();
         }
         KeyCode::Left | KeyCode::PageUp => {
-            let _ = event_tx
+            event_tx
                 .send(UiEventType::ScrollPage(
                     -1,
                     terminal.size().unwrap_or_default(),
                 ))
-                .await;
+                .await
+                .ok();
         }
         KeyCode::Char('b') if key_event.modifiers.intersects(KeyModifiers::CONTROL) => {
-            let _ = event_tx
+            event_tx
                 .send(UiEventType::ScrollPage(
                     -1,
                     terminal.size().unwrap_or_default(),
                 ))
-                .await;
+                .await
+                .ok();
         }
         KeyCode::Right | KeyCode::PageDown => {
-            let _ = event_tx
+            event_tx
                 .send(UiEventType::ScrollPage(
                     1,
                     terminal.size().unwrap_or_default(),
                 ))
-                .await;
+                .await
+                .ok();
         }
         KeyCode::Char('f') if key_event.modifiers.intersects(KeyModifiers::CONTROL) => {
-            let _ = event_tx
+            event_tx
                 .send(UiEventType::ScrollPage(
                     1,
                     terminal.size().unwrap_or_default(),
                 ))
-                .await;
+                .await
+                .ok();
         }
         KeyCode::Char('?') | KeyCode::F(1) => {
-            let _ = event_tx.send(UiEventType::ToggleHelp).await;
+            event_tx.send(UiEventType::ToggleHelp).await.ok();
         }
         KeyCode::Char('s') | KeyCode::F(6) => {
-            let _ = event_tx.send(UiEventType::ToggleSortMenu).await;
+            event_tx.send(UiEventType::ToggleSortMenu).await.ok();
         }
         KeyCode::Char('r') | KeyCode::F(7) => {
-            let _ = event_tx.send(UiEventType::ToggleSortDirection).await;
+            event_tx.send(UiEventType::ToggleSortDirection).await.ok();
         }
         KeyCode::Char(d) if d.is_ascii_digit() => {
             let col = match d {
@@ -118,10 +126,10 @@ async fn handle_top_input<B: Backend>(
                 '0' => SortColumn::MemoryUsed,
                 _ => return false,
             };
-            let _ = event_tx.send(UiEventType::SortByColumn(col)).await;
+            event_tx.send(UiEventType::SortByColumn(col)).await.ok();
         }
         KeyCode::F(4) | KeyCode::Char('f') | KeyCode::Char('/') => {
-            let _ = event_tx.send(UiEventType::ToggleFilterMenu).await;
+            event_tx.send(UiEventType::ToggleFilterMenu).await.ok();
         }
         _ => (),
     }
@@ -135,7 +143,7 @@ async fn handle_help_input<B: Backend>(
 ) -> bool {
     match key_event.code {
         KeyCode::Esc => {
-            let _ = event_tx.send(UiEventType::ToggleHelp).await;
+            event_tx.send(UiEventType::ToggleHelp).await.ok();
         }
         _ => return handle_top_input(key_event, event_tx, terminal).await,
     }
@@ -149,16 +157,16 @@ async fn handle_sort_input<B: Backend>(
 ) -> bool {
     match key_event.code {
         KeyCode::Esc => {
-            let _ = event_tx.send(UiEventType::ToggleSortMenu).await;
+            event_tx.send(UiEventType::ToggleSortMenu).await.ok();
         }
         KeyCode::Up | KeyCode::BackTab | KeyCode::Char('k') => {
-            let _ = event_tx.send(UiEventType::SortSelection(-1)).await;
+            event_tx.send(UiEventType::SortSelection(-1)).await.ok();
         }
         KeyCode::Down | KeyCode::Tab | KeyCode::Char('j') => {
-            let _ = event_tx.send(UiEventType::SortSelection(1)).await;
+            event_tx.send(UiEventType::SortSelection(1)).await.ok();
         }
         KeyCode::Enter => {
-            let _ = event_tx.send(UiEventType::SortConfirmation).await;
+            event_tx.send(UiEventType::SortConfirmation).await.ok();
         }
         _ => return handle_top_input(key_event, event_tx, terminal).await,
     }
@@ -172,22 +180,28 @@ async fn handle_filter_input<B: Backend>(
 ) -> bool {
     match key_event.code {
         KeyCode::Esc => {
-            let _ = event_tx.send(UiEventType::ToggleFilterMenu).await;
+            event_tx.send(UiEventType::ToggleFilterMenu).await.ok();
         }
         KeyCode::BackTab | KeyCode::Up => {
-            let _ = event_tx.send(UiEventType::FilterColumnSelection(-1)).await;
+            event_tx
+                .send(UiEventType::FilterColumnSelection(-1))
+                .await
+                .ok();
         }
         KeyCode::Tab | KeyCode::Down => {
-            let _ = event_tx.send(UiEventType::FilterColumnSelection(1)).await;
+            event_tx
+                .send(UiEventType::FilterColumnSelection(1))
+                .await
+                .ok();
         }
         KeyCode::Backspace => {
-            let _ = event_tx.send(UiEventType::FilterBackspace).await;
+            event_tx.send(UiEventType::FilterBackspace).await.ok();
         }
         KeyCode::Enter => {
-            let _ = event_tx.send(UiEventType::FilterConfirmation).await;
+            event_tx.send(UiEventType::FilterConfirmation).await.ok();
         }
         KeyCode::Char(any) => {
-            let _ = event_tx.send(UiEventType::FilterInput(any)).await;
+            event_tx.send(UiEventType::FilterInput(any)).await.ok();
         }
         _ => return handle_top_input(key_event, event_tx, terminal).await,
     }

--- a/lib/vector-top/src/input.rs
+++ b/lib/vector-top/src/input.rs
@@ -1,3 +1,4 @@
+// Event sends only fail when the receiver is dropped (UI shutting down), so errors are ignored.
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::{Terminal, prelude::Backend};
 

--- a/lib/vector-vrl/category/Cargo.toml
+++ b/lib/vector-vrl/category/Cargo.toml
@@ -6,5 +6,8 @@ edition = "2024"
 publish = false
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 strum.workspace = true

--- a/lib/vector-vrl/cli/Cargo.toml
+++ b/lib/vector-vrl/cli/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2024"
 publish = false
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [features]
 # Enable the full VRL stdlib, which includes all available VRL functions.
 default = ["vrl/stdlib"]

--- a/lib/vector-vrl/dnstap-parser/Cargo.toml
+++ b/lib/vector-vrl/dnstap-parser/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2024"
 publish = false
 license = "MIT"
 
+[lints]
+workspace = true
+
 [dependencies]
 base64 = { workspace = true, features = ["alloc"] }
 bytes = { workspace = true, features = ["serde"] }

--- a/lib/vector-vrl/doc-builder/Cargo.toml
+++ b/lib/vector-vrl/doc-builder/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2024"
 publish = false
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 clap.workspace = true

--- a/lib/vector-vrl/enrichment/Cargo.toml
+++ b/lib/vector-vrl/enrichment/Cargo.toml
@@ -5,6 +5,9 @@ authors = ["Vector Contributors <vector@datadoghq.com>"]
 edition = "2024"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 arc-swap.workspace = true
 chrono.workspace = true

--- a/lib/vector-vrl/functions/Cargo.toml
+++ b/lib/vector-vrl/functions/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2024"
 publish = false
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 indoc.workspace = true
 vrl.workspace = true

--- a/lib/vector-vrl/metrics/Cargo.toml
+++ b/lib/vector-vrl/metrics/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2021"
 publish = false
 license = "MPL-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 arc-swap.workspace = true
 const-str.workspace = true

--- a/lib/vector-vrl/metrics/src/common.rs
+++ b/lib/vector-vrl/metrics/src/common.rs
@@ -100,13 +100,12 @@ impl MetricsStorage {
 
 /// Checks if the tag matches - also considers wildcards
 fn tag_matches(metric: &Metric, (tag_key, tag_value): (&String, &String)) -> bool {
-    if let Some(wildcard_index) = tag_value.find('*') {
+    if let Some((prefix, suffix)) = tag_value.split_once('*') {
         let Some(metric_tag_value) = metric.tag_value(tag_key) else {
             return false;
         };
 
-        metric_tag_value.starts_with(&tag_value[0..wildcard_index])
-            && metric_tag_value.ends_with(&tag_value[(wildcard_index + 1)..])
+        metric_tag_value.starts_with(prefix) && metric_tag_value.ends_with(suffix)
     } else {
         metric.tag_matches(tag_key, tag_value)
     }

--- a/lib/vector-vrl/tests/Cargo.toml
+++ b/lib/vector-vrl/tests/Cargo.toml
@@ -5,6 +5,9 @@ authors = ["Vector Contributors <vector@datadoghq.com>"]
 edition = "2024"
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 chrono-tz.workspace = true
 vector-vrl-functions = { workspace = true, features = ["dnstap", "vrl-metrics"] }

--- a/lib/vector-vrl/web-playground/Cargo.toml
+++ b/lib/vector-vrl/web-playground/Cargo.toml
@@ -8,6 +8,9 @@ license = "MPL-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[lints]
+workspace = true
+
 [lib]
 crate-type = ["cdylib"]
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -589,7 +589,7 @@ mod tests {
         if setrlimit(Resource::RLIMIT_NOFILE, hard, hard).is_err() {
             #[cfg(target_os = "macos")]
             if let Some(maxfiles) = super::macos_maxfilesperproc() {
-                let _ = setrlimit(Resource::RLIMIT_NOFILE, maxfiles, hard);
+                setrlimit(Resource::RLIMIT_NOFILE, maxfiles, hard).ok();
             }
         }
 

--- a/src/components/validation/resources/http.rs
+++ b/src/components/validation/resources/http.rs
@@ -427,7 +427,7 @@ impl HttpResourceOutputContext<'_> {
             resource_shutdown_rx.wait().await;
 
             // signal the server to shutdown
-            let _ = http_server_shutdown_tx.send(());
+            http_server_shutdown_tx.send(()).ok();
 
             // mark ourselves as done
             resource_completed.mark_as_done();

--- a/src/components/validation/resources/http.rs
+++ b/src/components/validation/resources/http.rs
@@ -188,8 +188,8 @@ fn spawn_input_http_server(
         // Wait for the runner to signal us to shutdown
         resource_shutdown_rx.wait().await;
 
-        // Shutdown the server
-        _ = http_server_shutdown_tx.send(());
+        // Shutdown the server; error is ignored since it only fails if the server already stopped.
+        http_server_shutdown_tx.send(()).ok();
 
         info!("HTTP server external input resource marking as done.");
         resource_completed.mark_as_done();

--- a/src/config/unit_test/unit_test_components.rs
+++ b/src/config/unit_test/unit_test_components.rs
@@ -1,3 +1,6 @@
+// Derivative's Debug impl generates `let _ = field.fmt(f)` which triggers this lint.
+#![allow(clippy::let_underscore_must_use)]
+
 use std::sync::Arc;
 
 use futures::{Sink, Stream, stream};

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -34,9 +34,10 @@ impl Resolver {
             spawn_blocking(move || {
                 let name_ref = match name.as_str() {
                     // strip IPv6 prefix and suffix
-                    name if name.starts_with('[') && name.ends_with(']') => {
-                        &name[1..name.len() - 1]
-                    }
+                    name if name.starts_with('[') && name.ends_with(']') => name
+                        .strip_prefix('[')
+                        .and_then(|s| s.strip_suffix(']'))
+                        .unwrap(),
                     name => name,
                 };
                 (name_ref, dummy_port).to_socket_addrs()

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -32,14 +32,12 @@ impl Resolver {
             ))
         } else {
             spawn_blocking(move || {
-                let name_ref = match name.as_str() {
-                    // strip IPv6 prefix and suffix
-                    name if name.starts_with('[') && name.ends_with(']') => name
-                        .strip_prefix('[')
-                        .and_then(|s| s.strip_suffix(']'))
-                        .unwrap(),
-                    name => name,
-                };
+                // strip IPv6 prefix and suffix
+                let name_str = name.as_str();
+                let name_ref = name_str
+                    .strip_prefix('[')
+                    .and_then(|s| s.strip_suffix(']'))
+                    .unwrap_or(name_str);
                 (name_ref, dummy_port).to_socket_addrs()
             })
             .await

--- a/src/encoding_transcode.rs
+++ b/src/encoding_transcode.rs
@@ -154,6 +154,10 @@ impl Encoder {
         let mut total_had_errors = false;
 
         loop {
+            #[expect(
+                clippy::string_slice,
+                reason = "total_read_from_input is a byte offset returned by the encoder, always a char boundary"
+            )]
             let (result, read, written, had_errors) = self.inner.encode_from_utf8(
                 &input[total_read_from_input..],
                 &mut self.buffer,

--- a/src/internal_events/parser.rs
+++ b/src/internal_events/parser.rs
@@ -16,6 +16,10 @@ fn truncate_string_at(s: &str, maxlen: usize) -> Cow<'_, str> {
         while !s.is_char_boundary(len) {
             len -= 1;
         }
+        #[expect(
+            clippy::string_slice,
+            reason = "len is adjusted to a char boundary in the loop above"
+        )]
         format!("{}{}", &s[..len], ellipsis).into()
     } else {
         s.into()
@@ -34,7 +38,7 @@ impl InternalEvent for ParserMatchError<'_> {
             error_code = "no_match_found",
             error_type = error_type::CONDITION_FAILED,
             stage = error_stage::PROCESSING,
-            field = &truncate_string_at(&String::from_utf8_lossy(self.value), 60)[..]
+            field = truncate_string_at(&String::from_utf8_lossy(self.value), 60).as_ref()
         );
         counter!(
             CounterName::ComponentErrorsTotal,

--- a/src/sinks/aws_cloudwatch_logs/config.rs
+++ b/src/sinks/aws_cloudwatch_logs/config.rs
@@ -68,7 +68,7 @@ where
         Ok(days)
     } else {
         let msg = format!("one of allowed values: {ALLOWED_VALUES:?}").to_owned();
-        let expected: &str = &msg[..];
+        let expected: &str = msg.as_str();
         Err(de::Error::invalid_value(
             de::Unexpected::Signed(days.into()),
             &expected,

--- a/src/sinks/aws_kinesis/sink.rs
+++ b/src/sinks/aws_kinesis/sink.rs
@@ -114,7 +114,12 @@ pub(crate) fn process_log(
         Cow::Owned(gen_partition_key())
     };
     let partition_key = if partition_key.len() >= 256 {
-        partition_key[..256].to_string()
+        #[expect(
+            clippy::string_slice,
+            reason = "floor_char_boundary guarantees a valid char boundary"
+        )]
+        let s = &partition_key[..partition_key.floor_char_boundary(256)];
+        s.to_string()
     } else {
         partition_key.into_owned()
     };

--- a/src/sinks/azure_common/shared_key_policy.rs
+++ b/src/sinks/azure_common/shared_key_policy.rs
@@ -192,7 +192,7 @@ impl SharedKeyAuthorizationPolicy {
             vals.sort();
             vals.dedup();
             let joined = vals.join(",");
-            let _ = writeln!(s, "{}:{}", k, joined);
+            writeln!(s, "{}:{}", k, joined).ok();
         }
 
         // CanonicalizedResource
@@ -280,7 +280,7 @@ fn append_canonicalized_resource(s: &mut String, account: &str, url: &Url) -> Az
         for (k, mut vals) in qp_map {
             vals.sort();
             let mut line = String::new();
-            let _ = write!(&mut line, "\n{}:", k);
+            write!(&mut line, "\n{}:", k).ok();
             let joined = vals.join(",");
             line.push_str(&joined);
             s.push_str(&line);

--- a/src/sinks/databend/config.rs
+++ b/src/sinks/databend/config.rs
@@ -125,6 +125,7 @@ impl SinkConfig for DatabendConfig {
         let mut endpoint = url::Url::parse(&endpoint)?;
         match auth {
             Some(Auth::Basic { user, password }) => {
+                // Only fails for host-less URLs, which cannot happen given the scheme validation above.
                 endpoint.set_username(&user).ok();
                 endpoint.set_password(Some(password.inner())).ok();
             }

--- a/src/sinks/databend/config.rs
+++ b/src/sinks/databend/config.rs
@@ -125,8 +125,8 @@ impl SinkConfig for DatabendConfig {
         let mut endpoint = url::Url::parse(&endpoint)?;
         match auth {
             Some(Auth::Basic { user, password }) => {
-                let _ = endpoint.set_username(&user);
-                let _ = endpoint.set_password(Some(password.inner()));
+                endpoint.set_username(&user).ok();
+                endpoint.set_password(Some(password.inner())).ok();
             }
             Some(Auth::Bearer { .. }) => {
                 return Err("Bearer authentication is not supported currently".into());

--- a/src/sinks/doris/client.rs
+++ b/src/sinks/doris/client.rs
@@ -177,7 +177,7 @@ impl DorisSinkClient {
 
         // Add custom headers
         for (header, value) in self.headers.as_ref() {
-            builder = builder.header(&header[..], &value[..]);
+            builder = builder.header(header.as_str(), value.as_str());
         }
 
         let body = Body::from(payload.clone());

--- a/src/sinks/elasticsearch/common.rs
+++ b/src/sinks/elasticsearch/common.rs
@@ -429,7 +429,7 @@ async fn get(
     let mut builder = Request::get(format!("{base_url}{path}"));
 
     for (header, value) in &request.headers {
-        builder = builder.header(&header[..], &value[..]);
+        builder = builder.header(header.as_str(), value.as_str());
     }
     let mut request = builder.body(Bytes::new())?;
 

--- a/src/sinks/elasticsearch/integration_tests.rs
+++ b/src/sinks/elasticsearch/integration_tests.rs
@@ -55,7 +55,7 @@ impl ElasticsearchCommon {
         }
 
         for (header, value) in &self.request.headers {
-            builder = builder.header(&header[..], &value[..]);
+            builder = builder.header(header.as_str(), value.as_str());
         }
 
         let mut request = builder.body(Bytes::new())?;

--- a/src/sinks/elasticsearch/service.rs
+++ b/src/sinks/elasticsearch/service.rs
@@ -131,7 +131,7 @@ impl HttpRequestBuilder {
         }
 
         for (header, value) in &self.http_request_config.headers {
-            builder = builder.header(&header[..], &value[..]);
+            builder = builder.header(header.as_str(), value.as_str());
         }
 
         let mut request = builder

--- a/src/sinks/influxdb/logs.rs
+++ b/src/sinks/influxdb/logs.rs
@@ -291,7 +291,7 @@ impl HttpEventEncoder<BytesMut> for InfluxDbLogsEncoder {
         let mut tags = MetricTags::default();
         let mut fields: HashMap<KeyString, Field> = HashMap::new();
         log.convert_to_fields().for_each(|(key, value)| {
-            if self.tags.contains(&key[..]) {
+            if self.tags.contains(key.as_str()) {
                 tags.replace(key.into(), value.to_string_lossy().into_owned());
             } else {
                 fields.insert(key, to_field(value));

--- a/src/sinks/influxdb/mod.rs
+++ b/src/sinks/influxdb/mod.rs
@@ -553,6 +553,10 @@ pub mod test_util {
 
     // InfluxDB strips off trailing zeros in timestamps in metrics
     fn strip_timestamp(timestamp: String) -> String {
+        #[expect(
+            clippy::string_slice,
+            reason = "last two bytes are always ASCII ('0Z' or '.Z'), guaranteed char boundaries"
+        )]
         let strip_one = || format!("{}Z", &timestamp[..timestamp.len() - 2]);
         match timestamp {
             _ if timestamp.ends_with("0Z") => strip_timestamp(strip_one()),

--- a/src/sinks/kafka/sink.rs
+++ b/src/sinks/kafka/sink.rs
@@ -134,7 +134,7 @@ pub(crate) async fn healthcheck(
 
     tokio::task::spawn_blocking(move || {
         let producer: BaseProducer = client_config.create().unwrap();
-        let topic = topic.as_ref().map(|topic| &topic[..]);
+        let topic = topic.as_deref();
 
         producer
             .client()

--- a/src/sinks/prometheus/collector.rs
+++ b/src/sinks/prometheus/collector.rs
@@ -301,11 +301,17 @@ impl StringCollector {
         result.push_str(key);
         result.push_str("=\"");
         while let Some(i) = value.find(['\\', '"']) {
-            result.push_str(&value[..i]);
-            result.push('\\');
-            // Ugly but works because we know the character at `i` is ASCII
-            result.push(value.as_bytes()[i] as char);
-            value = &value[i + 1..];
+            #[expect(
+                clippy::string_slice,
+                reason = "i comes from find() on ASCII chars, i and i+1 are char boundaries"
+            )]
+            {
+                result.push_str(&value[..i]);
+                result.push('\\');
+                // Ugly but works because we know the character at `i` is ASCII
+                result.push(value.as_bytes()[i] as char);
+                value = &value[i + 1..];
+            }
         }
         result.push_str(value);
         result.push('"');

--- a/src/sinks/prometheus/exporter.rs
+++ b/src/sinks/prometheus/exporter.rs
@@ -811,7 +811,7 @@ mod tests {
 
         let mut gz = GzDecoder::new(&body_raw[..]);
         let mut body_decoded = String::new();
-        let _ = gz.read_to_string(&mut body_decoded);
+        gz.read_to_string(&mut body_decoded).ok();
 
         assert!(body_raw.len() < expected.len());
         assert_eq!(body_decoded, expected);

--- a/src/sinks/prometheus/exporter.rs
+++ b/src/sinks/prometheus/exporter.rs
@@ -811,7 +811,7 @@ mod tests {
 
         let mut gz = GzDecoder::new(&body_raw[..]);
         let mut body_decoded = String::new();
-        gz.read_to_string(&mut body_decoded).ok();
+        gz.read_to_string(&mut body_decoded).unwrap();
 
         assert!(body_raw.len() < expected.len());
         assert_eq!(body_decoded, expected);

--- a/src/sinks/splunk_hec/logs/integration_tests.rs
+++ b/src/sinks/splunk_hec/logs/integration_tests.rs
@@ -59,7 +59,7 @@ async fn recent_entries(index: Option<&str>) -> Vec<JsonValue> {
             splunk_api_address()
         ))
         .form(&vec![
-            ("search", &search_query[..]),
+            ("search", search_query.as_str()),
             ("exec_mode", "oneshot"),
             ("f", "*"),
         ])

--- a/src/sinks/util/service/net/mod.rs
+++ b/src/sinks/util/service/net/mod.rs
@@ -343,14 +343,14 @@ impl Service<Vec<u8>> for NetworkService {
 
                     // Send the socket back to the service, since theoretically it's still valid to
                     // reuse given that we may have simply overrun the OS socket buffers, etc.
-                    let _ = tx.send(Some(socket));
+                    tx.send(Some(socket)).ok();
 
                     Ok(sent)
                 }
                 Err(e) => {
                     // We need to signal back to the service that it needs to create a fresh socket
                     // since this one could be tainted.
-                    let _ = tx.send(None);
+                    tx.send(None).ok();
 
                     Err(e)
                 }

--- a/src/sinks/websocket_server/sink.rs
+++ b/src/sinks/websocket_server/sink.rs
@@ -888,6 +888,7 @@ mod tests {
                 }
             }
 
+            // Error is ignored since it only fails if the channel is already closed.
             tx.close().await.ok();
         })
     }

--- a/src/sinks/websocket_server/sink.rs
+++ b/src/sinks/websocket_server/sink.rs
@@ -888,7 +888,7 @@ mod tests {
                 }
             }
 
-            let _ = tx.close().await;
+            tx.close().await.ok();
         })
     }
 

--- a/src/sources/apache_metrics/mod.rs
+++ b/src/sources/apache_metrics/mod.rs
@@ -382,11 +382,10 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
 
                 match m.tags() {
                     Some(tags) => {
-                        assert_eq!(
-                            tags.get("endpoint"),
-                            Some(&format!("http://{in_addr}/metrics")[..])
-                        );
-                        assert_eq!(tags.get("host"), Some(&in_addr.to_string()[..]));
+                        let endpoint = format!("http://{in_addr}/metrics");
+                        let host = in_addr.to_string();
+                        assert_eq!(tags.get("endpoint"), Some(endpoint.as_str()));
+                        assert_eq!(tags.get("host"), Some(host.as_str()));
                     }
                     None => error!(message = "No tags for metric.", metric = ?m),
                 }

--- a/src/sources/datadog_agent/tests.rs
+++ b/src/sources/datadog_agent/tests.rs
@@ -574,7 +574,7 @@ async fn api_key_in_url() {
             assert_eq!(log["ddtags"], "one,two,three".into());
             assert_eq!(*log.get_source_type().unwrap(), "datadog_agent".into());
             assert_eq!(
-                &event.metadata().datadog_api_key().as_ref().unwrap()[..],
+                event.metadata().datadog_api_key().as_deref().unwrap(),
                 DD_API_KEY
             );
             assert_eq!(
@@ -632,7 +632,7 @@ async fn api_key_in_query_params() {
             assert_eq!(log["ddtags"], "one,two,three".into());
             assert_eq!(*log.get_source_type().unwrap(), "datadog_agent".into());
             assert_eq!(
-                &event.metadata().datadog_api_key().as_ref().unwrap()[..],
+                event.metadata().datadog_api_key().as_deref().unwrap(),
                 DD_API_KEY
             );
             assert_eq!(
@@ -690,7 +690,7 @@ async fn api_key_in_header() {
             assert_eq!(log["ddtags"], "one,two,three".into());
             assert_eq!(*log.get_source_type().unwrap(), "datadog_agent".into());
             assert_eq!(
-                &event.metadata().datadog_api_key().as_ref().unwrap()[..],
+                event.metadata().datadog_api_key().as_deref().unwrap(),
                 DD_API_KEY
             );
             assert_eq!(
@@ -989,7 +989,7 @@ async fn decode_series_endpoint_v1() {
             );
 
             assert_eq!(
-                &events[0].metadata().datadog_api_key().as_ref().unwrap()[..],
+                events[0].metadata().datadog_api_key().as_deref().unwrap(),
                 DD_API_KEY
             );
 
@@ -1015,7 +1015,7 @@ async fn decode_series_endpoint_v1() {
             );
 
             assert_eq!(
-                &events[1].metadata().datadog_api_key().as_ref().unwrap()[..],
+                events[1].metadata().datadog_api_key().as_deref().unwrap(),
                 DD_API_KEY
             );
 
@@ -1046,7 +1046,7 @@ async fn decode_series_endpoint_v1() {
             );
 
             assert_eq!(
-                &events[2].metadata().datadog_api_key().as_ref().unwrap()[..],
+                events[2].metadata().datadog_api_key().as_deref().unwrap(),
                 DD_API_KEY
             );
 
@@ -1084,7 +1084,7 @@ async fn decode_series_endpoint_v1() {
             assert_eq!(metric.namespace(), Some("system"));
 
             assert_eq!(
-                &events[3].metadata().datadog_api_key().as_ref().unwrap()[..],
+                events[3].metadata().datadog_api_key().as_deref().unwrap(),
                 DD_API_KEY
             );
         }
@@ -1180,7 +1180,7 @@ async fn decode_sketches() {
             }
 
             assert_eq!(
-                &events[0].metadata().datadog_api_key().as_ref().unwrap()[..],
+                events[0].metadata().datadog_api_key().as_deref().unwrap(),
                 DD_API_KEY
             );
 
@@ -1343,7 +1343,7 @@ async fn decode_traces() {
                 0.577.into()
             );
             assert_eq!(
-                &events[0].metadata().datadog_api_key().as_ref().unwrap()[..],
+                events[0].metadata().datadog_api_key().as_deref().unwrap(),
                 DD_API_KEY
             );
 
@@ -1361,7 +1361,7 @@ async fn decode_traces() {
             assert_eq!(span_from_apm_event["resource"], "a_resource".into());
 
             assert_eq!(
-                &events[1].metadata().datadog_api_key().as_ref().unwrap()[..],
+                events[1].metadata().datadog_api_key().as_deref().unwrap(),
                 DD_API_KEY
             );
 
@@ -1423,7 +1423,7 @@ async fn decode_traces() {
                 0.577.into()
             );
             assert_eq!(
-                &events[2].metadata().datadog_api_key().as_ref().unwrap()[..],
+                events[2].metadata().datadog_api_key().as_deref().unwrap(),
                 DD_API_KEY
             );
         }
@@ -1512,7 +1512,7 @@ async fn split_outputs() {
                 ),
             );
             assert_eq!(
-                &event.metadata().datadog_api_key().as_ref().unwrap()[..],
+                event.metadata().datadog_api_key().as_deref().unwrap(),
                 "abcdefgh12345678abcdefgh12345678"
             );
         }
@@ -1535,7 +1535,7 @@ async fn split_outputs() {
             assert_eq!(log["ddtags"], "one,two,three".into());
             assert_eq!(*log.get_source_type().unwrap(), "datadog_agent".into());
             assert_eq!(
-                &event.metadata().datadog_api_key().as_ref().unwrap()[..],
+                event.metadata().datadog_api_key().as_deref().unwrap(),
                 DD_API_KEY
             );
             assert_eq!(
@@ -2201,7 +2201,7 @@ async fn decode_series_endpoint_v2() {
             assert_eq!(metric.namespace(), Some("namespace"));
 
             assert_eq!(
-                &events[0].metadata().datadog_api_key().as_ref().unwrap()[..],
+                events[0].metadata().datadog_api_key().as_deref().unwrap(),
                 DD_API_KEY
             );
 
@@ -2231,7 +2231,7 @@ async fn decode_series_endpoint_v2() {
             assert_eq!(metric.namespace(), Some("namespace"));
 
             assert_eq!(
-                &events[1].metadata().datadog_api_key().as_ref().unwrap()[..],
+                events[1].metadata().datadog_api_key().as_deref().unwrap(),
                 DD_API_KEY
             );
 
@@ -2264,7 +2264,7 @@ async fn decode_series_endpoint_v2() {
             assert_eq!(metric.namespace(), Some("another_namespace"));
 
             assert_eq!(
-                &events[2].metadata().datadog_api_key().as_ref().unwrap()[..],
+                events[2].metadata().datadog_api_key().as_deref().unwrap(),
                 DD_API_KEY
             );
 
@@ -2296,7 +2296,7 @@ async fn decode_series_endpoint_v2() {
             assert_eq!(metric.namespace(), None);
 
             assert_eq!(
-                &events[3].metadata().datadog_api_key().as_ref().unwrap()[..],
+                events[3].metadata().datadog_api_key().as_deref().unwrap(),
                 DD_API_KEY
             );
 

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -2571,7 +2571,7 @@ mod tests {
                     let mut rx = rx;
                     while let Some(event) = rx.next().await {
                         counter.fetch_add(1, Ordering::SeqCst);
-                        let _ = relay_tx.send(event);
+                        relay_tx.send(event).ok();
                     }
                 });
 

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -2571,7 +2571,7 @@ mod tests {
                     let mut rx = rx;
                     while let Some(event) = rx.next().await {
                         counter.fetch_add(1, Ordering::SeqCst);
-                        relay_tx.send(event).ok();
+                        relay_tx.send(event).ok(); // receiver gone means pipeline is shutting down
                     }
                 });
 

--- a/src/sources/file_descriptors/file_descriptor.rs
+++ b/src/sources/file_descriptors/file_descriptor.rs
@@ -249,7 +249,7 @@ mod tests {
             write(&write_fd, b"hello world\nhello world again\n").unwrap();
             // Consume the OwnedFd without closing it to avoid double-close
             // with the File created in build().
-            let _ = write_fd.into_raw_fd();
+            _ = write_fd.into_raw_fd();
 
             let context = SourceContext::new_test(tx, None);
             config.build(context).await.unwrap().await.unwrap();

--- a/src/sources/host_metrics/cgroups.rs
+++ b/src/sources/host_metrics/cgroups.rs
@@ -389,8 +389,8 @@ macro_rules! define_stat_struct {
                 for line in text.lines(){
                     if false {}
                     $(
-                        else if line.starts_with(concat!(stringify!($field), ' ')) {
-                            result.$field = line[stringify!($field).len()+1..].parse()?;
+                        else if let Some(rest) = line.strip_prefix(concat!(stringify!($field), ' ')) {
+                            result.$field = rest.parse()?;
                         }
                     )*
                 }

--- a/src/sources/host_metrics/mod.rs
+++ b/src/sources/host_metrics/mod.rs
@@ -913,7 +913,12 @@ mod tests {
         let keys = collect_tag_values(&all_metrics, tag);
         // Pick an arbitrary key value
         if let Some(key) = keys.into_iter().next() {
-            let key_prefix = &key[..key.len() - 1].to_string();
+            #[expect(
+                clippy::string_slice,
+                reason = "index from char_indices, always a char boundary"
+            )]
+            let key_prefix =
+                &key[..key.char_indices().next_back().map_or(0, |(i, _)| i)].to_string();
             let key_prefix_pattern = PatternWrapper::try_from(format!("{key_prefix}*")).unwrap();
             let key_pattern = PatternWrapper::try_from(key.clone()).unwrap();
 

--- a/src/sources/journald.rs
+++ b/src/sources/journald.rs
@@ -1110,10 +1110,7 @@ impl Checkpointer {
             0 => Ok(None),
             _ => {
                 let text = String::from_utf8_lossy(&buf);
-                match text.find('\n') {
-                    Some(nl) => Ok(Some(String::from(&text[..nl]))),
-                    None => Ok(None), // Maybe return an error?
-                }
+                Ok(text.split_once('\n').map(|(line, _)| line.to_string()))
             }
         }
     }

--- a/src/sources/kafka.rs
+++ b/src/sources/kafka.rs
@@ -1309,13 +1309,15 @@ impl KafkaSourceContext {
             return;
         }
         let (send, rendezvous) = sync_channel(0);
-        let _ = self.callbacks.send(KafkaCallback::PartitionsAssigned(
-            tpl.elements()
-                .iter()
-                .map(|tp| (tp.topic().into(), tp.partition()))
-                .collect(),
-            send,
-        ));
+        self.callbacks
+            .send(KafkaCallback::PartitionsAssigned(
+                tpl.elements()
+                    .iter()
+                    .map(|tp| (tp.topic().into(), tp.partition()))
+                    .collect(),
+                send,
+            ))
+            .ok();
 
         while rendezvous.recv().is_ok() {
             // no-op: wait for partition assignment handler to complete
@@ -1329,13 +1331,15 @@ impl KafkaSourceContext {
     /// sender is dropped by the callback handler.
     fn revoke_partitions(&self, tpl: &TopicPartitionList) {
         let (send, rendezvous) = sync_channel(0);
-        let _ = self.callbacks.send(KafkaCallback::PartitionsRevoked(
-            tpl.elements()
-                .iter()
-                .map(|tp| (tp.topic().into(), tp.partition()))
-                .collect(),
-            send,
-        ));
+        self.callbacks
+            .send(KafkaCallback::PartitionsRevoked(
+                tpl.elements()
+                    .iter()
+                    .map(|tp| (tp.topic().into(), tp.partition()))
+                    .collect(),
+                send,
+            ))
+            .ok();
 
         while rendezvous.recv().is_ok() {
             self.commit_consumer_state();

--- a/src/sources/kubernetes_logs/parser/cri.rs
+++ b/src/sources/kubernetes_logs/parser/cri.rs
@@ -1,3 +1,6 @@
+// Derivative's Debug impl generates `let _ = field.fmt(f)` which triggers this lint.
+#![allow(clippy::let_underscore_must_use)]
+
 use chrono::{DateTime, Utc};
 use derivative::Derivative;
 use vector_lib::{

--- a/src/sources/mongodb_metrics/mod.rs
+++ b/src/sources/mongodb_metrics/mod.rs
@@ -1009,6 +1009,10 @@ fn document_size(doc: &Document) -> usize {
 /// `endpoint` argument would not be required, but field `original_uri` in `ClientOptions` is private.
 /// `.unwrap()` in function is safe because endpoint was already verified by `ClientOptions`.
 /// Based on ClientOptions::parse_uri -- <https://github.com/mongodb/mongo-rust-driver/blob/09e1193f93dcd850ebebb7fb82f6ab786fd85de1/src/client/options/mod.rs#L708>
+#[expect(
+    clippy::string_slice,
+    reason = "all indices come from find() on ASCII chars ('/', '?', '=', '@', ':'), guaranteed char boundaries"
+)]
 fn sanitize_endpoint(endpoint: &str, options: &ClientOptions) -> String {
     let mut endpoint = endpoint.to_owned();
     if options.credential.is_some() {
@@ -1164,8 +1168,8 @@ mod integration_tests {
                 assert!((timestamp - Utc::now()).num_seconds() < 1);
                 // validate basic tags
                 let tags = metric.tags().expect("existed tags");
-                assert_eq!(tags.get("endpoint"), Some(&clean_endpoint[..]));
-                assert_eq!(tags.get("host"), Some(&host[..]));
+                assert_eq!(tags.get("endpoint"), Some(clean_endpoint.as_str()));
+                assert_eq!(tags.get("host"), Some(host.as_str()));
             }
         })
         .await;

--- a/src/sources/splunk_hec/mod.rs
+++ b/src/sources/splunk_hec/mod.rs
@@ -2714,7 +2714,7 @@ mod tests {
                 message.into()
             );
             assert_eq!(
-                &event.metadata().splunk_hec_token().as_ref().unwrap()[..],
+                event.metadata().splunk_hec_token().as_deref().unwrap(),
                 TOKEN
             );
         })
@@ -2741,7 +2741,7 @@ mod tests {
                 "splunk_hec".into()
             );
             assert_eq!(
-                &event.metadata().splunk_hec_token().as_ref().unwrap()[..],
+                event.metadata().splunk_hec_token().as_deref().unwrap(),
                 TOKEN
             );
         })
@@ -2792,7 +2792,7 @@ mod tests {
                 message.into()
             );
             assert_eq!(
-                &event.metadata().splunk_hec_token().as_ref().unwrap()[..],
+                event.metadata().splunk_hec_token().as_deref().unwrap(),
                 TOKEN
             );
         })

--- a/src/sources/statsd/parser.rs
+++ b/src/sources/statsd/parser.rs
@@ -139,13 +139,14 @@ impl Parser {
 }
 
 fn parse_sampling(input: &str) -> Result<f64, ParseError> {
-    if !input.starts_with('@') || input.len() < 2 {
-        return Err(ParseError::Malformed(
+    let rest = input
+        .strip_prefix('@')
+        .filter(|s| !s.is_empty())
+        .ok_or(ParseError::Malformed(
             "expected non empty '@'-prefixed sampling component",
-        ));
-    }
+        ))?;
 
-    let num: f64 = input[1..].parse()?;
+    let num: f64 = rest.parse()?;
     if num.is_sign_positive() {
         Ok(num)
     } else {
@@ -155,16 +156,14 @@ fn parse_sampling(input: &str) -> Result<f64, ParseError> {
 
 /// Statsd (and dogstatsd) support bare, single and multi-value tags.
 fn parse_tags(input: &&str) -> Result<MetricTags, ParseError> {
-    if !input.starts_with('#') || input.len() < 2 {
-        return Err(ParseError::Malformed(
+    let rest = input
+        .strip_prefix('#')
+        .filter(|s| !s.is_empty())
+        .ok_or(ParseError::Malformed(
             "expected non empty '#'-prefixed tags component",
-        ));
-    }
+        ))?;
 
-    Ok(input[1..]
-        .split(',')
-        .map(extract_tag_key_and_value)
-        .collect())
+    Ok(rest.split(',').map(extract_tag_key_and_value).collect())
 }
 
 fn parse_direction(input: &str) -> Result<Option<f64>, ParseError> {

--- a/src/sources/util/net/mod.rs
+++ b/src/sources/util/net/mod.rs
@@ -112,7 +112,9 @@ impl TryFrom<String> for SocketListenAddr {
             Err(_) => {
                 let fd: usize = match input.as_str() {
                     "systemd" => Ok(0),
-                    s if s.starts_with("systemd#") => s[8..]
+                    s if s.starts_with("systemd#") => s
+                        .strip_prefix("systemd#")
+                        .unwrap()
                         .parse::<usize>()
                         .map_err(|_| Self::Error::UsizeParse)?
                         .checked_sub(1)

--- a/src/sources/util/net/mod.rs
+++ b/src/sources/util/net/mod.rs
@@ -112,9 +112,7 @@ impl TryFrom<String> for SocketListenAddr {
             Err(_) => {
                 let fd: usize = match input.as_str() {
                     "systemd" => Ok(0),
-                    s if s.starts_with("systemd#") => s
-                        .strip_prefix("systemd#")
-                        .unwrap()
+                    s if let Some(rest) = s.strip_prefix("systemd#") => rest
                         .parse::<usize>()
                         .map_err(|_| Self::Error::UsizeParse)?
                         .checked_sub(1)

--- a/src/sources/websocket/source.rs
+++ b/src/sources/websocket/source.rs
@@ -649,7 +649,7 @@ mod tests {
                     code: CloseCode::Error,
                     reason: Cow::from("Simulated Internal Server Error"),
                 };
-                websocket.close(Some(close_frame)).await.ok();
+                websocket.close(Some(close_frame)).await.ok(); // connection may already be gone
             }
         });
 

--- a/src/sources/websocket/source.rs
+++ b/src/sources/websocket/source.rs
@@ -649,7 +649,7 @@ mod tests {
                     code: CloseCode::Error,
                     reason: Cow::from("Simulated Internal Server Error"),
                 };
-                let _ = websocket.close(Some(close_frame)).await;
+                websocket.close(Some(close_frame)).await.ok();
             }
         });
 

--- a/src/sources/windows_event_log/integration_tests.rs
+++ b/src/sources/windows_event_log/integration_tests.rs
@@ -511,7 +511,7 @@ async fn test_include_xml_well_formed() {
     assert!(
         xml_str.contains("<Event") && xml_str.contains("</Event>"),
         "XML field should contain well-formed <Event>...</Event>, got: {}",
-        &xml_str[..xml_str.len().min(200)]
+        xml_str.chars().take(200).collect::<String>()
     );
 }
 
@@ -1583,7 +1583,7 @@ async fn test_full_data_path_produces_checkpoint() {
         contents.contains("\"version\"") && contents.contains("\"channels\""),
         "Checkpoint file should contain valid JSON with version and channels. \
          Got: {}",
-        &contents[..contents.len().min(200)]
+        contents.chars().take(200).collect::<String>()
     );
 }
 

--- a/src/template.rs
+++ b/src/template.rs
@@ -584,9 +584,9 @@ fn render_metric_field<'a>(key: &str, metric: &'a Metric) -> Option<&'a str> {
     match key {
         "name" => Some(metric.name()),
         "namespace" => metric.namespace(),
-        _ if let Some(tag_key) = key.strip_prefix("tags.") => metric
-            .tags()
-            .and_then(|tags| tags.get(tag_key)),
+        _ if let Some(tag_key) = key.strip_prefix("tags.") => {
+            metric.tags().and_then(|tags| tags.get(tag_key))
+        }
         _ => None,
     }
 }

--- a/src/template.rs
+++ b/src/template.rs
@@ -584,9 +584,9 @@ fn render_metric_field<'a>(key: &str, metric: &'a Metric) -> Option<&'a str> {
     match key {
         "name" => Some(metric.name()),
         "namespace" => metric.namespace(),
-        _ if key.starts_with("tags.") => metric
+        _ if let Some(tag_key) = key.strip_prefix("tags.") => metric
             .tags()
-            .and_then(|tags| tags.get(key.strip_prefix("tags.").unwrap())),
+            .and_then(|tags| tags.get(tag_key)),
         _ => None,
     }
 }

--- a/src/template.rs
+++ b/src/template.rs
@@ -551,6 +551,10 @@ fn parse_template(src: &str) -> Result<Vec<Part>, TemplateParseError> {
     for cap in RE.captures_iter(src) {
         let all = cap.get(0).expect("Capture 0 is always defined");
         if all.start() > last_end {
+            #[expect(
+                clippy::string_slice,
+                reason = "indices come from regex match positions, always char boundaries"
+            )]
             parts.push(parse_literal(&src[last_end..all.start()])?);
         }
 
@@ -566,6 +570,10 @@ fn parse_template(src: &str) -> Result<Vec<Part>, TemplateParseError> {
         last_end = all.end();
     }
     if src.len() > last_end {
+        #[expect(
+            clippy::string_slice,
+            reason = "last_end comes from a regex match end position, always a char boundary"
+        )]
         parts.push(parse_literal(&src[last_end..])?);
     }
 
@@ -576,7 +584,9 @@ fn render_metric_field<'a>(key: &str, metric: &'a Metric) -> Option<&'a str> {
     match key {
         "name" => Some(metric.name()),
         "namespace" => metric.namespace(),
-        _ if key.starts_with("tags.") => metric.tags().and_then(|tags| tags.get(&key[5..])),
+        _ if key.starts_with("tags.") => metric
+            .tags()
+            .and_then(|tags| tags.get(key.strip_prefix("tags.").unwrap())),
         _ => None,
     }
 }

--- a/src/test_util/mock/sinks/completion.rs
+++ b/src/test_util/mock/sinks/completion.rs
@@ -81,13 +81,13 @@ impl StreamSink<Event> for CompletionSink {
                 if self.remaining == 0
                     && let Some(tx) = self.completion_tx.take()
                 {
-                    tx.send(true).ok();
+                    tx.send(true).ok(); // receiver may be gone if the test already completed
                 }
             }
         }
 
         if let Some(tx) = self.completion_tx.take() {
-            tx.send(self.remaining == 0).ok();
+            tx.send(self.remaining == 0).ok(); // receiver may be gone if the test already completed
         }
 
         Ok(())

--- a/src/test_util/mock/sinks/completion.rs
+++ b/src/test_util/mock/sinks/completion.rs
@@ -81,13 +81,13 @@ impl StreamSink<Event> for CompletionSink {
                 if self.remaining == 0
                     && let Some(tx) = self.completion_tx.take()
                 {
-                    let _ = tx.send(true);
+                    tx.send(true).ok();
                 }
             }
         }
 
         if let Some(tx) = self.completion_tx.take() {
-            let _ = tx.send(self.remaining == 0);
+            tx.send(self.remaining == 0).ok();
         }
 
         Ok(())

--- a/src/transforms/lua/v1/mod.rs
+++ b/src/transforms/lua/v1/mod.rs
@@ -1,3 +1,6 @@
+// Derivative's Debug impl generates `let _ = field.fmt(f)` which triggers this lint.
+#![allow(clippy::let_underscore_must_use)]
+
 use std::{future::ready, pin::Pin};
 
 use futures::{Stream, StreamExt, stream};

--- a/src/transforms/remap.rs
+++ b/src/transforms/remap.rs
@@ -1,3 +1,6 @@
+// Derivative's Debug impl generates `let _ = field.fmt(f)` which triggers this lint.
+#![allow(clippy::let_underscore_must_use)]
+
 use std::{
     collections::{BTreeMap, HashMap},
     fs::File,
@@ -321,7 +324,7 @@ impl TransformConfig for RemapConfig {
                         // Attempt to copy over the meanings from the input definition.
                         // The function will fail if the meaning that now points to a field that no longer exists,
                         // this is fine since we will no longer want that meaning in the output definition.
-                        let _ = new_type_def.try_with_meaning(path.clone(), id);
+                        new_type_def.try_with_meaning(path.clone(), id).ok();
                     }
 
                     // Apply any semantic meanings set in the VRL program

--- a/src/utilization.rs
+++ b/src/utilization.rs
@@ -81,7 +81,7 @@ where
         // all the timers and emits utilization value periodically
         let this = self.project();
         this.timer_tx.try_send_start_wait();
-        let _ = this.intervals.poll_next_unpin(cx);
+        _ = this.intervals.poll_next_unpin(cx);
         let result = ready!(this.inner.poll_next_unpin(cx));
         this.timer_tx.try_send_stop_wait();
         Poll::Ready(result)

--- a/tests/antithesis/harness/Cargo.toml
+++ b/tests/antithesis/harness/Cargo.toml
@@ -8,6 +8,9 @@ publish = false
 # and the eventually-phase conservation/liveness judge. They are buffer-agnostic,
 # so each scenario builds them with `-p antithesis-harness` and points them at its own
 # topology through environment variables.
+[lints]
+workspace = true
+
 [dependencies]
 antithesis_sdk = { workspace = true, features = ["full"] }
 axum = { workspace = true, features = ["http1", "tokio"] }

--- a/vdev/Cargo.toml
+++ b/vdev/Cargo.toml
@@ -16,6 +16,9 @@ include = [
   "src/**",
 ]
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 chrono.workspace = true

--- a/vdev/src/app.rs
+++ b/vdev/src/app.rs
@@ -207,14 +207,15 @@ fn format_command_error(
     }
 
     if let Some(description) = command_description {
-        let _ = writeln!(error_msg, "{description}");
+        writeln!(error_msg, "{description}").ok();
     }
 
-    let _ = write!(
+    write!(
         error_msg,
         "failed with exit code: {}",
         output.status.code().unwrap()
-    );
+    )
+    .ok();
 
     error_msg
 }

--- a/vdev/src/commands/check/events.rs
+++ b/vdev/src/commands/check/events.rs
@@ -426,6 +426,10 @@ fn normalize_value(s: &str) -> String {
 /// fragment a `registered_event!` field. `>` only decrements when there is a
 /// matching `<`, so the `>` in `key => value` tag pairs (used by `counter!`
 /// args) doesn't underflow.
+#[expect(
+    clippy::string_slice,
+    reason = "indices from byte-iterator over ASCII delimiters, always char boundaries"
+)]
 fn split_comma_args(s: &str) -> Vec<String> {
     let mut out = Vec::new();
     let mut depth: i32 = 0;
@@ -786,6 +790,10 @@ impl<'ast> Visit<'ast> for Scanner<'_> {
 impl Scanner<'_> {
     /// Parse a `registered_event!` invocation's tokens to extract the event
     /// name, members, handle metrics, and emit-block log calls.
+    #[expect(
+        clippy::string_slice,
+        reason = "indices from find() on ASCII patterns or match_paren_end(), always char boundaries"
+    )]
     fn handle_registered_event(&mut self, mac: &syn::Macro) {
         let raw = mac.tokens.to_string();
         // Event name: first ident.
@@ -911,6 +919,10 @@ impl Scanner<'_> {
 /// Operates on the raw source rather than via the AST so that log calls
 /// nested inside opaque outer macros (`tokio::select!`, `cfg_if!`, …) are
 /// also covered — those bodies are not visited by `syn`.
+#[expect(
+    clippy::string_slice,
+    reason = "indices from regex .end() and match_paren_end(), always char boundaries"
+)]
 fn format_check_log_messages(text: &str, path_str: &str) -> Vec<String> {
     let mut reports = Vec::new();
     for caps in RE_LOG_CALL_OPEN.captures_iter(text) {
@@ -1017,6 +1029,10 @@ fn match_paren_end(s: &str) -> Option<usize> {
 }
 
 /// Split a `{ ... }` block off the front of `s`, returning `(inside, rest)`.
+#[expect(
+    clippy::string_slice,
+    reason = "indices from byte-iterator over ASCII '{' '}', always char boundaries"
+)]
 fn split_brace_block(s: &str) -> (&str, &str) {
     if !s.starts_with('{') {
         return ("", s);

--- a/vdev/src/commands/compose_tests/test.rs
+++ b/vdev/src/commands/compose_tests/test.rs
@@ -51,14 +51,14 @@ pub fn exec(
         let merged_path = coverage_dir.join(coverage_filename(None));
         // Remove any stale lcov.info from a previous run so callers never pick
         // up outdated data if the merge below fails to read a per-env file.
-        let _ = std::fs::remove_file(&merged_path);
+        std::fs::remove_file(&merged_path).ok();
         let mut merged = String::new();
         for env_name in &ran_environments {
             let env_file = coverage_dir.join(coverage_filename(Some(env_name)));
             match std::fs::read_to_string(&env_file) {
                 Ok(contents) => {
                     merged.push_str(&contents);
-                    let _ = std::fs::remove_file(&env_file);
+                    std::fs::remove_file(&env_file).ok();
                 }
                 Err(e) => {
                     warn!("Could not read coverage file {}: {e}", env_file.display());

--- a/vdev/src/utils/deprecation.rs
+++ b/vdev/src/utils/deprecation.rs
@@ -204,18 +204,19 @@ fn split_frontmatter<'a>(content: &'a str, path: &Path) -> Result<(&'a str, &'a 
     }
 
     // Advance past the opening `---` (and optional trailing whitespace on that line)
-    let after_open = content[3..].trim_start_matches([' ', '\t']);
+    let after_open = content
+        .strip_prefix("---")
+        .unwrap()
+        .trim_start_matches([' ', '\t']);
     let after_open = after_open.trim_start_matches('\n');
 
-    let close_pos = after_open.find("\n---").ok_or_else(|| {
+    let (frontmatter, rest) = after_open.split_once("\n---").ok_or_else(|| {
         anyhow!(
             "Deprecation fragment {} has unclosed frontmatter",
             path.display()
         )
     })?;
-
-    let frontmatter = &after_open[..close_pos];
-    let rest = &after_open[close_pos + 4..]; // skip `\n---`
+    let rest = rest.trim_start_matches(['\r', '\n']);
     let body = rest.trim_start_matches(['\r', '\n']);
 
     Ok((frontmatter, body))

--- a/vdev/src/utils/deprecation.rs
+++ b/vdev/src/utils/deprecation.rs
@@ -196,19 +196,17 @@ fn parse_deprecation_fragment(path: &Path) -> Result<DeprecationEntry> {
 /// The file must begin with `---`, and have a closing `---` on its own line.
 fn split_frontmatter<'a>(content: &'a str, path: &Path) -> Result<(&'a str, &'a str)> {
     let content = content.trim_start();
-    if !content.starts_with("---") {
-        bail!(
-            "Deprecation fragment {} must begin with YAML frontmatter (---)",
-            path.display()
-        );
-    }
-
     // Advance past the opening `---` (and optional trailing whitespace on that line)
     let after_open = content
         .strip_prefix("---")
-        .unwrap()
-        .trim_start_matches([' ', '\t']);
-    let after_open = after_open.trim_start_matches('\n');
+        .ok_or_else(|| {
+            anyhow!(
+                "Deprecation fragment {} must begin with YAML frontmatter (---)",
+                path.display()
+            )
+        })?
+        .trim_start_matches([' ', '\t'])
+        .trim_start_matches('\n');
 
     let (frontmatter, rest) = after_open.split_once("\n---").ok_or_else(|| {
         anyhow!(


### PR DESCRIPTION
## Motivation

A recent bug ([#25582](https://github.com/vectordotdev/vector/pull/25582)) was caused by byte-indexing into a `&str` that could contain multi-byte UTF-8 characters. Clippy's `string_slice` lint would have caught it. This PR enables that lint — plus two other high-value lints — across the entire workspace.

## Changes

Adds to `[workspace.lints.clippy]`:

- **`string_slice`** — flags `&str[n..]` byte-index slicing that can panic on multi-byte boundaries
- **`await_holding_lock`** — flags `.await` while holding a `MutexGuard` (potential deadlock)
- **`let_underscore_must_use`** — flags `let _ = expr` where the return value is `#[must_use]`

All existing violations are resolved. Where a clean API exists (`strip_prefix`, `split_once`, `.ok()`), that's used. `#[expect]` is reserved for cases where the index is provably on a char boundary (e.g., indices from `find()` on ASCII chars, or `char_indices()`).

Also incidentally fixes a latent panic in the `aws_kinesis` sink where `partition_key[..256]` could panic on multi-byte keys; replaced with `floor_char_boundary(256)`.