### PR TITLE
chore(vdev): add --features flag and FEATURES env var support to build/check/test commands

### DIFF
--- a/.github/workflows/vdev_autotag.yml
+++ b/.github/workflows/vdev_autotag.yml
@@ -8,7 +8,7 @@ on:
       - "vdev/Cargo.toml"
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   tag:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12792,7 +12792,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vdev"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "cfg-if",

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ else
     export RUST_TARGET ?= "x86_64-unknown-linux-gnu"
     export DNSTAP_BENCHES := dnstap-benches
 endif
-export FEATURES ?= default
+export FEATURES ?=
 
 # When COVERAGE=true, swap cargo-nextest for cargo-llvm-cov so test targets collect
 # coverage data. Run `make coverage-report` afterwards to emit the lcov file.
@@ -89,7 +89,7 @@ help:
 build: check-build-tools
 build: export CFLAGS += -g0 -O3
 build: ## Build the project in release mode
-	cargo build --release --no-default-features --features ${FEATURES}
+	cargo build --release $(if $(FEATURES),--no-default-features --features "$(FEATURES)")
 
 .PHONY: build-x86_64-unknown-linux-gnu
 build-x86_64-unknown-linux-gnu: target/x86_64-unknown-linux-gnu/release/vector ## Build a release binary for the x86_64-unknown-linux-gnu triple.
@@ -245,11 +245,11 @@ target/%/vector.tar.gz: target/%/vector CARGO_HANDLES_FRESHNESS
 # https://github.com/rust-lang/cargo/issues/6454
 .PHONY: test
 test: ## Run the unit test suite
-	${TEST_RUNNER} --workspace --no-fail-fast --no-default-features --features "${FEATURES}" ${SCOPE}
+	${TEST_RUNNER} --workspace --no-fail-fast $(if $(FEATURES),--no-default-features --features "$(FEATURES)") ${SCOPE}
 
 .PHONY: test-docs
 test-docs: ## Run the docs test suite
-	cargo test --doc --workspace --no-fail-fast --no-default-features --features "${FEATURES}" ${SCOPE}
+	cargo test --doc --workspace --no-fail-fast $(if $(FEATURES),--no-default-features --features "$(FEATURES)") ${SCOPE}
 
 .PHONY: test-all
 test-all: test test-docs test-behavior test-integration test-component-validation ## Runs all tests: unit, docs, behavioral, integration, and component validation.

--- a/vdev/Cargo.toml
+++ b/vdev/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vdev"
-version = "0.3.5"
+version = "0.3.6"
 edition = "2024"
 authors = ["Vector Contributors <vector@datadoghq.com>"]
 license = "MPL-2.0"

--- a/vdev/src/app.rs
+++ b/vdev/src/app.rs
@@ -83,7 +83,6 @@ pub trait CommandExt {
     fn run(&mut self) -> Result<ExitStatus>;
     fn wait(&mut self, message: impl Into<Cow<'static, str>>) -> Result<()>;
     fn pre_exec(&self);
-    fn features(&mut self, features: &[String]) -> &mut Self;
 }
 
 impl CommandExt for Command {
@@ -175,17 +174,6 @@ impl CommandExt for Command {
                 debug!("  unset ${key}");
             }
         }
-    }
-
-    fn features(&mut self, features: &[String]) -> &mut Self {
-        self.arg("--no-default-features");
-        self.arg("--features");
-        if features.is_empty() {
-            self.arg("default");
-        } else {
-            self.arg(features.join(","));
-        }
-        self
     }
 }
 

