### PR TITLE
docs(guarantees): update stable component criteria

### DIFF
--- a/website/content/en/docs/architecture/guarantees.md
+++ b/website/content/en/docs/architecture/guarantees.md
@@ -92,13 +92,10 @@ The `stable` status is a _subjective_ status defined by the Vector team. It's in
 general idea of a feature's suitability for production environments. A feature is considered stable
 if it meets the following criteria:
 
-1. A meaningful number of users (generally over 50) have been using the feature in a production
-    environment for a sustained period of time without issue.
-2. The feature has had sufficient time (generally more than 4 months) to be community tested.
-
-3. The feature API is stable and unlikely to change.
-
-4. There are no major [open bugs][bugs] for the feature.
+1. The feature has had sufficient time (generally more than 4 months) to be community tested.
+2. The feature API is stable and unlikely to change.
+3. There are no major [open bugs][bugs] for the feature.
+4. There is positive community signal that the feature is being used successfully in production environments.
 
 ### Beta
 


### PR DESCRIPTION
## Summary

Removed the unmeasurable criterion that required "a meaningful number of users (generally over 50)" using a feature in production because there is no way to verify this.

## Vector configuration

N/A

## How did you test this PR?

Docs-only change.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

N/A