### PR TITLE
fix(ci): fix two failures in cleanup-ghcr-images workflow

### DIFF
--- a/.github/workflows/cleanup-ghcr-images.yml
+++ b/.github/workflows/cleanup-ghcr-images.yml
@@ -2,8 +2,11 @@
 #
 # This workflow cleans up old images from GitHub Container Registry
 # to prevent unlimited storage growth. It runs weekly and removes:
-# 1. Old dated nightly tags for vector (keeps last ~8)
-# 2. Old test-runner versions (keeps 5 most recent)
+# 1. Old test-runner versions (keeps 5 most recent)
+#
+# Note: cleanup of dated vector nightly images requires a token with
+# delete:packages scope (GITHUB_TOKEN is insufficient for org-owned
+# container packages). This is tracked separately.
 
 name: Cleanup GHCR Images
 
@@ -17,19 +20,6 @@ permissions:
   contents: read # Restrictive default
 
 jobs:
-  cleanup-vector-nightlies:
-    runs-on: ubuntu-24.04
-    permissions:
-      packages: write # Required to delete package versions from GHCR
-    steps:
-      - name: Delete old dated nightly vector images
-        uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55 # v5.0.0
-        with:
-          package-name: vector
-          package-type: container
-          min-versions-to-keep: 30
-          ignore-versions: '^(nightly$|\d+\.\d+)'
-
   cleanup-test-runner:
     runs-on: ubuntu-24.04
     permissions:
@@ -38,7 +28,6 @@ jobs:
       - name: Delete old test-runner images
         uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55 # v5.0.0
         with:
-          package-name: test-runner
+          package-name: vector/test-runner
           package-type: container
           min-versions-to-keep: 5
-          num-old-versions-to-delete: 100


### PR DESCRIPTION
## Summary

The `cleanup-ghcr-images` workflow has been failing on every weekly run due to two bugs in the `cleanup-test-runner` job:

- **Wrong package name**: the package is namespaced as `vector/test-runner` in GHCR, not `test-runner`. The action was failing immediately with `get versions API failed. Package not found.`
- **Invalid input combination**: `num-old-versions-to-delete` and `min-versions-to-keep` are mutually exclusive in `actions/delete-package-versions` v5. Specifying both caused `Invalid input combination` on every run.

The `cleanup-vector-nightlies` job is removed. Investigation revealed that `GITHUB_TOKEN` with `packages: write` cannot delete org-owned container package versions — the `delete:packages` scope is required, which `GITHUB_TOKEN` does not provide.

Until then, we can run [purge github nightly](https://github.com/vectordotdev/github-tools/blob/main/src/commands/purge.rs) after each release.

## How did you test this PR?

- Triggered `workflow_dispatch` runs on the branch; `cleanup-test-runner` now passes cleanly.
- Confirmed `vector/test-runner` package exists at the correct GHCR path.

## Change Type

- [x] Non-functional (chore, refactoring, docs)

## Is this a breaking change?

- [x] No

## Does this PR include user facing changes?

- [x] No. A maintainer will apply the `no-changelog` label to this PR.