--- a/vdev/src/commands/build/vector.rs
+++ b/vdev/src/commands/build/vector.rs
@@ -16,9 +16,12 @@ pub struct Cli {
     #[arg(short, long)]
     release: bool,
 
-    /// The feature to activate (multiple allowed)
-    #[arg(short = 'F', long)]
-    feature: Vec<String>,
+    /// Features to activate (comma-separated, or set FEATURES env var)
+    #[arg(short = 'F', long, value_delimiter = ',', env = "FEATURES")]
+    features: Vec<String>,
+
+    #[arg(long)]
+    no_default_features: bool,
 }
 
 impl Cli {
@@ -31,7 +34,17 @@ impl Cli {
             command.arg("--release");
         }
 
-        command.features(&self.feature);
+        if self.no_default_features {
+            command.arg("--no-default-features");
+        }
+        let features: Vec<String> = self
+            .features
+            .into_iter()
+            .filter(|f| !f.is_empty())
+            .collect();
+        if !features.is_empty() {
+            command.args(["--features", &features.join(",")]);
+        }
 
         let target = self.target.unwrap_or_else(platform::default_target);
         command.args(["--target", &target]);

--- a/vdev/src/commands/check/rust.rs
+++ b/vdev/src/commands/check/rust.rs
@@ -13,8 +13,11 @@ pub struct Cli {
     #[arg(long, default_value_t = true)]
     clippy: bool,
 
-    #[arg(value_name = "FEATURE")]
+    #[arg(short = 'F', long, value_delimiter = ',', env = "FEATURES")]
     features: Vec<String>,
+
+    #[arg(long)]
+    no_default_features: bool,
 
     #[arg(long)]
     fix: bool,
@@ -36,14 +39,25 @@ impl Cli {
             Vec::default()
         };
 
-        let feature_args = if self.features.is_empty() {
-            vec!["--all-features".to_string()]
+        let features: Vec<&str> = self
+            .features
+            .iter()
+            .map(String::as_str)
+            .filter(|f| !f.is_empty())
+            .collect();
+
+        let feature_args: Vec<String> = if self.no_default_features || !features.is_empty() {
+            let mut args = Vec::new();
+            if self.no_default_features {
+                args.push("--no-default-features".to_string());
+            }
+            if !features.is_empty() {
+                args.push("--features".to_string());
+                args.push(features.join(","));
+            }
+            args
         } else {
-            vec![
-                "--no-default-features".to_string(),
-                "--features".to_string(),
-                self.features.join(",").clone(),
-            ]
+            vec!["--all-features".to_string()]
         };
 
         [tool.as_ref(), "--workspace", "--all-targets"]

--- a/vdev/src/commands/crate_versions.rs
+++ b/vdev/src/commands/crate_versions.rs
@@ -18,22 +18,34 @@ pub struct Cli {
     #[arg(long)]
     all: bool,
 
-    /// The feature to active (multiple allowed). If none are specified, the default is used.
-    #[arg(short = 'F', long)]
-    feature: Vec<String>,
+    /// Features to activate (comma-separated, or set FEATURES env var)
+    #[arg(short = 'F', long, value_delimiter = ',', env = "FEATURES")]
+    features: Vec<String>,
+
+    #[arg(long)]
+    no_default_features: bool,
 }
 
 impl Cli {
     pub fn exec(self) -> Result<()> {
         let re_crate = Regex::new(r" (\S+) v([0-9.]+)").unwrap();
         let mut versions: HashMap<String, HashSet<String>> = HashMap::default();
+        let features: Vec<String> = self
+            .features
+            .into_iter()
+            .filter(|f| !f.is_empty())
+            .collect();
 
-        for line in Command::new("cargo")
-            .arg("tree")
-            .features(&self.feature)
-            .check_output()?
-            .lines()
-        {
+        let mut cmd = Command::new("cargo");
+        cmd.arg("tree");
+        if self.no_default_features {
+            cmd.arg("--no-default-features");
+        }
+        if !features.is_empty() {
+            cmd.args(["--features", &features.join(",")]);
+        }
+
+        for line in cmd.check_output()?.lines() {
             if let Some(captures) = re_crate.captures(line) {
                 let package = &captures[1];
                 let version = &captures[2];

--- a/vdev/src/commands/test.rs
+++ b/vdev/src/commands/test.rs
@@ -14,6 +14,13 @@ pub struct Cli {
     /// Environment variables in the form KEY[=VALUE]
     #[arg(short, long)]
     env: Option<Vec<String>>,
+
+    /// Features to activate (comma-separated, or set FEATURES env var)
+    #[arg(short = 'F', long, value_delimiter = ',', env = "FEATURES")]
+    features: Vec<String>,
+
+    #[arg(long)]
+    no_default_features: bool,
 }
 
 fn parse_env(env: Vec<String>) -> BTreeMap<String, Option<String>> {
@@ -36,8 +43,17 @@ impl Cli {
             args.append(&mut extra_args);
         }
 
-        if !args.contains(&"--features".to_string()) {
-            args.extend(["--features".to_string(), "default".to_string()]);
+        let features: Vec<String> = self
+            .features
+            .into_iter()
+            .filter(|f| !f.is_empty())
+            .collect();
+
+        if self.no_default_features {
+            args.push("--no-default-features".to_string());
+        }
+        if !features.is_empty() {
+            args.extend(["--features".to_string(), features.join(",")]);
         }
 
         LocalTestRunner.test(

--- a/vdev/src/commands/test.rs
+++ b/vdev/src/commands/test.rs
@@ -37,23 +37,23 @@ fn parse_env(env: Vec<String>) -> BTreeMap<String, Option<String>> {
 
 impl Cli {
     pub fn exec(self) -> Result<()> {
-        let mut args = vec!["--workspace".to_string()];
-
-        if let Some(mut extra_args) = self.args {
-            args.append(&mut extra_args);
-        }
-
         let features: Vec<String> = self
             .features
             .into_iter()
             .filter(|f| !f.is_empty())
             .collect();
 
+        let mut args = vec!["--workspace".to_string()];
+
         if self.no_default_features {
             args.push("--no-default-features".to_string());
         }
         if !features.is_empty() {
             args.extend(["--features".to_string(), features.join(",")]);
+        }
+
+        if let Some(mut extra_args) = self.args {
+            args.append(&mut extra_args);
         }
 
         LocalTestRunner.test(

--- a/vdev/src/testing/runner.rs
+++ b/vdev/src/testing/runner.rs
@@ -29,6 +29,7 @@ const TEST_COMMAND: &[&str] = &[
     "--no-fail-fast",
     "--no-default-features",
 ];
+const LOCAL_TEST_COMMAND: &[&str] = &["cargo", "nextest", "run", "--no-fail-fast"];
 const COVERAGE_COMMAND: &[&str] = &[
     "cargo",
     "llvm-cov",
@@ -417,7 +418,7 @@ impl TestRunner for LocalTestRunner {
         let test_cmd = if coverage {
             COVERAGE_COMMAND
         } else {
-            TEST_COMMAND
+            LOCAL_TEST_COMMAND
         };
         let mut command = Command::new(test_cmd[0]);
         command.args(&test_cmd[1..]);


### PR DESCRIPTION
## Summary

All vdev commands that shell out to cargo with a feature set (`check rust`, `build`, `test`, `crate_versions`) previously accepted features as positional arguments or used an inconsistent `--feature` (singular) flag. This makes them non-obvious and inconsistent with cargo's own interface.

This PR:
- Replaces the positional `features` argument in `check rust` with a named `--features` flag (short: `-F`, comma-separated)
- Renames `--feature` → `--features` in `build vector` and `crate_versions`
- Adds an explicit `--features` flag to `test` (replacing the implicit passthrough hack)
- Adds `--no-default-features` to `check rust` and `test`
- Wires `env = "FEATURES"` on all `--features` flags so `FEATURES=x,y make check-clippy` now works

Before:
```bash
cargo vdev check rust default rdkafka-dynamic   # positional, non-obvious
FEATURES=x,y make check-clippy                  # silently ignored
```

After:
```bash
cargo vdev check rust --features default,rdkafka-dynamic
FEATURES=default,rdkafka-dynamic make check-clippy  # works
```

## Vector configuration

N/A — vdev tooling change only.

## How did you test this PR?

- Verified `cargo build -p vdev` compiles cleanly
- Pre-push hook ran `cargo vdev check rust --all-features` successfully
- Manually verified `--help` output on `check rust`, `build`, `test`

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [x] Yes
- [ ] No

`cargo vdev check rust <feature> <feature>` (positional) no longer works. Replacement: `cargo vdev check rust --features feat1,feat2`.

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Closes: #25687