### PR TITLE
chore(metrics): add a regression test for component cpu metric

### DIFF
--- a/src/test_util/mock/transforms/noop.rs
+++ b/src/test_util/mock/transforms/noop.rs
@@ -25,6 +25,13 @@ pub struct NoopTransformConfig {
     /// This is intended for tests that need deterministic, non-zero component latency.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     delay_ms: Option<u64>,
+
+    /// When `true`, the transform reports `enable_concurrency() == true`, causing
+    /// the topology builder to run it on the concurrent (multi-task) code path.
+    ///
+    /// Only meaningful for `Function` and `Synchronous` transform types.
+    #[serde(default, skip_serializing_if = "vector_lib::serde::is_default")]
+    enable_concurrency: bool,
 }
 
 impl GenerateConfig for NoopTransformConfig {
@@ -32,6 +39,7 @@ impl GenerateConfig for NoopTransformConfig {
         toml::Value::try_from(&Self {
             transform_type: TransformType::Function,
             delay_ms: None,
+            enable_concurrency: false,
         })
         .unwrap()
     }
@@ -40,6 +48,11 @@ impl GenerateConfig for NoopTransformConfig {
 impl NoopTransformConfig {
     pub fn with_delay_ms(mut self, delay_ms: u64) -> Self {
         self.delay_ms = Some(delay_ms);
+        self
+    }
+
+    pub fn with_concurrency(mut self) -> Self {
+        self.enable_concurrency = true;
         self
     }
 }
@@ -75,6 +88,10 @@ impl TransformConfig for NoopTransformConfig {
             TransformType::Task => Ok(Transform::Task(Box::new(NoopTransform { delay }))),
         }
     }
+
+    fn enable_concurrency(&self) -> bool {
+        self.enable_concurrency
+    }
 }
 
 impl From<TransformType> for NoopTransformConfig {
@@ -82,6 +99,7 @@ impl From<TransformType> for NoopTransformConfig {
         Self {
             transform_type,
             delay_ms: None,
+            enable_concurrency: false,
         }
     }
 }

