### PR TITLE
docs(website): fix stale references and add FIPS disclaimer

### DIFF
--- a/website/content/en/community/_index.md
+++ b/website/content/en/community/_index.md
@@ -40,7 +40,7 @@ Vector is [open source][oss] and welcomes contributions. A few guidelines to hel
 
 2. Start with [good first issues][first_issues].
 
-3. Join our [discord] if you have any questions. We are happy to help!
+3. Use [GitHub Discussions][vector_discussions] if you have any questions. We are happy to help!
 
 ### What is Vector's governance model?
 

--- a/website/content/en/docs/architecture/guarantees.md
+++ b/website/content/en/docs/architecture/guarantees.md
@@ -129,7 +129,7 @@ by themselves guarantee end-to-end delivery.
 
 ### Does Vector support exactly-once delivery?
 
-No, Vector does not support exactly once delivery. There are future plans to partially support this for sources and sinks that support it, for example Kafka, but it remains unclear if Vector will ever be able to achieve this. Follow the [GitHub issue tracker](https://github.com/vectordotdev/vector/issues) or release highlights to stay informed if this ever changes.
+No, Vector does not support exactly once delivery. There are future plans to partially support this for sources and sinks that support it, for example Kafka, but it remains unclear if Vector will ever be able to achieve this.
 
 ### How can I find components that meet these guarantees?
 

--- a/website/content/en/docs/architecture/guarantees.md
+++ b/website/content/en/docs/architecture/guarantees.md
@@ -129,7 +129,7 @@ by themselves guarantee end-to-end delivery.
 
 ### Does Vector support exactly-once delivery?
 
-No, Vector does not support exactly once delivery. There are future plans to partially support this for sources and sinks that support it, for example Kafka, but it remains unclear if Vector will ever be able to achieve this. We recommend [subscribing to our mailing list](/community), which will keep you in the loop if this ever changes.
+No, Vector does not support exactly once delivery. There are future plans to partially support this for sources and sinks that support it, for example Kafka, but it remains unclear if Vector will ever be able to achieve this. Follow the [GitHub issue tracker](https://github.com/vectordotdev/vector/issues) or release highlights to stay informed if this ever changes.
 
 ### How can I find components that meet these guarantees?
 

--- a/website/content/en/docs/reference/configuration/tls.md
+++ b/website/content/en/docs/reference/configuration/tls.md
@@ -97,6 +97,12 @@ in the running system may also use this file and unintentionally switch to the l
 
 ### FIPS provider example
 
+{{< warning >}}
+Using the OpenSSL FIPS provider restricts TLS to FIPS-approved algorithms, but **does not make Vector
+fully FIPS-compliant**. See [issue #8435](https://github.com/vectordotdev/vector/issues/8435)
+for the current status of FIPS support in Vector.
+{{< /warning >}}
+
 To use the _FIPS_ provider in Vector, the [OpenSSL FIPS module][openssl-fips-module] must be installed
 and [configured][openssl-fips-module]. This is beyond the scope of this document, however
 [instructions][openssl-fips] can be found in the OpenSSL repository.


### PR DESCRIPTION
## Summary

- Remove mailing list reference in guarantees.md; point to GitHub issue tracker and release highlights instead
- Update community contribution guide to recommend GitHub Discussions instead of Discord
- Add a warning to the TLS FIPS provider example clarifying that using the OpenSSL FIPS provider does not make Vector fully FIPS-compliant

## Vector configuration

NA

## How did you test this PR?

Reviewed the rendered markdown changes locally.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

NA