### PR TITLE
chore(ci): fix race between labeler and docs-review-on-hold workflow

### DIFF
--- a/.github/workflows/add_docs_review_label.yml
+++ b/.github/workflows/add_docs_review_label.yml
@@ -3,6 +3,10 @@
 # this into a reusable workflow (`workflow_call`) with the label as an input.
 name: Add Docs Review Label
 
+concurrency:
+  group: pr-labels-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
 permissions:
   pull-requests: write
 

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -16,4 +16,4 @@ jobs:
       - uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b # v6.0.1
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
-          sync-labels: true
+          sync-labels: false

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -2,6 +2,10 @@ name: "Pull Request Labeler"
 on:
   pull_request_target:
 
+concurrency:
+  group: pr-labels-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 
@@ -16,4 +20,4 @@ jobs:
       - uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b # v6.0.1
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
-          sync-labels: false
+          sync-labels: true


### PR DESCRIPTION
## Summary

The `actions/labeler` action calls `issues.setLabels` (a full label replace)
on every PR push. If `Add Docs Review Label` adds `docs review on hold`
between the labeler fetching PR state and calling `setLabels`, the label
gets silently wiped.

Both workflows share a `concurrency` group keyed on the PR number with
`cancel-in-progress: false`, so they queue rather than race. The labeler
retains `sync-labels: true` — domain label cleanup is unaffected.

## Change Type

- [x] Non-functional (chore, refactoring, docs)

## Is this a breaking change?

- [x] No

## Does this PR include user facing changes?

- [x] No. A maintainer will apply the `no-changelog` label to this PR.