--- a/src/topology/test/cpu_metrics.rs
+++ b/src/topology/test/cpu_metrics.rs
@@ -121,7 +121,6 @@ fn assert_cpu_counter_positive(metrics: &[Metric]) {
 /// Function transform (non-concurrent, inline runner): `component_cpu_usage_ns_total`
 /// must be present with the correct component tags and a positive value when
 /// `measure_cpu_usage = true`.
-#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
 #[tokio::test]
 async fn component_cpu_usage_emitted_function_transform() {
     let metrics = run_cpu_topology(|c| c).await;
@@ -131,7 +130,6 @@ async fn component_cpu_usage_emitted_function_transform() {
 /// Task transform (non-concurrent): the same `cpu_timed` wrapper is applied to
 /// the task future in `build_task_transform`, so the counter must also be
 /// emitted when `measure_cpu_usage = true`.
-#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
 #[tokio::test]
 async fn component_cpu_usage_emitted_task_transform() {
     let metrics = run_cpu_topology(|_| NoopTransformConfig::from(TransformType::Task)).await;
@@ -141,7 +139,6 @@ async fn component_cpu_usage_emitted_task_transform() {
 /// Concurrent sync transform: the driver future goes through `run_concurrently()`
 /// in `build_sync_transform`, and each spawned batch task is wrapped via
 /// `spawn_timed`. The counter must still be emitted when `measure_cpu_usage = true`.
-#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
 #[tokio::test]
 async fn component_cpu_usage_emitted_concurrent_transform() {
     let metrics = run_cpu_topology(|c| c.with_concurrency()).await;

--- a/src/topology/test/cpu_metrics.rs
+++ b/src/topology/test/cpu_metrics.rs
@@ -18,47 +18,88 @@ use crate::{
 };
 
 const EVENT_COUNT: usize = 100;
-const SOURCE_ID: &str = "cpu_source";
-const TRANSFORM_ID: &str = "cpu_transform";
 const TRANSFORM_TYPE: &str = "test_noop";
 const TRANSFORM_KIND: &str = "transform";
-const SINK_ID: &str = "cpu_sink";
+
+fn has_transform_tags<'a>(metric: &'a Metric, transform_id: &str) -> bool {
+    metric.tags().is_some_and(|tags| {
+        tags.get("component_id") == Some(transform_id)
+            && tags.get("component_type") == Some(TRANSFORM_TYPE)
+            && tags.get("component_kind") == Some(TRANSFORM_KIND)
+    })
+}
+
+fn assert_cpu_counter_positive(metrics: &[Metric], transform_id: &str) {
+    let cpu_metric = metrics
+        .iter()
+        .find(|m| m.name() == "component_cpu_usage_ns_total" && has_transform_tags(m, transform_id))
+        .unwrap_or_else(|| {
+            panic!(
+                "component_cpu_usage_ns_total not found for transform '{}'; \
+                 available metrics: {:?}",
+                transform_id,
+                metrics
+                    .iter()
+                    .map(|m| m.name())
+                    .collect::<std::collections::BTreeSet<_>>(),
+            )
+        });
+
+    match cpu_metric.value() {
+        MetricValue::Counter { value } => {
+            assert!(
+                *value > 0.0,
+                "expected component_cpu_usage_ns_total > 0, got {value}"
+            );
+        }
+        other => panic!("expected Counter metric, got {other:?}"),
+    }
+}
 
 /// Builds and runs a source → transform (with `measure_cpu_usage = true`) → sink
 /// topology, sends `EVENT_COUNT` events through it, and returns the captured
 /// metrics after the topology stops.
 ///
+/// `transform_id` is unique per call-site so that `has_transform_tags` can
+/// discriminate this topology's metrics from those of concurrently-running
+/// tests that share the same process-wide registry.
+///
 /// `make_config` receives a base `NoopTransformConfig` and can apply extra
 /// options (e.g. `.with_concurrency()`) before the topology is assembled.
 async fn run_cpu_topology(
+    transform_id: &str,
     make_config: impl FnOnce(NoopTransformConfig) -> NoopTransformConfig,
 ) -> Vec<Metric> {
     trace_init();
 
+    // Derive unique source/sink IDs from the transform ID so every parallel
+    // topology uses a fully disjoint set of component names.
+    let source_id = format!("{transform_id}_source");
+    let sink_id = format!("{transform_id}_sink");
+
     let controller = Controller::get().expect("metrics controller");
-    controller.reset();
 
     let (mut source_tx, source_config) = basic_source();
     let (sink_done_tx, sink_done_rx) = oneshot::channel();
     let sink_config = CompletionSinkConfig::new(EVENT_COUNT, sink_done_tx);
 
     let mut config = Config::builder();
-    config.add_source(SOURCE_ID, source_config);
+    config.add_source(&source_id, source_config);
 
     // Add a plain noop transform first, then flip the measure_cpu_usage flag on
     // the TransformOuter that the builder just inserted.
     config.add_transform(
-        TRANSFORM_ID,
-        &[SOURCE_ID],
+        transform_id,
+        &[source_id.as_str()],
         make_config(NoopTransformConfig::from(TransformType::Function)),
     );
     config
         .transforms
-        .get_mut(&ComponentKey::from(TRANSFORM_ID))
+        .get_mut(&ComponentKey::from(transform_id))
         .expect("transform not found in builder")
         .measure_cpu_usage = true;
 
-    config.add_sink(SINK_ID, &[TRANSFORM_ID], sink_config);
+    config.add_sink(&sink_id, &[transform_id], sink_config);
 
     let (topology, _) = start_topology(config.build().unwrap(), false).await;
 
@@ -83,48 +124,14 @@ async fn run_cpu_topology(
     controller.capture_metrics()
 }
 
-fn has_transform_tags(metric: &Metric) -> bool {
-    metric.tags().is_some_and(|tags| {
-        tags.get("component_id") == Some(TRANSFORM_ID)
-            && tags.get("component_type") == Some(TRANSFORM_TYPE)
-            && tags.get("component_kind") == Some(TRANSFORM_KIND)
-    })
-}
-
-fn assert_cpu_counter_positive(metrics: &[Metric]) {
-    let cpu_metric = metrics
-        .iter()
-        .find(|m| m.name() == "component_cpu_usage_ns_total" && has_transform_tags(m))
-        .unwrap_or_else(|| {
-            panic!(
-                "component_cpu_usage_ns_total not found for transform '{}'; \
-                 available metrics: {:?}",
-                TRANSFORM_ID,
-                metrics
-                    .iter()
-                    .map(|m| m.name())
-                    .collect::<std::collections::BTreeSet<_>>(),
-            )
-        });
-
-    match cpu_metric.value() {
-        MetricValue::Counter { value } => {
-            assert!(
-                *value > 0.0,
-                "expected component_cpu_usage_ns_total > 0, got {value}"
-            );
-        }
-        other => panic!("expected Counter metric, got {other:?}"),
-    }
-}
-
 /// Function transform (non-concurrent, inline runner): `component_cpu_usage_ns_total`
 /// must be present with the correct component tags and a positive value when
 /// `measure_cpu_usage = true`.
 #[tokio::test]
 async fn component_cpu_usage_emitted_function_transform() {
-    let metrics = run_cpu_topology(|c| c).await;
-    assert_cpu_counter_positive(&metrics);
+    let id = "cpu_transform_fn";
+    let metrics = run_cpu_topology(id, |c| c).await;
+    assert_cpu_counter_positive(&metrics, id);
 }
 
 /// Task transform (non-concurrent): the same `cpu_timed` wrapper is applied to
@@ -132,8 +139,10 @@ async fn component_cpu_usage_emitted_function_transform() {
 /// emitted when `measure_cpu_usage = true`.
 #[tokio::test]
 async fn component_cpu_usage_emitted_task_transform() {
-    let metrics = run_cpu_topology(|_| NoopTransformConfig::from(TransformType::Task)).await;
-    assert_cpu_counter_positive(&metrics);
+    let id = "cpu_transform_task";
+    let metrics =
+        run_cpu_topology(id, |_| NoopTransformConfig::from(TransformType::Task)).await;
+    assert_cpu_counter_positive(&metrics, id);
 }
 
 /// Concurrent sync transform: the driver future goes through `run_concurrently()`
@@ -141,8 +150,9 @@ async fn component_cpu_usage_emitted_task_transform() {
 /// `spawn_timed`. The counter must still be emitted when `measure_cpu_usage = true`.
 #[tokio::test]
 async fn component_cpu_usage_emitted_concurrent_transform() {
-    let metrics = run_cpu_topology(|c| c.with_concurrency()).await;
-    assert_cpu_counter_positive(&metrics);
+    let id = "cpu_transform_concurrent";
+    let metrics = run_cpu_topology(id, |c| c.with_concurrency()).await;
+    assert_cpu_counter_positive(&metrics, id);
 }
 
 /// When `measure_cpu_usage = false` (the default), no
@@ -151,22 +161,25 @@ async fn component_cpu_usage_emitted_concurrent_transform() {
 async fn component_cpu_usage_not_emitted_without_measure_cpu_usage() {
     trace_init();
 
+    let transform_id = "cpu_transform_no_measure";
+    let source_id = format!("{transform_id}_source");
+    let sink_id = format!("{transform_id}_sink");
+
     let controller = Controller::get().expect("metrics controller");
-    controller.reset();
 
     let (mut source_tx, source_config) = basic_source();
     let (sink_done_tx, sink_done_rx) = oneshot::channel();
     let sink_config = CompletionSinkConfig::new(EVENT_COUNT, sink_done_tx);
 
     let mut config = Config::builder();
-    config.add_source(SOURCE_ID, source_config);
+    config.add_source(&source_id, source_config);
     // Default: measure_cpu_usage = false
     config.add_transform(
-        TRANSFORM_ID,
-        &[SOURCE_ID],
+        transform_id,
+        &[source_id.as_str()],
         NoopTransformConfig::from(TransformType::Function),
     );
-    config.add_sink(SINK_ID, &[TRANSFORM_ID], sink_config);
+    config.add_sink(&sink_id, &[transform_id], sink_config);
 
     let (topology, _) = start_topology(config.build().unwrap(), false).await;
 
@@ -186,7 +199,7 @@ async fn component_cpu_usage_not_emitted_without_measure_cpu_usage() {
     let metrics = controller.capture_metrics();
     let found = metrics
         .iter()
-        .any(|m| m.name() == "component_cpu_usage_ns_total" && has_transform_tags(m));
+        .any(|m| m.name() == "component_cpu_usage_ns_total" && has_transform_tags(m, transform_id));
 
     assert!(
         !found,

--- a/src/topology/test/cpu_metrics.rs
+++ b/src/topology/test/cpu_metrics.rs
@@ -1,0 +1,170 @@
+use tokio::{
+    sync::oneshot,
+    time::{Duration, timeout},
+};
+use vector_lib::{config::ComponentKey, metrics::Controller};
+
+use crate::{
+    config::Config,
+    event::{Event, LogEvent, Metric, MetricValue},
+    test_util::{
+        mock::{
+            basic_source,
+            sinks::CompletionSinkConfig,
+            transforms::{NoopTransformConfig, TransformType},
+        },
+        start_topology, trace_init,
+    },
+};
+
+const EVENT_COUNT: usize = 100;
+const SOURCE_ID: &str = "cpu_source";
+const TRANSFORM_ID: &str = "cpu_transform";
+const TRANSFORM_TYPE: &str = "test_noop";
+const TRANSFORM_KIND: &str = "transform";
+const SINK_ID: &str = "cpu_sink";
+
+/// Builds and runs a source → transform → sink topology where the transform
+/// has `measure_cpu_usage = true`, sends `EVENT_COUNT` events through it, and
+/// returns the captured metrics after the topology stops.
+async fn run_cpu_topology() -> Vec<Metric> {
+    trace_init();
+
+    let controller = Controller::get().expect("metrics controller");
+    controller.reset();
+
+    let (mut source_tx, source_config) = basic_source();
+    let (sink_done_tx, sink_done_rx) = oneshot::channel();
+    let sink_config = CompletionSinkConfig::new(EVENT_COUNT, sink_done_tx);
+
+    let mut config = Config::builder();
+    config.add_source(SOURCE_ID, source_config);
+
+    // Add a plain noop transform first, then flip the measure_cpu_usage flag on
+    // the TransformOuter that the builder just inserted.
+    config.add_transform(
+        TRANSFORM_ID,
+        &[SOURCE_ID],
+        NoopTransformConfig::from(TransformType::Function),
+    );
+    config
+        .transforms
+        .get_mut(&ComponentKey::from(TRANSFORM_ID))
+        .expect("transform not found in builder")
+        .measure_cpu_usage = true;
+
+    config.add_sink(SINK_ID, &[TRANSFORM_ID], sink_config);
+
+    let (topology, _) = start_topology(config.build().unwrap(), false).await;
+
+    for idx in 0..EVENT_COUNT {
+        let event = Event::Log(LogEvent::from(format!("payload-{idx}")));
+        source_tx.send_event(event).await.unwrap();
+    }
+
+    drop(source_tx);
+
+    let completed = timeout(Duration::from_secs(5), sink_done_rx)
+        .await
+        .expect("timed out waiting for completion sink to finish")
+        .expect("completion sink sender dropped");
+    assert!(
+        completed,
+        "completion sink finished before receiving all events"
+    );
+
+    topology.stop().await;
+
+    controller.capture_metrics()
+}
+
+fn has_transform_tags(metric: &Metric) -> bool {
+    metric.tags().is_some_and(|tags| {
+        tags.get("component_id") == Some(TRANSFORM_ID)
+            && tags.get("component_type") == Some(TRANSFORM_TYPE)
+            && tags.get("component_kind") == Some(TRANSFORM_KIND)
+    })
+}
+
+/// `component_cpu_usage_ns_total` must be present with the correct component
+/// tags when `measure_cpu_usage = true`, and its value must be positive
+/// (the transform did actual CPU work for 100 events).
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+#[tokio::test]
+async fn component_cpu_usage_emitted_when_measure_cpu_usage_is_set() {
+    let metrics = run_cpu_topology().await;
+
+    let cpu_metric = metrics
+        .iter()
+        .find(|m| m.name() == "component_cpu_usage_ns_total" && has_transform_tags(m))
+        .unwrap_or_else(|| {
+            panic!(
+                "component_cpu_usage_ns_total not found for transform '{}'; \
+                 available metrics: {:?}",
+                TRANSFORM_ID,
+                metrics
+                    .iter()
+                    .map(|m| m.name())
+                    .collect::<std::collections::BTreeSet<_>>(),
+            )
+        });
+
+    match cpu_metric.value() {
+        MetricValue::Counter { value } => {
+            assert!(
+                *value > 0.0,
+                "expected component_cpu_usage_ns_total > 0, got {value}"
+            );
+        }
+        other => panic!("expected Counter metric, got {other:?}"),
+    }
+}
+
+/// When `measure_cpu_usage = false` (the default), no
+/// `component_cpu_usage_ns_total` counter should be emitted for the transform.
+#[tokio::test]
+async fn component_cpu_usage_not_emitted_without_measure_cpu_usage() {
+    trace_init();
+
+    let controller = Controller::get().expect("metrics controller");
+    controller.reset();
+
+    let (mut source_tx, source_config) = basic_source();
+    let (sink_done_tx, sink_done_rx) = oneshot::channel();
+    let sink_config = CompletionSinkConfig::new(EVENT_COUNT, sink_done_tx);
+
+    let mut config = Config::builder();
+    config.add_source(SOURCE_ID, source_config);
+    // Default: measure_cpu_usage = false
+    config.add_transform(
+        TRANSFORM_ID,
+        &[SOURCE_ID],
+        NoopTransformConfig::from(TransformType::Function),
+    );
+    config.add_sink(SINK_ID, &[TRANSFORM_ID], sink_config);
+
+    let (topology, _) = start_topology(config.build().unwrap(), false).await;
+
+    for idx in 0..EVENT_COUNT {
+        let event = Event::Log(LogEvent::from(format!("payload-{idx}")));
+        source_tx.send_event(event).await.unwrap();
+    }
+    drop(source_tx);
+
+    timeout(Duration::from_secs(5), sink_done_rx)
+        .await
+        .expect("timed out")
+        .expect("sender dropped");
+
+    topology.stop().await;
+
+    let metrics = controller.capture_metrics();
+    let found = metrics
+        .iter()
+        .any(|m| m.name() == "component_cpu_usage_ns_total" && has_transform_tags(m));
+
+    assert!(
+        !found,
+        "component_cpu_usage_ns_total should NOT be emitted when measure_cpu_usage = false"
+    );
+}

--- a/src/topology/test/cpu_metrics.rs
+++ b/src/topology/test/cpu_metrics.rs
@@ -21,7 +21,7 @@ const EVENT_COUNT: usize = 100;
 const TRANSFORM_TYPE: &str = "test_noop";
 const TRANSFORM_KIND: &str = "transform";
 
-fn has_transform_tags<'a>(metric: &'a Metric, transform_id: &str) -> bool {
+fn has_transform_tags(metric: &Metric, transform_id: &str) -> bool {
     metric.tags().is_some_and(|tags| {
         tags.get("component_id") == Some(transform_id)
             && tags.get("component_type") == Some(TRANSFORM_TYPE)
@@ -140,8 +140,7 @@ async fn component_cpu_usage_emitted_function_transform() {
 #[tokio::test]
 async fn component_cpu_usage_emitted_task_transform() {
     let id = "cpu_transform_task";
-    let metrics =
-        run_cpu_topology(id, |_| NoopTransformConfig::from(TransformType::Task)).await;
+    let metrics = run_cpu_topology(id, |_| NoopTransformConfig::from(TransformType::Task)).await;
     assert_cpu_counter_positive(&metrics, id);
 }
 

--- a/src/topology/test/cpu_metrics.rs
+++ b/src/topology/test/cpu_metrics.rs
@@ -24,10 +24,15 @@ const TRANSFORM_TYPE: &str = "test_noop";
 const TRANSFORM_KIND: &str = "transform";
 const SINK_ID: &str = "cpu_sink";
 
-/// Builds and runs a source → transform → sink topology where the transform
-/// has `measure_cpu_usage = true`, sends `EVENT_COUNT` events through it, and
-/// returns the captured metrics after the topology stops.
-async fn run_cpu_topology() -> Vec<Metric> {
+/// Builds and runs a source → transform (with `measure_cpu_usage = true`) → sink
+/// topology, sends `EVENT_COUNT` events through it, and returns the captured
+/// metrics after the topology stops.
+///
+/// `make_config` receives a base `NoopTransformConfig` and can apply extra
+/// options (e.g. `.with_concurrency()`) before the topology is assembled.
+async fn run_cpu_topology(
+    make_config: impl FnOnce(NoopTransformConfig) -> NoopTransformConfig,
+) -> Vec<Metric> {
     trace_init();
 
     let controller = Controller::get().expect("metrics controller");
@@ -45,7 +50,7 @@ async fn run_cpu_topology() -> Vec<Metric> {
     config.add_transform(
         TRANSFORM_ID,
         &[SOURCE_ID],
-        NoopTransformConfig::from(TransformType::Function),
+        make_config(NoopTransformConfig::from(TransformType::Function)),
     );
     config
         .transforms
@@ -86,14 +91,7 @@ fn has_transform_tags(metric: &Metric) -> bool {
     })
 }
 
-/// `component_cpu_usage_ns_total` must be present with the correct component
-/// tags when `measure_cpu_usage = true`, and its value must be positive
-/// (the transform did actual CPU work for 100 events).
-#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
-#[tokio::test]
-async fn component_cpu_usage_emitted_when_measure_cpu_usage_is_set() {
-    let metrics = run_cpu_topology().await;
-
+fn assert_cpu_counter_positive(metrics: &[Metric]) {
     let cpu_metric = metrics
         .iter()
         .find(|m| m.name() == "component_cpu_usage_ns_total" && has_transform_tags(m))
@@ -118,6 +116,36 @@ async fn component_cpu_usage_emitted_when_measure_cpu_usage_is_set() {
         }
         other => panic!("expected Counter metric, got {other:?}"),
     }
+}
+
+/// Function transform (non-concurrent, inline runner): `component_cpu_usage_ns_total`
+/// must be present with the correct component tags and a positive value when
+/// `measure_cpu_usage = true`.
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+#[tokio::test]
+async fn component_cpu_usage_emitted_function_transform() {
+    let metrics = run_cpu_topology(|c| c).await;
+    assert_cpu_counter_positive(&metrics);
+}
+
+/// Task transform (non-concurrent): the same `cpu_timed` wrapper is applied to
+/// the task future in `build_task_transform`, so the counter must also be
+/// emitted when `measure_cpu_usage = true`.
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+#[tokio::test]
+async fn component_cpu_usage_emitted_task_transform() {
+    let metrics = run_cpu_topology(|_| NoopTransformConfig::from(TransformType::Task)).await;
+    assert_cpu_counter_positive(&metrics);
+}
+
+/// Concurrent sync transform: the driver future goes through `run_concurrently()`
+/// in `build_sync_transform`, and each spawned batch task is wrapped via
+/// `spawn_timed`. The counter must still be emitted when `measure_cpu_usage = true`.
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
+#[tokio::test]
+async fn component_cpu_usage_emitted_concurrent_transform() {
+    let metrics = run_cpu_topology(|c| c.with_concurrency()).await;
+    assert_cpu_counter_positive(&metrics);
 }
 
 /// When `measure_cpu_usage = false` (the default), no

--- a/src/topology/test/cpu_metrics.rs
+++ b/src/topology/test/cpu_metrics.rs
@@ -35,9 +35,8 @@ fn assert_cpu_counter_positive(metrics: &[Metric], transform_id: &str) {
         .find(|m| m.name() == "component_cpu_usage_ns_total" && has_transform_tags(m, transform_id))
         .unwrap_or_else(|| {
             panic!(
-                "component_cpu_usage_ns_total not found for transform '{}'; \
+                "component_cpu_usage_ns_total not found for transform '{transform_id}'; \
                  available metrics: {:?}",
-                transform_id,
                 metrics
                     .iter()
                     .map(|m| m.name())

--- a/src/topology/test/cpu_metrics.rs
+++ b/src/topology/test/cpu_metrics.rs
@@ -142,10 +142,8 @@ async fn component_cpu_usage_emitted_function_transform() {
 #[tokio::test]
 async fn component_cpu_usage_emitted_task_transform() {
     let id = "cpu_transform_task";
-    let metrics = run_cpu_topology(id, true, |_| {
-        NoopTransformConfig::from(TransformType::Task)
-    })
-    .await;
+    let metrics =
+        run_cpu_topology(id, true, |_| NoopTransformConfig::from(TransformType::Task)).await;
     assert_cpu_counter_positive(&metrics, id);
 }
 

--- a/src/topology/test/cpu_metrics.rs
+++ b/src/topology/test/cpu_metrics.rs
@@ -55,18 +55,21 @@ fn assert_cpu_counter_positive(metrics: &[Metric], transform_id: &str) {
     }
 }
 
-/// Builds and runs a source → transform (with `measure_cpu_usage = true`) → sink
-/// topology, sends `EVENT_COUNT` events through it, and returns the captured
-/// metrics after the topology stops.
+/// Builds and runs a source → transform → sink topology, sends `EVENT_COUNT`
+/// events through it, and returns the captured metrics after the topology
+/// stops.
 ///
 /// `transform_id` is unique per call-site so that `has_transform_tags` can
 /// discriminate this topology's metrics from those of concurrently-running
 /// tests that share the same process-wide registry.
 ///
+/// `measure_cpu_usage` controls the transform's `measure_cpu_usage` flag.
+///
 /// `make_config` receives a base `NoopTransformConfig` and can apply extra
 /// options (e.g. `.with_concurrency()`) before the topology is assembled.
 async fn run_cpu_topology(
     transform_id: &str,
+    measure_cpu_usage: bool,
     make_config: impl FnOnce(NoopTransformConfig) -> NoopTransformConfig,
 ) -> Vec<Metric> {
     trace_init();
@@ -96,7 +99,7 @@ async fn run_cpu_topology(
         .transforms
         .get_mut(&ComponentKey::from(transform_id))
         .expect("transform not found in builder")
-        .measure_cpu_usage = true;
+        .measure_cpu_usage = measure_cpu_usage;
 
     config.add_sink(&sink_id, &[transform_id], sink_config);
 
@@ -129,7 +132,7 @@ async fn run_cpu_topology(
 #[tokio::test]
 async fn component_cpu_usage_emitted_function_transform() {
     let id = "cpu_transform_fn";
-    let metrics = run_cpu_topology(id, |c| c).await;
+    let metrics = run_cpu_topology(id, true, |c| c).await;
     assert_cpu_counter_positive(&metrics, id);
 }
 
@@ -139,7 +142,10 @@ async fn component_cpu_usage_emitted_function_transform() {
 #[tokio::test]
 async fn component_cpu_usage_emitted_task_transform() {
     let id = "cpu_transform_task";
-    let metrics = run_cpu_topology(id, |_| NoopTransformConfig::from(TransformType::Task)).await;
+    let metrics = run_cpu_topology(id, true, |_| {
+        NoopTransformConfig::from(TransformType::Task)
+    })
+    .await;
     assert_cpu_counter_positive(&metrics, id);
 }
 
@@ -149,7 +155,7 @@ async fn component_cpu_usage_emitted_task_transform() {
 #[tokio::test]
 async fn component_cpu_usage_emitted_concurrent_transform() {
     let id = "cpu_transform_concurrent";
-    let metrics = run_cpu_topology(id, |c| c.with_concurrency()).await;
+    let metrics = run_cpu_topology(id, true, |c| c.with_concurrency()).await;
     assert_cpu_counter_positive(&metrics, id);
 }
 
@@ -157,47 +163,12 @@ async fn component_cpu_usage_emitted_concurrent_transform() {
 /// `component_cpu_usage_ns_total` counter should be emitted for the transform.
 #[tokio::test]
 async fn component_cpu_usage_not_emitted_without_measure_cpu_usage() {
-    trace_init();
+    let id = "cpu_transform_no_measure";
+    let metrics = run_cpu_topology(id, false, |c| c).await;
 
-    let transform_id = "cpu_transform_no_measure";
-    let source_id = format!("{transform_id}_source");
-    let sink_id = format!("{transform_id}_sink");
-
-    let controller = Controller::get().expect("metrics controller");
-
-    let (mut source_tx, source_config) = basic_source();
-    let (sink_done_tx, sink_done_rx) = oneshot::channel();
-    let sink_config = CompletionSinkConfig::new(EVENT_COUNT, sink_done_tx);
-
-    let mut config = Config::builder();
-    config.add_source(&source_id, source_config);
-    // Default: measure_cpu_usage = false
-    config.add_transform(
-        transform_id,
-        &[source_id.as_str()],
-        NoopTransformConfig::from(TransformType::Function),
-    );
-    config.add_sink(&sink_id, &[transform_id], sink_config);
-
-    let (topology, _) = start_topology(config.build().unwrap(), false).await;
-
-    for idx in 0..EVENT_COUNT {
-        let event = Event::Log(LogEvent::from(format!("payload-{idx}")));
-        source_tx.send_event(event).await.unwrap();
-    }
-    drop(source_tx);
-
-    timeout(Duration::from_secs(5), sink_done_rx)
-        .await
-        .expect("timed out")
-        .expect("sender dropped");
-
-    topology.stop().await;
-
-    let metrics = controller.capture_metrics();
     let found = metrics
         .iter()
-        .any(|m| m.name() == "component_cpu_usage_ns_total" && has_transform_tags(m, transform_id));
+        .any(|m| m.name() == "component_cpu_usage_ns_total" && has_transform_tags(m, id));
 
     assert!(
         !found,

--- a/src/topology/test/mod.rs
+++ b/src/topology/test/mod.rs
@@ -34,6 +34,7 @@ use crate::{
 
 mod backpressure;
 mod compliance;
+#[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
 mod cpu_metrics;
 #[cfg(all(feature = "sinks-socket", feature = "sources-socket"))]
 mod crash;

--- a/src/topology/test/mod.rs
+++ b/src/topology/test/mod.rs
@@ -34,6 +34,7 @@ use crate::{
 
 mod backpressure;
 mod compliance;
+mod cpu_metrics;
 #[cfg(all(feature = "sinks-socket", feature = "sources-socket"))]
 mod crash;
 mod doesnt_reload;


### PR DESCRIPTION
## Summary

Component CPU usage measurement was added in https://github.com/vectordotdev/vector/pull/25317 but there no regression test was added. This PR adds one to make sure that the metric is correctly produced if measure_cpu_usage is set on a transform (and not produced if it is not set).

## Vector configuration


n/a

## How did you test this PR?

Unit test

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Closes: #<issue/PR number or link>
-->
<!--
- Related: #<issue/PR number or link>
-->

## Notes

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details on the [dd-rust-license-tool](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert, perf
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional but appreciated; letters, digits, spaces, hyphens, underscores (e.g. `kafka source`, `amazon-linux`)
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
