### PR TITLE
docs(buffers): note known restart bugs in disk buffer docs

### DIFF
--- a/website/content/en/docs/architecture/buffering-model.md
+++ b/website/content/en/docs/architecture/buffering-model.md
@@ -124,7 +124,7 @@ detected, to give as accurate of a view into the number of events that were lost
 Disk buffers have some unique monitoring requirements compared to in-memory buffers,
 specifically around free storage space.
 
-Please take a look at [known bugs][disk_buffer_bugs] before deploying to production.
+Look at [known bugs][disk_buffer_bugs] before deploying to production.
 
 [disk_buffer_bugs]: https://github.com/vectordotdev/vector/issues?q=sort%3Aupdated-desc+is%3Aissue+state%3Aopen+label%3A%22domain%3A+buffers%22+type%3ABug
 {{< /warning >}}

--- a/website/content/en/docs/architecture/buffering-model.md
+++ b/website/content/en/docs/architecture/buffering-model.md
@@ -123,6 +123,10 @@ detected, to give as accurate of a view into the number of events that were lost
 {{< warning >}}
 Disk buffers have some unique monitoring requirements compared to in-memory buffers,
 specifically around free storage space.
+
+Please take a look at [known bugs][disk_buffer_bugs] before deploying to production.
+
+[disk_buffer_bugs]: https://github.com/vectordotdev/vector/issues?q=sort%3Aupdated-desc+is%3Aissue+state%3Aopen+label%3A%22domain%3A+buffers%22+type%3ABug
 {{< /warning >}}
 
 I/O errors are notoriously hard to recover from, as it can be difficult to know what data made it to


### PR DESCRIPTION
## Summary

Adds a brief callout to the [buffering model docs](https://vector.dev/docs/architecture/buffering-model/) noting the known disk buffer restart bugs, with a link to the open issue list.

## Vector configuration

N/A

## How did you test this PR?

Docs-only change.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: #25642, #18130, #18336, #20212