### PR TITLE
chore(tests): convert test config strings from TOML to YAML

### DIFF
--- a/src/aws/auth.rs
+++ b/src/aws/auth.rs
@@ -416,6 +416,7 @@ async fn default_credentials_provider(
 
 #[cfg(test)]
 mod tests {
+    use indoc::indoc;
     use serde::{Deserialize, Serialize};
 
     use super::*;
@@ -433,18 +434,17 @@ mod tests {
 
     #[test]
     fn parsing_default() {
-        let config = toml::from_str::<ComponentConfig>("").unwrap();
+        let config = serde_yaml::from_str::<ComponentConfig>("").unwrap();
 
         assert!(matches!(config.auth, AwsAuthentication::Default { .. }));
     }
 
     #[test]
     fn parsing_default_with_load_timeout() {
-        let config = toml::from_str::<ComponentConfig>(
-            "
-            auth.load_timeout_secs = 10
-        ",
-        )
+        let config = serde_yaml::from_str::<ComponentConfig>(indoc! {"
+            auth:
+              load_timeout_secs: 10
+        "})
         .unwrap();
 
         assert!(matches!(
@@ -459,11 +459,10 @@ mod tests {
 
     #[test]
     fn parsing_default_with_region() {
-        let config = toml::from_str::<ComponentConfig>(
-            r#"
-            auth.region = "us-east-2"
-        "#,
-        )
+        let config = serde_yaml::from_str::<ComponentConfig>(indoc! {r#"
+            auth:
+              region: "us-east-2"
+        "#})
         .unwrap();
 
         match config.auth {
@@ -476,13 +475,13 @@ mod tests {
 
     #[test]
     fn parsing_default_with_imds_client() {
-        let config = toml::from_str::<ComponentConfig>(
-            "
-            auth.imds.max_attempts = 5
-            auth.imds.connect_timeout_seconds = 30
-            auth.imds.read_timeout_seconds = 10
-        ",
-        )
+        let config = serde_yaml::from_str::<ComponentConfig>(indoc! {"
+            auth:
+              imds:
+                max_attempts: 5
+                connect_timeout_seconds: 30
+                read_timeout_seconds: 10
+        "})
         .unwrap();
 
         assert!(matches!(
@@ -501,11 +500,9 @@ mod tests {
 
     #[test]
     fn parsing_old_assume_role() {
-        let config = toml::from_str::<ComponentConfig>(
-            r#"
-            assume_role = "root"
-        "#,
-        )
+        let config = serde_yaml::from_str::<ComponentConfig>(indoc! {r#"
+            assume_role: "root"
+        "#})
         .unwrap();
 
         assert!(matches!(config.auth, AwsAuthentication::Default { .. }));
@@ -513,12 +510,11 @@ mod tests {
 
     #[test]
     fn parsing_assume_role() {
-        let config = toml::from_str::<ComponentConfig>(
-            r#"
-            auth.assume_role = "root"
-            auth.load_timeout_secs = 10
-        "#,
-        )
+        let config = serde_yaml::from_str::<ComponentConfig>(indoc! {r#"
+            auth:
+              assume_role: "root"
+              load_timeout_secs: 10
+        "#})
         .unwrap();
 
         assert!(matches!(config.auth, AwsAuthentication::Role { .. }));
@@ -526,13 +522,12 @@ mod tests {
 
     #[test]
     fn parsing_external_id_with_assume_role() {
-        let config = toml::from_str::<ComponentConfig>(
-            r#"
-            auth.assume_role = "root"
-            auth.external_id = "id"
-            auth.load_timeout_secs = 10
-        "#,
-        )
+        let config = serde_yaml::from_str::<ComponentConfig>(indoc! {r#"
+            auth:
+              assume_role: "root"
+              external_id: "id"
+              load_timeout_secs: 10
+        "#})
         .unwrap();
 
         assert!(matches!(config.auth, AwsAuthentication::Role { .. }));
@@ -540,13 +535,12 @@ mod tests {
 
     #[test]
     fn parsing_session_name_with_assume_role() {
-        let config = toml::from_str::<ComponentConfig>(
-            r#"
-            auth.assume_role = "root"
-            auth.session_name = "session_name"
-            auth.load_timeout_secs = 10
-        "#,
-        )
+        let config = serde_yaml::from_str::<ComponentConfig>(indoc! {r#"
+            auth:
+              assume_role: "root"
+              session_name: "session_name"
+              load_timeout_secs: 10
+        "#})
         .unwrap();
 
         match config.auth {
@@ -559,14 +553,14 @@ mod tests {
 
     #[test]
     fn parsing_assume_role_with_imds_client() {
-        let config = toml::from_str::<ComponentConfig>(
-            r#"
-            auth.assume_role = "root"
-            auth.imds.max_attempts = 5
-            auth.imds.connect_timeout_seconds = 30
-            auth.imds.read_timeout_seconds = 10
-        "#,
-        )
+        let config = serde_yaml::from_str::<ComponentConfig>(indoc! {r#"
+            auth:
+              assume_role: "root"
+              imds:
+                max_attempts: 5
+                connect_timeout_seconds: 30
+                read_timeout_seconds: 10
+        "#})
         .unwrap();
 
         match config.auth {
@@ -598,14 +592,13 @@ mod tests {
 
     #[test]
     fn parsing_both_assume_role() {
-        let config = toml::from_str::<ComponentConfig>(
-            r#"
-            assume_role = "root"
-            auth.assume_role = "auth.root"
-            auth.load_timeout_secs = 10
-            auth.region = "us-west-2"
-        "#,
-        )
+        let config = serde_yaml::from_str::<ComponentConfig>(indoc! {r#"
+            assume_role: "root"
+            auth:
+              assume_role: "auth.root"
+              load_timeout_secs: 10
+              region: "us-west-2"
+        "#})
         .unwrap();
 
         match config.auth {
@@ -630,12 +623,11 @@ mod tests {
 
     #[test]
     fn parsing_static() {
-        let config = toml::from_str::<ComponentConfig>(
-            r#"
-            auth.access_key_id = "key"
-            auth.secret_access_key = "other"
-        "#,
-        )
+        let config = serde_yaml::from_str::<ComponentConfig>(indoc! {r#"
+            auth:
+              access_key_id: "key"
+              secret_access_key: "other"
+        "#})
         .unwrap();
 
         assert!(matches!(config.auth, AwsAuthentication::AccessKey { .. }));
@@ -643,13 +635,12 @@ mod tests {
 
     #[test]
     fn parsing_static_with_assume_role() {
-        let config = toml::from_str::<ComponentConfig>(
-            r#"
-            auth.access_key_id = "key"
-            auth.secret_access_key = "other"
-            auth.assume_role = "root"
-        "#,
-        )
+        let config = serde_yaml::from_str::<ComponentConfig>(indoc! {r#"
+            auth:
+              access_key_id: "key"
+              secret_access_key: "other"
+              assume_role: "root"
+        "#})
         .unwrap();
 
         match config.auth {
@@ -672,14 +663,13 @@ mod tests {
 
     #[test]
     fn parsing_static_with_assume_role_and_external_id() {
-        let config = toml::from_str::<ComponentConfig>(
-            r#"
-            auth.access_key_id = "key"
-            auth.secret_access_key = "other"
-            auth.assume_role = "root"
-            auth.external_id = "id"
-        "#,
-        )
+        let config = serde_yaml::from_str::<ComponentConfig>(indoc! {r#"
+            auth:
+              access_key_id: "key"
+              secret_access_key: "other"
+              assume_role: "root"
+              external_id: "id"
+        "#})
         .unwrap();
 
         match config.auth {
@@ -704,13 +694,12 @@ mod tests {
 
     #[test]
     fn parsing_file() {
-        let config = toml::from_str::<ComponentConfig>(
-            r#"
-            auth.credentials_file = "/path/to/file"
-            auth.profile = "foo"
-            auth.region = "us-west-2"
-        "#,
-        )
+        let config = serde_yaml::from_str::<ComponentConfig>(indoc! {r#"
+            auth:
+              credentials_file: "/path/to/file"
+              profile: "foo"
+              region: "us-west-2"
+        "#})
         .unwrap();
 
         match config.auth {
@@ -726,11 +715,10 @@ mod tests {
             _ => panic!(),
         }
 
-        let config = toml::from_str::<ComponentConfig>(
-            r#"
-            auth.credentials_file = "/path/to/file"
-        "#,
-        )
+        let config = serde_yaml::from_str::<ComponentConfig>(indoc! {r#"
+            auth:
+              credentials_file: "/path/to/file"
+        "#})
         .unwrap();
 
         match config.auth {

--- a/src/aws/region.rs
+++ b/src/aws/region.rs
@@ -56,7 +56,7 @@ mod tests {
     #[test]
     fn optional() {
         assert!(
-            toml::from_str::<RegionOrEndpoint>(indoc! {"
+            serde_yaml::from_str::<RegionOrEndpoint>(indoc! {"
             "})
             .is_ok()
         );
@@ -65,8 +65,8 @@ mod tests {
     #[test]
     fn region_optional() {
         assert!(
-            toml::from_str::<RegionOrEndpoint>(indoc! {r#"
-            endpoint = "http://localhost:8080"
+            serde_yaml::from_str::<RegionOrEndpoint>(indoc! {r#"
+            endpoint: "http://localhost:8080"
         "#})
             .is_ok()
         );
@@ -75,8 +75,8 @@ mod tests {
     #[test]
     fn endpoint_optional() {
         assert!(
-            toml::from_str::<RegionOrEndpoint>(indoc! {r#"
-            region = "us-east-1"
+            serde_yaml::from_str::<RegionOrEndpoint>(indoc! {r#"
+            region: "us-east-1"
         "#})
             .is_ok()
         );

--- a/src/aws/timeout.rs
+++ b/src/aws/timeout.rs
@@ -69,13 +69,11 @@ mod tests {
 
     #[test]
     fn parsing_timeout_configuration() {
-        let config = toml::from_str::<AwsTimeout>(
-            r"
-            connect_timeout_seconds = 20
-            operation_timeout_seconds = 20
-            read_timeout_seconds = 60
-        ",
-        )
+        let config = serde_yaml::from_str::<AwsTimeout>(indoc::indoc! {r"
+            connect_timeout_seconds: 20
+            operation_timeout_seconds: 20
+            read_timeout_seconds: 60
+        "})
         .unwrap();
 
         assert_eq!(config.connect_timeout, Some(20));

--- a/src/conditions/mod.rs
+++ b/src/conditions/mod.rs
@@ -232,7 +232,7 @@ mod tests {
 
     #[test]
     fn deserialize_anycondition_default() {
-        let conf: Test = toml::from_str(r#"condition = ".nork == false""#).unwrap();
+        let conf: Test = serde_yaml::from_str(r#"condition: ".nork == false""#).unwrap();
         assert_eq!(
             r#"String(".nork == false")"#,
             format!("{:?}", conf.condition)
@@ -241,10 +241,11 @@ mod tests {
 
     #[test]
     fn deserialize_anycondition_vrl() {
-        let conf: Test = toml::from_str(indoc! {r#"
-            condition.type = "vrl"
-            condition.source = '.nork == true'
-        "#})
+        let conf: Test = serde_yaml::from_str(indoc! {"
+            condition:
+              type: vrl
+              source: '.nork == true'
+        "})
         .unwrap();
 
         assert_eq!(

--- a/src/config/unit_test/tests.rs
+++ b/src/config/unit_test/tests.rs
@@ -7,26 +7,24 @@ use crate::config::ConfigBuilder;
 async fn parse_no_input() {
     crate::test_util::trace_init();
 
-    let config: ConfigBuilder = toml::from_str(indoc! {r#"
-        [transforms.bar]
-          inputs = ["foo"]
-          type = "remap"
-          source = '''
-          .my_string_field = "string value"
-          '''
-
-          [[tests]]
-            name = "broken test"
-
-          [tests.input]
-            insert_at = "foo"
-            value = "nah this doesnt matter"
-
-          [[tests.outputs]]
-            extract_from = "bar"
-            [[tests.outputs.conditions]]
-              type = "vrl"
-              source = ""
+    let config: ConfigBuilder = serde_yaml::from_str(indoc! {r#"
+        transforms:
+          bar:
+            inputs:
+              - foo
+            type: remap
+            source: |
+              .my_string_field = "string value"
+        tests:
+          - name: "broken test"
+            input:
+              insert_at: foo
+              value: "nah this doesnt matter"
+            outputs:
+              - extract_from: bar
+                conditions:
+                  - type: vrl
+                    source: ""
     "#})
     .unwrap();
 
@@ -41,30 +39,26 @@ async fn parse_no_input() {
         ]
     );
 
-    let config: ConfigBuilder = toml::from_str(indoc! {r#"
-        [transforms.bar]
-          inputs = ["foo"]
-          type = "remap"
-          source = '''
-          .my_string_field = "string value"
-          '''
-
-          [[tests]]
-            name = "broken test"
-
-          [[tests.inputs]]
-            insert_at = "bar"
-            value = "nah this doesnt matter"
-
-          [[tests.inputs]]
-            insert_at = "foo"
-            value = "nah this doesnt matter"
-
-          [[tests.outputs]]
-            extract_from = "bar"
-            [[tests.outputs.conditions]]
-              type = "vrl"
-              source = ""
+    let config: ConfigBuilder = serde_yaml::from_str(indoc! {r#"
+        transforms:
+          bar:
+            inputs:
+              - foo
+            type: remap
+            source: |
+              .my_string_field = "string value"
+        tests:
+          - name: "broken test"
+            inputs:
+              - insert_at: bar
+                value: "nah this doesnt matter"
+              - insert_at: foo
+                value: "nah this doesnt matter"
+            outputs:
+              - extract_from: bar
+                conditions:
+                  - type: vrl
+                    source: ""
     "#})
     .unwrap();
 
@@ -84,22 +78,21 @@ async fn parse_no_input() {
 async fn parse_no_test_input() {
     crate::test_util::trace_init();
 
-    let config: ConfigBuilder = toml::from_str(indoc! {r#"
-        [transforms.bar]
-          inputs = ["foo"]
-          type = "remap"
-          source = '''
-          .my_string_field = "string value"
-          '''
-
-          [[tests]]
-            name = "broken test"
-
-          [[tests.outputs]]
-            extract_from = "bar"
-            [[tests.outputs.conditions]]
-              type = "vrl"
-              source = ""
+    let config: ConfigBuilder = serde_yaml::from_str(indoc! {r#"
+        transforms:
+          bar:
+            inputs:
+              - foo
+            type: remap
+            source: |
+              .my_string_field = "string value"
+        tests:
+          - name: "broken test"
+            outputs:
+              - extract_from: bar
+                conditions:
+                  - type: vrl
+                    source: ""
     "#})
     .unwrap();
 
@@ -119,20 +112,19 @@ async fn parse_no_test_input() {
 async fn parse_no_outputs() {
     crate::test_util::trace_init();
 
-    let config: ConfigBuilder = toml::from_str(indoc! {r#"
-        [transforms.foo]
-          inputs = ["ignored"]
-          type = "remap"
-          source = '''
-          .my_string_field = "string value"
-          '''
-
-          [[tests]]
-            name = "broken test"
-
-          [tests.input]
-            insert_at = "foo"
-            value = "nah this doesnt matter"
+    let config: ConfigBuilder = serde_yaml::from_str(indoc! {r#"
+        transforms:
+          foo:
+            inputs:
+              - ignored
+            type: remap
+            source: |
+              .my_string_field = "string value"
+        tests:
+          - name: "broken test"
+            input:
+              insert_at: foo
+              value: "nah this doesnt matter"
     "#})
     .unwrap();
 
@@ -152,26 +144,24 @@ async fn parse_no_outputs() {
 async fn parse_invalid_output_targets() {
     crate::test_util::trace_init();
 
-    let config: ConfigBuilder = toml::from_str(indoc! {r#"
-        [transforms.bar]
-          inputs = ["foo"]
-          type = "remap"
-          source = '''
-          .my_string_field = "string value"
-          '''
-
-          [[tests]]
-            name = "broken test"
-
-          [tests.input]
-            insert_at = "bar"
-            value = "any value"
-
-          [[tests.outputs]]
-            extract_from = "nonexistent"
-            [[tests.outputs.conditions]]
-              type = "vrl"
-              source = ""
+    let config: ConfigBuilder = serde_yaml::from_str(indoc! {r#"
+        transforms:
+          bar:
+            inputs:
+              - foo
+            type: remap
+            source: |
+              .my_string_field = "string value"
+        tests:
+          - name: "broken test"
+            input:
+              insert_at: bar
+              value: "any value"
+            outputs:
+              - extract_from: nonexistent
+                conditions:
+                  - type: vrl
+                    source: ""
     "#})
     .unwrap();
 
@@ -186,21 +176,21 @@ async fn parse_invalid_output_targets() {
         ]
     );
 
-    let config: ConfigBuilder = toml::from_str(indoc! {r#"
-        [transforms.bar]
-          inputs = ["foo"]
-          type = "remap"
-          source = '''
-          .my_string_field = "string value"
-          '''
-
-          [[tests]]
-            name = "broken test"
-            no_outputs_from = [ "nonexistent" ]
-
-          [[tests.inputs]]
-            insert_at = "bar"
-            value = "any value"
+    let config: ConfigBuilder = serde_yaml::from_str(indoc! {r#"
+        transforms:
+          bar:
+            inputs:
+              - foo
+            type: remap
+            source: |
+              .my_string_field = "string value"
+        tests:
+          - name: "broken test"
+            no_outputs_from:
+              - nonexistent
+            inputs:
+              - insert_at: bar
+                value: "any value"
     "#})
     .unwrap();
 
@@ -220,99 +210,76 @@ async fn parse_invalid_output_targets() {
 async fn parse_broken_topology() {
     crate::test_util::trace_init();
 
-    let config: ConfigBuilder = toml::from_str(indoc! {r#"
-        [transforms.foo]
-          inputs = ["something"]
-          type = "remap"
-          source = '''
-          .mfoo_field = "string value"
-          '''
-
-        [transforms.nah]
-          inputs = ["ignored"]
-          type = "remap"
-          source = '''
-          .new_field = "string value"
-          '''
-
-        [transforms.baz]
-          inputs = ["bar"]
-          type = "remap"
-          source = '''
-          .baz_field = "string value"
-          '''
-
-        [transforms.quz]
-          inputs = ["bar"]
-          type = "remap"
-          source = '''
-          .quz_field = "string value"
-          '''
-
-        [[tests]]
-          name = "broken test"
-
-          [tests.input]
-            insert_at = "foo"
-            value = "nah this doesnt matter"
-
-          [[tests.outputs]]
-            extract_from = "baz"
-            [[tests.outputs.conditions]]
-              type = "vrl"
-              source = """
-                assert_eq!(.message, "not this")
-              """
-
-          [[tests.outputs]]
-            extract_from = "quz"
-            [[tests.outputs.conditions]]
-              type = "vrl"
-              source = """
-                assert_eq!(.message, "not this")
-              """
-
-        [[tests]]
-          name = "broken test 2"
-
-          [[tests.inputs]]
-            insert_at = "foo"
-            value = "nah this doesnt matter"
-
-          [[tests.inputs]]
-            insert_at = "nah"
-            value = "nah this doesnt matter"
-
-          [[tests.outputs]]
-            extract_from = "baz"
-            [[tests.outputs.conditions]]
-              type = "vrl"
-              source = """
-                assert_eq!(.message, "not this")
-              """
-
-          [[tests.outputs]]
-            extract_from = "quz"
-            [[tests.outputs.conditions]]
-              type = "vrl"
-              source = """
-                assert_eq!(.message, "not this")
-              """
-
-        [[tests]]
-          name = "successful test"
-          [[tests.inputs]]
-          insert_at = "foo"
-          value = "this does matter"
-
-        [[tests.outputs]]
-          extract_from = "foo"
-          [[tests.outputs.conditions]]
-            type = "vrl"
-            source = """
-            assert_eq!(.message, "this does matter")
-            assert_eq!(.foo_field, "string value")
-            """
+    let config: ConfigBuilder = serde_yaml::from_str(indoc! {r#"
+        transforms:
+          foo:
+            inputs:
+              - something
+            type: remap
+            source: |
+              .mfoo_field = "string value"
+          nah:
+            inputs:
+              - ignored
+            type: remap
+            source: |
+              .new_field = "string value"
+          baz:
+            inputs:
+              - bar
+            type: remap
+            source: |
+              .baz_field = "string value"
+          quz:
+            inputs:
+              - bar
+            type: remap
+            source: |
+              .quz_field = "string value"
+        tests:
+          - name: "broken test"
+            input:
+              insert_at: foo
+              value: "nah this doesnt matter"
+            outputs:
+              - extract_from: baz
+                conditions:
+                  - type: vrl
+                    source: |
+                      assert_eq!(.message, "not this")
+              - extract_from: quz
+                conditions:
+                  - type: vrl
+                    source: |
+                      assert_eq!(.message, "not this")
+          - name: "broken test 2"
+            inputs:
+              - insert_at: foo
+                value: "nah this doesnt matter"
+              - insert_at: nah
+                value: "nah this doesnt matter"
+            outputs:
+              - extract_from: baz
+                conditions:
+                  - type: vrl
+                    source: |
+                      assert_eq!(.message, "not this")
+              - extract_from: quz
+                conditions:
+                  - type: vrl
+                    source: |
+                      assert_eq!(.message, "not this")
+          - name: "successful test"
+            inputs:
+              - insert_at: foo
+                value: "this does matter"
+            outputs:
+              - extract_from: foo
+                conditions:
+                  - type: vrl
+                    source: |
+                      assert_eq!(.message, "this does matter")
+                      assert_eq!(.foo_field, "string value")
     "#})
     .unwrap();
 
@@ -323,27 +290,25 @@ async fn parse_broken_topology() {
 async fn parse_bad_input_event() {
     crate::test_util::trace_init();
 
-    let config: ConfigBuilder = toml::from_str(indoc! {r#"
-        [transforms.foo]
-          inputs = ["ignored"]
-          type = "remap"
-          source = '''
-          .my_string_field = "string value"
-          '''
-
-          [[tests]]
-            name = "broken test"
-
-          [tests.input]
-            insert_at = "foo"
-            type = "nah"
-            value = "nah this doesnt matter"
-
-          [[tests.outputs]]
-            extract_from = "foo"
-            [[tests.outputs.conditions]]
-              type = "vrl"
-              source = ""
+    let config: ConfigBuilder = serde_yaml::from_str(indoc! {r#"
+        transforms:
+          foo:
+            inputs:
+              - ignored
+            type: remap
+            source: |
+              .my_string_field = "string value"
+        tests:
+          - name: "broken test"
+            input:
+              insert_at: foo
+              type: nah
+              value: "nah this doesnt matter"
+            outputs:
+              - extract_from: foo
+                conditions:
+                  - type: vrl
+                    source: ""
     "#})
     .unwrap();
 
@@ -363,99 +328,79 @@ async fn parse_bad_input_event() {
 async fn test_success_multi_inputs() {
     crate::test_util::trace_init();
 
-    let config: ConfigBuilder = toml::from_str(indoc! {r#"
-        [transforms.foo]
-          inputs = ["ignored"]
-          type = "remap"
-          source = '''
-          .new_field = "string value"
-          '''
-
-        [transforms.foo_two]
-          inputs = ["ignored"]
-          type = "remap"
-          source = '''
-          .new_field_two = "second string value"
-          '''
-
-        [transforms.bar]
-          inputs = ["foo", "foo_two"]
-          type = "remap"
-          source = '''
-          .second_new_field = "also a string value"
-          '''
-
-        [transforms.baz]
-          inputs = ["bar"]
-          type = "remap"
-          source = '''
-          .third_new_field = "also also a string value"
-          '''
-
-        [[tests]]
-          name = "successful test"
-
-          [[tests.inputs]]
-            insert_at = "foo"
-            value = "nah this doesnt matter"
-
-          [[tests.inputs]]
-            insert_at = "foo_two"
-            value = "nah this also doesnt matter"
-
-          [[tests.outputs]]
-            extract_from = "foo"
-            [[tests.outputs.conditions]]
-              type = "vrl"
-              source = """
-                assert_eq!(.new_field, "string value")
-                assert_eq!(.message, "nah this doesnt matter")
-              """
-
-          [[tests.outputs]]
-            extract_from = "foo_two"
-            [[tests.outputs.conditions]]
-              type = "vrl"
-              source = """
-                assert_eq!(.new_field_two, "second string value")
-                assert_eq!(.message, "nah this also doesnt matter")
-              """
-
-          [[tests.outputs]]
-            extract_from = "bar"
-            [[tests.outputs.conditions]]
-              type = "vrl"
-              source = """
-                assert_eq!(.new_field, "string value")
-                assert_eq!(.second_new_field, "also a string value")
-                assert_eq!(.message, "nah this doesnt matter")
-              """
-            [[tests.outputs.conditions]]
-              type = "vrl"
-              source = """
-                assert_eq!(.new_field_two, "second string value")
-                assert_eq!(.second_new_field, "also a string value")
-                assert_eq!(.message, "nah this also doesnt matter")
-              """
-
-          [[tests.outputs]]
-            extract_from = "baz"
-            [[tests.outputs.conditions]]
-              type = "vrl"
-              source = """
-                assert_eq!(.new_field, "string value")
-                assert_eq!(.second_new_field, "also a string value")
-                assert_eq!(.third_new_field, "also also a string value")
-                assert_eq!(.message, "nah this doesnt matter")
-              """
-            [[tests.outputs.conditions]]
-              type = "vrl"
-              source = """
-                assert_eq!(.new_field_two, "second string value")
-                assert_eq!(.second_new_field, "also a string value")
-                assert_eq!(.third_new_field, "also also a string value")
-                assert_eq!(.message, "nah this also doesnt matter")
-              """
+    let config: ConfigBuilder = serde_yaml::from_str(indoc! {r#"
+        transforms:
+          foo:
+            inputs:
+              - ignored
+            type: remap
+            source: |
+              .new_field = "string value"
+          foo_two:
+            inputs:
+              - ignored
+            type: remap
+            source: |
+              .new_field_two = "second string value"
+          bar:
+            inputs:
+              - foo
+              - foo_two
+            type: remap
+            source: |
+              .second_new_field = "also a string value"
+          baz:
+            inputs:
+              - bar
+            type: remap
+            source: |
+              .third_new_field = "also also a string value"
+        tests:
+          - name: "successful test"
+            inputs:
+              - insert_at: foo
+                value: "nah this doesnt matter"
+              - insert_at: foo_two
+                value: "nah this also doesnt matter"
+            outputs:
+              - extract_from: foo
+                conditions:
+                  - type: vrl
+                    source: |
+                      assert_eq!(.new_field, "string value")
+                      assert_eq!(.message, "nah this doesnt matter")
+              - extract_from: foo_two
+                conditions:
+                  - type: vrl
+                    source: |
+                      assert_eq!(.new_field_two, "second string value")
+                      assert_eq!(.message, "nah this also doesnt matter")
+              - extract_from: bar
+                conditions:
+                  - type: vrl
+                    source: |
+                      assert_eq!(.new_field, "string value")
+                      assert_eq!(.second_new_field, "also a string value")
+                      assert_eq!(.message, "nah this doesnt matter")
+                  - type: vrl
+                    source: |
+                      assert_eq!(.new_field_two, "second string value")
+                      assert_eq!(.second_new_field, "also a string value")
+                      assert_eq!(.message, "nah this also doesnt matter")
+              - extract_from: baz
+                conditions:
+                  - type: vrl
+                    source: |
+                      assert_eq!(.new_field, "string value")
+                      assert_eq!(.second_new_field, "also a string value")
+                      assert_eq!(.third_new_field, "also also a string value")
+                      assert_eq!(.message, "nah this doesnt matter")
+                  - type: vrl
+                    source: |
+                      assert_eq!(.new_field_two, "second string value")
+                      assert_eq!(.second_new_field, "also a string value")
+                      assert_eq!(.third_new_field, "also also a string value")
+                      assert_eq!(.message, "nah this also doesnt matter")
     "#})
     .unwrap();
 
@@ -467,64 +412,53 @@ async fn test_success_multi_inputs() {
 async fn test_success() {
     crate::test_util::trace_init();
 
-    let config: ConfigBuilder = toml::from_str(indoc! {r#"
-        [transforms.foo]
-          inputs = ["ignored"]
-          type = "remap"
-          source = '''
-          .new_field = "string value"
-          '''
-
-        [transforms.bar]
-          inputs = ["foo"]
-          type = "remap"
-          source = '''
-          .second_new_field = "also a string value"
-          '''
-
-        [transforms.baz]
-          inputs = ["bar"]
-          type = "remap"
-          source = '''
-          .third_new_field = "also also a string value"
-          '''
-
-        [[tests]]
-          name = "successful test"
-
-          [tests.input]
-            insert_at = "foo"
-            value = "nah this doesnt matter"
-
-          [[tests.outputs]]
-            extract_from = "foo"
-            [[tests.outputs.conditions]]
-              type = "vrl"
-              source = """
-                assert_eq!(.new_field, "string value")
-                assert_eq!(.message, "nah this doesnt matter")
-              """
-
-          [[tests.outputs]]
-            extract_from = "bar"
-            [[tests.outputs.conditions]]
-              type = "vrl"
-              source = """
-                assert_eq!(.new_field, "string value")
-                assert_eq!(.second_new_field, "also a string value")
-                assert_eq!(.message, "nah this doesnt matter")
-              """
-
-          [[tests.outputs]]
-            extract_from = "baz"
-            [[tests.outputs.conditions]]
-              type = "vrl"
-              source = """
-                assert_eq!(.new_field, "string value")
-                assert_eq!(.second_new_field, "also a string value")
-                assert_eq!(.third_new_field, "also also a string value")
-                assert_eq!(.message, "nah this doesnt matter")
-              """
+    let config: ConfigBuilder = serde_yaml::from_str(indoc! {r#"
+        transforms:
+          foo:
+            inputs:
+              - ignored
+            type: remap
+            source: |
+              .new_field = "string value"
+          bar:
+            inputs:
+              - foo
+            type: remap
+            source: |
+              .second_new_field = "also a string value"
+          baz:
+            inputs:
+              - bar
+            type: remap
+            source: |
+              .third_new_field = "also also a string value"
+        tests:
+          - name: "successful test"
+            input:
+              insert_at: foo
+              value: "nah this doesnt matter"
+            outputs:
+              - extract_from: foo
+                conditions:
+                  - type: vrl
+                    source: |
+                      assert_eq!(.new_field, "string value")
+                      assert_eq!(.message, "nah this doesnt matter")
+              - extract_from: bar
+                conditions:
+                  - type: vrl
+                    source: |
+                      assert_eq!(.new_field, "string value")
+                      assert_eq!(.second_new_field, "also a string value")
+                      assert_eq!(.message, "nah this doesnt matter")
+              - extract_from: baz
+                conditions:
+                  - type: vrl
+                    source: |
+                      assert_eq!(.new_field, "string value")
+                      assert_eq!(.second_new_field, "also a string value")
+                      assert_eq!(.third_new_field, "also also a string value")
+                      assert_eq!(.message, "nah this doesnt matter")
     "#})
     .unwrap();
 
@@ -536,60 +470,49 @@ async fn test_success() {
 async fn test_route() {
     crate::test_util::trace_init();
 
-    let config: ConfigBuilder = toml::from_str(indoc! {r#"
-          [transforms.foo]
-            inputs = ["ignored"]
-            type = "route"
-              [transforms.foo.route]
-              first = '.message == "test swimlane 1"'
-              second = '.message == "test swimlane 2"'
-
-          [transforms.bar]
-            inputs = ["foo.first"]
-            type = "remap"
-            source = '''
-            .new_field = "new field added"
-            '''
-
-          [[tests]]
-            name = "successful route test 1"
-
-            [tests.input]
-              insert_at = "foo"
-              value = "test swimlane 1"
-
-            [[tests.outputs]]
-              extract_from = "foo.first"
-              [[tests.outputs.conditions]]
-                type = "vrl"
-                source = """
-                    assert_eq!(.message, "test swimlane 1")
-                """
-
-            [[tests.outputs]]
-              extract_from = "bar"
-              [[tests.outputs.conditions]]
-                type = "vrl"
-                source = """
-                    assert_eq!(.message, "test swimlane 1")
-                    assert_eq!(.new_field, "new field added")
-                """
-
-          [[tests]]
-            name = "successful route test 2"
-
-            [tests.input]
-              insert_at = "foo"
-              value = "test swimlane 2"
-
-            [[tests.outputs]]
-              extract_from = "foo.second"
-              [[tests.outputs.conditions]]
-                type = "vrl"
-                source = """
-                    assert_eq!(.message, "test swimlane 2")
-                """
-      "#})
+    let config: ConfigBuilder = serde_yaml::from_str(indoc! {r#"
+        transforms:
+          foo:
+            inputs:
+              - ignored
+            type: route
+            route:
+              first: '.message == "test swimlane 1"'
+              second: '.message == "test swimlane 2"'
+          bar:
+            inputs:
+              - foo.first
+            type: remap
+            source: |
+              .new_field = "new field added"
+        tests:
+          - name: "successful route test 1"
+            input:
+              insert_at: foo
+              value: "test swimlane 1"
+            outputs:
+              - extract_from: foo.first
+                conditions:
+                  - type: vrl
+                    source: |
+                      assert_eq!(.message, "test swimlane 1")
+              - extract_from: bar
+                conditions:
+                  - type: vrl
+                    source: |
+                      assert_eq!(.message, "test swimlane 1")
+                      assert_eq!(.new_field, "new field added")
+          - name: "successful route test 2"
+            input:
+              insert_at: foo
+              value: "test swimlane 2"
+            outputs:
+              - extract_from: foo.second
+                conditions:
+                  - type: vrl
+                    source: |
+                      assert_eq!(.message, "test swimlane 2")
+    "#})
     .unwrap();
 
     let mut tests = build_unit_tests(config).await.unwrap();
@@ -600,31 +523,29 @@ async fn test_route() {
 async fn test_fail_no_outputs() {
     crate::test_util::trace_init();
 
-    let config: ConfigBuilder = toml::from_str(indoc! {r#"
-          [transforms.foo]
-            inputs = [ "TODO" ]
-            type = "filter"
-            [transforms.foo.condition]
-              type = "vrl"
-              source = """
+    let config: ConfigBuilder = serde_yaml::from_str(indoc! {r#"
+        transforms:
+          foo:
+            inputs:
+              - TODO
+            type: filter
+            condition:
+              type: vrl
+              source: |
                 .not_exist == "not_value"
-              """
-
-            [[tests]]
-              name = "check_no_outputs"
-              [tests.input]
-                insert_at = "foo"
-                type = "raw"
-                value = "test value"
-
-              [[tests.outputs]]
-                extract_from = "foo"
-                [[tests.outputs.conditions]]
-                  type = "vrl"
-                  source = """
-                    assert_eq!(.message, "test value")
-                  """
-      "#})
+        tests:
+          - name: check_no_outputs
+            input:
+              insert_at: foo
+              type: raw
+              value: "test value"
+            outputs:
+              - extract_from: foo
+                conditions:
+                  - type: vrl
+                    source: |
+                      assert_eq!(.message, "test value")
+    "#})
     .unwrap();
 
     let mut tests = build_unit_tests(config).await.unwrap();
@@ -635,76 +556,61 @@ async fn test_fail_no_outputs() {
 async fn test_fail_two_output_events() {
     crate::test_util::trace_init();
 
-    let config: ConfigBuilder = toml::from_str(indoc! {r#"
-          [transforms.foo]
-            inputs = [ "TODO" ]
-            type = "remap"
-            source = '''
-            .foo = "new field 1"
-            '''
-
-          [transforms.bar]
-            inputs = [ "foo" ]
-            type = "remap"
-            source = '''
-            .bar = "new field 2"
-            '''
-
-          [transforms.baz]
-            inputs = [ "foo" ]
-            type = "remap"
-            source = '''
-            .baz = "new field 3"
-            '''
-
-          [transforms.boo]
-            inputs = [ "bar", "baz" ]
-            type = "remap"
-            source = '''
-            .boo = "new field 4"
-            '''
-
-          [[tests]]
-            name = "check_multi_payloads"
-
-            [tests.input]
-              insert_at = "foo"
-              type = "raw"
-              value = "first"
-
-            [[tests.outputs]]
-              extract_from = "boo"
-
-              [[tests.outputs.conditions]]
-                type = "vrl"
-                source = """
-                  assert_eq!(.baz, "new field 3")
-                """
-
-              [[tests.outputs.conditions]]
-                type = "vrl"
-                source = """
-                  assert_eq!(.bar, "new field 2")
-                """
-
-          [[tests]]
-            name = "check_multi_payloads_bad"
-
-            [tests.input]
-              insert_at = "foo"
-              type = "raw"
-              value = "first"
-
-            [[tests.outputs]]
-              extract_from = "boo"
-
-              [[tests.outputs.conditions]]
-                type = "vrl"
-                source = """
-                    assert_eq!(.baz, "new field 3")
-                    assert_eq!(.bar, "new field 2")
-                """
-      "#})
+    let config: ConfigBuilder = serde_yaml::from_str(indoc! {r#"
+        transforms:
+          foo:
+            inputs:
+              - TODO
+            type: remap
+            source: |
+              .foo = "new field 1"
+          bar:
+            inputs:
+              - foo
+            type: remap
+            source: |
+              .bar = "new field 2"
+          baz:
+            inputs:
+              - foo
+            type: remap
+            source: |
+              .baz = "new field 3"
+          boo:
+            inputs:
+              - bar
+              - baz
+            type: remap
+            source: |
+              .boo = "new field 4"
+        tests:
+          - name: check_multi_payloads
+            input:
+              insert_at: foo
+              type: raw
+              value: first
+            outputs:
+              - extract_from: boo
+                conditions:
+                  - type: vrl
+                    source: |
+                      assert_eq!(.baz, "new field 3")
+                  - type: vrl
+                    source: |
+                      assert_eq!(.bar, "new field 2")
+          - name: check_multi_payloads_bad
+            input:
+              insert_at: foo
+              type: raw
+              value: first
+            outputs:
+              - extract_from: boo
+                conditions:
+                  - type: vrl
+                    source: |
+                      assert_eq!(.baz, "new field 3")
+                      assert_eq!(.bar, "new field 2")
+    "#})
     .unwrap();
 
     let mut tests = build_unit_tests(config).await.unwrap();
@@ -716,34 +622,32 @@ async fn test_fail_two_output_events() {
 async fn test_no_outputs_from() {
     crate::test_util::trace_init();
 
-    let config: ConfigBuilder = toml::from_str(indoc! {r#"
-          [transforms.foo]
-            inputs = [ "ignored" ]
-            type = "filter"
-            [transforms.foo.condition]
-              type = "vrl"
-              source = """
+    let config: ConfigBuilder = serde_yaml::from_str(indoc! {r#"
+        transforms:
+          foo:
+            inputs:
+              - ignored
+            type: filter
+            condition:
+              type: vrl
+              source: |
                 .message == "foo"
-              """
-
-          [[tests]]
-            name = "check_no_outputs_from_succeeds"
-            no_outputs_from = [ "foo" ]
-
-            [tests.input]
-              insert_at = "foo"
-              type = "raw"
-              value = "not foo at all"
-
-          [[tests]]
-            name = "check_no_outputs_from_fails"
-            no_outputs_from = [ "foo" ]
-
-            [tests.input]
-              insert_at = "foo"
-              type = "raw"
-              value = "foo"
-      "#})
+        tests:
+          - name: check_no_outputs_from_succeeds
+            no_outputs_from:
+              - foo
+            input:
+              insert_at: foo
+              type: raw
+              value: "not foo at all"
+          - name: check_no_outputs_from_fails
+            no_outputs_from:
+              - foo
+            input:
+              insert_at: foo
+              type: raw
+              value: foo
+    "#})
     .unwrap();
 
     let mut tests = build_unit_tests(config).await.unwrap();
@@ -755,41 +659,38 @@ async fn test_no_outputs_from() {
 async fn test_no_outputs_from_chained() {
     crate::test_util::trace_init();
 
-    let config: ConfigBuilder = toml::from_str(indoc! { r#"
-          [transforms.foo]
-            inputs = [ "ignored" ]
-            type = "filter"
-            [transforms.foo.condition]
-              type = "vrl"
-              source = """
+    let config: ConfigBuilder = serde_yaml::from_str(indoc! {r#"
+        transforms:
+          foo:
+            inputs:
+              - ignored
+            type: filter
+            condition:
+              type: vrl
+              source: |
                 .message == "foo"
-              """
-
-          [transforms.bar]
-            inputs = [ "foo" ]
-            type = "remap"
-            source = '''
-            .bar = "new field"
-            '''
-
-          [[tests]]
-            name = "check_no_outputs_from_succeeds"
-            no_outputs_from = [ "bar" ]
-
-            [tests.input]
-              insert_at = "foo"
-              type = "raw"
-              value = "not foo at all"
-
-          [[tests]]
-            name = "check_no_outputs_from_fails"
-            no_outputs_from = [ "bar" ]
-
-            [tests.input]
-              insert_at = "foo"
-              type = "raw"
-              value = "foo"
-      "#})
+          bar:
+            inputs:
+              - foo
+            type: remap
+            source: |
+              .bar = "new field"
+        tests:
+          - name: check_no_outputs_from_succeeds
+            no_outputs_from:
+              - bar
+            input:
+              insert_at: foo
+              type: raw
+              value: "not foo at all"
+          - name: check_no_outputs_from_fails
+            no_outputs_from:
+              - bar
+            input:
+              insert_at: foo
+              type: raw
+              value: foo
+    "#})
     .unwrap();
 
     let mut tests = build_unit_tests(config).await.unwrap();
@@ -801,44 +702,47 @@ async fn test_no_outputs_from_chained() {
 async fn test_log_input() {
     crate::test_util::trace_init();
 
-    let config: ConfigBuilder = toml::from_str(indoc! { r#"
-          [transforms.foo]
-            inputs = ["ignored"]
-            type = "remap"
-            source = '''
-            .new_field = "string value"
-            '''
-
-          [[tests]]
-            name = "successful test with log event"
-
-            [tests.input]
-              insert_at = "foo"
-              type = "log"
-              [tests.input.log_fields]
-                message = "this is the message"
-                int_val = 5
-                bool_val = true
-                arr_val = [1, 2, "hi", false]
-                obj_val = { a =  true, b = "b", c = 5 }
-
-
-            [[tests.outputs]]
-              extract_from = "foo"
-              [[tests.outputs.conditions]]
-                type = "vrl"
-                source = """
-                    assert_eq!(.new_field, "string value")
-                    assert_eq!(.message, "this is the message")
-                    assert_eq!(.message, "this is the message")
-                    assert!(.bool_val)
-                    assert_eq!(.int_val, 5)
-                    assert_eq!(.arr_val, [1, 2, "hi", false])
-                    assert!(.obj_val.a)
-                    assert_eq!(.obj_val.b, "b")
-                    assert_eq!(.obj_val.c, 5)
-                """
-      "#})
+    let config: ConfigBuilder = serde_yaml::from_str(indoc! {r#"
+        transforms:
+          foo:
+            inputs:
+              - ignored
+            type: remap
+            source: |
+              .new_field = "string value"
+        tests:
+          - name: "successful test with log event"
+            input:
+              insert_at: foo
+              type: log
+              log_fields:
+                message: "this is the message"
+                int_val: 5
+                bool_val: true
+                arr_val:
+                  - 1
+                  - 2
+                  - hi
+                  - false
+                obj_val:
+                  a: true
+                  b: b
+                  c: 5
+            outputs:
+              - extract_from: foo
+                conditions:
+                  - type: vrl
+                    source: |
+                      assert_eq!(.new_field, "string value")
+                      assert_eq!(.message, "this is the message")
+                      assert_eq!(.message, "this is the message")
+                      assert!(.bool_val)
+                      assert_eq!(.int_val, 5)
+                      assert_eq!(.arr_val, [1, 2, "hi", false])
+                      assert!(.obj_val.a)
+                      assert_eq!(.obj_val.b, "b")
+                      assert_eq!(.obj_val.c, 5)
+    "#})
     .unwrap();
 
     let mut tests = build_unit_tests(config).await.unwrap();
@@ -849,37 +753,34 @@ async fn test_log_input() {
 async fn test_metric_input() {
     crate::test_util::trace_init();
 
-    let config: ConfigBuilder = toml::from_str(indoc! { r#"
-          [transforms.foo]
-            inputs = ["ignored"]
-            type = "remap"
-            source = '''
-            .tags.new_tag = "new value added"
-            '''
-
-          [[tests]]
-            name = "successful test with metric event"
-
-            [tests.input]
-              insert_at = "foo"
-              type = "metric"
-              [tests.input.metric]
-                kind = "incremental"
-                name = "foometric"
-                [tests.input.metric.tags]
-                  tagfoo = "valfoo"
-                [tests.input.metric.counter]
-                  value = 100.0
-
-            [[tests.outputs]]
-              extract_from = "foo"
-              [[tests.outputs.conditions]]
-                type = "vrl"
-                source = """
-                    assert_eq!(.tags.tagfoo, "valfoo")
-                    assert_eq!(.tags.new_tag, "new value added")
-                """
-      "#})
+    let config: ConfigBuilder = serde_yaml::from_str(indoc! {r#"
+        transforms:
+          foo:
+            inputs:
+              - ignored
+            type: remap
+            source: |
+              .tags.new_tag = "new value added"
+        tests:
+          - name: "successful test with metric event"
+            input:
+              insert_at: foo
+              type: metric
+              metric:
+                kind: incremental
+                name: foometric
+                tags:
+                  tagfoo: valfoo
+                counter:
+                  value: 100.0
+            outputs:
+              - extract_from: foo
+                conditions:
+                  - type: vrl
+                    source: |
+                      assert_eq!(.tags.tagfoo, "valfoo")
+                      assert_eq!(.tags.new_tag, "new value added")
+    "#})
     .unwrap();
 
     let mut tests = build_unit_tests(config).await.unwrap();
@@ -890,46 +791,41 @@ async fn test_metric_input() {
 async fn test_success_over_gap() {
     crate::test_util::trace_init();
 
-    let config: ConfigBuilder = toml::from_str(indoc! { r#"
-          [transforms.foo]
-            inputs = ["ignored"]
-            type = "remap"
-            source = '''
-            .new_field = "string value"
-            '''
-
-          [transforms.bar]
-            inputs = ["foo"]
-            type = "remap"
-            source = '''
-            .second_new_field = "also a string value"
-            '''
-
-          [transforms.baz]
-            inputs = ["bar"]
-            type = "remap"
-            source = '''
-            .third_new_field = "also also a string value"
-            '''
-
-          [[tests]]
-            name = "successful test"
-
-            [tests.input]
-              insert_at = "foo"
-              value = "nah this doesnt matter"
-
-            [[tests.outputs]]
-              extract_from = "baz"
-              [[tests.outputs.conditions]]
-                type = "vrl"
-                source = """
-                    assert_eq!(.new_field, "string value")
-                    assert_eq!(.second_new_field, "also a string value")
-                    assert_eq!(.third_new_field, "also also a string value")
-                    assert_eq!(.message, "nah this doesnt matter")
-                """
-      "#})
+    let config: ConfigBuilder = serde_yaml::from_str(indoc! {r#"
+        transforms:
+          foo:
+            inputs:
+              - ignored
+            type: remap
+            source: |
+              .new_field = "string value"
+          bar:
+            inputs:
+              - foo
+            type: remap
+            source: |
+              .second_new_field = "also a string value"
+          baz:
+            inputs:
+              - bar
+            type: remap
+            source: |
+              .third_new_field = "also also a string value"
+        tests:
+          - name: "successful test"
+            input:
+              insert_at: foo
+              value: "nah this doesnt matter"
+            outputs:
+              - extract_from: baz
+                conditions:
+                  - type: vrl
+                    source: |
+                      assert_eq!(.new_field, "string value")
+                      assert_eq!(.second_new_field, "also a string value")
+                      assert_eq!(.third_new_field, "also also a string value")
+                      assert_eq!(.message, "nah this doesnt matter")
+    "#})
     .unwrap();
 
     let mut tests = build_unit_tests(config).await.unwrap();
@@ -940,62 +836,53 @@ async fn test_success_over_gap() {
 async fn test_success_tree() {
     crate::test_util::trace_init();
 
-    let config: ConfigBuilder = toml::from_str(indoc! { r#"
-          [transforms.ignored]
-            inputs = ["also_ignored"]
-            type = "remap"
-            source = '''
-            .not_field = "string value"
-            '''
-
-          [transforms.foo]
-            inputs = ["ignored"]
-            type = "remap"
-            source = '''
-            .new_field = "string value"
-            '''
-
-          [transforms.bar]
-            inputs = ["foo"]
-            type = "remap"
-            source = '''
-            .second_new_field = "also a string value"
-            '''
-
-          [transforms.baz]
-            inputs = ["foo"]
-            type = "remap"
-            source = '''
-            .second_new_field = "also also a string value"
-            '''
-
-          [[tests]]
-            name = "successful test"
-
-            [tests.input]
-              insert_at = "foo"
-              value = "nah this doesnt matter"
-
-            [[tests.outputs]]
-              extract_from = "bar"
-              [[tests.outputs.conditions]]
-                type = "vrl"
-                source = """
-                    assert_eq!(.new_field, "string value")
-                    assert_eq!(.second_new_field, "also a string value")
-                    assert_eq!(.message, "nah this doesnt matter")
-                """
-
-            [[tests.outputs]]
-              extract_from = "baz"
-              [[tests.outputs.conditions]]
-                type = "vrl"
-                source = """
-                    assert_eq!(.new_field, "string value")
-                    assert_eq!(.second_new_field, "also also a string value")
-                    assert_eq!(.message, "nah this doesnt matter")
-                """
-      "#})
+    let config: ConfigBuilder = serde_yaml::from_str(indoc! {r#"
+        transforms:
+          ignored:
+            inputs:
+              - also_ignored
+            type: remap
+            source: |
+              .not_field = "string value"
+          foo:
+            inputs:
+              - ignored
+            type: remap
+            source: |
+              .new_field = "string value"
+          bar:
+            inputs:
+              - foo
+            type: remap
+            source: |
+              .second_new_field = "also a string value"
+          baz:
+            inputs:
+              - foo
+            type: remap
+            source: |
+              .second_new_field = "also also a string value"
+        tests:
+          - name: "successful test"
+            input:
+              insert_at: foo
+              value: "nah this doesnt matter"
+            outputs:
+              - extract_from: bar
+                conditions:
+                  - type: vrl
+                    source: |
+                      assert_eq!(.new_field, "string value")
+                      assert_eq!(.second_new_field, "also a string value")
+                      assert_eq!(.message, "nah this doesnt matter")
+              - extract_from: baz
+                conditions:
+                  - type: vrl
+                    source: |
+                      assert_eq!(.new_field, "string value")
+                      assert_eq!(.second_new_field, "also also a string value")
+                      assert_eq!(.message, "nah this doesnt matter")
+    "#})
     .unwrap();
 
     let mut tests = build_unit_tests(config).await.unwrap();
@@ -1006,81 +893,63 @@ async fn test_success_tree() {
 async fn test_fails() {
     crate::test_util::trace_init();
 
-    let config: ConfigBuilder = toml::from_str(indoc! { r#"
-          [transforms.foo]
-            inputs = ["ignored"]
-            type = "remap"
-            source = '''
-            del(.timestamp)
-            '''
-
-          [transforms.bar]
-            inputs = ["foo"]
-            type = "remap"
-            source = '''
-            .second_new_field = "also a string value"
-            '''
-
-          [transforms.baz]
-            inputs = ["bar"]
-            type = "remap"
-            source = '''
-            .third_new_field = "also also a string value"
-            '''
-
-          [[tests]]
-            name = "failing test"
-
-            [tests.input]
-              insert_at = "foo"
-              value = "nah this doesnt matter"
-
-            [[tests.outputs]]
-              extract_from = "foo"
-              [[tests.outputs.conditions]]
-                type = "vrl"
-                source = """
-                  assert_eq!(.message, "nah this doesnt matter")
-                """
-
-            [[tests.outputs]]
-              extract_from = "bar"
-              [[tests.outputs.conditions]]
-                type = "vrl"
-                source = """
-                  assert_eq!(.message, "not this")
-                """
-              [[tests.outputs.conditions]]
-                type = "vrl"
-                source = """
-                  assert_eq!(.second_new_field, "and not this")
-                """
-
-          [[tests]]
-            name = "another failing test"
-
-            [tests.input]
-              insert_at = "foo"
-              value = "also this doesnt matter"
-
-            [[tests.outputs]]
-              extract_from = "foo"
-              [[tests.outputs.conditions]]
-                type = "vrl"
-                source = """
-                  assert_eq!(.message, "also this doesnt matter")
-                """
-
-            [[tests.outputs]]
-              extract_from = "baz"
-              [[tests.outputs.conditions]]
-                type = "vrl"
-                source = """
-                  assert_eq!(.second_new_field, "nope not this")
-                  assert_eq!(.third_new_field, "and not this")
-                  assert_eq!(.message, "also this doesnt matter")
-                """
-      "#})
+    let config: ConfigBuilder = serde_yaml::from_str(indoc! {r#"
+        transforms:
+          foo:
+            inputs:
+              - ignored
+            type: remap
+            source: |
+              del(.timestamp)
+          bar:
+            inputs:
+              - foo
+            type: remap
+            source: |
+              .second_new_field = "also a string value"
+          baz:
+            inputs:
+              - bar
+            type: remap
+            source: |
+              .third_new_field = "also also a string value"
+        tests:
+          - name: "failing test"
+            input:
+              insert_at: foo
+              value: "nah this doesnt matter"
+            outputs:
+              - extract_from: foo
+                conditions:
+                  - type: vrl
+                    source: |
+                      assert_eq!(.message, "nah this doesnt matter")
+              - extract_from: bar
+                conditions:
+                  - type: vrl
+                    source: |
+                      assert_eq!(.message, "not this")
+                  - type: vrl
+                    source: |
+                      assert_eq!(.second_new_field, "and not this")
+          - name: "another failing test"
+            input:
+              insert_at: foo
+              value: "also this doesnt matter"
+            outputs:
+              - extract_from: foo
+                conditions:
+                  - type: vrl
+                    source: |
+                      assert_eq!(.message, "also this doesnt matter")
+              - extract_from: baz
+                conditions:
+                  - type: vrl
+                    source: |
+                      assert_eq!(.second_new_field, "nope not this")
+                      assert_eq!(.third_new_field, "and not this")
+                      assert_eq!(.message, "also this doesnt matter")
+    "#})
     .unwrap();
 
     let mut tests = build_unit_tests(config).await.unwrap();
@@ -1092,80 +961,64 @@ async fn test_fails() {
 async fn test_dropped_branch() {
     crate::test_util::trace_init();
 
-    let config: ConfigBuilder = toml::from_str(indoc! {r#"
-    [transforms.droptest]
-      type = "remap"
-      inputs = [ "ignored" ]
-      drop_on_error = true
-      drop_on_abort = true
-      reroute_dropped = true
-      source = "abort"
-
-    [transforms.another]
-      type = "remap"
-      inputs = [ "droptest.dropped" ]
-      source = """
-          .new_field = "a new field"
-      """
-
-    [[tests]]
-      name = "dropped branch test"
-      no_outputs_from = [ "droptest" ]
-
-      [[tests.inputs]]
-        type = "log"
-        insert_at = "droptest"
-
-        [tests.inputs.log_fields]
-          message = "test1"
-
-      [[tests.inputs]]
-        type = "log"
-        insert_at = "droptest"
-
-        [tests.inputs.log_fields]
-          message = "test2"
-
-      [[tests.outputs]]
-        extract_from = "droptest.dropped"
-
-        [[tests.outputs.conditions]]
-          type = "vrl"
-          source = """
-              assert_eq!(.message, "test2", "incorrect message")
-          """
-
-    [[tests]]
-      name = "dropped branch test no_outputs_from on branch (should fail)"
-      no_outputs_from = [ "droptest.dropped" ]
-
-      [[tests.inputs]]
-        type = "log"
-        insert_at = "droptest"
-
-        [tests.inputs.log_fields]
-          message = "test1"
-
-    [[tests]]
-      name = "dropped branch test failure"
-      no_outputs_from = [ "droptest" ]
-
-      [[tests.inputs]]
-        type = "log"
-        insert_at = "droptest"
-
-        [tests.inputs.log_fields]
-          message = "test1"
-
-      [[tests.outputs]]
-        extract_from = "droptest.dropped"
-
-        [[tests.outputs.conditions]]
-          type = "vrl"
-          source = """
-              assert_eq!(.message, "bad message", "incorrect message")
-          """
-  "#})
+    let config: ConfigBuilder = serde_yaml::from_str(indoc! {r#"
+        transforms:
+          droptest:
+            type: remap
+            inputs:
+              - ignored
+            drop_on_error: true
+            drop_on_abort: true
+            reroute_dropped: true
+            source: abort
+          another:
+            type: remap
+            inputs:
+              - droptest.dropped
+            source: |
+              .new_field = "a new field"
+        tests:
+          - name: "dropped branch test"
+            no_outputs_from:
+              - droptest
+            inputs:
+              - type: log
+                insert_at: droptest
+                log_fields:
+                  message: test1
+              - type: log
+                insert_at: droptest
+                log_fields:
+                  message: test2
+            outputs:
+              - extract_from: droptest.dropped
+                conditions:
+                  - type: vrl
+                    source: |
+                      assert_eq!(.message, "test2", "incorrect message")
+          - name: "dropped branch test no_outputs_from on branch (should fail)"
+            no_outputs_from:
+              - droptest.dropped
+            inputs:
+              - type: log
+                insert_at: droptest
+                log_fields:
+                  message: test1
+          - name: "dropped branch test failure"
+            no_outputs_from:
+              - droptest
+            inputs:
+              - type: log
+                insert_at: droptest
+                log_fields:
+                  message: test1
+            outputs:
+              - extract_from: droptest.dropped
+                conditions:
+                  - type: vrl
+                    source: |
+                      assert_eq!(.message, "bad message", "incorrect message")
+    "#})
     .unwrap();
 
     let mut tests = build_unit_tests(config).await.unwrap();
@@ -1178,77 +1031,62 @@ async fn test_dropped_branch() {
 async fn test_task_transform() {
     crate::test_util::trace_init();
 
-    let config: ConfigBuilder = toml::from_str(indoc! {r#"
-        [transforms.ingress1]
-          type = "remap"
-          inputs = [ "ignored" ]
-          source = '.new_field = "value1"'
-
-        [transforms.ingress2]
-          type = "remap"
-          inputs = [ "ignored" ]
-          source = '.another_new_field = "value2"'
-
-        [transforms.task-transform]
-          type = "reduce"
-          inputs = [ "ingress1", "ingress2" ]
-          group_by = [ "message" ]
-
-        [[tests]]
-          name = "task transform test"
-
-          [[tests.inputs]]
-            type = "log"
-            insert_at = "ingress1"
-
-            [tests.inputs.log_fields]
-              message = "test1"
-
-          [[tests.inputs]]
-            type = "log"
-            insert_at = "ingress2"
-
-            [tests.inputs.log_fields]
-              message = "test1"
-
-          [[tests.outputs]]
-            extract_from = "task-transform"
-
-            [[tests.outputs.conditions]]
-              type = "vrl"
-              source = """
-                assert_eq!(.message, "test1", "incorrect message")
-                assert_eq!(.new_field, "value1", "incorrect value")
-                assert_eq!(.another_new_field, "value2", "incorrect value")
-              """
-
-        [[tests]]
-          name = "task transform test failure"
-
-          [[tests.inputs]]
-            type = "log"
-            insert_at = "ingress1"
-
-            [tests.inputs.log_fields]
-              message = "test1"
-
-          [[tests.inputs]]
-            type = "log"
-            insert_at = "ingress2"
-
-            [tests.inputs.log_fields]
-              message = "different message"
-
-          [[tests.outputs]]
-            extract_from = "task-transform"
-
-            [[tests.outputs.conditions]]
-              type = "vrl"
-              source = """
-                assert_eq!(.message, "test1", "incorrect message")
-                assert_eq!(.new_field, "value1", "incorrect value")
-                assert_eq!(.another_new_field, "value2", "incorrect value")
-              """
+    let config: ConfigBuilder = serde_yaml::from_str(indoc! {r#"
+        transforms:
+          ingress1:
+            type: remap
+            inputs:
+              - ignored
+            source: '.new_field = "value1"'
+          ingress2:
+            type: remap
+            inputs:
+              - ignored
+            source: '.another_new_field = "value2"'
+          task-transform:
+            type: reduce
+            inputs:
+              - ingress1
+              - ingress2
+            group_by:
+              - message
+        tests:
+          - name: "task transform test"
+            inputs:
+              - type: log
+                insert_at: ingress1
+                log_fields:
+                  message: test1
+              - type: log
+                insert_at: ingress2
+                log_fields:
+                  message: test1
+            outputs:
+              - extract_from: task-transform
+                conditions:
+                  - type: vrl
+                    source: |
+                      assert_eq!(.message, "test1", "incorrect message")
+                      assert_eq!(.new_field, "value1", "incorrect value")
+                      assert_eq!(.another_new_field, "value2", "incorrect value")
+          - name: "task transform test failure"
+            inputs:
+              - type: log
+                insert_at: ingress1
+                log_fields:
+                  message: test1
+              - type: log
+                insert_at: ingress2
+                log_fields:
+                  message: "different message"
+            outputs:
+              - extract_from: task-transform
+                conditions:
+                  - type: vrl
+                    source: |
+                      assert_eq!(.message, "test1", "incorrect message")
+                      assert_eq!(.new_field, "value1", "incorrect value")
+                      assert_eq!(.another_new_field, "value2", "incorrect value")
     "#})
     .unwrap();
 
@@ -1261,37 +1099,33 @@ async fn test_task_transform() {
 async fn test_glob_input() {
     crate::test_util::trace_init();
 
-    let config: ConfigBuilder = toml::from_str(indoc! {r#"
-        [transforms.ingress1]
-          type = "remap"
-          inputs = [ "ignored" ]
-          source = '.new_field = "value1"'
-
-        [transforms.final]
-          type = "remap"
-          inputs = [ "ingress*" ]
-          source = '.another_new_field = "value2"'
-
-        [[tests]]
-          name = "glob input test"
-
-          [[tests.inputs]]
-            type = "log"
-            insert_at = "ingress1"
-
-            [tests.inputs.log_fields]
-              message = "test1"
-
-          [[tests.outputs]]
-            extract_from = "final"
-
-            [[tests.outputs.conditions]]
-              type = "vrl"
-              source = """
-                assert_eq!(.message, "test1", "incorrect message")
-                assert_eq!(.new_field, "value1", "incorrect value")
-                assert_eq!(.another_new_field, "value2", "incorrect value")
-              """
+    let config: ConfigBuilder = serde_yaml::from_str(indoc! {r#"
+        transforms:
+          ingress1:
+            type: remap
+            inputs:
+              - ignored
+            source: '.new_field = "value1"'
+          final:
+            type: remap
+            inputs:
+              - "ingress*"
+            source: '.another_new_field = "value2"'
+        tests:
+          - name: "glob input test"
+            inputs:
+              - type: log
+                insert_at: ingress1
+                log_fields:
+                  message: test1
+            outputs:
+              - extract_from: final
+                conditions:
+                  - type: vrl
+                    source: |
+                      assert_eq!(.message, "test1", "incorrect message")
+                      assert_eq!(.new_field, "value1", "incorrect value")
+                      assert_eq!(.another_new_field, "value2", "incorrect value")
     "#})
     .unwrap();
 

--- a/src/gcp.rs
+++ b/src/gcp.rs
@@ -327,12 +327,10 @@ mod tests {
 
     #[tokio::test]
     async fn skip_authentication() {
-        let auth = build_auth(
-            r#"
-                skip_authentication = true
-                api_key = "testing"
-            "#,
-        )
+        let auth = build_auth(indoc::indoc! {r#"
+            skip_authentication: true
+            api_key: "testing"
+        "#})
         .await
         .expect("build_auth failed");
         assert!(matches!(auth, GcpAuthenticator::None));
@@ -342,7 +340,7 @@ mod tests {
     async fn uses_api_key() {
         let key = crate::test_util::random_string(16);
 
-        let auth = build_auth(&format!(r#"api_key = "{key}""#))
+        let auth = build_auth(&format!("api_key: \"{key}\""))
             .await
             .expect("build_auth failed");
         assert!(matches!(auth, GcpAuthenticator::ApiKey(..)));
@@ -367,7 +365,7 @@ mod tests {
 
     #[tokio::test]
     async fn fails_bad_api_key() {
-        let error = build_auth(r#"api_key = "abc%xyz""#)
+        let error = build_auth(r#"api_key: "abc%xyz""#)
             .await
             .expect_err("build failed to error");
         assert_downcast_matches!(error, GcpError, GcpError::InvalidApiKey { .. });
@@ -379,8 +377,8 @@ mod tests {
         uri.to_string()
     }
 
-    async fn build_auth(toml: &str) -> crate::Result<GcpAuthenticator> {
-        let config: GcpAuthConfig = toml::from_str(toml).expect("Invalid TOML");
+    async fn build_auth(yaml: &str) -> crate::Result<GcpAuthenticator> {
+        let config: GcpAuthConfig = serde_yaml::from_str(yaml).expect("Invalid YAML");
         config.build(Scope::Compute).await
     }
 }

--- a/src/nats.rs
+++ b/src/nats.rs
@@ -186,145 +186,135 @@ pub(crate) fn from_tls_auth_config(
 
 #[cfg(test)]
 mod tests {
+    use indoc::indoc;
+
     use super::*;
 
     fn parse_auth(s: &str) -> Result<async_nats::ConnectOptions, crate::Error> {
-        toml::from_str(s)
+        serde_yaml::from_str(s)
             .map_err(Into::into)
             .and_then(|config: NatsAuthConfig| config.to_nats_options().map_err(Into::into))
     }
 
     #[test]
     fn auth_user_password_ok() {
-        parse_auth(
-            r#"
-            strategy = "user_password"
-            user_password.user = "username"
-            user_password.password = "password"
-        "#,
-        )
+        parse_auth(indoc! {r#"
+            strategy: user_password
+            user_password:
+              user: username
+              password: password
+        "#})
         .unwrap();
     }
 
     #[test]
     fn auth_user_password_missing_user() {
-        parse_auth(
-            r#"
-            strategy = "user_password"
-            user_password.password = "password"
-        "#,
-        )
+        parse_auth(indoc! {r#"
+            strategy: user_password
+            user_password:
+              password: password
+        "#})
         .unwrap_err();
     }
 
     #[test]
     fn auth_user_password_missing_password() {
-        parse_auth(
-            r#"
-            strategy = "user_password"
-            user_password.user = "username"
-        "#,
-        )
+        parse_auth(indoc! {r#"
+            strategy: user_password
+            user_password:
+              user: username
+        "#})
         .unwrap_err();
     }
 
     #[test]
     fn auth_user_password_missing_all() {
-        parse_auth(
-            r#"
-            strategy = "user_password"
-            token.value = "foobar"
-            "#,
-        )
+        parse_auth(indoc! {r#"
+            strategy: user_password
+            token:
+              value: foobar
+        "#})
         .unwrap_err();
     }
 
     #[test]
     fn auth_token_ok() {
-        parse_auth(
-            r#"
-            strategy = "token"
-            token.value = "token"
-        "#,
-        )
+        parse_auth(indoc! {r#"
+            strategy: token
+            token:
+              value: token
+        "#})
         .unwrap();
     }
 
     #[test]
     fn auth_token_missing() {
-        parse_auth(
-            r#"
-            strategy = "token"
-            user_password.user = "foobar"
-            "#,
-        )
+        parse_auth(indoc! {r#"
+            strategy: token
+            user_password:
+              user: foobar
+        "#})
         .unwrap_err();
     }
 
     #[test]
     fn auth_credentials_file_ok() {
-        parse_auth(
-            r#"
-            strategy = "credentials_file"
-            credentials_file.path = "tests/integration/nats/data/nats.creds"
-        "#,
-        )
+        parse_auth(indoc! {r#"
+            strategy: credentials_file
+            credentials_file:
+              path: tests/integration/nats/data/nats.creds
+        "#})
         .unwrap();
     }
 
     #[test]
     fn auth_credentials_file_missing() {
-        parse_auth(
-            r#"
-            strategy = "credentials_file"
-            token.value = "foobar"
-            "#,
-        )
+        parse_auth(indoc! {r#"
+            strategy: credentials_file
+            token:
+              value: foobar
+        "#})
         .unwrap_err();
     }
 
     #[test]
     fn auth_nkey_ok() {
-        parse_auth(
-            r#"
-            strategy = "nkey"
-            nkey.nkey = "UC435ZYS52HF72E2VMQF4GO6CUJOCHDUUPEBU7XDXW5AQLIC6JZ46PO5"
-            nkey.seed = "SUAAEZYNLTEA2MDTG7L5X7QODZXYHPOI2LT2KH5I4GD6YVP24SE766EGPA"
-        "#,
-        )
+        parse_auth(indoc! {r#"
+            strategy: nkey
+            nkey:
+              nkey: UC435ZYS52HF72E2VMQF4GO6CUJOCHDUUPEBU7XDXW5AQLIC6JZ46PO5
+              seed: SUAAEZYNLTEA2MDTG7L5X7QODZXYHPOI2LT2KH5I4GD6YVP24SE766EGPA
+        "#})
         .unwrap();
     }
 
     #[test]
     fn auth_nkey_missing_nkey() {
-        parse_auth(
-            r#"
-            strategy = "nkey"
-            nkey.seed = "SUAAEZYNLTEA2MDTG7L5X7QODZXYHPOI2LT2KH5I4GD6YVP24SE766EGPA"
-        "#,
-        )
+        parse_auth(indoc! {r#"
+            strategy: nkey
+            nkey:
+              seed: SUAAEZYNLTEA2MDTG7L5X7QODZXYHPOI2LT2KH5I4GD6YVP24SE766EGPA
+        "#})
         .unwrap_err();
     }
 
     #[test]
     fn auth_nkey_missing_seed() {
-        parse_auth(
-            r#"
-            strategy = "nkey"
-            nkey.nkey = "UC435ZYS52HF72E2VMQF4GO6CUJOCHDUUPEBU7XDXW5AQLIC6JZ46PO5"
-        "#,
-        )
+        parse_auth(indoc! {r#"
+            strategy: nkey
+            nkey:
+              nkey: UC435ZYS52HF72E2VMQF4GO6CUJOCHDUUPEBU7XDXW5AQLIC6JZ46PO5
+        "#})
         .unwrap_err();
     }
 
     #[test]
     fn auth_nkey_missing_both() {
-        parse_auth(
-            r#"
-            strategy = "nkey"
-            user_password.user = "foobar"
-            "#,
-        )
+        parse_auth(indoc! {r#"
+            strategy: nkey
+            user_password:
+              user: foobar
+        "#})
         .unwrap_err();
     }
 }

--- a/src/sinks/aws_s3/config.rs
+++ b/src/sinks/aws_s3/config.rs
@@ -380,23 +380,17 @@ mod tests {
     #[cfg(feature = "codecs-parquet")]
     #[test]
     fn parquet_batch_encoding_correct_toml_shape() {
-        let config: S3SinkConfig = toml::from_str(
-            r#"
-            bucket = "test-bucket"
-            compression = "none"
-
-            [encoding]
-            codec = "text"
-
-            [batch_encoding]
-            schema_mode = "auto_infer"
-            codec = "parquet"
-
-            [batch_encoding.compression]
-            algorithm = "snappy"
-
-            "#,
-        )
+        let config: S3SinkConfig = serde_yaml::from_str(indoc::indoc! {r#"
+            bucket: test-bucket
+            compression: none
+            encoding:
+              codec: text
+            batch_encoding:
+              schema_mode: auto_infer
+              codec: parquet
+              compression:
+                algorithm: snappy
+            "#})
         .expect("correct batch_encoding shape should parse");
 
         let batch_enc = config
@@ -470,24 +464,19 @@ mod tests {
     #[cfg(feature = "codecs-parquet")]
     #[test]
     fn parquet_content_type_user_override_preserved() {
-        let config: S3SinkConfig = toml::from_str(
-            r#"
-            bucket = "test-bucket"
-            compression = "none"
-            content_type = "application/octet-stream"
-
-            [encoding]
-            codec = "text"
-
-            [batch_encoding]
-            codec = "parquet"
-            schema_mode = "auto_infer"
-
-            [batch_encoding.compression]
-            algorithm = "gzip"
-            level = 9
-            "#,
-        )
+        let config: S3SinkConfig = serde_yaml::from_str(indoc::indoc! {r#"
+            bucket: test-bucket
+            compression: none
+            content_type: "application/octet-stream"
+            encoding:
+              codec: text
+            batch_encoding:
+              codec: parquet
+              schema_mode: auto_infer
+              compression:
+                algorithm: gzip
+                level: 9
+            "#})
         .unwrap();
 
         let super::S3BatchEncoding::Parquet(p) = config.batch_encoding.as_ref().unwrap();
@@ -534,20 +523,16 @@ mod tests {
     #[cfg(feature = "codecs-parquet")]
     #[test]
     fn parquet_filename_extension_user_override() {
-        let config: S3SinkConfig = toml::from_str(
-            r#"
-            bucket = "test-bucket"
-            compression = "none"
-            filename_extension = "pq"
-
-            [encoding]
-            codec = "text"
-
-            [batch_encoding]
-            codec = "parquet"
-            schema_mode = "auto_infer"
-            "#,
-        )
+        let config: S3SinkConfig = serde_yaml::from_str(indoc::indoc! {r#"
+            bucket: test-bucket
+            compression: none
+            filename_extension: pq
+            encoding:
+              codec: text
+            batch_encoding:
+              codec: parquet
+              schema_mode: auto_infer
+            "#})
         .unwrap();
 
         assert_eq!(config.filename_extension.as_deref(), Some("pq"));
@@ -559,18 +544,14 @@ mod tests {
     fn parquet_schema_mode_defaults_to_relaxed() {
         use vector_lib::codecs::encoding::format::ParquetSchemaMode;
 
-        let config: S3SinkConfig = toml::from_str(
-            r#"
-            bucket = "test-bucket"
-            compression = "none"
-
-            [encoding]
-            codec = "text"
-
-            [batch_encoding]
-            codec = "parquet"
-            "#,
-        )
+        let config: S3SinkConfig = serde_yaml::from_str(indoc::indoc! {r#"
+            bucket: test-bucket
+            compression: none
+            encoding:
+              codec: text
+            batch_encoding:
+              codec: parquet
+            "#})
         .unwrap();
 
         let super::S3BatchEncoding::Parquet(p) = config.batch_encoding.unwrap();
@@ -583,20 +564,16 @@ mod tests {
     fn parquet_schema_mode_strict_parsed() {
         use vector_lib::codecs::encoding::format::ParquetSchemaMode;
 
-        let config: S3SinkConfig = toml::from_str(
-            r#"
-            bucket = "test-bucket"
-            compression = "none"
-
-            [encoding]
-            codec = "text"
-
-            [batch_encoding]
-            codec = "parquet"
-            schema_mode = "strict"
-            schema_file = "tmp/something.schema"
-            "#,
-        )
+        let config: S3SinkConfig = serde_yaml::from_str(indoc::indoc! {r#"
+            bucket: test-bucket
+            compression: none
+            encoding:
+              codec: text
+            batch_encoding:
+              codec: parquet
+              schema_mode: strict
+              schema_file: tmp/something.schema
+            "#})
         .unwrap();
 
         let super::S3BatchEncoding::Parquet(p) = config.batch_encoding.unwrap();

--- a/src/sinks/axiom/config.rs
+++ b/src/sinks/axiom/config.rs
@@ -328,13 +328,11 @@ mod test {
     #[test]
     fn test_url_or_region_deserialization_with_url() {
         // Test that url can be deserialized at the top level (flattened)
-        let config: super::AxiomConfig = toml::from_str(
-            r#"
-            token = "test-token"
-            dataset = "test-dataset"
-            url = "https://api.eu.axiom.co"
-            "#,
-        )
+        let config: super::AxiomConfig = serde_yaml::from_str(indoc::indoc! {r#"
+            token: "test-token"
+            dataset: "test-dataset"
+            url: "https://api.eu.axiom.co"
+        "#})
         .unwrap();
 
         assert_eq!(config.endpoint.url(), Some("https://api.eu.axiom.co"));
@@ -344,13 +342,11 @@ mod test {
     #[test]
     fn test_url_or_region_deserialization_with_region() {
         // Test that region can be deserialized at the top level (flattened)
-        let config: super::AxiomConfig = toml::from_str(
-            r#"
-            token = "test-token"
-            dataset = "test-dataset"
-            region = "mumbai.axiom.co"
-            "#,
-        )
+        let config: super::AxiomConfig = serde_yaml::from_str(indoc::indoc! {r#"
+            token: "test-token"
+            dataset: "test-dataset"
+            region: "mumbai.axiom.co"
+        "#})
         .unwrap();
 
         assert_eq!(config.endpoint.url(), None);

--- a/src/sinks/azure_blob/test.rs
+++ b/src/sinks/azure_blob/test.rs
@@ -243,17 +243,14 @@ fn azure_blob_build_request_with_uuid() {
 
 #[tokio::test]
 async fn azure_blob_build_config_with_null_auth() {
-    let config: Result<AzureBlobSinkConfig, toml::de::Error> = toml::from_str::<AzureBlobSinkConfig>(
-        r#"
-            connection_string = "AccountName=mylogstorage"
-            container_name = "my-logs"
-
-            [encoding]
-            codec = "json"
-
-            [auth]
-        "#,
-    );
+    let config: Result<AzureBlobSinkConfig, _> =
+        serde_yaml::from_str::<AzureBlobSinkConfig>(indoc::indoc! {r#"
+            connection_string: "AccountName=mylogstorage"
+            container_name: my-logs
+            encoding:
+              codec: json
+            auth: {}
+        "#});
 
     match config {
         Ok(_) => panic!("Config parsing should have failed due to invalid auth config"),
@@ -270,22 +267,19 @@ async fn azure_blob_build_config_with_null_auth() {
 
 #[tokio::test]
 async fn azure_blob_build_config_with_client_id_and_secret() {
-    let config: AzureBlobSinkConfig = toml::from_str::<AzureBlobSinkConfig>(
-        r#"
-            connection_string = "AccountName=mylogstorage"
-            container_name = "my-logs"
-
-            [encoding]
-            codec = "json"
-
-            [auth]
-            azure_credential_kind = "client_secret_credential"
-            azure_tenant_id = "00000000-0000-0000-0000-000000000000"
-            azure_client_id = "mock-client-id"
-            azure_client_secret = "mock-client-secret"
-        "#,
-    )
-    .unwrap_or_else(|error| panic!("Config parsing failed: {error:?}"));
+    let config: AzureBlobSinkConfig =
+        serde_yaml::from_str::<AzureBlobSinkConfig>(indoc::indoc! {r#"
+            connection_string: "AccountName=mylogstorage"
+            container_name: my-logs
+            encoding:
+              codec: json
+            auth:
+              azure_credential_kind: client_secret_credential
+              azure_tenant_id: "00000000-0000-0000-0000-000000000000"
+              azure_client_id: mock-client-id
+              azure_client_secret: mock-client-secret
+        "#})
+        .unwrap_or_else(|error| panic!("Config parsing failed: {error:?}"));
 
     assert!(&config.auth.is_some());
 
@@ -312,23 +306,20 @@ async fn azure_blob_build_config_with_client_id_and_secret() {
 
 #[tokio::test]
 async fn azure_blob_build_config_with_client_certificate() {
-    let config: AzureBlobSinkConfig = toml::from_str::<AzureBlobSinkConfig>(
-        r#"
-            connection_string = "AccountName=mylogstorage"
-            container_name = "my-logs"
-
-            [encoding]
-            codec = "json"
-
-            [auth]
-            azure_credential_kind = "client_certificate_credential"
-            azure_tenant_id = "00000000-0000-0000-0000-000000000000"
-            azure_client_id = "mock-client-id"
-            certificate_path = "tests/data/ClientCertificateAuth.pfx"
-            certificate_password = "MockPassword123"
-        "#,
-    )
-    .unwrap_or_else(|error| panic!("Config parsing failed: {error:?}"));
+    let config: AzureBlobSinkConfig =
+        serde_yaml::from_str::<AzureBlobSinkConfig>(indoc::indoc! {r#"
+            connection_string: "AccountName=mylogstorage"
+            container_name: my-logs
+            encoding:
+              codec: json
+            auth:
+              azure_credential_kind: client_certificate_credential
+              azure_tenant_id: "00000000-0000-0000-0000-000000000000"
+              azure_client_id: mock-client-id
+              certificate_path: tests/data/ClientCertificateAuth.pfx
+              certificate_password: MockPassword123
+        "#})
+        .unwrap_or_else(|error| panic!("Config parsing failed: {error:?}"));
 
     assert!(&config.auth.is_some());
 
@@ -350,22 +341,19 @@ async fn azure_blob_build_config_with_client_certificate() {
 
 #[tokio::test]
 async fn azure_blob_build_config_with_account_name() {
-    let config: AzureBlobSinkConfig = toml::from_str::<AzureBlobSinkConfig>(
-        r#"
-            account_name = "mylogstorage"
-            container_name = "my-logs"
-
-            [encoding]
-            codec = "json"
-
-            [auth]
-            azure_credential_kind = "client_secret_credential"
-            azure_tenant_id = "00000000-0000-0000-0000-000000000000"
-            azure_client_id = "mock-client-id"
-            azure_client_secret = "mock-client-secret"
-        "#,
-    )
-    .unwrap_or_else(|error| panic!("Config parsing failed: {error:?}"));
+    let config: AzureBlobSinkConfig =
+        serde_yaml::from_str::<AzureBlobSinkConfig>(indoc::indoc! {r#"
+            account_name: mylogstorage
+            container_name: my-logs
+            encoding:
+              codec: json
+            auth:
+              azure_credential_kind: client_secret_credential
+              azure_tenant_id: "00000000-0000-0000-0000-000000000000"
+              azure_client_id: mock-client-id
+              azure_client_secret: mock-client-secret
+        "#})
+        .unwrap_or_else(|error| panic!("Config parsing failed: {error:?}"));
 
     let cx = SinkContext::default();
     let _ = config
@@ -376,16 +364,14 @@ async fn azure_blob_build_config_with_account_name() {
 
 #[tokio::test]
 async fn azure_blob_build_config_with_account_name_with_no_auth() {
-    let config: AzureBlobSinkConfig = toml::from_str::<AzureBlobSinkConfig>(
-        r#"
-            account_name = "mylogstorage"
-            container_name = "my-logs"
-
-            [encoding]
-            codec = "json"
-        "#,
-    )
-    .unwrap_or_else(|error| panic!("Config parsing failed: {error:?}"));
+    let config: AzureBlobSinkConfig =
+        serde_yaml::from_str::<AzureBlobSinkConfig>(indoc::indoc! {r#"
+            account_name: mylogstorage
+            container_name: my-logs
+            encoding:
+              codec: json
+        "#})
+        .unwrap_or_else(|error| panic!("Config parsing failed: {error:?}"));
 
     let cx = SinkContext::default();
     let sink = config.build(cx).await;
@@ -404,22 +390,19 @@ async fn azure_blob_build_config_with_account_name_with_no_auth() {
 
 #[tokio::test]
 async fn azure_blob_build_config_with_blob_endpoint() {
-    let config: AzureBlobSinkConfig = toml::from_str::<AzureBlobSinkConfig>(
-        r#"
-            blob_endpoint = "https://localhost:10000/devstoreaccount1"
-            container_name = "my-logs"
-
-            [encoding]
-            codec = "json"
-
-            [auth]
-            azure_credential_kind = "client_secret_credential"
-            azure_tenant_id = "00000000-0000-0000-0000-000000000000"
-            azure_client_id = "mock-client-id"
-            azure_client_secret = "mock-client-secret"
-        "#,
-    )
-    .unwrap_or_else(|error| panic!("Config parsing failed: {error:?}"));
+    let config: AzureBlobSinkConfig =
+        serde_yaml::from_str::<AzureBlobSinkConfig>(indoc::indoc! {r#"
+            blob_endpoint: "https://localhost:10000/devstoreaccount1"
+            container_name: my-logs
+            encoding:
+              codec: json
+            auth:
+              azure_credential_kind: client_secret_credential
+              azure_tenant_id: "00000000-0000-0000-0000-000000000000"
+              azure_client_id: mock-client-id
+              azure_client_secret: mock-client-secret
+        "#})
+        .unwrap_or_else(|error| panic!("Config parsing failed: {error:?}"));
 
     let cx = SinkContext::default();
     let _ = config
@@ -430,16 +413,14 @@ async fn azure_blob_build_config_with_blob_endpoint() {
 
 #[tokio::test]
 async fn azure_blob_build_config_with_blob_endpoint_with_no_auth() {
-    let config: AzureBlobSinkConfig = toml::from_str::<AzureBlobSinkConfig>(
-        r#"
-            blob_endpoint = "https://localhost:10000/devstoreaccount1"
-            container_name = "my-logs"
-
-            [encoding]
-            codec = "json"
-        "#,
-    )
-    .unwrap_or_else(|error| panic!("Config parsing failed: {error:?}"));
+    let config: AzureBlobSinkConfig =
+        serde_yaml::from_str::<AzureBlobSinkConfig>(indoc::indoc! {r#"
+            blob_endpoint: "https://localhost:10000/devstoreaccount1"
+            container_name: my-logs
+            encoding:
+              codec: json
+        "#})
+        .unwrap_or_else(|error| panic!("Config parsing failed: {error:?}"));
 
     let cx = SinkContext::default();
     let sink = config.build(cx).await;
@@ -458,17 +439,15 @@ async fn azure_blob_build_config_with_blob_endpoint_with_no_auth() {
 
 #[tokio::test]
 async fn azure_blob_build_config_with_conflicting_connection_string_and_account_name() {
-    let config: AzureBlobSinkConfig = toml::from_str::<AzureBlobSinkConfig>(
-        r#"
-            connection_string = "AccountName=mylogstorage"
-            account_name = "mylogstorage"
-            container_name = "my-logs"
-
-            [encoding]
-            codec = "json"
-        "#,
-    )
-    .unwrap_or_else(|error| panic!("Config parsing failed: {error:?}"));
+    let config: AzureBlobSinkConfig =
+        serde_yaml::from_str::<AzureBlobSinkConfig>(indoc::indoc! {r#"
+            connection_string: "AccountName=mylogstorage"
+            account_name: mylogstorage
+            container_name: my-logs
+            encoding:
+              codec: json
+        "#})
+        .unwrap_or_else(|error| panic!("Config parsing failed: {error:?}"));
 
     let cx = SinkContext::default();
     let sink = config.build(cx).await;
@@ -489,22 +468,19 @@ async fn azure_blob_build_config_with_conflicting_connection_string_and_account_
 
 #[tokio::test]
 async fn azure_blob_build_config_with_conflicting_connection_string_and_client_id_and_secret() {
-    let config: AzureBlobSinkConfig = toml::from_str::<AzureBlobSinkConfig>(
-        r#"
-            connection_string = "AccountName=mylogstorage;AccountKey=mockkey"
-            container_name = "my-logs"
-
-            [encoding]
-            codec = "json"
-
-            [auth]
-            azure_credential_kind = "client_secret_credential"
-            azure_tenant_id = "00000000-0000-0000-0000-000000000000"
-            azure_client_id = "mock-client-id"
-            azure_client_secret = "mock-client-secret"
-        "#,
-    )
-    .unwrap_or_else(|error| panic!("Config parsing failed: {error:?}"));
+    let config: AzureBlobSinkConfig =
+        serde_yaml::from_str::<AzureBlobSinkConfig>(indoc::indoc! {r#"
+            connection_string: "AccountName=mylogstorage;AccountKey=mockkey"
+            container_name: my-logs
+            encoding:
+              codec: json
+            auth:
+              azure_credential_kind: client_secret_credential
+              azure_tenant_id: "00000000-0000-0000-0000-000000000000"
+              azure_client_id: mock-client-id
+              azure_client_secret: mock-client-secret
+        "#})
+        .unwrap_or_else(|error| panic!("Config parsing failed: {error:?}"));
 
     assert!(&config.auth.is_some());
 
@@ -528,25 +504,21 @@ async fn azure_blob_build_config_with_conflicting_connection_string_and_client_i
 
 #[tokio::test]
 async fn azure_blob_build_config_with_custom_ca_certificate() {
-    let config: AzureBlobSinkConfig = toml::from_str::<AzureBlobSinkConfig>(
-        r#"
-            account_name = "mylogstorage"
-            container_name = "my-logs"
-
-            [encoding]
-            codec = "json"
-
-            [tls]
-            ca_file = "tests/data/ca/certs/ca.cert.pem"
-
-            [auth]
-            azure_credential_kind = "client_secret_credential"
-            azure_tenant_id = "00000000-0000-0000-0000-000000000000"
-            azure_client_id = "mock-client-id"
-            azure_client_secret = "mock-client-secret"
-        "#,
-    )
-    .unwrap_or_else(|error| panic!("Config parsing failed: {error:?}"));
+    let config: AzureBlobSinkConfig =
+        serde_yaml::from_str::<AzureBlobSinkConfig>(indoc::indoc! {r#"
+            account_name: mylogstorage
+            container_name: my-logs
+            encoding:
+              codec: json
+            tls:
+              ca_file: tests/data/ca/certs/ca.cert.pem
+            auth:
+              azure_credential_kind: client_secret_credential
+              azure_tenant_id: "00000000-0000-0000-0000-000000000000"
+              azure_client_id: mock-client-id
+              azure_client_secret: mock-client-secret
+        "#})
+        .unwrap_or_else(|error| panic!("Config parsing failed: {error:?}"));
 
     let cx = SinkContext::default();
     let _ = config

--- a/src/sinks/azure_logs_ingestion/tests.rs
+++ b/src/sinks/azure_logs_ingestion/tests.rs
@@ -28,14 +28,12 @@ fn generate_config() {
 
 #[tokio::test]
 async fn basic_config_error_with_no_auth() {
-    let config: Result<AzureLogsIngestionConfig, toml::de::Error> =
-        toml::from_str::<AzureLogsIngestionConfig>(
-            r#"
-            endpoint = "https://my-dce-5kyl.eastus-1.ingest.monitor.azure.com"
-            dcr_immutable_id = "dcr-00000000000000000000000000000000"
-            stream_name = "Custom-UnitTest"
-        "#,
-        );
+    let config: Result<AzureLogsIngestionConfig, _> =
+        serde_yaml::from_str::<AzureLogsIngestionConfig>(indoc::indoc! {r#"
+            endpoint: "https://my-dce-5kyl.eastus-1.ingest.monitor.azure.com"
+            dcr_immutable_id: dcr-00000000000000000000000000000000
+            stream_name: Custom-UnitTest
+        "#});
 
     match config {
         Ok(_) => panic!("Config parsing should have failed due to missing auth config"),
@@ -52,20 +50,18 @@ async fn basic_config_error_with_no_auth() {
 
 #[test]
 fn basic_config_with_client_credentials() {
-    let config: AzureLogsIngestionConfig = toml::from_str::<AzureLogsIngestionConfig>(
-        r#"
-            endpoint = "https://my-dce-5kyl.eastus-1.ingest.monitor.azure.com"
-            dcr_immutable_id = "dcr-00000000000000000000000000000000"
-            stream_name = "Custom-UnitTest"
-
-            [auth]
-            azure_credential_kind = "client_secret_credential"
-            azure_tenant_id = "00000000-0000-0000-0000-000000000000"
-            azure_client_id = "mock-client-id"
-            azure_client_secret = "mock-client-secret"
-        "#,
-    )
-    .expect("Config parsing failed");
+    let config: AzureLogsIngestionConfig =
+        serde_yaml::from_str::<AzureLogsIngestionConfig>(indoc::indoc! {r#"
+            endpoint: "https://my-dce-5kyl.eastus-1.ingest.monitor.azure.com"
+            dcr_immutable_id: dcr-00000000000000000000000000000000
+            stream_name: Custom-UnitTest
+            auth:
+              azure_credential_kind: client_secret_credential
+              azure_tenant_id: "00000000-0000-0000-0000-000000000000"
+              azure_client_id: mock-client-id
+              azure_client_secret: mock-client-secret
+        "#})
+        .expect("Config parsing failed");
 
     assert_eq!(
         config.endpoint,
@@ -96,17 +92,15 @@ fn basic_config_with_client_credentials() {
 
 #[test]
 fn basic_config_with_managed_identity() {
-    let config: AzureLogsIngestionConfig = toml::from_str::<AzureLogsIngestionConfig>(
-        r#"
-            endpoint = "https://my-dce-5kyl.eastus-1.ingest.monitor.azure.com"
-            dcr_immutable_id = "dcr-00000000000000000000000000000000"
-            stream_name = "Custom-UnitTest"
-
-            [auth]
-            azure_credential_kind = "managed_identity"
-        "#,
-    )
-    .expect("Config parsing failed");
+    let config: AzureLogsIngestionConfig =
+        serde_yaml::from_str::<AzureLogsIngestionConfig>(indoc::indoc! {r#"
+            endpoint: "https://my-dce-5kyl.eastus-1.ingest.monitor.azure.com"
+            dcr_immutable_id: dcr-00000000000000000000000000000000
+            stream_name: Custom-UnitTest
+            auth:
+              azure_credential_kind: managed_identity
+        "#})
+        .expect("Config parsing failed");
 
     assert_eq!(
         config.endpoint,
@@ -146,19 +140,16 @@ fn insert_timestamp_kv(log: &mut LogEvent) -> (String, String) {
 async fn correct_request() {
     let credential = std::sync::Arc::new(create_mock_credential());
 
-    let config: AzureLogsIngestionConfig = toml::from_str(
-        r#"
-            endpoint = "http://localhost:9001"
-            dcr_immutable_id = "dcr-00000000000000000000000000000000"
-            stream_name = "Custom-UnitTest"
-
-            [auth]
-            azure_credential_kind = "client_secret_credential"
-            azure_tenant_id = "00000000-0000-0000-0000-000000000000"
-            azure_client_id = "mock-client-id"
-            azure_client_secret = "mock-client-secret"
-        "#,
-    )
+    let config: AzureLogsIngestionConfig = serde_yaml::from_str(indoc::indoc! {r#"
+            endpoint: "http://localhost:9001"
+            dcr_immutable_id: dcr-00000000000000000000000000000000
+            stream_name: Custom-UnitTest
+            auth:
+              azure_credential_kind: client_secret_credential
+              azure_tenant_id: "00000000-0000-0000-0000-000000000000"
+              azure_client_id: mock-client-id
+              azure_client_secret: mock-client-secret
+        "#})
     .unwrap();
 
     let mut log1 = [("message", "hello")].iter().copied().collect::<LogEvent>();
@@ -257,19 +248,16 @@ fn create_mock_credential() -> impl TokenCredential {
 
 #[tokio::test]
 async fn mock_healthcheck_with_400_response() {
-    let config: AzureLogsIngestionConfig = toml::from_str(
-        r#"
-            endpoint = "http://localhost:9001"
-            dcr_immutable_id = "dcr-00000000000000000000000000000000"
-            stream_name = "Custom-UnitTest"
-
-            [auth]
-            azure_credential_kind = "client_secret_credential"
-            azure_tenant_id = "00000000-0000-0000-0000-000000000000"
-            azure_client_id = "mock-client-id"
-            azure_client_secret = "mock-client-secret"
-        "#,
-    )
+    let config: AzureLogsIngestionConfig = serde_yaml::from_str(indoc::indoc! {r#"
+            endpoint: "http://localhost:9001"
+            dcr_immutable_id: dcr-00000000000000000000000000000000
+            stream_name: Custom-UnitTest
+            auth:
+              azure_credential_kind: client_secret_credential
+              azure_tenant_id: "00000000-0000-0000-0000-000000000000"
+              azure_client_id: mock-client-id
+              azure_client_secret: mock-client-secret
+        "#})
     .unwrap();
 
     let mut log1 = [("message", "hello")].iter().copied().collect::<LogEvent>();
@@ -327,19 +315,16 @@ async fn mock_healthcheck_with_400_response() {
 
 #[tokio::test]
 async fn mock_healthcheck_with_403_response() {
-    let config: AzureLogsIngestionConfig = toml::from_str(
-        r#"
-            endpoint = "http://localhost:9001"
-            dcr_immutable_id = "dcr-00000000000000000000000000000000"
-            stream_name = "Custom-UnitTest"
-
-            [auth]
-            azure_credential_kind = "client_secret_credential"
-            azure_tenant_id = "00000000-0000-0000-0000-000000000000"
-            azure_client_id = "mock-client-id"
-            azure_client_secret = "mock-client-secret"
-        "#,
-    )
+    let config: AzureLogsIngestionConfig = serde_yaml::from_str(indoc::indoc! {r#"
+            endpoint: "http://localhost:9001"
+            dcr_immutable_id: dcr-00000000000000000000000000000000
+            stream_name: Custom-UnitTest
+            auth:
+              azure_credential_kind: client_secret_credential
+              azure_tenant_id: "00000000-0000-0000-0000-000000000000"
+              azure_client_id: mock-client-id
+              azure_client_secret: mock-client-secret
+        "#})
     .unwrap();
 
     let mut log1 = [("message", "hello")].iter().copied().collect::<LogEvent>();

--- a/src/sinks/azure_monitor_logs/tests.rs
+++ b/src/sinks/azure_monitor_logs/tests.rs
@@ -47,14 +47,12 @@ async fn component_spec_compliance() {
 
 #[tokio::test]
 async fn fails_missing_creds() {
-    let config: AzureMonitorLogsConfig = toml::from_str(
-        r#"
-            customer_id = "97ce69d9-b4be-4241-8dbd-d265edcf06c4"
-            shared_key = ""
-            log_type = "Vector"
-            azure_resource_id = "97ce69d9-b4be-4241-8dbd-d265edcf06c4"
-        "#,
-    )
+    let config: AzureMonitorLogsConfig = serde_yaml::from_str(indoc::indoc! {r#"
+            customer_id: 97ce69d9-b4be-4241-8dbd-d265edcf06c4
+            shared_key: ""
+            log_type: Vector
+            azure_resource_id: 97ce69d9-b4be-4241-8dbd-d265edcf06c4
+        "#})
     .unwrap();
     if config.build(SinkContext::default()).await.is_ok() {
         panic!("config.build failed to error");
@@ -63,23 +61,23 @@ async fn fails_missing_creds() {
 
 #[test]
 fn correct_host() {
-    let config_default = toml::from_str::<AzureMonitorLogsConfig>(
-            r#"
-            customer_id = "97ce69d9-b4be-4241-8dbd-d265edcf06c4"
-            shared_key = "SERsIYhgMVlJB6uPsq49gCxNiruf6v0vhMYE+lfzbSGcXjdViZdV/e5pEMTYtw9f8SkVLf4LFlLCc2KxtRZfCA=="
-            log_type = "Vector"
-        "#,
+    let config_default = serde_yaml::from_str::<AzureMonitorLogsConfig>(
+            indoc::indoc! {r#"
+            customer_id: 97ce69d9-b4be-4241-8dbd-d265edcf06c4
+            shared_key: "SERsIYhgMVlJB6uPsq49gCxNiruf6v0vhMYE+lfzbSGcXjdViZdV/e5pEMTYtw9f8SkVLf4LFlLCc2KxtRZfCA=="
+            log_type: Vector
+        "#},
         )
         .expect("Config parsing failed without custom host");
     assert_eq!(config_default.host, default_host());
 
-    let config_cn = toml::from_str::<AzureMonitorLogsConfig>(
-            r#"
-            customer_id = "97ce69d9-b4be-4241-8dbd-d265edcf06c4"
-            shared_key = "SERsIYhgMVlJB6uPsq49gCxNiruf6v0vhMYE+lfzbSGcXjdViZdV/e5pEMTYtw9f8SkVLf4LFlLCc2KxtRZfCA=="
-            log_type = "Vector"
-            host = "ods.opinsights.azure.cn"
-        "#,
+    let config_cn = serde_yaml::from_str::<AzureMonitorLogsConfig>(
+            indoc::indoc! {r#"
+            customer_id: 97ce69d9-b4be-4241-8dbd-d265edcf06c4
+            shared_key: "SERsIYhgMVlJB6uPsq49gCxNiruf6v0vhMYE+lfzbSGcXjdViZdV/e5pEMTYtw9f8SkVLf4LFlLCc2KxtRZfCA=="
+            log_type: Vector
+            host: ods.opinsights.azure.cn
+        "#},
         )
         .expect("Config parsing failed with .cn custom host");
     assert_eq!(config_cn.host, "ods.opinsights.azure.cn");
@@ -87,14 +85,12 @@ fn correct_host() {
 
 #[tokio::test]
 async fn fails_invalid_base64() {
-    let config: AzureMonitorLogsConfig = toml::from_str(
-        r#"
-            customer_id = "97ce69d9-b4be-4241-8dbd-d265edcf06c4"
-            shared_key = "1Qs77Vz40+iDMBBTRmROKJwnEX"
-            log_type = "Vector"
-            azure_resource_id = "97ce69d9-b4be-4241-8dbd-d265edcf06c4"
-        "#,
-    )
+    let config: AzureMonitorLogsConfig = serde_yaml::from_str(indoc::indoc! {r#"
+            customer_id: 97ce69d9-b4be-4241-8dbd-d265edcf06c4
+            shared_key: 1Qs77Vz40+iDMBBTRmROKJwnEX
+            log_type: Vector
+            azure_resource_id: 97ce69d9-b4be-4241-8dbd-d265edcf06c4
+        "#})
     .unwrap();
     if config.build(SinkContext::default()).await.is_ok() {
         panic!("config.build failed to error");
@@ -103,29 +99,27 @@ async fn fails_invalid_base64() {
 
 #[test]
 fn fails_config_missing_fields() {
-    toml::from_str::<AzureMonitorLogsConfig>(
-            r#"
-            customer_id = "97ce69d9-b4be-4241-8dbd-d265edcf06c4"
-            shared_key = "SERsIYhgMVlJB6uPsq49gCxNiruf6v0vhMYE+lfzbSGcXjdViZdV/e5pEMTYtw9f8SkVLf4LFlLCc2KxtRZfCA=="
-            azure_resource_id = "97ce69d9-b4be-4241-8dbd-d265edcf06c4"
-        "#,
+    serde_yaml::from_str::<AzureMonitorLogsConfig>(
+            indoc::indoc! {r#"
+            customer_id: 97ce69d9-b4be-4241-8dbd-d265edcf06c4
+            shared_key: "SERsIYhgMVlJB6uPsq49gCxNiruf6v0vhMYE+lfzbSGcXjdViZdV/e5pEMTYtw9f8SkVLf4LFlLCc2KxtRZfCA=="
+            azure_resource_id: 97ce69d9-b4be-4241-8dbd-d265edcf06c4
+        "#},
         )
         .expect_err("Config parsing failed to error with missing log_type");
 
-    toml::from_str::<AzureMonitorLogsConfig>(
-        r#"
-            customer_id = "97ce69d9-b4be-4241-8dbd-d265edcf06c4"
-            log_type = "Vector"
-            azure_resource_id = "97ce69d9-b4be-4241-8dbd-d265edcf06c4"
-        "#,
-    )
+    serde_yaml::from_str::<AzureMonitorLogsConfig>(indoc::indoc! {r#"
+            customer_id: 97ce69d9-b4be-4241-8dbd-d265edcf06c4
+            log_type: Vector
+            azure_resource_id: 97ce69d9-b4be-4241-8dbd-d265edcf06c4
+        "#})
     .expect_err("Config parsing failed to error with missing shared_key");
 
-    toml::from_str::<AzureMonitorLogsConfig>(
-            r#"
-            shared_key = "SERsIYhgMVlJB6uPsq49gCxNiruf6v0vhMYE+lfzbSGcXjdViZdV/e5pEMTYtw9f8SkVLf4LFlLCc2KxtRZfCA=="
-            log_type = "Vector"
-        "#,
+    serde_yaml::from_str::<AzureMonitorLogsConfig>(
+            indoc::indoc! {r#"
+            shared_key: "SERsIYhgMVlJB6uPsq49gCxNiruf6v0vhMYE+lfzbSGcXjdViZdV/e5pEMTYtw9f8SkVLf4LFlLCc2KxtRZfCA=="
+            log_type: Vector
+        "#},
         )
         .expect_err("Config parsing failed to error with missing customer_id");
 }
@@ -161,14 +155,14 @@ fn build_authorization_header_value(
 
 #[tokio::test]
 async fn correct_request() {
-    let config: AzureMonitorLogsConfig = toml::from_str(
-            r#"
+    let config: AzureMonitorLogsConfig = serde_yaml::from_str(
+            indoc::indoc! {r#"
             # random GUID and random 64 Base-64 encoded bytes
-            customer_id = "97ce69d9-b4be-4241-8dbd-d265edcf06c4"
-            shared_key = "SERsIYhgMVlJB6uPsq49gCxNiruf6v0vhMYE+lfzbSGcXjdViZdV/e5pEMTYtw9f8SkVLf4LFlLCc2KxtRZfCA=="
-            log_type = "Vector"
-            azure_resource_id = "97ce69d9-b4be-4241-8dbd-d265edcf06c4"
-        "#,
+            customer_id: 97ce69d9-b4be-4241-8dbd-d265edcf06c4
+            shared_key: "SERsIYhgMVlJB6uPsq49gCxNiruf6v0vhMYE+lfzbSGcXjdViZdV/e5pEMTYtw9f8SkVLf4LFlLCc2KxtRZfCA=="
+            log_type: Vector
+            azure_resource_id: 97ce69d9-b4be-4241-8dbd-d265edcf06c4
+        "#},
         )
         .unwrap();
 

--- a/src/sinks/clickhouse/integration_tests.rs
+++ b/src/sinks/clickhouse/integration_tests.rs
@@ -203,17 +203,20 @@ async fn insert_events_unix_timestamps_toml_config() {
     let table = random_table_name();
     let host = clickhouse_address();
 
-    let config: ClickhouseConfig = toml::from_str(&format!(
-        r#"
-host = "{host}"
-table = "{table}"
-compression = "none"
-[request]
-retry_attempts = 1
-[batch]
-max_events = 1
-[encoding]
-timestamp_format = "unix""#
+    let config: ClickhouseConfig = serde_yaml::from_str(&format!(
+        indoc::indoc! {r#"
+            host: "{host}"
+            table: "{table}"
+            compression: "none"
+            request:
+              retry_attempts: 1
+            batch:
+              max_events: 1
+            encoding:
+              timestamp_format: "unix"
+        "#},
+        host = host,
+        table = table,
     ))
     .unwrap();
 

--- a/src/sinks/databend/config.rs
+++ b/src/sinks/databend/config.rs
@@ -224,12 +224,10 @@ mod tests {
 
     #[test]
     fn parse_config() {
-        let cfg = toml::from_str::<DatabendConfig>(
-            r#"
-            endpoint = "databend://localhost:8000/mydatabase?sslmode=disable"
-            table = "mytable"
-        "#,
-        )
+        let cfg = serde_yaml::from_str::<DatabendConfig>(indoc::indoc! {r#"
+            endpoint: "databend://localhost:8000/mydatabase?sslmode=disable"
+            table: "mytable"
+        "#})
         .unwrap();
         assert_eq!(
             cfg.endpoint.uri,
@@ -245,15 +243,18 @@ mod tests {
 
     #[test]
     fn parse_config_with_encoding_compression() {
-        let cfg = toml::from_str::<DatabendConfig>(
-            r#"
-            endpoint = "databend://localhost:8000/mydatabase?sslmode=disable"
-            table = "mytable"
-            encoding.codec = "csv"
-            encoding.csv.fields = ["host", "timestamp", "message"]
-            compression = "gzip"
-        "#,
-        )
+        let cfg = serde_yaml::from_str::<DatabendConfig>(indoc::indoc! {r#"
+            endpoint: "databend://localhost:8000/mydatabase?sslmode=disable"
+            table: "mytable"
+            encoding:
+              codec: "csv"
+              csv:
+                fields:
+                  - "host"
+                  - "timestamp"
+                  - "message"
+            compression: "gzip"
+        "#})
         .unwrap();
         assert_eq!(
             cfg.endpoint.uri,

--- a/src/sinks/datadog/traces/apm_stats/integration_tests.rs
+++ b/src/sinks/datadog/traces/apm_stats/integration_tests.rs
@@ -329,10 +329,10 @@ fn validate_stats(agent_stats: &StatsPayload, vector_stats: &StatsPayload) {
 async fn start_vector() -> (RunningTopology, ShutdownErrorReceiver) {
     let dd_agent_address = format!("0.0.0.0:{}", vector_receive_port());
 
-    let source_config = toml::from_str::<DatadogAgentConfig>(&format!(
+    let source_config = serde_yaml::from_str::<DatadogAgentConfig>(&format!(
         indoc! { r#"
-            address = "{}"
-            multiple_outputs = true
+            address: "{}"
+            multiple_outputs: true
         "#},
         dd_agent_address,
     ))
@@ -344,9 +344,10 @@ async fn start_vector() -> (RunningTopology, ShutdownErrorReceiver) {
     let dd_traces_endpoint = format!("http://127.0.0.1:{}", server_port_for_vector());
     let cfg = format!(
         indoc! { r#"
-            default_api_key = "atoken"
-            endpoint = "{}"
-            batch.max_events = 1
+            default_api_key: "atoken"
+            endpoint: "{}"
+            batch:
+              max_events: 1
         "#},
         dd_traces_endpoint
     );
@@ -356,7 +357,7 @@ async fn start_vector() -> (RunningTopology, ShutdownErrorReceiver) {
     assert!(!api_key.is_empty(), "TEST_DATADOG_API_KEY required");
     let cfg = cfg.replace("atoken", &api_key);
 
-    let sink_config = toml::from_str::<DatadogTracesConfig>(&cfg).unwrap();
+    let sink_config = serde_yaml::from_str::<DatadogTracesConfig>(&cfg).unwrap();
 
     builder.add_sink("out", &["in.traces"], sink_config);
 

--- a/src/sinks/elasticsearch/config.rs
+++ b/src/sinks/elasticsearch/config.rs
@@ -608,33 +608,30 @@ mod tests {
 
     #[test]
     fn parse_aws_auth() {
-        toml::from_str::<ElasticsearchConfig>(
-            r#"
-            endpoints = [""]
-            auth.strategy = "aws"
-            auth.assume_role = "role"
-        "#,
-        )
+        serde_yaml::from_str::<ElasticsearchConfig>(indoc::indoc! {r#"
+            endpoints: [""]
+            auth:
+              strategy: aws
+              assume_role: role
+        "#})
         .unwrap();
 
-        toml::from_str::<ElasticsearchConfig>(
-            r#"
-            endpoints = [""]
-            auth.strategy = "aws"
-        "#,
-        )
+        serde_yaml::from_str::<ElasticsearchConfig>(indoc::indoc! {r#"
+            endpoints: [""]
+            auth:
+              strategy: aws
+        "#})
         .unwrap();
     }
 
     #[test]
     fn parse_mode() {
-        let config = toml::from_str::<ElasticsearchConfig>(
-            r#"
-            endpoints = [""]
-            mode = "data_stream"
-            data_stream.type = "synthetics"
-        "#,
-        )
+        let config = serde_yaml::from_str::<ElasticsearchConfig>(indoc::indoc! {r#"
+            endpoints: [""]
+            mode: data_stream
+            data_stream:
+              type: synthetics
+        "#})
         .unwrap();
         assert!(matches!(config.mode, ElasticsearchMode::DataStream));
         assert!(config.data_stream.is_some());
@@ -642,46 +639,39 @@ mod tests {
 
     #[test]
     fn parse_distribution() {
-        toml::from_str::<ElasticsearchConfig>(
-            r#"
-            endpoints = ["", ""]
-            distribution.retry_initial_backoff_secs = 10
-        "#,
-        )
+        serde_yaml::from_str::<ElasticsearchConfig>(indoc::indoc! {r#"
+            endpoints: ["", ""]
+            distribution:
+              retry_initial_backoff_secs: 10
+        "#})
         .unwrap();
     }
 
     #[test]
     fn parse_version() {
-        let config = toml::from_str::<ElasticsearchConfig>(
-            r#"
-            endpoints = [""]
-            api_version = "v7"
-        "#,
-        )
+        let config = serde_yaml::from_str::<ElasticsearchConfig>(indoc::indoc! {r#"
+            endpoints: [""]
+            api_version: v7
+        "#})
         .unwrap();
         assert_eq!(config.api_version, ElasticsearchApiVersion::V7);
     }
 
     #[test]
     fn parse_version_auto() {
-        let config = toml::from_str::<ElasticsearchConfig>(
-            r#"
-            endpoints = [""]
-            api_version = "auto"
-        "#,
-        )
+        let config = serde_yaml::from_str::<ElasticsearchConfig>(indoc::indoc! {r#"
+            endpoints: [""]
+            api_version: auto
+        "#})
         .unwrap();
         assert_eq!(config.api_version, ElasticsearchApiVersion::Auto);
     }
 
     #[test]
     fn parse_default_bulk() {
-        let config = toml::from_str::<ElasticsearchConfig>(
-            r#"
-            endpoints = [""]
-        "#,
-        )
+        let config = serde_yaml::from_str::<ElasticsearchConfig>(indoc::indoc! {r#"
+            endpoints: [""]
+        "#})
         .unwrap();
         assert_eq!(config.mode, ElasticsearchMode::Bulk);
         assert_eq!(config.bulk, BulkConfig::default());
@@ -689,12 +679,10 @@ mod tests {
 
     #[test]
     fn parse_opensearch_service_type_managed() {
-        let config = toml::from_str::<ElasticsearchConfig>(
-            r#"
-            endpoints = [""]
-            opensearch_service_type = "managed"
-        "#,
-        )
+        let config = serde_yaml::from_str::<ElasticsearchConfig>(indoc::indoc! {r#"
+            endpoints: [""]
+            opensearch_service_type: managed
+        "#})
         .unwrap();
         assert_eq!(
             config.opensearch_service_type,
@@ -704,14 +692,13 @@ mod tests {
 
     #[test]
     fn parse_opensearch_service_type_serverless() {
-        let config = toml::from_str::<ElasticsearchConfig>(
-            r#"
-            endpoints = [""]
-            opensearch_service_type = "serverless"
-            auth.strategy = "aws"
-            api_version = "auto"
-        "#,
-        )
+        let config = serde_yaml::from_str::<ElasticsearchConfig>(indoc::indoc! {r#"
+            endpoints: [""]
+            opensearch_service_type: serverless
+            auth:
+              strategy: aws
+            api_version: auto
+        "#})
         .unwrap();
         assert_eq!(
             config.opensearch_service_type,
@@ -721,11 +708,9 @@ mod tests {
 
     #[test]
     fn parse_opensearch_service_type_default() {
-        let config = toml::from_str::<ElasticsearchConfig>(
-            r#"
-            endpoints = [""]
-        "#,
-        )
+        let config = serde_yaml::from_str::<ElasticsearchConfig>(indoc::indoc! {r#"
+            endpoints: [""]
+        "#})
         .unwrap();
         assert_eq!(
             config.opensearch_service_type,
@@ -736,14 +721,13 @@ mod tests {
     #[cfg(feature = "aws-core")]
     #[test]
     fn parse_opensearch_serverless_with_aws_auth() {
-        let config = toml::from_str::<ElasticsearchConfig>(
-            r#"
-            endpoints = [""]
-            opensearch_service_type = "serverless"
-            auth.strategy = "aws"
-            api_version = "auto"
-        "#,
-        )
+        let config = serde_yaml::from_str::<ElasticsearchConfig>(indoc::indoc! {r#"
+            endpoints: [""]
+            opensearch_service_type: serverless
+            auth:
+              strategy: aws
+            api_version: auto
+        "#})
         .unwrap();
         assert_eq!(
             config.opensearch_service_type,

--- a/src/sinks/gcp/pubsub.rs
+++ b/src/sinks/gcp/pubsub.rs
@@ -253,10 +253,11 @@ mod tests {
 
     #[tokio::test]
     async fn fails_missing_creds() {
-        let config: PubsubConfig = toml::from_str(indoc! {r#"
-                project = "project"
-                topic = "topic"
-                encoding.codec = "json"
+        let config: PubsubConfig = serde_yaml::from_str(indoc! {r#"
+                project: project
+                topic: topic
+                encoding:
+                  codec: json
             "#})
         .unwrap();
         if config.build(SinkContext::default()).await.is_ok() {

--- a/src/sinks/gcp/stackdriver/logs/tests.rs
+++ b/src/sinks/gcp/stackdriver/logs/tests.rs
@@ -317,11 +317,12 @@ async fn correct_request() {
 
 #[tokio::test]
 async fn fails_missing_creds() {
-    let config: StackdriverConfig = toml::from_str(indoc! {r#"
-            project_id = "project"
-            log_id = "testlogs"
-            resource.type = "generic_node"
-            resource.namespace = "office"
+    let config: StackdriverConfig = serde_yaml::from_str(indoc! {r#"
+            project_id: project
+            log_id: testlogs
+            resource:
+              type: generic_node
+              namespace: office
         "#})
     .unwrap();
     if config.build(SinkContext::default()).await.is_ok() {
@@ -331,19 +332,21 @@ async fn fails_missing_creds() {
 
 #[test]
 fn fails_invalid_log_names() {
-    toml::from_str::<StackdriverConfig>(indoc! {r#"
-            log_id = "testlogs"
-            resource.type = "generic_node"
-            resource.namespace = "office"
+    serde_yaml::from_str::<StackdriverConfig>(indoc! {r#"
+            log_id: testlogs
+            resource:
+              type: generic_node
+              namespace: office
         "#})
     .expect_err("Config parsing failed to error with missing ids");
 
-    toml::from_str::<StackdriverConfig>(indoc! {r#"
-            project_id = "project"
-            folder_id = "folder"
-            log_id = "testlogs"
-            resource.type = "generic_node"
-            resource.namespace = "office"
+    serde_yaml::from_str::<StackdriverConfig>(indoc! {r#"
+            project_id: project
+            folder_id: folder
+            log_id: testlogs
+            resource:
+              type: generic_node
+              namespace: office
         "#})
     .expect_err("Config parsing failed to error with extraneous ids");
 }

--- a/src/sinks/gcp_chronicle/chronicle_unstructured.rs
+++ b/src/sinks/gcp_chronicle/chronicle_unstructured.rs
@@ -691,17 +691,18 @@ mod integration_tests {
         let address = std::env::var(ADDRESS_ENV_VAR).unwrap();
         let config = format!(
             indoc! { r#"
-             endpoint = "{}"
-             customer_id = "customer id"
-             namespace = "namespace"
-             credentials_path = "{}"
-             log_type = "{}"
-             encoding.codec = "text"
+             endpoint: "{}"
+             customer_id: "customer id"
+             namespace: namespace
+             credentials_path: "{}"
+             log_type: "{}"
+             encoding:
+               codec: text
         "# },
             address, auth_path, log_type
         );
 
-        let config: ChronicleUnstructuredConfig = toml::from_str(&config).unwrap();
+        let config: ChronicleUnstructuredConfig = serde_yaml::from_str(&config).unwrap();
         config
     }
 

--- a/src/sinks/greptimedb/metrics/config.rs
+++ b/src/sinks/greptimedb/metrics/config.rs
@@ -173,10 +173,10 @@ mod tests {
     #[test]
     fn test_config_with_username() {
         let config = indoc! {r#"
-            endpoint = "foo-bar.ap-southeast-1.aws.greptime.cloud:4001"
-            dbname = "foo-bar"
+            endpoint: "foo-bar.ap-southeast-1.aws.greptime.cloud:4001"
+            dbname: "foo-bar"
         "#};
 
-        toml::from_str::<GreptimeDBMetricsConfig>(config).unwrap();
+        serde_yaml::from_str::<GreptimeDBMetricsConfig>(config).unwrap();
     }
 }

--- a/src/sinks/http/tests.rs
+++ b/src/sinks/http/tests.rs
@@ -122,27 +122,31 @@ fn http_encode_event_ndjson() {
 
 #[test]
 fn http_validates_normal_headers() {
-    let config = r#"
-        uri = "http://$IN_ADDR/frames"
-        encoding.codec = "text"
-        [request.headers]
-        Auth = "token:thing_and-stuff"
-        X-Custom-Nonsense = "_%_{}_-_&_._`_|_~_!_#_&_$_"
-        "#;
-    let config: HttpSinkConfig = toml::from_str(config).unwrap();
+    let config = indoc::indoc! {r#"
+        uri: "http://$IN_ADDR/frames"
+        encoding:
+          codec: text
+        request:
+          headers:
+            Auth: "token:thing_and-stuff"
+            X-Custom-Nonsense: "_%_{}_-_&_._`_|_~_!_#_&_$_"
+        "#};
+    let config: HttpSinkConfig = serde_yaml::from_str(config).unwrap();
 
     assert!(validate_headers(&config.request.headers, false).is_ok());
 }
 
 #[test]
 fn http_catches_bad_header_names() {
-    let config = r#"
-        uri = "http://$IN_ADDR/frames"
-        encoding.codec = "text"
-        [request.headers]
-        "\u0001" = "bad"
-        "#;
-    let config: HttpSinkConfig = toml::from_str(config).unwrap();
+    let config = indoc::indoc! {r#"
+        uri: "http://$IN_ADDR/frames"
+        encoding:
+          codec: text
+        request:
+          headers:
+            "\x01": "bad"
+        "#};
+    let config: HttpSinkConfig = serde_yaml::from_str(config).unwrap();
 
     assert_downcast_matches!(
         validate_headers(&config.request.headers, false).unwrap_err(),
@@ -153,13 +157,14 @@ fn http_catches_bad_header_names() {
 
 #[test]
 fn http_validates_payload_prefix_and_suffix() {
-    let config = r#"
-        uri = "http://$IN_ADDR/"
-        encoding.codec = "json"
-        payload_prefix = '{"data":'
-        payload_suffix = "}"
-        "#;
-    let config: HttpSinkConfig = toml::from_str(config).unwrap();
+    let config = indoc::indoc! {r#"
+        uri: "http://$IN_ADDR/"
+        encoding:
+          codec: json
+        payload_prefix: '{"data":'
+        payload_suffix: "}"
+        "#};
+    let config: HttpSinkConfig = serde_yaml::from_str(config).unwrap();
     let (framer, serializer) = config.encoding.build(SinkType::MessageBased).unwrap();
     let encoder = Encoder::<Framer>::new(framer, serializer);
     assert!(
@@ -169,13 +174,14 @@ fn http_validates_payload_prefix_and_suffix() {
 
 #[test]
 fn http_validates_payload_prefix_and_suffix_fails_on_invalid_json() {
-    let config = r#"
-        uri = "http://$IN_ADDR/"
-        encoding.codec = "json"
-        payload_prefix = '{"data":'
-        payload_suffix = ""
-        "#;
-    let config: HttpSinkConfig = toml::from_str(config).unwrap();
+    let config = indoc::indoc! {r#"
+        uri: "http://$IN_ADDR/"
+        encoding:
+          codec: json
+        payload_prefix: '{"data":'
+        payload_suffix: ""
+        "#};
+    let config: HttpSinkConfig = serde_yaml::from_str(config).unwrap();
     let (framer, serializer) = config.encoding.build(SinkType::MessageBased).unwrap();
     let encoder = Encoder::<Framer>::new(framer, serializer);
     assert!(
@@ -188,17 +194,19 @@ fn http_validates_payload_prefix_and_suffix_fails_on_invalid_json() {
 #[tokio::test]
 #[should_panic(expected = "Authorization header can not be used with defined auth options")]
 async fn http_headers_auth_conflict() {
-    let config = r#"
-        uri = "http://$IN_ADDR/"
-        encoding.codec = "text"
-        [request.headers]
-        Authorization = "Basic base64encodedstring"
-        [auth]
-        strategy = "basic"
-        user = "user"
-        password = "password"
-        "#;
-    let config: HttpSinkConfig = toml::from_str(config).unwrap();
+    let config = indoc::indoc! {r#"
+        uri: "http://$IN_ADDR/"
+        encoding:
+          codec: text
+        request:
+          headers:
+            Authorization: "Basic base64encodedstring"
+        auth:
+          strategy: basic
+          user: user
+          password: password
+        "#};
+    let config: HttpSinkConfig = serde_yaml::from_str(config).unwrap();
 
     let cx = SinkContext::default();
 
@@ -208,12 +216,12 @@ async fn http_headers_auth_conflict() {
 #[tokio::test]
 async fn http_happy_path_post() {
     run_sink(
-        r#"
-        [auth]
-        strategy = "basic"
-        user = "waldo"
-        password = "hunter2"
-    "#,
+        indoc::indoc! {r#"
+        auth:
+          strategy: basic
+          user: waldo
+          password: hunter2
+        "#},
         |parts| {
             assert_eq!(Method::POST, parts.method);
             assert_eq!("/frames", parts.uri.path());
@@ -229,13 +237,13 @@ async fn http_happy_path_post() {
 #[tokio::test]
 async fn http_happy_path_put() {
     run_sink(
-        r#"
-        method = "put"
-        [auth]
-        strategy = "basic"
-        user = "waldo"
-        password = "hunter2"
-    "#,
+        indoc::indoc! {r#"
+        method: put
+        auth:
+          strategy: basic
+          user: waldo
+          password: hunter2
+        "#},
         |parts| {
             assert_eq!(Method::PUT, parts.method);
             assert_eq!("/frames", parts.uri.path());
@@ -251,11 +259,12 @@ async fn http_happy_path_put() {
 #[tokio::test]
 async fn http_passes_custom_headers() {
     run_sink(
-        r#"
-        [request.headers]
-        foo = "bar"
-        baz = "quux"
-    "#,
+        indoc::indoc! {r#"
+        request:
+          headers:
+            foo: bar
+            baz: quux
+        "#},
         |parts| {
             assert_eq!(Method::POST, parts.method);
             assert_eq!("/frames", parts.uri.path());
@@ -275,14 +284,15 @@ async fn http_passes_custom_headers() {
 #[tokio::test]
 async fn http_passes_template_headers() {
     run_sink_with_events(
-        r#"
-        [request.headers]
-        Static-Header = "static-value"
-        Accept = "application/vnd.api+json"
-        X-Event-Level = "{{level}}"
-        X-Event-Message = "{{message}}"
-        X-Static-Template = "constant-value"
-    "#,
+        indoc::indoc! {r#"
+        request:
+          headers:
+            Static-Header: static-value
+            Accept: "application/vnd.api+json"
+            X-Event-Level: "{{level}}"
+            X-Event-Message: "{{message}}"
+            X-Static-Template: constant-value
+        "#},
         || {
             let mut event = Event::Log(LogEvent::from("test message"));
             event.as_mut_log().insert("level", "info");
@@ -334,11 +344,12 @@ async fn http_passes_template_headers() {
 #[tokio::test]
 async fn http_template_headers_missing_fields() {
     run_sink_with_events(
-        r#"
-        [request.headers]
-        X-Required-Field = "{{required_field}}"
-        X-Static = "static-value"
-    "#,
+        indoc::indoc! {r#"
+        request:
+          headers:
+            X-Required-Field: "{{required_field}}"
+            X-Static: static-value
+        "#},
         || {
             let mut event = Event::Log(LogEvent::from("good event"));
             event.as_mut_log().insert("required_field", "present");
@@ -451,13 +462,15 @@ async fn custom_retry_retries_only_configured_status_code() {
     components::assert_sink_compliance(&HTTP_SINK_TAGS, async {
         const NUM_LINES: usize = 1;
         const NUM_FAILURES: usize = 2;
-        const CUSTOM_RETRY_CONFIG: &str = r#"
-            request.retry_attempts = 2
-            request.retry_initial_backoff_secs = 1
-            request.retry_max_duration_secs = 1
-            retry_strategy.type = "custom"
-            retry_strategy.status_codes = [408, 425, 429, 503]
-        "#;
+        const CUSTOM_RETRY_CONFIG: &str = indoc::indoc! {r#"
+            request:
+              retry_attempts: 2
+              retry_initial_backoff_secs: 1
+              retry_max_duration_secs: 1
+            retry_strategy:
+              type: custom
+              status_codes: [408, 425, 429, 503]
+        "#};
 
         let (in_addr, sink) = build_sink(CUSTOM_RETRY_CONFIG).await;
 
@@ -504,13 +517,15 @@ async fn custom_retry_retries_only_configured_status_code() {
 async fn custom_retry_does_not_retry_unconfigured_status_code() {
     components::assert_sink_error(&COMPONENT_ERROR_TAGS, async {
         const NUM_LINES: usize = 1;
-        const CUSTOM_RETRY_CONFIG: &str = r#"
-            request.retry_attempts = 2
-            request.retry_initial_backoff_secs = 1
-            request.retry_max_duration_secs = 1
-            retry_strategy.type = "custom"
-            retry_strategy.status_codes = [408, 425, 429, 503]
-        "#;
+        const CUSTOM_RETRY_CONFIG: &str = indoc::indoc! {r#"
+            request:
+              retry_attempts: 2
+              retry_initial_backoff_secs: 1
+              retry_max_duration_secs: 1
+            retry_strategy:
+              type: custom
+              status_codes: [408, 425, 429, 503]
+        "#};
 
         let (in_addr, sink) = build_sink(CUSTOM_RETRY_CONFIG).await;
 
@@ -609,20 +624,20 @@ async fn json_compression(compression: &str) {
         let (_guard, in_addr) = next_addr();
 
         let config = r#"
-        uri = "http://$IN_ADDR/frames"
-        compression = "$COMPRESSION"
-        encoding.codec = "json"
-        method = "post"
-
-        [auth]
-        strategy = "basic"
-        user = "waldo"
-        password = "hunter2"
+        uri: "http://$IN_ADDR/frames"
+        compression: "$COMPRESSION"
+        encoding:
+          codec: json
+        method: post
+        auth:
+          strategy: basic
+          user: waldo
+          password: hunter2
     "#
         .replace("$IN_ADDR", &in_addr.to_string())
         .replace("$COMPRESSION", compression);
 
-        let config: HttpSinkConfig = toml::from_str(&config).unwrap();
+        let config: HttpSinkConfig = serde_yaml::from_str(&config).unwrap();
 
         let cx = SinkContext::default();
 
@@ -668,22 +683,22 @@ async fn json_compression_with_payload_wrapper(compression: &str) {
         let (_guard, in_addr) = next_addr();
 
         let config = r#"
-        uri = "http://$IN_ADDR/frames"
-        compression = "$COMPRESSION"
-        encoding.codec = "json"
-        payload_prefix = '{"data":'
-        payload_suffix = "}"
-        method = "post"
-
-        [auth]
-        strategy = "basic"
-        user = "waldo"
-        password = "hunter2"
+        uri: "http://$IN_ADDR/frames"
+        compression: "$COMPRESSION"
+        encoding:
+          codec: json
+        payload_prefix: '{"data":'
+        payload_suffix: "}"
+        method: post
+        auth:
+          strategy: basic
+          user: waldo
+          password: hunter2
     "#
         .replace("$IN_ADDR", &in_addr.to_string())
         .replace("$COMPRESSION", compression);
 
-        let config: HttpSinkConfig = toml::from_str(&config).unwrap();
+        let config: HttpSinkConfig = serde_yaml::from_str(&config).unwrap();
 
         let cx = SinkContext::default();
 
@@ -739,12 +754,13 @@ async fn templateable_uri_path() {
 
     let config = format!(
         r#"
-        uri = "http://{in_addr}/id/{{{{id}}}}"
-        encoding.codec = "json"
+        uri: "http://{in_addr}/id/{{{{id}}}}"
+        encoding:
+          codec: json
         "#
     );
 
-    let config: HttpSinkConfig = toml::from_str(&config).unwrap();
+    let config: HttpSinkConfig = serde_yaml::from_str(&config).unwrap();
 
     let cx = SinkContext::default();
 
@@ -809,12 +825,13 @@ async fn templateable_uri_auth() {
     let (_guard, in_addr) = next_addr();
     let config = format!(
         r#"
-        uri = "http://{{{{user}}}}:{{{{pass}}}}@{in_addr}/"
-        encoding.codec = "json"
+        uri: "http://{{{{user}}}}:{{{{pass}}}}@{in_addr}/"
+        encoding:
+          codec: json
         "#
     );
 
-    let config: HttpSinkConfig = toml::from_str(&config).unwrap();
+    let config: HttpSinkConfig = serde_yaml::from_str(&config).unwrap();
 
     let cx = SinkContext::default();
 
@@ -877,11 +894,12 @@ async fn missing_field_in_uri_template() {
     let (_guard, in_addr) = next_addr();
     let config = format!(
         r#"
-        uri = "http://{in_addr}/{{{{missing_field}}}}"
-        encoding.codec = "json"
+        uri: "http://{in_addr}/{{{{missing_field}}}}"
+        encoding:
+          codec: json
         "#
     );
-    let config: HttpSinkConfig = toml::from_str(&config).unwrap();
+    let config: HttpSinkConfig = serde_yaml::from_str(&config).unwrap();
 
     let cx = SinkContext::default();
 
@@ -922,14 +940,16 @@ async fn http_uri_auth_conflict() {
     let (_guard, in_addr) = next_addr();
     let config = format!(
         r#"
-        uri = "http://user:pass@{in_addr}/"
-        encoding.codec = "json"
-        auth.strategy = "basic"
-        auth.user = "user"
-        auth.password = "pass"
+        uri: "http://user:pass@{in_addr}/"
+        encoding:
+          codec: json
+        auth:
+          strategy: basic
+          user: user
+          password: pass
         "#
     );
-    let config: HttpSinkConfig = toml::from_str(&config).unwrap();
+    let config: HttpSinkConfig = serde_yaml::from_str(&config).unwrap();
 
     let cx = SinkContext::default();
 
@@ -1016,16 +1036,16 @@ async fn run_sink_with_events(
 async fn build_sink(extra_config: &str) -> (std::net::SocketAddr, crate::sinks::VectorSink) {
     let (_guard, in_addr) = next_addr();
 
-    let config = format!(
-        r#"
-                uri = "http://{in_addr}/frames"
-                compression = "gzip"
-                framing.method = "newline_delimited"
-                encoding.codec = "json"
-                {extra_config}
-            "#,
-    );
-    let config: HttpSinkConfig = toml::from_str(&config).unwrap();
+    let config = indoc::formatdoc! {r#"
+        uri: "http://{in_addr}/frames"
+        compression: gzip
+        framing:
+          method: newline_delimited
+        encoding:
+          codec: json
+        {extra_config}
+    "#};
+    let config: HttpSinkConfig = serde_yaml::from_str(&config).unwrap();
 
     let cx = SinkContext::default();
 

--- a/src/sinks/influxdb/logs.rs
+++ b/src/sinks/influxdb/logs.rs
@@ -423,24 +423,24 @@ mod tests {
     #[test]
     fn test_config_without_tags() {
         let config = indoc! {r#"
-            namespace = "vector-logs"
-            endpoint = "http://localhost:9999"
-            bucket = "my-bucket"
-            org = "my-org"
-            token = "my-token"
+            namespace: "vector-logs"
+            endpoint: "http://localhost:9999"
+            bucket: "my-bucket"
+            org: "my-org"
+            token: "my-token"
         "#};
 
-        toml::from_str::<InfluxDbLogsConfig>(config).unwrap();
+        serde_yaml::from_str::<InfluxDbLogsConfig>(config).unwrap();
     }
 
     #[test]
     fn test_config_measurement_from_namespace() {
         let config = indoc! {r#"
-            namespace = "ns"
-            endpoint = "http://localhost:9999"
+            namespace: "ns"
+            endpoint: "http://localhost:9999"
         "#};
 
-        let sink_config = toml::from_str::<InfluxDbLogsConfig>(config).unwrap();
+        let sink_config = serde_yaml::from_str::<InfluxDbLogsConfig>(config).unwrap();
         assert_eq!("ns.vector", sink_config.get_measurement().unwrap());
     }
 

--- a/src/sinks/influxdb/metrics.rs
+++ b/src/sinks/influxdb/metrics.rs
@@ -449,12 +449,13 @@ mod tests {
     #[test]
     fn test_config_with_tags() {
         let config = indoc! {r#"
-            namespace = "vector"
-            endpoint = "http://localhost:9999"
-            tags = {region="us-west-1"}
+            namespace: "vector"
+            endpoint: "http://localhost:9999"
+            tags:
+              region: "us-west-1"
         "#};
 
-        toml::from_str::<InfluxDbConfig>(config).unwrap();
+        serde_yaml::from_str::<InfluxDbConfig>(config).unwrap();
     }
 
     #[test]

--- a/src/sinks/influxdb/mod.rs
+++ b/src/sinks/influxdb/mod.rs
@@ -580,13 +580,13 @@ mod tests {
 
     #[test]
     fn test_influxdb_settings_both() {
-        let config = r#"
-        bucket = "my-bucket"
-        org = "my-org"
-        token = "my-token"
-        database = "my-database"
-    "#;
-        let config: InfluxDbTestConfig = toml::from_str(config).unwrap();
+        let config = indoc::indoc! {r#"
+        bucket: "my-bucket"
+        org: "my-org"
+        token: "my-token"
+        database: "my-database"
+        "#};
+        let config: InfluxDbTestConfig = serde_yaml::from_str(config).unwrap();
         let settings = influxdb_settings(config.influxdb1_settings, config.influxdb2_settings);
         assert_eq!(
             settings.expect_err("expected error").to_string(),
@@ -596,9 +596,8 @@ mod tests {
 
     #[test]
     fn test_influxdb_settings_missing() {
-        let config = r"
-    ";
-        let config: InfluxDbTestConfig = toml::from_str(config).unwrap();
+        let config = "{}";
+        let config: InfluxDbTestConfig = serde_yaml::from_str(config).unwrap();
         let settings = influxdb_settings(config.influxdb1_settings, config.influxdb2_settings);
         assert_eq!(
             settings.expect_err("expected error").to_string(),
@@ -608,21 +607,21 @@ mod tests {
 
     #[test]
     fn test_influxdb1_settings() {
-        let config = r#"
-        database = "my-database"
-    "#;
-        let config: InfluxDbTestConfig = toml::from_str(config).unwrap();
+        let config = indoc::indoc! {r#"
+        database: "my-database"
+        "#};
+        let config: InfluxDbTestConfig = serde_yaml::from_str(config).unwrap();
         _ = influxdb_settings(config.influxdb1_settings, config.influxdb2_settings).unwrap();
     }
 
     #[test]
     fn test_influxdb2_settings() {
-        let config = r#"
-        bucket = "my-bucket"
-        org = "my-org"
-        token = "my-token"
-    "#;
-        let config: InfluxDbTestConfig = toml::from_str(config).unwrap();
+        let config = indoc::indoc! {r#"
+        bucket: "my-bucket"
+        org: "my-org"
+        token: "my-token"
+        "#};
+        let config: InfluxDbTestConfig = serde_yaml::from_str(config).unwrap();
         _ = influxdb_settings(config.influxdb1_settings, config.influxdb2_settings).unwrap();
     }
 

--- a/src/sinks/postgres/config.rs
+++ b/src/sinks/postgres/config.rs
@@ -138,12 +138,10 @@ mod tests {
 
     #[test]
     fn parse_config() {
-        let cfg = toml::from_str::<PostgresConfig>(
-            r#"
-            endpoint = "postgres://user:password@localhost/default"
-            table = "mytable"
-        "#,
-        )
+        let cfg = serde_yaml::from_str::<PostgresConfig>(indoc::indoc! {r#"
+            endpoint: "postgres://user:password@localhost/default"
+            table: "mytable"
+        "#})
         .unwrap();
         assert_eq!(cfg.endpoint, "postgres://user:password@localhost/default");
         assert_eq!(cfg.table, "mytable");

--- a/src/sinks/prometheus/remote_write/tests.rs
+++ b/src/sinks/prometheus/remote_write/tests.rs
@@ -54,11 +54,11 @@ async fn sends_request() {
 async fn sends_authenticated_request() {
     let outputs = send_request(
         indoc! {r#"
-                tenant_id = "tenant-%Y"
-                [auth]
-                strategy = "basic"
-                user = "user"
-                password = "password"
+                tenant_id: "tenant-%Y"
+                auth:
+                  strategy: "basic"
+                  user: "user"
+                  password: "password"
             "#},
         vec![create_event("gauge-2".into(), 32.0)],
     )
@@ -84,13 +84,13 @@ async fn sends_authenticated_request() {
 async fn sends_authenticated_aws_request() {
     let outputs = send_request(
         indoc! {r#"
-                tenant_id = "tenant-%Y"
-                [aws]
-                region = "foo"
-                [auth]
-                strategy = "aws"
-                access_key_id = "foo"
-                secret_access_key = "bar"
+                tenant_id: "tenant-%Y"
+                aws:
+                  region: "foo"
+                auth:
+                  strategy: "aws"
+                  access_key_id: "foo"
+                  secret_access_key: "bar"
             "#},
         vec![create_event("gauge-2".into(), 32.0)],
     )
@@ -108,7 +108,7 @@ async fn sends_authenticated_aws_request() {
 #[tokio::test]
 async fn sends_x_scope_orgid_header() {
     let outputs = send_request(
-        r#"tenant_id = "tenant""#,
+        r#"tenant_id: "tenant""#,
         vec![create_event("gauge-3".into(), 12.0)],
     )
     .await;
@@ -121,7 +121,7 @@ async fn sends_x_scope_orgid_header() {
 #[tokio::test]
 async fn sends_templated_x_scope_orgid_header() {
     let outputs = send_request(
-        r#"tenant_id = "tenant-%Y""#,
+        r#"tenant_id: "tenant-%Y""#,
         vec![create_event("gauge-3".into(), 12.0)],
     )
     .await;
@@ -139,9 +139,10 @@ async fn sends_templated_x_scope_orgid_header() {
 async fn sends_custom_headers() {
     let outputs = send_request(
         indoc! {r#"
-                [request.headers]
-                X-Custom-Header = "custom-value"
-                X-Another-Header = "another-value"
+                request:
+                  headers:
+                    X-Custom-Header: "custom-value"
+                    X-Another-Header: "another-value"
             "#},
         vec![create_event("gauge-4".into(), 42.0)],
     )
@@ -172,7 +173,7 @@ async fn retains_state_between_requests() {
     // This sink converts all incremental events to absolute, and
     // should accumulate their totals between batches.
     let outputs = send_request(
-        r"batch.max_events = 1",
+        "batch:\n  max_events: 1",
         vec![
             create_inc_event("counter-1".into(), 12.0),
             create_inc_event("counter-2".into(), 13.0),
@@ -198,7 +199,7 @@ async fn retains_state_between_requests() {
 #[tokio::test]
 async fn aggregates_batches() {
     let outputs = send_request(
-        r"batch.max_events = 3",
+        "batch:\n  max_events: 3",
         vec![
             create_inc_event("counter-1".into(), 12.0),
             create_inc_event("counter-1".into(), 14.0),
@@ -224,12 +225,11 @@ async fn aggregates_batches() {
 #[tokio::test]
 async fn doesnt_aggregate_batches() {
     let outputs = send_request(
-        indoc! {
-            r"
-            batch.max_events = 3
-            batch.aggregate = false
-            "
-        },
+        indoc! {"
+            batch:
+              max_events: 3
+              aggregate: false
+        "},
         vec![
             create_inc_event("counter-1".into(), 12.0),
             create_inc_event("counter-1".into(), 14.0),
@@ -266,8 +266,10 @@ async fn send_request(config: &str, events: Vec<Event>) -> Vec<(HeaderMap, proto
         let (rx, trigger, server) = build_test_server(addr);
         tokio::spawn(server);
 
-        let config = format!("endpoint = \"http://{addr}/write\"\n{config}");
-        let config: RemoteWriteConfig = toml::from_str(&config).unwrap();
+        let config = indoc::formatdoc! {r#"
+            endpoint: "http://{addr}/write"
+            {config}"#};
+        let config: RemoteWriteConfig = serde_yaml::from_str(&config).unwrap();
         let cx = SinkContext::default();
 
         let (sink, _) = config.build(cx).await.unwrap();
@@ -323,15 +325,16 @@ fn create_inc_event(name: String, value: f64) -> Event {
 #[tokio::test]
 async fn conflicting_auth_headers_rejected() {
     let config = indoc! {r#"
-        endpoint = "http://localhost:9090/api/v1/write"
-        [request.headers]
-        Authorization = "Bearer my-token"
-        [auth]
-        strategy = "bearer"
-        token = "another-token"
+        endpoint: "http://localhost:9090/api/v1/write"
+        request:
+          headers:
+            Authorization: "Bearer my-token"
+        auth:
+          strategy: "bearer"
+          token: "another-token"
     "#};
 
-    let config: RemoteWriteConfig = toml::from_str(config).unwrap();
+    let config: RemoteWriteConfig = serde_yaml::from_str(config).unwrap();
     let cx = SinkContext::default();
 
     let result = config.build(cx).await;

--- a/src/sinks/util/service.rs
+++ b/src/sinks/util/service.rs
@@ -429,28 +429,28 @@ mod tests {
         let toml = toml::to_string(&cfg).unwrap();
         toml::from_str::<TowerRequestConfig>(&toml).expect("Default config failed");
 
-        let cfg = toml::from_str::<TowerRequestConfig>("").expect("Empty config failed");
+        let cfg = serde_yaml::from_str::<TowerRequestConfig>("").expect("Empty config failed");
         assert_eq!(cfg.concurrency, Concurrency::Adaptive);
 
-        let cfg = toml::from_str::<TowerRequestConfig>("concurrency = 10")
+        let cfg = serde_yaml::from_str::<TowerRequestConfig>("concurrency: 10")
             .expect("Fixed concurrency failed");
         assert_eq!(cfg.concurrency, Concurrency::Fixed(10));
 
-        let cfg = toml::from_str::<TowerRequestConfig>(r#"concurrency = "adaptive""#)
+        let cfg = serde_yaml::from_str::<TowerRequestConfig>(r#"concurrency: "adaptive""#)
             .expect("Adaptive concurrency setting failed");
         assert_eq!(cfg.concurrency, Concurrency::Adaptive);
 
-        let cfg = toml::from_str::<TowerRequestConfig>(r#"concurrency = "none""#)
+        let cfg = serde_yaml::from_str::<TowerRequestConfig>(r#"concurrency: "none""#)
             .expect("None concurrency setting failed");
         assert_eq!(cfg.concurrency, Concurrency::None);
 
-        toml::from_str::<TowerRequestConfig>(r#"concurrency = "broken""#)
+        serde_yaml::from_str::<TowerRequestConfig>(r#"concurrency: "broken""#)
             .expect_err("Invalid concurrency setting didn't fail");
 
-        toml::from_str::<TowerRequestConfig>(r"concurrency = 0")
+        serde_yaml::from_str::<TowerRequestConfig>("concurrency: 0")
             .expect_err("Invalid concurrency setting didn't fail on zero");
 
-        toml::from_str::<TowerRequestConfig>(r"concurrency = -9")
+        serde_yaml::from_str::<TowerRequestConfig>("concurrency: -9")
             .expect_err("Invalid concurrency setting didn't fail on negative number");
     }
 
@@ -498,16 +498,15 @@ mod tests {
     #[test]
     fn into_settings_with_populated_config() {
         // Populate with values not equal to the global defaults.
-        let cfg = toml::from_str::<TowerRequestConfig>(
-            r" concurrency = 16
-            timeout_secs = 1
-            rate_limit_duration_secs = 2
-            rate_limit_num = 3
-            retry_attempts = 4
-            retry_max_duration_secs = 5
-            retry_initial_backoff_secs = 6
-        ",
-        )
+        let cfg = serde_yaml::from_str::<TowerRequestConfig>(indoc::indoc! {"
+            concurrency: 16
+            timeout_secs: 1
+            rate_limit_duration_secs: 2
+            rate_limit_num: 3
+            retry_attempts: 4
+            retry_max_duration_secs: 5
+            retry_initial_backoff_secs: 6
+        "})
         .expect("Config failed to parse");
 
         // Merge with defaults

--- a/src/sinks/vector/mod.rs
+++ b/src/sinks/vector/mod.rs
@@ -89,15 +89,13 @@ mod tests {
         let (_guard, in_addr) = next_addr();
 
         let config = match compression {
-            Some(c) => format!(
-                r#"
-                    address = "http://{in_addr}/"
-                    compression = "{c}"
-                "#
-            ),
-            None => format!(r#"address = "http://{in_addr}/""#),
+            Some(c) => indoc::formatdoc! {r#"
+                address: "http://{in_addr}/"
+                compression: "{c}"
+            "#},
+            None => format!("address: \"http://{in_addr}/\"\n"),
         };
-        let config: VectorConfig = toml::from_str(&config).unwrap();
+        let config: VectorConfig = serde_yaml::from_str(&config).unwrap();
 
         let cx = SinkContext::default();
 
@@ -199,8 +197,8 @@ mod tests {
 
         let (_guard, in_addr) = next_addr();
 
-        let config = format!(r#"address = "http://{in_addr}/""#);
-        let config: VectorConfig = toml::from_str(&config).unwrap();
+        let config = format!("address: \"http://{in_addr}/\"");
+        let config: VectorConfig = serde_yaml::from_str(&config).unwrap();
 
         let cx = SinkContext::default();
 

--- a/src/sources/aws_s3/sqs.rs
+++ b/src/sources/aws_s3/sqs.rs
@@ -1246,10 +1246,9 @@ fn test_s3_sns_testevent() {
 
 #[test]
 fn parse_sqs_config() {
-    let config: Config = toml::from_str(
-        r#"
-            queue_url = "https://sqs.us-east-1.amazonaws.com/123456789012/MyQueue"
-        "#,
+    let config: Config = serde_yaml::from_str(
+        r#"queue_url: "https://sqs.us-east-1.amazonaws.com/123456789012/MyQueue"
+"#,
     )
     .unwrap();
     assert_eq!(
@@ -1258,14 +1257,12 @@ fn parse_sqs_config() {
     );
     assert!(config.deferred.is_none());
 
-    let config: Config = toml::from_str(
-        r#"
-            queue_url = "https://sqs.us-east-1.amazonaws.com/123456789012/MyQueue"
-            [deferred]
-            queue_url = "https://sqs.us-east-1.amazonaws.com/123456789012/MyDeferredQueue"
-            max_age_secs = 3600
-        "#,
-    )
+    let config: Config = serde_yaml::from_str(indoc::indoc! {r#"
+        queue_url: "https://sqs.us-east-1.amazonaws.com/123456789012/MyQueue"
+        deferred:
+          queue_url: "https://sqs.us-east-1.amazonaws.com/123456789012/MyDeferredQueue"
+          max_age_secs: 3600
+    "#})
     .unwrap();
     assert_eq!(
         config.queue_url,
@@ -1280,21 +1277,17 @@ fn parse_sqs_config() {
     );
     assert_eq!(deferred.max_age_secs, 3600);
 
-    let test: Result<Config, toml::de::Error> = toml::from_str(
-        r#"
-            queue_url = "https://sqs.us-east-1.amazonaws.com/123456789012/MyQueue"
-            [deferred]
-            max_age_secs = 3600
-        "#,
-    );
+    let test: Result<Config, serde_yaml::Error> = serde_yaml::from_str(indoc::indoc! {r#"
+        queue_url: "https://sqs.us-east-1.amazonaws.com/123456789012/MyQueue"
+        deferred:
+          max_age_secs: 3600
+    "#});
     assert!(test.is_err());
 
-    let test: Result<Config, toml::de::Error> = toml::from_str(
-        r#"
-            queue_url = "https://sqs.us-east-1.amazonaws.com/123456789012/MyQueue"
-            [deferred]
-            queue_url = "https://sqs.us-east-1.amazonaws.com/123456789012/MyDeferredQueue"
-        "#,
-    );
+    let test: Result<Config, serde_yaml::Error> = serde_yaml::from_str(indoc::indoc! {r#"
+        queue_url: "https://sqs.us-east-1.amazonaws.com/123456789012/MyQueue"
+        deferred:
+          queue_url: "https://sqs.us-east-1.amazonaws.com/123456789012/MyDeferredQueue"
+    "#});
     assert!(test.is_err());
 }

--- a/src/sources/datadog_agent/integration_tests.rs
+++ b/src/sources/datadog_agent/integration_tests.rs
@@ -124,8 +124,8 @@ async fn wait_for_traces() {
     ]);
     let context = SourceContext::new_test(sender, Some(schema_definitions));
     tokio::spawn(async move {
-        let config_raw = "address = \"0.0.0.0:8081\"".to_string();
-        let config = toml::from_str::<DatadogAgentConfig>(config_raw.as_str()).unwrap();
+        let config =
+            serde_yaml::from_str::<DatadogAgentConfig>("address: \"0.0.0.0:8081\"").unwrap();
         config.build(context).await.unwrap().await.unwrap()
     });
     let events = spawn_collect_n(

--- a/src/sources/datadog_agent/tests.rs
+++ b/src/sources/datadog_agent/tests.rs
@@ -300,15 +300,15 @@ async fn source_with_sender(
         );
     }
     let (guard, address) = next_addr();
-    let config = toml::from_str::<DatadogAgentConfig>(&format!(
+    let config = serde_yaml::from_str::<DatadogAgentConfig>(&format!(
         indoc! { r#"
-            address = "{}"
-            compression = "none"
-            store_api_key = {}
-            acknowledgements = {}
-            multiple_outputs = {}
-            split_metric_namespace = {}
-            trace_proto = "v1v2"
+            address: "{}"
+            compression: none
+            store_api_key: {}
+            acknowledgements: {}
+            multiple_outputs: {}
+            split_metric_namespace: {}
+            trace_proto: v1v2
         "#},
         address, store_api_key, acknowledgements, multiple_outputs, split_metric_namespace
     ))
@@ -779,9 +779,9 @@ async fn send_timeout_returns_service_unavailable() {
 
 #[test]
 fn parse_config_with_send_timeout_secs() {
-    let config = toml::from_str::<DatadogAgentConfig>(indoc! { r#"
-            address = "0.0.0.0:8012"
-            send_timeout_secs = 1.5
+    let config = serde_yaml::from_str::<DatadogAgentConfig>(indoc! { r#"
+            address: "0.0.0.0:8012"
+            send_timeout_secs: 1.5
         "#})
     .unwrap();
 
@@ -791,8 +791,8 @@ fn parse_config_with_send_timeout_secs() {
 
 #[test]
 fn parse_config_without_send_timeout_secs() {
-    let config = toml::from_str::<DatadogAgentConfig>(indoc! { r#"
-            address = "0.0.0.0:8012"
+    let config = serde_yaml::from_str::<DatadogAgentConfig>(indoc! { r#"
+            address: "0.0.0.0:8012"
         "#})
     .unwrap();
 
@@ -2334,9 +2334,10 @@ async fn decode_series_endpoint_v2() {
 
 #[test]
 fn test_output_schema_definition_json_vector_namespace() {
-    let definition = toml::from_str::<DatadogAgentConfig>(indoc! { r#"
-            address = "0.0.0.0:8012"
-            decoding.codec = "json"
+    let definition = serde_yaml::from_str::<DatadogAgentConfig>(indoc! { r#"
+            address: "0.0.0.0:8012"
+            decoding:
+              codec: json
         "#})
     .unwrap()
     .outputs(LogNamespace::Vector)
@@ -2393,9 +2394,10 @@ fn test_output_schema_definition_json_vector_namespace() {
 
 #[test]
 fn test_output_schema_definition_bytes_vector_namespace() {
-    let definition = toml::from_str::<DatadogAgentConfig>(indoc! { r#"
-            address = "0.0.0.0:8012"
-            decoding.codec = "bytes"
+    let definition = serde_yaml::from_str::<DatadogAgentConfig>(indoc! { r#"
+            address: "0.0.0.0:8012"
+            decoding:
+              codec: bytes
         "#})
     .unwrap()
     .outputs(LogNamespace::Vector)
@@ -2453,9 +2455,10 @@ fn test_output_schema_definition_bytes_vector_namespace() {
 
 #[test]
 fn test_output_schema_definition_json_legacy_namespace() {
-    let definition = toml::from_str::<DatadogAgentConfig>(indoc! { r#"
-            address = "0.0.0.0:8012"
-            decoding.codec = "json"
+    let definition = serde_yaml::from_str::<DatadogAgentConfig>(indoc! { r#"
+            address: "0.0.0.0:8012"
+            decoding:
+              codec: json
         "#})
     .unwrap()
     .outputs(LogNamespace::Legacy)
@@ -2483,9 +2486,10 @@ fn test_output_schema_definition_json_legacy_namespace() {
 
 #[test]
 fn test_output_schema_definition_bytes_legacy_namespace() {
-    let definition = toml::from_str::<DatadogAgentConfig>(indoc! { r#"
-            address = "0.0.0.0:8012"
-            decoding.codec = "bytes"
+    let definition = serde_yaml::from_str::<DatadogAgentConfig>(indoc! { r#"
+            address: "0.0.0.0:8012"
+            decoding:
+              codec: bytes
         "#})
     .unwrap()
     .outputs(LogNamespace::Legacy)

--- a/src/sources/demo_logs.rs
+++ b/src/sources/demo_logs.rs
@@ -339,6 +339,7 @@ mod tests {
     use std::time::{Duration, Instant};
 
     use futures::{Stream, StreamExt, poll};
+    use indoc::indoc;
 
     use super::*;
     use crate::{
@@ -357,7 +358,7 @@ mod tests {
     async fn runit(config: &str) -> impl Stream<Item = Event> + use<> {
         assert_source_compliance(&SOURCE_TAGS, async {
             let (tx, rx) = SourceSender::new_test();
-            let config: DemoLogsConfig = toml::from_str(config).unwrap();
+            let config: DemoLogsConfig = serde_yaml::from_str(config).unwrap();
             let decoder = DecodingConfig::new(
                 default_framing_message_based(),
                 default_decoding(),
@@ -403,11 +404,15 @@ mod tests {
     #[tokio::test]
     async fn shuffle_demo_logs_copies_lines() {
         let message_key = log_schema().message_key().unwrap().to_string();
-        let mut rx = runit(
-            r#"format = "shuffle"
-               lines = ["one", "two", "three", "four"]
-               count = 5"#,
-        )
+        let mut rx = runit(indoc! {r#"
+            format: shuffle
+            lines:
+              - one
+              - two
+              - three
+              - four
+            count: 5
+        "#})
         .await;
 
         let lines = &["one", "two", "three", "four"];
@@ -427,11 +432,13 @@ mod tests {
 
     #[tokio::test]
     async fn shuffle_demo_logs_limits_count() {
-        let mut rx = runit(
-            r#"format = "shuffle"
-               lines = ["one", "two"]
-               count = 5"#,
-        )
+        let mut rx = runit(indoc! {r#"
+            format: shuffle
+            lines:
+              - one
+              - two
+            count: 5
+        "#})
         .await;
 
         for _ in 0..5 {
@@ -443,12 +450,14 @@ mod tests {
     #[tokio::test]
     async fn shuffle_demo_logs_adds_sequence() {
         let message_key = log_schema().message_key().unwrap().to_string();
-        let mut rx = runit(
-            r#"format = "shuffle"
-               lines = ["one", "two"]
-               sequence = true
-               count = 5"#,
-        )
+        let mut rx = runit(indoc! {r#"
+            format: shuffle
+            lines:
+              - one
+              - two
+            sequence: true
+            count: 5
+        "#})
         .await;
 
         for n in 0..5 {
@@ -467,12 +476,14 @@ mod tests {
     #[tokio::test]
     async fn shuffle_demo_logs_obeys_interval() {
         let start = Instant::now();
-        let mut rx = runit(
-            r#"format = "shuffle"
-               lines = ["one", "two"]
-               count = 3
-               interval = 1.0"#,
-        )
+        let mut rx = runit(indoc! {r#"
+            format: shuffle
+            lines:
+              - one
+              - two
+            count: 3
+            interval: 1.0
+        "#})
         .await;
 
         for _ in 0..3 {
@@ -487,10 +498,10 @@ mod tests {
     #[tokio::test]
     async fn host_is_set() {
         let host_key = log_schema().host_key().unwrap().to_string();
-        let mut rx = runit(
-            r#"format = "syslog"
-            count = 5"#,
-        )
+        let mut rx = runit(indoc! {r#"
+            format: syslog
+            count: 5
+        "#})
         .await;
 
         let event = match poll!(rx.next()) {
@@ -504,10 +515,10 @@ mod tests {
 
     #[tokio::test]
     async fn apache_common_format_generates_output() {
-        let mut rx = runit(
-            r#"format = "apache_common"
-            count = 5"#,
-        )
+        let mut rx = runit(indoc! {r#"
+            format: apache_common
+            count: 5
+        "#})
         .await;
 
         for _ in 0..5 {
@@ -518,10 +529,10 @@ mod tests {
 
     #[tokio::test]
     async fn apache_error_format_generates_output() {
-        let mut rx = runit(
-            r#"format = "apache_error"
-            count = 5"#,
-        )
+        let mut rx = runit(indoc! {r#"
+            format: apache_error
+            count: 5
+        "#})
         .await;
 
         for _ in 0..5 {
@@ -532,10 +543,10 @@ mod tests {
 
     #[tokio::test]
     async fn syslog_5424_format_generates_output() {
-        let mut rx = runit(
-            r#"format = "syslog"
-            count = 5"#,
-        )
+        let mut rx = runit(indoc! {r#"
+            format: syslog
+            count: 5
+        "#})
         .await;
 
         for _ in 0..5 {
@@ -546,10 +557,10 @@ mod tests {
 
     #[tokio::test]
     async fn syslog_3164_format_generates_output() {
-        let mut rx = runit(
-            r#"format = "bsd_syslog"
-            count = 5"#,
-        )
+        let mut rx = runit(indoc! {r#"
+            format: bsd_syslog
+            count: 5
+        "#})
         .await;
 
         for _ in 0..5 {
@@ -561,10 +572,10 @@ mod tests {
     #[tokio::test]
     async fn json_format_generates_output() {
         let message_key = log_schema().message_key().unwrap().to_string();
-        let mut rx = runit(
-            r#"format = "json"
-            count = 5"#,
-        )
+        let mut rx = runit(indoc! {r#"
+            format: json
+            count: 5
+        "#})
         .await;
 
         for _ in 0..5 {

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -839,6 +839,7 @@ mod tests {
     };
 
     use encoding_rs::UTF_16LE;
+    use indoc::indoc;
     use similar_asserts::assert_eq;
     use tempfile::tempdir;
     use tokio::time::{Duration, sleep, timeout};
@@ -887,16 +888,17 @@ mod tests {
 
     #[test]
     fn parse_config() {
-        let config: FileConfig = toml::from_str(
+        let config: FileConfig = serde_yaml::from_str(indoc! {
             r#"
-            include = [ "/var/log/**/*.log" ]
-            file_key = "file"
-            glob_minimum_cooldown_ms = 1000
-            multi_line_timeout = 1000
-            max_read_bytes = 2048
-            line_delimiter = "\n"
-        "#,
-        )
+            include:
+              - /var/log/**/*.log
+            file_key: file
+            glob_minimum_cooldown_ms: 1000
+            multi_line_timeout: 1000
+            max_read_bytes: 2048
+            line_delimiter: "\n"
+            "#,
+        })
         .unwrap();
         assert_eq!(config, FileConfig::default());
         assert_eq!(
@@ -907,25 +909,27 @@ mod tests {
             }
         );
 
-        let config: FileConfig = toml::from_str(
+        let config: FileConfig = serde_yaml::from_str(indoc! {
             r#"
-        include = [ "/var/log/**/*.log" ]
-        [fingerprint]
-        strategy = "device_and_inode"
-        "#,
-        )
+            include:
+              - /var/log/**/*.log
+            fingerprint:
+              strategy: device_and_inode
+            "#,
+        })
         .unwrap();
         assert_eq!(config.fingerprint, FingerprintConfig::DevInode);
 
-        let config: FileConfig = toml::from_str(
+        let config: FileConfig = serde_yaml::from_str(indoc! {
             r#"
-        include = [ "/var/log/**/*.log" ]
-        [fingerprint]
-        strategy = "checksum"
-        bytes = 128
-        ignored_header_bytes = 512
-        "#,
-        )
+            include:
+              - /var/log/**/*.log
+            fingerprint:
+              strategy: checksum
+              bytes: 128
+              ignored_header_bytes: 512
+            "#,
+        })
         .unwrap();
         assert_eq!(
             config.fingerprint,
@@ -935,31 +939,34 @@ mod tests {
             }
         );
 
-        let config: FileConfig = toml::from_str(
+        let config: FileConfig = serde_yaml::from_str(indoc! {
             r#"
-        include = [ "/var/log/**/*.log" ]
-        [encoding]
-        charset = "utf-16le"
-        "#,
-        )
+            include:
+              - /var/log/**/*.log
+            encoding:
+              charset: utf-16le
+            "#,
+        })
         .unwrap();
         assert_eq!(config.encoding, Some(EncodingConfig { charset: UTF_16LE }));
 
-        let config: FileConfig = toml::from_str(
+        let config: FileConfig = serde_yaml::from_str(indoc! {
             r#"
-        include = [ "/var/log/**/*.log" ]
-        read_from = "beginning"
-        "#,
-        )
+            include:
+              - /var/log/**/*.log
+            read_from: beginning
+            "#,
+        })
         .unwrap();
         assert_eq!(config.read_from, ReadFromConfig::Beginning);
 
-        let config: FileConfig = toml::from_str(
+        let config: FileConfig = serde_yaml::from_str(indoc! {
             r#"
-        include = [ "/var/log/**/*.log" ]
-        read_from = "end"
-        "#,
-        )
+            include:
+              - /var/log/**/*.log
+            read_from: end
+            "#,
+        })
         .unwrap();
         assert_eq!(config.read_from, ReadFromConfig::End);
     }

--- a/src/sources/host_metrics/cgroups.rs
+++ b/src/sources/host_metrics/cgroups.rs
@@ -487,7 +487,11 @@ mod tests {
 
     #[tokio::test]
     async fn generates_cgroups_metrics() {
-        let config: HostMetricsConfig = toml::from_str(r#"collectors = ["cgroups"]"#).unwrap();
+        let config: HostMetricsConfig = serde_yaml::from_str(indoc::indoc! {r#"
+            collectors:
+              - cgroups
+        "#})
+        .unwrap();
         let mut buffer = MetricsBuffer::new(None);
         HostMetrics::new(config).cgroups_metrics(&mut buffer).await;
         let metrics = buffer.metrics;
@@ -600,12 +604,12 @@ mod tests {
 
         async fn test(&self) {
             let path = self.0.path();
-            let config: HostMetricsConfig = toml::from_str(&format!(
-                r#"
-                collectors = ["cgroups"]
-                cgroups.base_dir = {path:?}
-                "#
-            ))
+            let config: HostMetricsConfig = serde_yaml::from_str(&indoc::formatdoc! {r#"
+                collectors:
+                  - cgroups
+                cgroups:
+                  base_dir: {path:?}
+            "#})
             .unwrap();
             let mut buffer = MetricsBuffer::new(None);
             HostMetrics::new(config).cgroups_metrics(&mut buffer).await;

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -1169,6 +1169,7 @@ fn prepare_label_selector(selector: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    use indoc::indoc;
     use similar_asserts::assert_eq;
     use vector_lib::{
         config::LogNamespace,
@@ -1202,15 +1203,15 @@ mod tests {
 
     #[test]
     fn test_config_serialization_insert_namespace_fields() {
-        // Test that the flag serializes/deserializes correctly from TOML
-        let toml_config = r#"
-            insert_namespace_fields = false
-        "#;
-        let config: Config = toml::from_str(toml_config).unwrap();
+        // Test that the flag serializes/deserializes correctly from YAML
+        let yaml_config = indoc! {r#"
+            insert_namespace_fields: false
+        "#};
+        let config: Config = serde_yaml::from_str(yaml_config).unwrap();
         assert_eq!(config.insert_namespace_fields, false);
 
-        let default_toml = "";
-        let default_config: Config = toml::from_str(default_toml).unwrap();
+        let default_yaml = "";
+        let default_config: Config = serde_yaml::from_str(default_yaml).unwrap();
         assert_eq!(default_config.insert_namespace_fields, true);
     }
 
@@ -1369,7 +1370,7 @@ mod tests {
 
     #[test]
     fn test_output_schema_definition_vector_namespace() {
-        let definitions = toml::from_str::<Config>("")
+        let definitions = serde_yaml::from_str::<Config>("")
             .unwrap()
             .outputs(LogNamespace::Vector)
             .remove(0)
@@ -1485,7 +1486,7 @@ mod tests {
 
     #[test]
     fn test_output_schema_definition_legacy_namespace() {
-        let definitions = toml::from_str::<Config>("")
+        let definitions = serde_yaml::from_str::<Config>("")
             .unwrap()
             .outputs(LogNamespace::Legacy)
             .remove(0)

--- a/src/sources/opentelemetry/tests.rs
+++ b/src/sources/opentelemetry/tests.rs
@@ -1668,6 +1668,8 @@ async fn http_logs_use_otlp_decoding_emits_metric() {
 
 #[cfg(test)]
 mod otlp_decoding_config_tests {
+    use indoc::indoc;
+
     use crate::config::{DataType, LogNamespace, SourceConfig};
     use crate::sources::opentelemetry::config::{
         GrpcConfig, HttpConfig, OpentelemetryConfig, OtlpDecodingConfig,
@@ -1724,34 +1726,30 @@ mod otlp_decoding_config_tests {
         assert!(!config_false.any_enabled());
         assert!(!config_false.is_mixed());
 
-        // Test TOML deserialization (which uses From<bool> under the hood)
-        let config: OpentelemetryConfig = toml::from_str(
+        // Test YAML deserialization (which uses From<bool> under the hood)
+        let config: OpentelemetryConfig = serde_yaml::from_str(indoc! {
             r#"
-            use_otlp_decoding = true
-
-            [grpc]
-            address = "0.0.0.0:4317"
-
-            [http]
-            address = "0.0.0.0:4318"
+            use_otlp_decoding: true
+            grpc:
+              address: "0.0.0.0:4317"
+            http:
+              address: "0.0.0.0:4318"
             "#,
-        )
+        })
         .unwrap();
         assert!(config.use_otlp_decoding.logs);
         assert!(config.use_otlp_decoding.metrics);
         assert!(config.use_otlp_decoding.traces);
 
-        let config: OpentelemetryConfig = toml::from_str(
+        let config: OpentelemetryConfig = serde_yaml::from_str(indoc! {
             r#"
-            use_otlp_decoding = false
-
-            [grpc]
-            address = "0.0.0.0:4317"
-
-            [http]
-            address = "0.0.0.0:4318"
+            use_otlp_decoding: false
+            grpc:
+              address: "0.0.0.0:4317"
+            http:
+              address: "0.0.0.0:4318"
             "#,
-        )
+        })
         .unwrap();
         assert!(!config.use_otlp_decoding.logs);
         assert!(!config.use_otlp_decoding.metrics);
@@ -1761,38 +1759,34 @@ mod otlp_decoding_config_tests {
     #[test]
     fn test_otlp_decoding_deserialization_from_struct() {
         // Test deserializing from a struct with all fields
-        let config: OpentelemetryConfig = toml::from_str(
+        let config: OpentelemetryConfig = serde_yaml::from_str(indoc! {
             r#"
-            [grpc]
-            address = "0.0.0.0:4317"
-
-            [http]
-            address = "0.0.0.0:4318"
-
-            [use_otlp_decoding]
-            logs = false
-            metrics = false
-            traces = true
+            grpc:
+              address: "0.0.0.0:4317"
+            http:
+              address: "0.0.0.0:4318"
+            use_otlp_decoding:
+              logs: false
+              metrics: false
+              traces: true
             "#,
-        )
+        })
         .unwrap();
         assert!(!config.use_otlp_decoding.logs);
         assert!(!config.use_otlp_decoding.metrics);
         assert!(config.use_otlp_decoding.traces);
 
         // Test deserializing from a struct with partial fields (using defaults)
-        let config: OpentelemetryConfig = toml::from_str(
+        let config: OpentelemetryConfig = serde_yaml::from_str(indoc! {
             r#"
-            [grpc]
-            address = "0.0.0.0:4317"
-
-            [http]
-            address = "0.0.0.0:4318"
-
-            [use_otlp_decoding]
-            traces = true
+            grpc:
+              address: "0.0.0.0:4317"
+            http:
+              address: "0.0.0.0:4318"
+            use_otlp_decoding:
+              traces: true
             "#,
-        )
+        })
         .unwrap();
         assert!(!config.use_otlp_decoding.logs); // default false
         assert!(!config.use_otlp_decoding.metrics); // default false
@@ -1802,15 +1796,14 @@ mod otlp_decoding_config_tests {
     #[test]
     fn test_otlp_decoding_default_when_not_specified() {
         // Test that when use_otlp_decoding is not specified, it uses defaults (all false)
-        let config: OpentelemetryConfig = toml::from_str(
+        let config: OpentelemetryConfig = serde_yaml::from_str(indoc! {
             r#"
-            [grpc]
-            address = "0.0.0.0:4317"
-
-            [http]
-            address = "0.0.0.0:4318"
+            grpc:
+              address: "0.0.0.0:4317"
+            http:
+              address: "0.0.0.0:4318"
             "#,
-        )
+        })
         .unwrap();
         assert!(!config.use_otlp_decoding.logs);
         assert!(!config.use_otlp_decoding.metrics);

--- a/src/sources/socket/mod.rs
+++ b/src/sources/socket/mod.rs
@@ -1581,23 +1581,16 @@ mod test {
 
     #[cfg(unix)]
     fn parses_unix_config(mode: &str) -> SocketConfig {
-        toml::from_str::<SocketConfig>(&format!(
-            r#"
-               mode = "{mode}"
-               path = "/does/not/exist"
-            "#
+        serde_yaml::from_str::<SocketConfig>(&format!(
+            "mode: \"{mode}\"\npath: \"/does/not/exist\""
         ))
         .unwrap()
     }
 
     #[cfg(unix)]
     fn parses_unix_config_file_mode(mode: &str) -> SocketConfig {
-        toml::from_str::<SocketConfig>(&format!(
-            r#"
-               mode = "{mode}"
-               path = "/does/not/exist"
-               socket_file_mode = 0o777
-            "#
+        serde_yaml::from_str::<SocketConfig>(&format!(
+            "mode: \"{mode}\"\npath: \"/does/not/exist\"\nsocket_file_mode: 511"
         ))
         .unwrap()
     }

--- a/src/sources/syslog.rs
+++ b/src/sources/syslog.rs
@@ -466,6 +466,7 @@ mod test {
     use std::{collections::HashMap, fmt, str::FromStr};
 
     use chrono::prelude::*;
+    use indoc::indoc;
     use rand::{Rng, rng};
     use serde::Deserialize;
     use tokio::time::{Duration, Instant, sleep};
@@ -670,25 +671,25 @@ mod test {
 
     #[test]
     fn config_tcp() {
-        let config: SyslogConfig = toml::from_str(
+        let config: SyslogConfig = serde_yaml::from_str(indoc! {
             r#"
-            mode = "tcp"
-            address = "127.0.0.1:1235"
-          "#,
-        )
+            mode: tcp
+            address: "127.0.0.1:1235"
+            "#,
+        })
         .unwrap();
         assert!(matches!(config.mode, Mode::Tcp { .. }));
     }
 
     #[test]
     fn config_tcp_with_receive_buffer_size() {
-        let config: SyslogConfig = toml::from_str(
+        let config: SyslogConfig = serde_yaml::from_str(indoc! {
             r#"
-            mode = "tcp"
-            address = "127.0.0.1:1235"
-            receive_buffer_bytes = 256
-          "#,
-        )
+            mode: tcp
+            address: "127.0.0.1:1235"
+            receive_buffer_bytes: 256
+            "#,
+        })
         .unwrap();
 
         let receive_buffer_bytes = match config.mode {
@@ -704,12 +705,12 @@ mod test {
 
     #[test]
     fn config_tcp_keepalive_empty() {
-        let config: SyslogConfig = toml::from_str(
+        let config: SyslogConfig = serde_yaml::from_str(indoc! {
             r#"
-            mode = "tcp"
-            address = "127.0.0.1:1235"
-          "#,
-        )
+            mode: tcp
+            address: "127.0.0.1:1235"
+            "#,
+        })
         .unwrap();
 
         let keepalive = match config.mode {
@@ -722,13 +723,14 @@ mod test {
 
     #[test]
     fn config_tcp_keepalive_full() {
-        let config: SyslogConfig = toml::from_str(
+        let config: SyslogConfig = serde_yaml::from_str(indoc! {
             r#"
-            mode = "tcp"
-            address = "127.0.0.1:1235"
-            keepalive.time_secs = 7200
-          "#,
-        )
+            mode: tcp
+            address: "127.0.0.1:1235"
+            keepalive:
+              time_secs: 7200
+            "#,
+        })
         .unwrap();
 
         let keepalive = match config.mode {
@@ -743,27 +745,27 @@ mod test {
 
     #[test]
     fn config_udp() {
-        let config: SyslogConfig = toml::from_str(
+        let config: SyslogConfig = serde_yaml::from_str(indoc! {
             r#"
-            mode = "udp"
-            address = "127.0.0.1:1235"
-            max_length = 32187
-          "#,
-        )
+            mode: udp
+            address: "127.0.0.1:1235"
+            max_length: 32187
+            "#,
+        })
         .unwrap();
         assert!(matches!(config.mode, Mode::Udp { .. }));
     }
 
     #[test]
     fn config_udp_with_receive_buffer_size() {
-        let config: SyslogConfig = toml::from_str(
+        let config: SyslogConfig = serde_yaml::from_str(indoc! {
             r#"
-            mode = "udp"
-            address = "127.0.0.1:1235"
-            max_length = 32187
-            receive_buffer_bytes = 256
-          "#,
-        )
+            mode: udp
+            address: "127.0.0.1:1235"
+            max_length: 32187
+            receive_buffer_bytes: 256
+            "#,
+        })
         .unwrap();
 
         let receive_buffer_bytes = match config.mode {
@@ -780,12 +782,12 @@ mod test {
     #[cfg(unix)]
     #[test]
     fn config_unix() {
-        let config: SyslogConfig = toml::from_str(
+        let config: SyslogConfig = serde_yaml::from_str(indoc! {
             r#"
-            mode = "unix"
-            path = "127.0.0.1:1235"
-          "#,
-        )
+            mode: unix
+            path: "127.0.0.1:1235"
+            "#,
+        })
         .unwrap();
         assert!(matches!(config.mode, Mode::Unix { .. }));
     }
@@ -793,13 +795,13 @@ mod test {
     #[cfg(unix)]
     #[test]
     fn config_unix_permissions() {
-        let config: SyslogConfig = toml::from_str(
+        let config: SyslogConfig = serde_yaml::from_str(indoc! {
             r#"
-            mode = "unix"
-            path = "127.0.0.1:1235"
-            socket_file_mode = 0o777
-          "#,
-        )
+            mode: unix
+            path: "127.0.0.1:1235"
+            socket_file_mode: 511
+            "#,
+        })
         .unwrap();
         let socket_file_mode = match config.mode {
             Mode::Unix {

--- a/src/sources/util/net/mod.rs
+++ b/src/sources/util/net/mod.rs
@@ -158,7 +158,7 @@ mod test {
 
     #[test]
     fn parse_socket_listen_addr_success() {
-        let test: Config = toml::from_str(r#"addr="127.1.2.3:1234""#).unwrap();
+        let test: Config = serde_yaml::from_str(r#"addr: "127.1.2.3:1234""#).unwrap();
         assert_eq!(
             test.addr,
             SocketListenAddr::SocketAddr(SocketAddr::V4(SocketAddrV4::new(
@@ -166,25 +166,25 @@ mod test {
                 1234,
             )))
         );
-        let test: Config = toml::from_str(r#"addr="systemd""#).unwrap();
+        let test: Config = serde_yaml::from_str(r#"addr: "systemd""#).unwrap();
         assert_eq!(test.addr, SocketListenAddr::SystemdFd(0));
-        let test: Config = toml::from_str(r#"addr="systemd#3""#).unwrap();
+        let test: Config = serde_yaml::from_str(r#"addr: "systemd#3""#).unwrap();
         assert_eq!(test.addr, SocketListenAddr::SystemdFd(2));
     }
 
     #[test]
     fn parse_socket_listen_addr_fail() {
         // no port specified
-        let test: Result<Config, toml::de::Error> = toml::from_str(r#"addr="127.1.2.3""#);
+        let test: Result<Config, serde_yaml::Error> = serde_yaml::from_str(r#"addr: "127.1.2.3""#);
         assert!(test.is_err());
 
         // systemd fd indexing should be one based not zero.
         // the user should leave off the {#N} to get the fd 0.
-        let test: Result<Config, toml::de::Error> = toml::from_str(r#"addr="systemd#0""#);
+        let test: Result<Config, serde_yaml::Error> = serde_yaml::from_str(r#"addr: "systemd#0""#);
         assert!(test.is_err());
 
         // typo
-        let test: Result<Config, toml::de::Error> = toml::from_str(r#"addr="system""#);
+        let test: Result<Config, serde_yaml::Error> = serde_yaml::from_str(r#"addr: "system""#);
         assert!(test.is_err());
     }
 }

--- a/src/sources/vector/mod.rs
+++ b/src/sources/vector/mod.rs
@@ -309,8 +309,8 @@ mod tests {
     async fn run_test(compression: Option<&str>) {
         let (_guard, addr) = test_util::addr::next_addr();
 
-        let source_config = format!(r#"address = "{addr}""#);
-        let source: VectorConfig = toml::from_str(&source_config).unwrap();
+        let source_config = format!("address: \"{addr}\"");
+        let source: VectorConfig = serde_yaml::from_str(&source_config).unwrap();
 
         let (tx, rx) = SourceSender::new_test();
         let server = source
@@ -324,15 +324,13 @@ mod tests {
         // but the sink side already does such a test and this is good
         // to ensure interoperability.
         let sink_config = match compression {
-            Some(c) => format!(
-                r#"
-                    address = "{addr}"
-                    compression = "{c}"
-                "#
-            ),
-            None => format!(r#"address = "{addr}""#),
+            Some(c) => indoc::formatdoc! {r#"
+                address: "{addr}"
+                compression: "{c}"
+            "#},
+            None => format!("address: \"{addr}\"\n"),
         };
-        let sink: SinkConfig = toml::from_str(&sink_config).unwrap();
+        let sink: SinkConfig = serde_yaml::from_str(&sink_config).unwrap();
         let cx = SinkContext::default();
         let (sink, _) = sink.build(cx).await.unwrap();
 
@@ -371,8 +369,8 @@ mod tests {
 
         let (_guard, addr) = test_util::addr::next_addr();
 
-        let config = format!(r#"address = "{addr}""#);
-        let source: VectorConfig = toml::from_str(&config).unwrap();
+        let config = format!("address: \"{addr}\"");
+        let source: VectorConfig = serde_yaml::from_str(&config).unwrap();
 
         let (tx, _rx) = SourceSender::new_test();
         let server = source
@@ -409,8 +407,8 @@ mod tests {
 
         let (_guard, addr) = test_util::addr::next_addr();
 
-        let config = format!(r#"address = "{addr}""#);
-        let source: VectorConfig = toml::from_str(&config).unwrap();
+        let config = format!("address: \"{addr}\"");
+        let source: VectorConfig = serde_yaml::from_str(&config).unwrap();
 
         let (tx, _rx) = SourceSender::new_test();
         let server = source

--- a/src/sources/windows_event_log/tests.rs
+++ b/src/sources/windows_event_log/tests.rs
@@ -1180,6 +1180,8 @@ mod fault_tolerance_tests {
 
 #[cfg(test)]
 mod acknowledgement_tests {
+    use indoc::indoc;
+
     use super::*;
     use crate::config::{SourceAcknowledgementsConfig, SourceConfig};
 
@@ -1237,37 +1239,40 @@ mod acknowledgement_tests {
 
     #[test]
     fn test_acknowledgements_toml_parsing() {
-        // Test parsing from TOML with acknowledgements enabled
-        let toml_with_acks = r#"
-            channels = ["System"]
-            acknowledgements = true
-        "#;
+        // Test parsing from YAML with acknowledgements enabled
+        let yaml_with_acks = indoc! {r#"
+            channels:
+              - System
+            acknowledgements: true
+        "#};
         let config: WindowsEventLogConfig =
-            toml::from_str(toml_with_acks).expect("TOML parsing should succeed");
+            serde_yaml::from_str(yaml_with_acks).expect("YAML parsing should succeed");
         assert!(
             config.acknowledgements.enabled(),
-            "Acknowledgements should be enabled from TOML"
+            "Acknowledgements should be enabled from YAML"
         );
 
         // Test parsing with acknowledgements as struct
-        let toml_with_acks_struct = r#"
-            channels = ["System"]
-            [acknowledgements]
-            enabled = true
-        "#;
+        let yaml_with_acks_struct = indoc! {r#"
+            channels:
+              - System
+            acknowledgements:
+              enabled: true
+        "#};
         let config: WindowsEventLogConfig =
-            toml::from_str(toml_with_acks_struct).expect("TOML parsing should succeed");
+            serde_yaml::from_str(yaml_with_acks_struct).expect("YAML parsing should succeed");
         assert!(
             config.acknowledgements.enabled(),
-            "Acknowledgements should be enabled from TOML struct"
+            "Acknowledgements should be enabled from YAML struct"
         );
 
         // Test parsing without acknowledgements (default)
-        let toml_without_acks = r#"
-            channels = ["System"]
-        "#;
+        let yaml_without_acks = indoc! {r#"
+            channels:
+              - System
+        "#};
         let config: WindowsEventLogConfig =
-            toml::from_str(toml_without_acks).expect("TOML parsing should succeed");
+            serde_yaml::from_str(yaml_without_acks).expect("YAML parsing should succeed");
         assert!(
             !config.acknowledgements.enabled(),
             "Acknowledgements should be disabled by default"
@@ -1281,6 +1286,8 @@ mod acknowledgement_tests {
 
 #[cfg(test)]
 mod rate_limiting_tests {
+    use indoc::indoc;
+
     use super::*;
 
     #[test]
@@ -1305,15 +1312,16 @@ mod rate_limiting_tests {
 
     #[test]
     fn test_rate_limiting_toml_parsing() {
-        let toml_with_rate_limit = r#"
-            channels = ["System"]
-            events_per_second = 50
-        "#;
+        let yaml_with_rate_limit = indoc! {r#"
+            channels:
+              - System
+            events_per_second: 50
+        "#};
         let config: WindowsEventLogConfig =
-            toml::from_str(toml_with_rate_limit).expect("TOML parsing should succeed");
+            serde_yaml::from_str(yaml_with_rate_limit).expect("YAML parsing should succeed");
         assert_eq!(
             config.events_per_second, 50,
-            "Rate limiting should be parsed from TOML"
+            "Rate limiting should be parsed from YAML"
         );
     }
 
@@ -1343,6 +1351,8 @@ mod rate_limiting_tests {
 
 #[cfg(test)]
 mod checkpoint_tests {
+    use indoc::indoc;
+
     use super::*;
 
     #[test]
@@ -1357,15 +1367,16 @@ mod checkpoint_tests {
 
     #[test]
     fn test_checkpoint_toml_parsing() {
-        let toml_with_data_dir = r#"
-            channels = ["System"]
-            data_dir = "/var/lib/vector/wineventlog"
-        "#;
+        let yaml_with_data_dir = indoc! {r#"
+            channels:
+              - System
+            data_dir: /var/lib/vector/wineventlog
+        "#};
         let config: WindowsEventLogConfig =
-            toml::from_str(toml_with_data_dir).expect("TOML parsing should succeed");
+            serde_yaml::from_str(yaml_with_data_dir).expect("YAML parsing should succeed");
         assert!(
             config.data_dir.is_some(),
-            "data_dir should be parsed from TOML"
+            "data_dir should be parsed from YAML"
         );
     }
 
@@ -1383,6 +1394,8 @@ mod checkpoint_tests {
 
 #[cfg(test)]
 mod message_rendering_tests {
+    use indoc::indoc;
+
     use super::*;
 
     #[test]
@@ -1396,15 +1409,16 @@ mod message_rendering_tests {
 
     #[test]
     fn test_render_message_config_enabled() {
-        let toml_with_render = r#"
-            channels = ["System"]
-            render_message = true
-        "#;
+        let yaml_with_render = indoc! {r#"
+            channels:
+              - System
+            render_message: true
+        "#};
         let config: WindowsEventLogConfig =
-            toml::from_str(toml_with_render).expect("TOML parsing should succeed");
+            serde_yaml::from_str(yaml_with_render).expect("YAML parsing should succeed");
         assert!(
             config.render_message,
-            "render_message should be enabled from TOML"
+            "render_message should be enabled from YAML"
         );
     }
 
@@ -1486,6 +1500,8 @@ mod message_rendering_tests {
 
 #[cfg(test)]
 mod truncation_tests {
+    use indoc::indoc;
+
     use super::*;
 
     #[test]
@@ -1500,15 +1516,16 @@ mod truncation_tests {
 
     #[test]
     fn test_max_event_data_length_toml_parsing() {
-        let toml_with_truncation = r#"
-            channels = ["System"]
-            max_event_data_length = 256
-        "#;
+        let yaml_with_truncation = indoc! {r#"
+            channels:
+              - System
+            max_event_data_length: 256
+        "#};
         let config: WindowsEventLogConfig =
-            toml::from_str(toml_with_truncation).expect("TOML parsing should succeed");
+            serde_yaml::from_str(yaml_with_truncation).expect("YAML parsing should succeed");
         assert_eq!(
             config.max_event_data_length, 256,
-            "max_event_data_length should be parsed from TOML"
+            "max_event_data_length should be parsed from YAML"
         );
     }
 

--- a/src/transforms/aggregate.rs
+++ b/src/transforms/aggregate.rs
@@ -421,6 +421,7 @@ mod tests {
     use std::{collections::BTreeSet, sync::Arc, task::Poll};
 
     use futures::stream;
+    use indoc::indoc;
     use tokio::sync::mpsc;
     use tokio_stream::wrappers::ReceiverStream;
     use vector_lib::config::{ComponentKey, LogNamespace};
@@ -1113,11 +1114,9 @@ mod tests {
 
     #[tokio::test]
     async fn transform_shutdown() {
-        let agg = toml::from_str::<AggregateConfig>(
-            r"
-interval_ms = 999999
-",
-        )
+        let agg = serde_yaml::from_str::<AggregateConfig>(indoc! {"
+            interval_ms: 999999
+        "})
         .unwrap()
         .build(&TransformContext::default())
         .await
@@ -1175,7 +1174,7 @@ interval_ms = 999999
 
     #[tokio::test]
     async fn transform_interval() {
-        let transform_config = toml::from_str::<AggregateConfig>("").unwrap();
+        let transform_config = serde_yaml::from_str::<AggregateConfig>("{}").unwrap();
 
         let counter_a_1 = make_metric(
             "counter_a",

--- a/src/transforms/delay.rs
+++ b/src/transforms/delay.rs
@@ -243,8 +243,8 @@ mod tests {
 
     #[tokio::test]
     async fn delay_events() {
-        let config = toml::from_str::<DelayConfig>(indoc! {"
-            delay_ms = 200
+        let config = serde_yaml::from_str::<DelayConfig>(indoc! {"
+            delay_ms: 200
         "})
         .unwrap();
 
@@ -271,11 +271,11 @@ mod tests {
 
     #[tokio::test]
     async fn delay_events_at_capacity_drop_newest() {
-        let config = toml::from_str::<DelayConfig>(indoc! {r#"
-            delay_ms = 200
-            queue_capacity = 1
-            overflow_strategy = "drop_newest"
-        "#})
+        let config = serde_yaml::from_str::<DelayConfig>(indoc! {"
+            delay_ms: 200
+            queue_capacity: 1
+            overflow_strategy: drop_newest
+        "})
         .unwrap();
 
         let delay =
@@ -306,11 +306,11 @@ mod tests {
 
     #[tokio::test]
     async fn delay_events_at_capacity_pass() {
-        let config = toml::from_str::<DelayConfig>(indoc! {r#"
-            delay_ms = 200
-            queue_capacity = 1
-            overflow_strategy = "forward"
-        "#})
+        let config = serde_yaml::from_str::<DelayConfig>(indoc! {"
+            delay_ms: 200
+            queue_capacity: 1
+            overflow_strategy: forward
+        "})
         .unwrap();
 
         let delay =

--- a/src/transforms/incremental_to_absolute.rs
+++ b/src/transforms/incremental_to_absolute.rs
@@ -100,6 +100,7 @@ mod tests {
     use std::sync::Arc;
 
     use futures_util::SinkExt;
+    use indoc::indoc;
     use similar_asserts::assert_eq;
     use vector_lib::config::ComponentKey;
 
@@ -136,12 +137,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_incremental_to_absolute() {
-        let config = toml::from_str::<IncrementalToAbsoluteConfig>(
-            r#"
-[cache]
-max_events = 100
-"#,
-        )
+        let config = serde_yaml::from_str::<IncrementalToAbsoluteConfig>(indoc! {"
+            cache:
+              max_events: 100
+        "})
         .unwrap();
         let incremental_to_absolute = IncrementalToAbsolute::new(&config)
             .map(Transform::event_task)

--- a/src/transforms/lua/v2/mod.rs
+++ b/src/transforms/lua/v2/mod.rs
@@ -532,9 +532,19 @@ mod tests {
     async fn lua_runs_init_hook() {
         let line1 = random_string(9);
         run_transform(
-            &format!(
-                "version: \"2\"\nhooks:\n  init: |\n    function (emit)\n      event = {{log={{message=\"{line1}\"}}}}\n      emit(event)\n    end\n  process: |\n    function (event, emit)\n      emit(event)\n    end\n"
-            ),
+            &indoc::formatdoc! {r#"
+                version: "2"
+                hooks:
+                  init: |
+                    function (emit)
+                      event = {{log={{message="{line1}"}}}}
+                      emit(event)
+                    end
+                  process: |
+                    function (event, emit)
+                      emit(event)
+                    end
+            "#},
             |tx, out| async move {
                 let line2 = random_string(9);
                 tx.send(Event::Log(LogEvent::from(line2.as_str())))
@@ -901,10 +911,20 @@ mod tests {
         .unwrap();
 
         run_transform(
-            &format!(
-                "version: \"2\"\nhooks:\n  process: |\n    function (event, emit)\n      local script2 = require(\"script2\")\n      script2.modify(event)\n      emit(event)\n    end\nsearch_dirs:\n  - {:?}\n",
-                dir.path().as_os_str() // This seems a bit weird, but recall we also support windows.
-            ),
+            &indoc::formatdoc! {r#"
+                version: "2"
+                hooks:
+                  process: |
+                    function (event, emit)
+                      local script2 = require("script2")
+                      script2.modify(event)
+                      emit(event)
+                    end
+                search_dirs:
+                  - {dir}
+            "#,
+                dir = dir.path().as_os_str().to_string_lossy(), // recall we also support windows
+            },
             |tx, out| async move {
                 let event = LogEvent::default();
                 tx.send(event.into()).await.unwrap();

--- a/src/transforms/lua/v2/mod.rs
+++ b/src/transforms/lua/v2/mod.rs
@@ -460,6 +460,7 @@ impl RuntimeTransform for Lua {
 mod tests {
     use std::{future::Future, sync::Arc};
 
+    use indoc::indoc;
     use similar_asserts::assert_eq;
     use tokio::sync::{
         Mutex,
@@ -488,7 +489,7 @@ mod tests {
     }
 
     fn from_config(config: &str) -> crate::Result<Box<Lua>> {
-        Lua::new(&toml::from_str(config).unwrap(), "transform".into()).map(Box::new)
+        Lua::new(&serde_yaml::from_str(config).unwrap(), "transform".into()).map(Box::new)
     }
 
     async fn run_transform<T: Future>(
@@ -497,7 +498,7 @@ mod tests {
     ) -> T::Output {
         test_util::trace_init();
         assert_transform_compliance(async move {
-            let config = super::super::LuaConfig::V2(toml::from_str(config).unwrap());
+            let config = super::super::LuaConfig::V2(serde_yaml::from_str(config).unwrap());
             let (tx, rx) = mpsc::channel(1);
             let (topology, out) = create_topology(ReceiverStream::new(rx), config).await;
 
@@ -532,18 +533,7 @@ mod tests {
         let line1 = random_string(9);
         run_transform(
             &format!(
-                r#"
-            version = "2"
-            hooks.init = """function (emit)
-                event = {{log={{message="{line1}"}}}}
-                emit(event)
-            end
-            """
-            hooks.process = """function (event, emit)
-                emit(event)
-            end
-            """
-            "#
+                "version: \"2\"\nhooks:\n  init: |\n    function (emit)\n      event = {{log={{message=\"{line1}\"}}}}\n      emit(event)\n    end\n  process: |\n    function (event, emit)\n      emit(event)\n    end\n"
             ),
             |tx, out| async move {
                 let line2 = random_string(9);
@@ -567,14 +557,15 @@ mod tests {
     #[tokio::test]
     async fn lua_add_field() {
         run_transform(
-            r#"
-            version = "2"
-            hooks.process = """function (event, emit)
-                event["log"]["hello"] = "goodbye"
-                emit(event)
-            end
-            """
-            "#,
+            indoc! {r#"
+            version: "2"
+            hooks:
+              process: |
+                function (event, emit)
+                  event["log"]["hello"] = "goodbye"
+                  emit(event)
+                end
+            "#},
             |tx, out| async move {
                 let event = Event::Log(LogEvent::from("program me"));
                 tx.send(event).await.unwrap();
@@ -591,15 +582,16 @@ mod tests {
     #[tokio::test]
     async fn lua_read_field() {
         run_transform(
-            r#"
-            version = "2"
-            hooks.process = """function (event, emit)
-                _, _, name = string.find(event.log.message, "Hello, my name is (%a+).")
-                event.log.name = name
-                emit(event)
-            end
-            """
-            "#,
+            indoc! {r#"
+            version: "2"
+            hooks:
+              process: |
+                function (event, emit)
+                  _, _, name = string.find(event.log.message, "Hello, my name is (%a+).")
+                  event.log.name = name
+                  emit(event)
+                end
+            "#},
             |tx, out| async move {
                 let event = Event::Log(LogEvent::from("Hello, my name is Bob."));
                 tx.send(event).await.unwrap();
@@ -613,14 +605,15 @@ mod tests {
     #[tokio::test]
     async fn lua_remove_field() {
         run_transform(
-            r#"
-            version = "2"
-            hooks.process = """function (event, emit)
-                event.log.name = nil
-                emit(event)
-            end
-            """
-            "#,
+            indoc! {r#"
+            version: "2"
+            hooks:
+              process: |
+                function (event, emit)
+                  event.log.name = nil
+                  emit(event)
+                end
+            "#},
             |tx, out| async move {
                 let mut event = LogEvent::default();
                 event.insert("name", "Bob");
@@ -636,13 +629,14 @@ mod tests {
     #[tokio::test]
     async fn lua_drop_event() {
         run_transform(
-            r#"
-            version = "2"
-            hooks.process = """function (event, emit)
-                -- emit nothing
-            end
-            """
-            "#,
+            indoc! {r#"
+            version: "2"
+            hooks:
+              process: |
+                function (event, emit)
+                  -- emit nothing
+                end
+            "#},
             |tx, _out| async move {
                 let event = LogEvent::default().into();
                 tx.send(event).await.unwrap();
@@ -656,14 +650,15 @@ mod tests {
     #[tokio::test]
     async fn lua_duplicate_event() {
         run_transform(
-            r#"
-            version = "2"
-            hooks.process = """function (event, emit)
-                emit(event)
-                emit(event)
-            end
-            """
-            "#,
+            indoc! {r#"
+            version: "2"
+            hooks:
+              process: |
+                function (event, emit)
+                  emit(event)
+                  emit(event)
+                end
+            "#},
             |tx, out| async move {
                 let mut event = LogEvent::default();
                 event.insert("host", "127.0.0.1");
@@ -679,18 +674,19 @@ mod tests {
     #[tokio::test]
     async fn lua_read_empty_field() {
         run_transform(
-            r#"
-            version = "2"
-            hooks.process = """function (event, emit)
-                if event["log"]["non-existent"] == nil then
-                  event["log"]["result"] = "empty"
-                else
-                  event["log"]["result"] = "found"
+            indoc! {r#"
+            version: "2"
+            hooks:
+              process: |
+                function (event, emit)
+                  if event["log"]["non-existent"] == nil then
+                    event["log"]["result"] = "empty"
+                  else
+                    event["log"]["result"] = "found"
+                  end
+                  emit(event)
                 end
-                emit(event)
-            end
-            """
-            "#,
+            "#},
             |tx, out| async move {
                 let event = LogEvent::default();
                 tx.send(event.into()).await.unwrap();
@@ -707,14 +703,15 @@ mod tests {
     #[tokio::test]
     async fn lua_integer_value() {
         run_transform(
-            r#"
-            version = "2"
-            hooks.process = """function (event, emit)
-                event["log"]["number"] = 3
-                emit(event)
-            end
-            """
-            "#,
+            indoc! {r#"
+            version: "2"
+            hooks:
+              process: |
+                function (event, emit)
+                  event["log"]["number"] = 3
+                  emit(event)
+                end
+            "#},
             |tx, out| async move {
                 let event = LogEvent::default();
                 tx.send(event.into()).await.unwrap();
@@ -731,14 +728,15 @@ mod tests {
     #[tokio::test]
     async fn lua_numeric_value() {
         run_transform(
-            r#"
-            version = "2"
-            hooks.process = """function (event, emit)
-                event["log"]["number"] = 3.14159
-                emit(event)
-            end
-            """
-            "#,
+            indoc! {r#"
+            version: "2"
+            hooks:
+              process: |
+                function (event, emit)
+                  event["log"]["number"] = 3.14159
+                  emit(event)
+                end
+            "#},
             |tx, out| async move {
                 let event = LogEvent::default();
                 tx.send(event.into()).await.unwrap();
@@ -755,14 +753,15 @@ mod tests {
     #[tokio::test]
     async fn lua_boolean_value() {
         run_transform(
-            r#"
-            version = "2"
-            hooks.process = """function (event, emit)
-                event["log"]["bool"] = true
-                emit(event)
-            end
-            """
-            "#,
+            indoc! {r#"
+            version: "2"
+            hooks:
+              process: |
+                function (event, emit)
+                  event["log"]["bool"] = true
+                  emit(event)
+                end
+            "#},
             |tx, out| async move {
                 let event = LogEvent::default();
                 tx.send(event.into()).await.unwrap();
@@ -779,14 +778,15 @@ mod tests {
     #[tokio::test]
     async fn lua_non_coercible_value() {
         run_transform(
-            r#"
-            version = "2"
-            hooks.process = """function (event, emit)
-                event["log"]["junk"] = nil
-                emit(event)
-            end
-            """
-            "#,
+            indoc! {r#"
+            version: "2"
+            hooks:
+              process: |
+                function (event, emit)
+                  event["log"]["junk"] = nil
+                  emit(event)
+                end
+            "#},
             |tx, out| async move {
                 let event = LogEvent::default();
                 tx.send(event.into()).await.unwrap();
@@ -799,15 +799,14 @@ mod tests {
 
     #[tokio::test]
     async fn lua_non_string_key_write() -> crate::Result<()> {
-        let mut transform = from_config(
-            r#"
-            hooks.process = """function (event, emit)
-                event["log"][false] = "hello"
-                emit(event)
-            end
-            """
-            "#,
-        )
+        let mut transform = from_config(indoc! {r#"
+            hooks:
+              process: |
+                function (event, emit)
+                  event["log"][false] = "hello"
+                  emit(event)
+                end
+            "#})
         .unwrap();
 
         let err = transform
@@ -825,14 +824,15 @@ mod tests {
     #[tokio::test]
     async fn lua_non_string_key_read() {
         run_transform(
-            r#"
-            version = "2"
-            hooks.process = """function (event, emit)
-                event.log.result = event.log[false]
-                emit(event)
-            end
-            """
-            "#,
+            indoc! {r#"
+            version: "2"
+            hooks:
+              process: |
+                function (event, emit)
+                  event.log.result = event.log[false]
+                  emit(event)
+                end
+            "#},
             |tx, out| async move {
                 let event = LogEvent::default();
                 tx.send(event.into()).await.unwrap();
@@ -845,14 +845,13 @@ mod tests {
 
     #[tokio::test]
     async fn lua_script_error() -> crate::Result<()> {
-        let mut transform = from_config(
-            r#"
-            hooks.process = """function (event, emit)
-                error("this is an error")
-            end
-            """
-            "#,
-        )
+        let mut transform = from_config(indoc! {r#"
+            hooks:
+              process: |
+                function (event, emit)
+                  error("this is an error")
+                end
+            "#})
         .unwrap();
 
         let err = transform
@@ -865,14 +864,13 @@ mod tests {
 
     #[tokio::test]
     async fn lua_syntax_error() -> crate::Result<()> {
-        let err = from_config(
-            r#"
-            hooks.process = """function (event, emit)
-                1234 = sadf <>&*!#@
-            end
-            """
-            "#,
-        )
+        let err = from_config(indoc! {r#"
+            hooks:
+              process: |
+                function (event, emit)
+                  1234 = sadf <>&*!#@
+                end
+            "#})
         .map(|_| ())
         .unwrap_err()
         .to_string();
@@ -904,16 +902,7 @@ mod tests {
 
         run_transform(
             &format!(
-                r#"
-            version = "2"
-            hooks.process = """function (event, emit)
-                local script2 = require("script2")
-                script2.modify(event)
-                emit(event)
-            end
-            """
-            search_dirs = [{:?}]
-            "#,
+                "version: \"2\"\nhooks:\n  process: |\n    function (event, emit)\n      local script2 = require(\"script2\")\n      script2.modify(event)\n      emit(event)\n    end\nsearch_dirs:\n  - {:?}\n",
                 dir.path().as_os_str() // This seems a bit weird, but recall we also support windows.
             ),
             |tx, out| async move {
@@ -932,16 +921,17 @@ mod tests {
     #[tokio::test]
     async fn lua_pairs() {
         run_transform(
-            r#"
-            version = "2"
-            hooks.process = """function (event, emit)
-                for k,v in pairs(event.log) do
-                  event.log[k] = k .. v
+            indoc! {r#"
+            version: "2"
+            hooks:
+              process: |
+                function (event, emit)
+                  for k,v in pairs(event.log) do
+                    event.log[k] = k .. v
+                  end
+                  emit(event)
                 end
-                emit(event)
-            end
-            """
-            "#,
+            "#},
             |tx, out| async move {
                 let mut event = LogEvent::default();
                 event.insert("name", "Bob");
@@ -960,14 +950,15 @@ mod tests {
     #[tokio::test]
     async fn lua_metric() {
         run_transform(
-            r#"
-            version = "2"
-                hooks.process = """function (event, emit)
-                event.metric.counter.value = event.metric.counter.value + 1
-                emit(event)
-            end
-            """
-            "#,
+            indoc! {r#"
+            version: "2"
+            hooks:
+              process: |
+                function (event, emit)
+                  event.metric.counter.value = event.metric.counter.value + 1
+                  emit(event)
+                end
+            "#},
             |tx, out| async move {
                 let metric = Metric::new(
                     "example counter",
@@ -993,14 +984,15 @@ mod tests {
     #[tokio::test]
     async fn lua_multiple_events() {
         run_transform(
-            r#"
-            version = "2"
-            hooks.process = """function (event, emit)
-                event["log"]["hello"] = "goodbye"
-                emit(event)
-            end
-            """
-            "#,
+            indoc! {r#"
+            version: "2"
+            hooks:
+              process: |
+                function (event, emit)
+                  event["log"]["hello"] = "goodbye"
+                  emit(event)
+                end
+            "#},
             |tx, out| async move {
                 let n: usize = 10;
                 let events = (0..n).map(|i| Event::Log(LogEvent::from(format!("program me {i}"))));

--- a/src/transforms/reduce/transform.rs
+++ b/src/transforms/reduce/transform.rs
@@ -374,15 +374,13 @@ mod test {
 
     #[tokio::test]
     async fn reduce_from_condition() {
-        let reduce_config = toml::from_str::<ReduceConfig>(
-            r#"
-group_by = [ "request_id" ]
-
-[ends_when]
-  type = "vrl"
-  source = "exists(.test_end)"
-"#,
-        )
+        let reduce_config = serde_yaml::from_str::<ReduceConfig>(indoc! {"
+            group_by:
+              - request_id
+            ends_when:
+              type: vrl
+              source: exists(.test_end)
+        "})
         .unwrap();
 
         assert_transform_compliance(async move {
@@ -478,19 +476,17 @@ group_by = [ "request_id" ]
 
     #[tokio::test]
     async fn reduce_merge_strategies() {
-        let reduce_config = toml::from_str::<ReduceConfig>(
-            r#"
-group_by = [ "request_id" ]
-
-merge_strategies.foo = "concat"
-merge_strategies.bar = "array"
-merge_strategies.baz = "max"
-
-[ends_when]
-  type = "vrl"
-  source = "exists(.test_end)"
-"#,
-        )
+        let reduce_config = serde_yaml::from_str::<ReduceConfig>(indoc! {"
+            group_by:
+              - request_id
+            merge_strategies:
+              foo: concat
+              bar: array
+              baz: max
+            ends_when:
+              type: vrl
+              source: exists(.test_end)
+        "})
         .unwrap();
 
         assert_transform_compliance(async move {
@@ -552,15 +548,13 @@ merge_strategies.baz = "max"
 
     #[tokio::test]
     async fn missing_group_by() {
-        let reduce_config = toml::from_str::<ReduceConfig>(
-            r#"
-group_by = [ "request_id" ]
-
-[ends_when]
-  type = "vrl"
-  source = "exists(.test_end)"
-"#,
-        )
+        let reduce_config = serde_yaml::from_str::<ReduceConfig>(indoc! {"
+            group_by:
+              - request_id
+            ends_when:
+              type: vrl
+              source: exists(.test_end)
+        "})
         .unwrap();
 
         assert_transform_compliance(async move {
@@ -629,14 +623,14 @@ group_by = [ "request_id" ]
 
     #[tokio::test]
     async fn max_events_0() {
-        let reduce_config = toml::from_str::<ReduceConfig>(
-            r#"
-group_by = [ "id" ]
-merge_strategies.id = "retain"
-merge_strategies.message = "array"
-max_events = 0
-            "#,
-        );
+        let reduce_config = serde_yaml::from_str::<ReduceConfig>(indoc! {"
+            group_by:
+              - id
+            merge_strategies:
+              id: retain
+              message: array
+            max_events: 0
+        "});
 
         match reduce_config {
             Ok(_conf) => unreachable!("max_events=0 should be rejected."),
@@ -649,14 +643,14 @@ max_events = 0
 
     #[tokio::test]
     async fn max_events_1() {
-        let reduce_config = toml::from_str::<ReduceConfig>(
-            r#"
-group_by = [ "id" ]
-merge_strategies.id = "retain"
-merge_strategies.message = "array"
-max_events = 1
-            "#,
-        )
+        let reduce_config = serde_yaml::from_str::<ReduceConfig>(indoc! {"
+            group_by:
+              - id
+            merge_strategies:
+              id: retain
+              message: array
+            max_events: 1
+        "})
         .unwrap();
         assert_transform_compliance(async move {
             let (tx, rx) = mpsc::channel(1);
@@ -692,14 +686,14 @@ max_events = 1
 
     #[tokio::test]
     async fn max_events() {
-        let reduce_config = toml::from_str::<ReduceConfig>(
-            r#"
-group_by = [ "id" ]
-merge_strategies.id = "retain"
-merge_strategies.message = "array"
-max_events = 3
-            "#,
-        )
+        let reduce_config = serde_yaml::from_str::<ReduceConfig>(indoc! {"
+            group_by:
+              - id
+            merge_strategies:
+              id: retain
+              message: array
+            max_events: 3
+        "})
         .unwrap();
 
         assert_transform_compliance(async move {
@@ -756,18 +750,16 @@ max_events = 3
 
     #[tokio::test]
     async fn arrays() {
-        let reduce_config = toml::from_str::<ReduceConfig>(
-            r#"
-group_by = [ "request_id" ]
-
-merge_strategies.foo = "array"
-merge_strategies.bar = "concat"
-
-[ends_when]
-  type = "vrl"
-  source = "exists(.test_end)"
-"#,
-        )
+        let reduce_config = serde_yaml::from_str::<ReduceConfig>(indoc! {"
+            group_by:
+              - request_id
+            merge_strategies:
+              foo: array
+              bar: concat
+            ends_when:
+              type: vrl
+              source: exists(.test_end)
+        "})
         .unwrap();
 
         assert_transform_compliance(async move {
@@ -849,18 +841,16 @@ merge_strategies.bar = "concat"
 
     #[tokio::test]
     async fn strategy_path_with_nested_fields() {
-        let reduce_config = toml::from_str::<ReduceConfig>(indoc!(
-            r#"
-            group_by = [ "id" ]
-
-            merge_strategies.id = "discard"
-            merge_strategies."message.a.b" = "array"
-
-            [ends_when]
-              type = "vrl"
-              source = "exists(.test_end)"
-            "#,
-        ))
+        let reduce_config = serde_yaml::from_str::<ReduceConfig>(indoc! {"
+            group_by:
+              - id
+            merge_strategies:
+              id: discard
+              message.a.b: array
+            ends_when:
+              type: vrl
+              source: exists(.test_end)
+        "})
         .unwrap();
 
         assert_transform_compliance(async move {
@@ -927,14 +917,13 @@ merge_strategies.bar = "concat"
 
     #[test]
     fn invalid_merge_strategies_containing_indexes() {
-        let config = toml::from_str::<ReduceConfig>(indoc!(
-            r#"
-            group_by = [ "id" ]
-
-            merge_strategies.id = "discard"
-            merge_strategies."nested.msg[0]" = "array"
-            "#,
-        ))
+        let config = serde_yaml::from_str::<ReduceConfig>(indoc! {"
+            group_by:
+              - id
+            merge_strategies:
+              id: discard
+              'nested.msg[0]': array
+        "})
         .unwrap();
         let error = Reduce::new(
             &config,
@@ -950,18 +939,17 @@ merge_strategies.bar = "concat"
 
     #[tokio::test]
     async fn merge_objects_in_array() {
-        let config = toml::from_str::<ReduceConfig>(indoc!(
-            r#"
-            group_by = [ "id" ]
-            merge_strategies.events = "array"
-            merge_strategies."\"a-b\"" = "retain"
-            merge_strategies.another = "discard"
-
-            [ends_when]
-              type = "vrl"
-              source = "exists(.test_end)"
-            "#,
-        ))
+        let config = serde_yaml::from_str::<ReduceConfig>(indoc! {r#"
+            group_by:
+              - id
+            merge_strategies:
+              events: array
+              '"a-b"': retain
+              another: discard
+            ends_when:
+              type: vrl
+              source: exists(.test_end)
+        "#})
         .unwrap();
 
         assert_transform_compliance(async move {
@@ -1014,13 +1002,11 @@ merge_strategies.bar = "concat"
 
     #[tokio::test]
     async fn merged_quoted_path() {
-        let config = toml::from_str::<ReduceConfig>(indoc!(
-            r#"
-            [ends_when]
-              type = "vrl"
-              source = "exists(.test_end)"
-            "#,
-        ))
+        let config = serde_yaml::from_str::<ReduceConfig>(indoc! {"
+            ends_when:
+              type: vrl
+              source: exists(.test_end)
+        "})
         .unwrap();
 
         assert_transform_compliance(async move {

--- a/src/transforms/remap.rs
+++ b/src/transforms/remap.rs
@@ -1543,27 +1543,25 @@ mod tests {
     async fn check_remap_branching_metrics_with_output() {
         init_test();
 
-        let config: ConfigBuilder = toml::from_str(indoc! {r#"
-            [transforms.foo]
-            inputs = []
-            type = "remap"
-            drop_on_abort = true
-            reroute_dropped = true
-            source = "abort"
-
-            [[tests]]
-            name = "metric output"
-
-            [tests.input]
-                insert_at = "foo"
-                value = "none"
-
-            [[tests.outputs]]
-                extract_from = "foo.dropped"
-                [[tests.outputs.conditions]]
-                type = "vrl"
-                source = "true"
-        "#})
+        let config: ConfigBuilder = serde_yaml::from_str(indoc! {"
+            transforms:
+              foo:
+                inputs: []
+                type: remap
+                drop_on_abort: true
+                reroute_dropped: true
+                source: abort
+            tests:
+              - name: metric output
+                input:
+                  insert_at: foo
+                  value: none
+                outputs:
+                  - extract_from: foo.dropped
+                    conditions:
+                      - type: vrl
+                        source: \"true\"
+        "})
         .unwrap();
 
         let mut tests = build_unit_tests(config).await.unwrap();

--- a/src/transforms/route.rs
+++ b/src/transforms/route.rs
@@ -196,12 +196,12 @@ mod test {
     fn can_serialize_remap() {
         // We need to serialize the config to check if a config has
         // changed when reloading.
-        let config = toml::from_str::<RouteConfig>(
-            r#"
-            route.first.type = "vrl"
-            route.first.source = '.message == "hello world"'
-        "#,
-        )
+        let config = serde_yaml::from_str::<RouteConfig>(indoc! {"
+            route:
+              first:
+                type: vrl
+                source: '.message == \"hello world\"'
+        "})
         .unwrap();
 
         assert_eq!(
@@ -218,18 +218,18 @@ mod test {
             LogNamespace::Legacy,
         )
         .unwrap();
-        let config = toml::from_str::<RouteConfig>(
-            r#"
-            route.first.type = "vrl"
-            route.first.source = '.message == "hello world"'
-
-            route.second.type = "vrl"
-            route.second.source = '.second == "second"'
-
-            route.third.type = "vrl"
-            route.third.source = '.third == "third"'
-        "#,
-        )
+        let config = serde_yaml::from_str::<RouteConfig>(indoc! {"
+            route:
+              first:
+                type: vrl
+                source: '.message == \"hello world\"'
+              second:
+                type: vrl
+                source: '.second == \"second\"'
+              third:
+                type: vrl
+                source: '.third == \"third\"'
+        "})
         .unwrap();
 
         let mut transform = Route::new(&config, &Default::default()).unwrap();
@@ -264,18 +264,18 @@ mod test {
             LogNamespace::Legacy,
         )
         .unwrap();
-        let config = toml::from_str::<RouteConfig>(
-            r#"
-            route.first.type = "vrl"
-            route.first.source = '.message == "hello world"'
-
-            route.second.type = "vrl"
-            route.second.source = '.second == "second"'
-
-            route.third.type = "vrl"
-            route.third.source = '.third == "third"'
-        "#,
-        )
+        let config = serde_yaml::from_str::<RouteConfig>(indoc! {"
+            route:
+              first:
+                type: vrl
+                source: '.message == \"hello world\"'
+              second:
+                type: vrl
+                source: '.second == \"second\"'
+              third:
+                type: vrl
+                source: '.third == \"third\"'
+        "})
         .unwrap();
 
         let mut transform = Route::new(&config, &Default::default()).unwrap();
@@ -307,18 +307,18 @@ mod test {
         let event =
             Event::from_json_value(serde_json::json!({"message": "NOPE"}), LogNamespace::Legacy)
                 .unwrap();
-        let config = toml::from_str::<RouteConfig>(
-            r#"
-            route.first.type = "vrl"
-            route.first.source = '.message == "hello world"'
-
-            route.second.type = "vrl"
-            route.second.source = '.second == "second"'
-
-            route.third.type = "vrl"
-            route.third.source = '.third == "third"'
-        "#,
-        )
+        let config = serde_yaml::from_str::<RouteConfig>(indoc! {"
+            route:
+              first:
+                type: vrl
+                source: '.message == \"hello world\"'
+              second:
+                type: vrl
+                source: '.second == \"second\"'
+              third:
+                type: vrl
+                source: '.third == \"third\"'
+        "})
         .unwrap();
 
         let mut transform = Route::new(&config, &Default::default()).unwrap();
@@ -350,20 +350,19 @@ mod test {
         let event =
             Event::from_json_value(serde_json::json!({"message": "NOPE"}), LogNamespace::Legacy)
                 .unwrap();
-        let config = toml::from_str::<RouteConfig>(
-            r#"
-            reroute_unmatched = false
-
-            route.first.type = "vrl"
-            route.first.source = '.message == "hello world"'
-
-            route.second.type = "vrl"
-            route.second.source = '.second == "second"'
-
-            route.third.type = "vrl"
-            route.third.source = '.third == "third"'
-        "#,
-        )
+        let config = serde_yaml::from_str::<RouteConfig>(indoc! {"
+            reroute_unmatched: false
+            route:
+              first:
+                type: vrl
+                source: '.message == \"hello world\"'
+              second:
+                type: vrl
+                source: '.second == \"second\"'
+              third:
+                type: vrl
+                source: '.third == \"third\"'
+        "})
         .unwrap();
 
         let mut transform = Route::new(&config, &Default::default()).unwrap();
@@ -389,26 +388,25 @@ mod test {
     async fn route_metrics_with_output_tag() {
         init_test();
 
-        let config: ConfigBuilder = toml::from_str(indoc! {r#"
-            [transforms.foo]
-            inputs = []
-            type = "route"
-            [transforms.foo.route.first]
-                type = "is_log"
-
-            [[tests]]
-            name = "metric output"
-
-            [tests.input]
-                insert_at = "foo"
-                value = "none"
-
-            [[tests.outputs]]
-                extract_from = "foo.first"
-                [[tests.outputs.conditions]]
-                type = "vrl"
-                source = "true"
-        "#})
+        let config: ConfigBuilder = serde_yaml::from_str(indoc! {"
+            transforms:
+              foo:
+                inputs: []
+                type: route
+                route:
+                  first:
+                    type: is_log
+            tests:
+              - name: metric output
+                input:
+                  insert_at: foo
+                  value: none
+                outputs:
+                  - extract_from: foo.first
+                    conditions:
+                      - type: vrl
+                        source: \"true\"
+        "})
         .unwrap();
 
         let mut tests = build_unit_tests(config).await.unwrap();

--- a/src/transforms/throttle/transform.rs
+++ b/src/transforms/throttle/transform.rs
@@ -150,6 +150,7 @@ mod tests {
     use std::task::Poll;
 
     use futures::SinkExt;
+    use indoc::indoc;
     use tokio::sync::mpsc;
     use tokio_stream::wrappers::ReceiverStream;
 
@@ -163,12 +164,10 @@ mod tests {
     #[tokio::test]
     async fn throttle_events() {
         let clock = clock::FakeRelativeClock::default();
-        let config = toml::from_str::<ThrottleConfig>(
-            r"
-threshold = 2
-window_secs = 5
-",
-        )
+        let config = serde_yaml::from_str::<ThrottleConfig>(indoc! {"
+            threshold: 2
+            window_secs: 5
+        "})
         .unwrap();
 
         let throttle = Throttle::new(&config, &TransformContext::default(), clock.clone())
@@ -231,15 +230,11 @@ window_secs = 5
     #[tokio::test]
     async fn throttle_exclude() {
         let clock = clock::FakeRelativeClock::default();
-        let config = toml::from_str::<ThrottleConfig>(
-            r#"
-threshold = 2
-window_secs = 5
-exclude = """
-exists(.special)
-"""
-"#,
-        )
+        let config = serde_yaml::from_str::<ThrottleConfig>(indoc! {"
+            threshold: 2
+            window_secs: 5
+            exclude: \"exists(.special)\"
+        "})
         .unwrap();
 
         let throttle = Throttle::new(&config, &TransformContext::default(), clock.clone())
@@ -313,13 +308,11 @@ exists(.special)
     #[tokio::test]
     async fn throttle_buckets() {
         let clock = clock::FakeRelativeClock::default();
-        let config = toml::from_str::<ThrottleConfig>(
-            r#"
-threshold = 1
-window_secs = 5
-key_field = "{{ bucket }}"
-"#,
-        )
+        let config = serde_yaml::from_str::<ThrottleConfig>(indoc! {r#"
+            threshold: 1
+            window_secs: 5
+            key_field: "{{ bucket }}"
+        "#})
         .unwrap();
 
         let throttle = Throttle::new(&config, &TransformContext::default(), clock.clone())


### PR DESCRIPTION
## Summary

Converts 200+ test configuration strings across 49 files from TOML to YAML. YAML is Vector's preferred and default configuration format, so test configs should reflect that.

Intentionally left as TOML:
- `generate_config()` implementations (they return `toml::Value`)
- `test_generate_config` / `load_sink` helpers (changing them would break all callers)
- `deserialization_toml` compression test (explicitly tests TOML-specific behavior)
- `adaptive_concurrency` tests (read `.toml` fixture files from disk)
- `config/cmd.rs` tests (pass results to `serialize_to_json` which requires `toml::value::Table`)

## Vector configuration

N/A — test-only change.

## How did you test this PR?

- `make check-clippy` passes clean
- Verified conversions using a throwaway round-trip script that extracted paired TOML/YAML raw string literals from the diff and confirmed both deserialize to the same structure. It caught one real bug: `auth:` in YAML deserializes to `null` whereas TOML `[auth]` deserializes to an empty map — fixed in `src/sinks/azure_blob/test.rs` (`auth: {}`).

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.