### PR TITLE
chore: replace default-msvc with default on Windows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -253,7 +253,7 @@ jobs:
       - name: Build Vector
         shell: bash
         run: |
-          export FEATURES="default-msvc"
+          export FEATURES="default"
           export ARCHIVE_TYPE="zip"
           export KEEP_SYMBOLS="true"
           export RUST_LTO=""

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -92,16 +92,8 @@ jobs:
             fi
           }
 
-          # Mirror the Makefile's OS-based default: `default-msvc` on Windows,
-          # `default` elsewhere. Keep in sync with the FEATURES defaults in Makefile.
-          if [[ "${RUNNER_OS}" == "Windows" ]]; then
-            DEFAULT_FEATURES="default-msvc"
-          else
-            DEFAULT_FEATURES="default"
-          fi
-
           if [[ "${{ inputs.default }}" == "true" ]]; then
-            FEATURES="${DEFAULT_FEATURES}"
+            FEATURES="default"
           else
             FEATURES=""
           fi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12791,7 +12791,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vdev"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -487,7 +487,7 @@ rdkafka = { workspace = true, features = ["cmake_build"], optional = true }
 [target.'cfg(unix)'.dependencies]
 libc.workspace = true
 nix = { version = "0.31", default-features = false, features = ["socket", "signal", "fs", "resource"] }
-tikv-jemallocator = { version = "0.7.0", default-features = false, features = ["unprefixed_malloc_on_supported_platforms"] }
+tikv-jemallocator = { version = "0.7.0", default-features = false, features = ["unprefixed_malloc_on_supported_platforms"], optional = true }
 dnsmsg-parser = { path = "lib/dnsmsg-parser", optional = true }
 dnstap-parser = { path = "lib/vector-vrl/dnstap-parser", optional = true }
 hickory-proto = { workspace = true, optional = true }
@@ -543,13 +543,13 @@ ntapi = { git = "https://github.com/MSxDOS/ntapi.git", rev = "24fc1e47677fc9f6e3
 # macOS releases pick it up through the `target-aarch64-apple-darwin` feature (see target
 # table below). Local dev builds skip it so they don't need `libsasl2-dev` / cyrus-sasl
 # installed, and so rdkafka's build script doesn't link GSSAPI.
-default = ["enable-api-client", "sources-dnstap"]
+default = ["enable-api-client", "sources-dnstap", "tikv-jemallocator"]
 antithesis-scenario-memory = ["dep:antithesis-instrumentation"]
 antithesis-scenario-disk = ["dep:antithesis-instrumentation", "vector-lib/antithesis-disk-asserts"]
 # Default features for `cargo docs`. We're not using `gssapi` which would require installing libsasl2 in our doc environment.
 docs = ["enable-api-client", "sources-dnstap"]
 # Default features for *-unknown-linux-* which make use of `cmake` for dependencies
-default-cmake = ["enable-api-client", "sources-dnstap", "vendored", "rdkafka?/cmake_build"]
+default-cmake = ["enable-api-client", "sources-dnstap", "tikv-jemallocator", "vendored", "rdkafka?/cmake_build"]
 
 # Enables Kerberos / GSSAPI SASL support for kafka via dynamic linkage to a
 # system-provided libsasl2 (and the host's GSS implementation). Requires
@@ -572,7 +572,7 @@ vendored = ["gssapi-vendored"]
 # TODO: Enable SASL https://github.com/vectordotdev/vector/pull/3081#issuecomment-659298042
 base = ["api", "enrichment-tables", "sinks", "sources", "transforms", "secrets", "vrl/stdlib", "codecs-parquet"]
 enable-api-client = ["base", "api-client"]
-default-musl = ["enable-api-client", "sources-dnstap", "vendored", "rdkafka?/cmake_build"]
+default-musl = ["enable-api-client", "sources-dnstap", "tikv-jemallocator", "vendored", "rdkafka?/cmake_build"]
 default-no-api-client = ["base", "sources-dnstap", "vendored"]
 
 tokio-console = ["dep:console-subscriber", "tokio/tracing"]
@@ -593,18 +593,18 @@ all-metrics = ["sinks-metrics", "sources-metrics", "transforms-metrics"]
 # The `make` tasks will select this according to the appropriate triple.
 # Use this section to turn off or on specific features for specific triples.
 target-base = ["enable-api-client", "rdkafka?/cmake_build", "sources-dnstap"]
-target-aarch64-unknown-linux-gnu =      ["target-base"]
-target-aarch64-unknown-linux-musl =     ["target-base"]
-target-armv7-unknown-linux-gnueabihf =  ["target-base"]
+target-aarch64-unknown-linux-gnu =      ["target-base", "tikv-jemallocator"]
+target-aarch64-unknown-linux-musl =     ["target-base", "tikv-jemallocator"]
+target-armv7-unknown-linux-gnueabihf =  ["target-base", "tikv-jemallocator"]
 target-armv7-unknown-linux-musleabihf = ["target-base"]
-target-arm-unknown-linux-gnueabi =      ["target-base"]
+target-arm-unknown-linux-gnueabi =      ["target-base", "tikv-jemallocator"]
 target-arm-unknown-linux-musleabi =     ["target-base"]
-target-x86_64-unknown-linux-gnu =       ["target-base", "vendored"]
-target-x86_64-unknown-linux-musl =      ["target-base"]
+target-x86_64-unknown-linux-gnu =       ["target-base", "tikv-jemallocator", "vendored"]
+target-x86_64-unknown-linux-musl =      ["target-base", "tikv-jemallocator"]
 # Apple targets opt into `gssapi` (dynamic linkage to system libsasl2 + Apple's
 # GSS framework). The `gssapi-vendored` path does not currently link on
 # macOS arm64 (unresolved gss_* symbols).
-target-aarch64-apple-darwin =           ["enable-api-client", "sources-dnstap", "gssapi"]
+target-aarch64-apple-darwin =           ["enable-api-client", "sources-dnstap", "tikv-jemallocator", "gssapi"]
 
 
 # Enables kubernetes dependencies and shared code. Kubernetes-related sources,

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -256,8 +256,6 @@ uuid.workspace = true
 vrl.workspace = true
 
 # Internal libs
-dnsmsg-parser = { path = "lib/dnsmsg-parser", optional = true }
-dnstap-parser = { path = "lib/vector-vrl/dnstap-parser", optional = true }
 fakedata = { path = "lib/fakedata", optional = true }
 tracing-limit = { path = "lib/tracing-limit" }
 vector-common = { path = "lib/vector-common", default-features = false }
@@ -460,7 +458,6 @@ syslog = { version = "6.1.1", default-features = false, optional = true }
 tokio-postgres = { version = "0.7.18", default-features = false, features = ["runtime", "with-chrono-0_4"], optional = true }
 tokio-tungstenite = { workspace = true, features = ["connect"], optional = true }
 toml.workspace = true
-hickory-proto = { workspace = true, optional = true }
 tonic = { workspace = true, optional = true }
 tonic-health = { workspace = true, optional = true }
 tonic-reflection = { workspace = true, optional = true }
@@ -490,7 +487,10 @@ rdkafka = { workspace = true, features = ["cmake_build"], optional = true }
 [target.'cfg(unix)'.dependencies]
 libc.workspace = true
 nix = { version = "0.31", default-features = false, features = ["socket", "signal", "fs", "resource"] }
-tikv-jemallocator = { version = "0.7.0", default-features = false, features = ["unprefixed_malloc_on_supported_platforms"], optional = true }
+tikv-jemallocator = { version = "0.7.0", default-features = false, features = ["unprefixed_malloc_on_supported_platforms"] }
+dnsmsg-parser = { path = "lib/dnsmsg-parser", optional = true }
+dnstap-parser = { path = "lib/vector-vrl/dnstap-parser", optional = true }
+hickory-proto = { workspace = true, optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 procfs = { version = "0.18.0", default-features = false }
@@ -543,13 +543,13 @@ ntapi = { git = "https://github.com/MSxDOS/ntapi.git", rev = "24fc1e47677fc9f6e3
 # macOS releases pick it up through the `target-aarch64-apple-darwin` feature (see target
 # table below). Local dev builds skip it so they don't need `libsasl2-dev` / cyrus-sasl
 # installed, and so rdkafka's build script doesn't link GSSAPI.
-default = ["enable-unix"]
+default = ["enable-api-client", "sources-dnstap"]
 antithesis-scenario-memory = ["dep:antithesis-instrumentation"]
 antithesis-scenario-disk = ["dep:antithesis-instrumentation", "vector-lib/antithesis-disk-asserts"]
 # Default features for `cargo docs`. We're not using `gssapi` which would require installing libsasl2 in our doc environment.
-docs = ["enable-unix"]
+docs = ["enable-api-client", "sources-dnstap"]
 # Default features for *-unknown-linux-* which make use of `cmake` for dependencies
-default-cmake = ["enable-unix", "vendored", "rdkafka?/cmake_build"]
+default-cmake = ["enable-api-client", "sources-dnstap", "vendored", "rdkafka?/cmake_build"]
 
 # Enables Kerberos / GSSAPI SASL support for kafka via dynamic linkage to a
 # system-provided libsasl2 (and the host's GSS implementation). Requires
@@ -572,11 +572,8 @@ vendored = ["gssapi-vendored"]
 # TODO: Enable SASL https://github.com/vectordotdev/vector/pull/3081#issuecomment-659298042
 base = ["api", "enrichment-tables", "sinks", "sources", "transforms", "secrets", "vrl/stdlib", "codecs-parquet"]
 enable-api-client = ["base", "api-client"]
-enable-unix = ["enable-api-client", "sources-dnstap", "unix"]
-
-default-msvc = ["enable-api-client", "rdkafka?/cmake_build"]
-default-musl = ["enable-unix", "vendored", "rdkafka?/cmake_build"]
-default-no-api-client = ["base", "sources-dnstap", "unix", "vendored"]
+default-musl = ["enable-api-client", "sources-dnstap", "vendored", "rdkafka?/cmake_build"]
+default-no-api-client = ["base", "sources-dnstap", "vendored"]
 
 tokio-console = ["dep:console-subscriber", "tokio/tracing"]
 
@@ -596,7 +593,7 @@ all-metrics = ["sinks-metrics", "sources-metrics", "transforms-metrics"]
 # The `make` tasks will select this according to the appropriate triple.
 # Use this section to turn off or on specific features for specific triples.
 target-base = ["enable-api-client", "rdkafka?/cmake_build", "sources-dnstap"]
-target-unix = ["target-base", "unix"]
+target-unix = ["target-base"]
 target-aarch64-unknown-linux-gnu =      ["target-unix"]
 target-aarch64-unknown-linux-musl =     ["target-unix"]
 target-armv7-unknown-linux-gnueabihf =  ["target-unix"]
@@ -608,11 +605,8 @@ target-x86_64-unknown-linux-musl =      ["target-unix"]
 # Apple targets opt into `gssapi` (dynamic linkage to system libsasl2 + Apple's
 # GSS framework). The `gssapi-vendored` path does not currently link on
 # macOS arm64 (unresolved gss_* symbols).
-target-aarch64-apple-darwin =           ["enable-unix", "gssapi"]
+target-aarch64-apple-darwin =           ["enable-api-client", "sources-dnstap", "gssapi"]
 
-# Enables features that work only on systems providing `cfg(unix)`
-unix = ["tikv-jemallocator", "allocation-tracing"]
-allocation-tracing = ["vector-lib/allocation-tracing"]
 
 # Enables kubernetes dependencies and shared code. Kubernetes-related sources,
 # transforms and sinks should depend on this feature.
@@ -1079,7 +1073,7 @@ datadog-agent-integration-tests = ["sources-datadog_agent"]
 datadog-logs-integration-tests = ["sinks-datadog_logs"]
 datadog-metrics-integration-tests = ["sinks-datadog_metrics", "dep:prost"]
 datadog-traces-integration-tests = ["sources-datadog_agent", "sinks-datadog_traces", "axum/tokio"]
-docker-logs-integration-tests = ["sources-docker_logs", "unix"]
+docker-logs-integration-tests = ["sources-docker_logs"]
 doris-integration-tests = ["sinks-doris"]
 es-integration-tests = ["sinks-elasticsearch", "aws-core"]
 eventstoredb_metrics-integration-tests = ["sources-eventstoredb_metrics"]
@@ -1109,7 +1103,7 @@ dnstap-integration-tests = ["sources-dnstap", "dep:bollard"]
 webhdfs-integration-tests = ["sinks-webhdfs"]
 windows-event-log-integration-tests = ["sources-windows_event_log-integration-tests"]
 disable-resolv-conf = []
-shutdown-tests = ["api", "sinks-blackhole", "sinks-console", "sinks-prometheus", "sources", "transforms-lua", "transforms-remap", "unix"]
+shutdown-tests = ["api", "sinks-blackhole", "sinks-console", "sinks-prometheus", "sources", "transforms-lua", "transforms-remap"]
 cli-tests = ["sinks-blackhole", "sinks-socket", "sources-demo_logs", "sources-file", "transforms-remap"]
 test-utils = ["vector-lib/test"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -573,7 +573,7 @@ vendored = ["gssapi-vendored"]
 base = ["api", "enrichment-tables", "sinks", "sources", "transforms", "secrets", "vrl/stdlib", "codecs-parquet"]
 enable-api-client = ["base", "api-client"]
 default-musl = ["enable-api-client", "sources-dnstap", "tikv-jemallocator", "vendored", "rdkafka?/cmake_build"]
-default-no-api-client = ["base", "sources-dnstap", "vendored"]
+default-no-api-client = ["base", "sources-dnstap", "tikv-jemallocator", "vendored"]
 
 tokio-console = ["dep:console-subscriber", "tokio/tracing"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -593,15 +593,14 @@ all-metrics = ["sinks-metrics", "sources-metrics", "transforms-metrics"]
 # The `make` tasks will select this according to the appropriate triple.
 # Use this section to turn off or on specific features for specific triples.
 target-base = ["enable-api-client", "rdkafka?/cmake_build", "sources-dnstap"]
-target-unix = ["target-base"]
-target-aarch64-unknown-linux-gnu =      ["target-unix"]
-target-aarch64-unknown-linux-musl =     ["target-unix"]
-target-armv7-unknown-linux-gnueabihf =  ["target-unix"]
+target-aarch64-unknown-linux-gnu =      ["target-base"]
+target-aarch64-unknown-linux-musl =     ["target-base"]
+target-armv7-unknown-linux-gnueabihf =  ["target-base"]
 target-armv7-unknown-linux-musleabihf = ["target-base"]
-target-arm-unknown-linux-gnueabi =      ["target-unix"]
+target-arm-unknown-linux-gnueabi =      ["target-base"]
 target-arm-unknown-linux-musleabi =     ["target-base"]
-target-x86_64-unknown-linux-gnu =       ["target-unix", "vendored"]
-target-x86_64-unknown-linux-musl =      ["target-unix"]
+target-x86_64-unknown-linux-gnu =       ["target-base", "vendored"]
+target-x86_64-unknown-linux-musl =      ["target-base"]
 # Apple targets opt into `gssapi` (dynamic linkage to system libsasl2 + Apple's
 # GSS framework). The `gssapi-vendored` path does not currently link on
 # macOS arm64 (unresolved gss_* symbols).

--- a/Makefile
+++ b/Makefile
@@ -13,14 +13,13 @@ export PATH := $(mkfile_dir)scripts/environment/npm-tools/node_modules/.bin:$(PA
 ifeq ($(OS),Windows_NT) # is Windows_NT on XP, 2000, 7, Vista, 10...
     export OPERATING_SYSTEM := Windows
     export RUST_TARGET ?= "x86_64-unknown-windows-msvc"
-    export FEATURES ?= default-msvc
     undefine DNSTAP_BENCHES
 else
     export OPERATING_SYSTEM := $(shell uname)  # same as "uname -s"
     export RUST_TARGET ?= "x86_64-unknown-linux-gnu"
-    export FEATURES ?= default
     export DNSTAP_BENCHES := dnstap-benches
 endif
+export FEATURES ?= default
 
 # When COVERAGE=true, swap cargo-nextest for cargo-llvm-cov so test targets collect
 # coverage data. Run `make coverage-report` afterwards to emit the lcov file.

--- a/lib/vector-lib/Cargo.toml
+++ b/lib/vector-lib/Cargo.toml
@@ -27,7 +27,6 @@ vector-top = { path = "../vector-top", optional = true }
 vrl = { workspace = true, optional = true }
 
 [features]
-allocation-tracing = ["vector-top?/allocation-tracing"]
 antithesis-disk-asserts = ["vector-buffers/antithesis-disk-asserts"]
 api-client = ["dep:vector-api-client"]
 arrow = ["codecs/arrow"]

--- a/lib/vector-top/Cargo.toml
+++ b/lib/vector-top/Cargo.toml
@@ -30,4 +30,3 @@ vector-common = { path = "../vector-common" }
 vector-api-client = { path = "../vector-api-client" }
 
 [features]
-allocation-tracing = []

--- a/lib/vector-top/src/dashboard.rs
+++ b/lib/vector-top/src/dashboard.rs
@@ -34,7 +34,7 @@ use super::{
 };
 
 pub const fn is_allocation_tracing_enabled() -> bool {
-    cfg!(feature = "allocation-tracing")
+    cfg!(unix)
 }
 
 macro_rules! row_comparator {
@@ -157,7 +157,7 @@ pub mod columns {
     pub const BYTES_OUT: &str = "Bytes Out";
     pub const BYTES_OUT_TOTAL: &str = "Bytes Out Total";
     pub const ERRORS: &str = "Errors";
-    #[cfg(feature = "allocation-tracing")]
+    #[cfg(unix)]
     pub const MEMORY_USED: &str = "Memory Used";
 }
 
@@ -170,7 +170,7 @@ static HEADER: [&str; NUM_COLUMNS] = [
     columns::BYTES_IN,
     columns::EVENTS_OUT,
     columns::BYTES_OUT,
-    #[cfg(feature = "allocation-tracing")]
+    #[cfg(unix)]
     columns::MEMORY_USED,
     columns::ERRORS,
 ];
@@ -286,7 +286,7 @@ impl<'a> Widgets<'a> {
                 SortColumn::BytesOut => row_comparator!(sent_bytes_throughput_sec),
                 SortColumn::BytesOutTotal => row_comparator!(sent_bytes_total),
                 SortColumn::Errors => row_comparator!(errors),
-                #[cfg(feature = "allocation-tracing")]
+                #[cfg(unix)]
                 SortColumn::MemoryUsed => row_comparator!(allocated_bytes),
             };
             if state.sort_state.reverse {
@@ -348,7 +348,7 @@ impl<'a> Widgets<'a> {
                     r.sent_bytes_throughput_sec,
                     self.human_metrics,
                 ),
-                #[cfg(feature = "allocation-tracing")]
+                #[cfg(unix)]
                 if state.allocation_tracing_active {
                     r.allocated_bytes.human_format_bytes()
                 } else {

--- a/lib/vector-top/src/input.rs
+++ b/lib/vector-top/src/input.rs
@@ -123,7 +123,7 @@ async fn handle_top_input<B: Backend>(
                 '7' => SortColumn::EventsOutTotal,
                 '8' => SortColumn::BytesOutTotal,
                 '9' => SortColumn::Errors,
-                #[cfg(feature = "allocation-tracing")]
+                #[cfg(unix)]
                 '0' => SortColumn::MemoryUsed,
                 _ => return false,
             };

--- a/lib/vector-top/src/metrics.rs
+++ b/lib/vector-top/src/metrics.rs
@@ -118,14 +118,14 @@ fn component_to_row(component: &Component) -> state::ComponentRow {
         sent_bytes_throughput_sec: 0,
         sent_events_total: metrics.and_then(|m| m.sent_events_total).unwrap_or(0),
         sent_events_throughput_sec: 0,
-        #[cfg(feature = "allocation-tracing")]
+        #[cfg(unix)]
         allocated_bytes: 0,
         errors: 0,
     }
 }
 
 /// Allocated bytes per component
-#[cfg(feature = "allocation-tracing")]
+#[cfg(unix)]
 async fn allocated_bytes(
     mut client: Client,
     tx: state::EventTx,
@@ -472,7 +472,7 @@ pub async fn subscribe(
         initial_components,
     ));
 
-    #[cfg_attr(not(feature = "allocation-tracing"), allow(unused_mut))]
+    #[cfg_attr(not(unix), allow(unused_mut))]
     let mut metric_handles = vec![
         tokio::spawn(received_bytes_totals(
             client.clone(),
@@ -531,7 +531,7 @@ pub async fn subscribe(
         tokio::spawn(uptime_changed(client.clone(), tx.clone(), interval)),
     ];
 
-    #[cfg(feature = "allocation-tracing")]
+    #[cfg(unix)]
     metric_handles.push(tokio::spawn(allocated_bytes(
         client,
         tx,
@@ -569,7 +569,7 @@ pub async fn init_components(
         })
         .collect::<BTreeMap<_, _>>();
 
-    #[cfg(feature = "allocation-tracing")]
+    #[cfg(unix)]
     {
         // Allocation tracing is a compile-time + startup-time setting on the
         // server, so querying once per connection is sufficient. On error
@@ -585,6 +585,6 @@ pub async fn init_components(
         Ok(state)
     }
 
-    #[cfg(not(feature = "allocation-tracing"))]
+    #[cfg(not(unix))]
     Ok(state::State::new(rows))
 }

--- a/lib/vector-top/src/state.rs
+++ b/lib/vector-top/src/state.rs
@@ -46,7 +46,7 @@ pub enum EventType {
     /// Throughput values already normalized to per-second by the server
     SentEventsThroughputs(Vec<SentEventsMetric>),
     ErrorsTotals(Vec<IdentifiedMetric>),
-    #[cfg(feature = "allocation-tracing")]
+    #[cfg(unix)]
     AllocatedBytes(Vec<IdentifiedMetric>),
     ComponentAdded(ComponentRow),
     ComponentRemoved(ComponentKey),
@@ -123,7 +123,7 @@ pub struct State {
     pub ui: UiState,
     /// Set to `true` once we receive the first `AllocatedBytes` event,
     /// indicating the connected Vector instance has allocation tracing active.
-    #[cfg(feature = "allocation-tracing")]
+    #[cfg(unix)]
     pub allocation_tracing_active: bool,
 }
 
@@ -141,7 +141,7 @@ pub enum SortColumn {
     BytesOut = 9,
     BytesOutTotal = 10,
     Errors = 11,
-    #[cfg(feature = "allocation-tracing")]
+    #[cfg(unix)]
     MemoryUsed = 12,
 }
 
@@ -164,7 +164,7 @@ impl SortColumn {
             SortColumn::EventsOut | SortColumn::EventsOutTotal => header == columns::EVENTS_OUT,
             SortColumn::BytesOut | SortColumn::BytesOutTotal => header == columns::BYTES_OUT,
             SortColumn::Errors => header == columns::ERRORS,
-            #[cfg(feature = "allocation-tracing")]
+            #[cfg(unix)]
             SortColumn::MemoryUsed => header == columns::MEMORY_USED,
         }
     }
@@ -183,7 +183,7 @@ impl SortColumn {
             columns::BYTES_OUT,
             columns::BYTES_OUT_TOTAL,
             columns::ERRORS,
-            #[cfg(feature = "allocation-tracing")]
+            #[cfg(unix)]
             columns::MEMORY_USED,
         ]
     }
@@ -217,7 +217,7 @@ impl From<usize> for SortColumn {
             9 => SortColumn::BytesOut,
             10 => SortColumn::BytesOutTotal,
             11 => SortColumn::Errors,
-            #[cfg(feature = "allocation-tracing")]
+            #[cfg(unix)]
             12 => SortColumn::MemoryUsed,
             _ => SortColumn::Id,
         }
@@ -346,7 +346,7 @@ impl State {
             ui: UiState::default(),
             sort_state: SortState::default(),
             filter_state: FilterState::default(),
-            #[cfg(feature = "allocation-tracing")]
+            #[cfg(unix)]
             allocation_tracing_active: false,
         }
     }
@@ -406,7 +406,7 @@ pub struct ComponentRow {
     pub sent_bytes_throughput_sec: i64,
     pub sent_events_total: i64,
     pub sent_events_throughput_sec: i64,
-    #[cfg(feature = "allocation-tracing")]
+    #[cfg(unix)]
     pub allocated_bytes: i64,
     pub errors: i64,
 }
@@ -527,7 +527,7 @@ pub async fn updater(
                                     }
                                 }
                             }
-                            #[cfg(feature = "allocation-tracing")]
+                            #[cfg(unix)]
                             EventType::AllocatedBytes(rows) => {
                                 for (key, v) in rows {
                                     if let Some(r) = state.components.get_mut(&key) {

--- a/lib/vector-vrl/functions/Cargo.toml
+++ b/lib/vector-vrl/functions/Cargo.toml
@@ -13,9 +13,11 @@ workspace = true
 indoc.workspace = true
 vrl.workspace = true
 enrichment = { path = "../enrichment" }
-dnstap-parser = { path = "../dnstap-parser", optional = true }
 vector-vrl-metrics = { path = "../metrics", optional = true }
 vector-vrl-category.workspace = true
+
+[target.'cfg(unix)'.dependencies]
+dnstap-parser = { path = "../dnstap-parser", optional = true }
 
 [features]
 default = ["dnstap", "vrl-metrics"]

--- a/lib/vector-vrl/functions/Cargo.toml
+++ b/lib/vector-vrl/functions/Cargo.toml
@@ -16,7 +16,6 @@ enrichment = { path = "../enrichment" }
 vector-vrl-metrics = { path = "../metrics", optional = true }
 vector-vrl-category.workspace = true
 
-[target.'cfg(unix)'.dependencies]
 dnstap-parser = { path = "../dnstap-parser", optional = true }
 
 [features]

--- a/lib/vector-vrl/functions/src/lib.rs
+++ b/lib/vector-vrl/functions/src/lib.rs
@@ -53,7 +53,7 @@ fn iter_all_without_vrl_stdlib() -> impl Iterator<Item = Box<dyn Function>> {
         .into_iter()
         .chain(enrichment::vrl_functions());
 
-    #[cfg(feature = "dnstap")]
+    #[cfg(all(unix, feature = "dnstap"))]
     let functions = functions.chain(dnstap_parser::vrl_functions());
 
     #[cfg(feature = "vrl-metrics")]

--- a/lib/vector-vrl/functions/src/lib.rs
+++ b/lib/vector-vrl/functions/src/lib.rs
@@ -53,7 +53,7 @@ fn iter_all_without_vrl_stdlib() -> impl Iterator<Item = Box<dyn Function>> {
         .into_iter()
         .chain(enrichment::vrl_functions());
 
-    #[cfg(all(unix, feature = "dnstap"))]
+    #[cfg(feature = "dnstap")]
     let functions = functions.chain(dnstap_parser::vrl_functions());
 
     #[cfg(feature = "vrl-metrics")]

--- a/src/api/grpc/service.rs
+++ b/src/api/grpc/service.rs
@@ -425,9 +425,9 @@ impl observability::Service for ObservabilityService {
         &self,
         _request: Request<GetAllocationTracingStatusRequest>,
     ) -> Result<Response<GetAllocationTracingStatusResponse>, Status> {
-        #[cfg(feature = "allocation-tracing")]
+        #[cfg(unix)]
         let enabled = crate::internal_telemetry::allocations::is_allocation_tracing_enabled();
-        #[cfg(not(feature = "allocation-tracing"))]
+        #[cfg(not(unix))]
         let enabled = false;
         Ok(Response::new(GetAllocationTracingStatusResponse {
             enabled,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -244,12 +244,12 @@ pub struct RootOpts {
     pub no_graceful_shutdown_limit: bool,
 
     /// Set runtime allocation tracing
-    #[cfg(unix)]
+    #[cfg(all(unix, feature = "tikv-jemallocator"))]
     #[arg(long, env = "ALLOCATION_TRACING", default_value = "false")]
     pub allocation_tracing: bool,
 
     /// Set allocation tracing reporting rate in milliseconds.
-    #[cfg(unix)]
+    #[cfg(all(unix, feature = "tikv-jemallocator"))]
     #[arg(
         long,
         env = "ALLOCATION_TRACING_REPORTING_INTERVAL_MS",

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -244,12 +244,12 @@ pub struct RootOpts {
     pub no_graceful_shutdown_limit: bool,
 
     /// Set runtime allocation tracing
-    #[cfg(feature = "allocation-tracing")]
+    #[cfg(unix)]
     #[arg(long, env = "ALLOCATION_TRACING", default_value = "false")]
     pub allocation_tracing: bool,
 
     /// Set allocation tracing reporting rate in milliseconds.
-    #[cfg(feature = "allocation-tracing")]
+    #[cfg(unix)]
     #[arg(
         long,
         env = "ALLOCATION_TRACING_REPORTING_INTERVAL_MS",

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -244,12 +244,12 @@ pub struct RootOpts {
     pub no_graceful_shutdown_limit: bool,
 
     /// Set runtime allocation tracing
-    #[cfg(feature = "tikv-jemallocator")]
+    #[cfg(all(unix, feature = "tikv-jemallocator"))]
     #[arg(long, env = "ALLOCATION_TRACING", default_value = "false")]
     pub allocation_tracing: bool,
 
     /// Set allocation tracing reporting rate in milliseconds.
-    #[cfg(feature = "tikv-jemallocator")]
+    #[cfg(all(unix, feature = "tikv-jemallocator"))]
     #[arg(
         long,
         env = "ALLOCATION_TRACING_REPORTING_INTERVAL_MS",

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -244,12 +244,12 @@ pub struct RootOpts {
     pub no_graceful_shutdown_limit: bool,
 
     /// Set runtime allocation tracing
-    #[cfg(all(unix, feature = "tikv-jemallocator"))]
+    #[cfg(feature = "tikv-jemallocator")]
     #[arg(long, env = "ALLOCATION_TRACING", default_value = "false")]
     pub allocation_tracing: bool,
 
     /// Set allocation tracing reporting rate in milliseconds.
-    #[cfg(all(unix, feature = "tikv-jemallocator"))]
+    #[cfg(feature = "tikv-jemallocator")]
     #[arg(
         long,
         env = "ALLOCATION_TRACING_REPORTING_INTERVAL_MS",

--- a/src/internal_telemetry/mod.rs
+++ b/src/internal_telemetry/mod.rs
@@ -1,4 +1,4 @@
 #![allow(missing_docs)]
 
-#[cfg(feature = "allocation-tracing")]
+#[cfg(unix)]
 pub mod allocations;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ pub use indoc::indoc;
 // re-export codecs for convenience
 pub use vector_lib::codecs;
 
-#[cfg(feature = "tikv-jemallocator")]
+#[cfg(all(unix, feature = "tikv-jemallocator"))]
 #[global_allocator]
 static ALLOC: self::internal_telemetry::allocations::Allocator<tikv_jemallocator::Jemalloc> =
     self::internal_telemetry::allocations::get_grouped_tracing_allocator(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ pub use indoc::indoc;
 // re-export codecs for convenience
 pub use vector_lib::codecs;
 
-#[cfg(unix)]
+#[cfg(all(unix, feature = "tikv-jemallocator"))]
 #[global_allocator]
 static ALLOC: self::internal_telemetry::allocations::Allocator<tikv_jemallocator::Jemalloc> =
     self::internal_telemetry::allocations::get_grouped_tracing_allocator(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ pub use indoc::indoc;
 // re-export codecs for convenience
 pub use vector_lib::codecs;
 
-#[cfg(all(unix, feature = "tikv-jemallocator"))]
+#[cfg(feature = "tikv-jemallocator")]
 #[global_allocator]
 static ALLOC: self::internal_telemetry::allocations::Allocator<tikv_jemallocator::Jemalloc> =
     self::internal_telemetry::allocations::get_grouped_tracing_allocator(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,15 +44,7 @@ pub use indoc::indoc;
 // re-export codecs for convenience
 pub use vector_lib::codecs;
 
-#[cfg(all(
-    unix,
-    feature = "tikv-jemallocator",
-    not(feature = "allocation-tracing")
-))]
-#[global_allocator]
-static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
-
-#[cfg(all(unix, feature = "tikv-jemallocator", feature = "allocation-tracing"))]
+#[cfg(unix)]
 #[global_allocator]
 static ALLOC: self::internal_telemetry::allocations::Allocator<tikv_jemallocator::Jemalloc> =
     self::internal_telemetry::allocations::get_grouped_tracing_allocator(

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use vector::{app::Application, extra_context::ExtraContext};
 
 #[cfg(unix)]
 fn main() -> ExitCode {
-    #[cfg(feature = "allocation-tracing")]
+    #[cfg(unix)]
     {
         use std::sync::atomic::Ordering;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use vector::{app::Application, extra_context::ExtraContext};
 
 #[cfg(unix)]
 fn main() -> ExitCode {
-    #[cfg(feature = "tikv-jemallocator")]
+    #[cfg(all(unix, feature = "tikv-jemallocator"))]
     {
         use std::sync::atomic::Ordering;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use vector::{app::Application, extra_context::ExtraContext};
 
 #[cfg(unix)]
 fn main() -> ExitCode {
-    #[cfg(unix)]
+    #[cfg(all(unix, feature = "tikv-jemallocator"))]
     {
         use std::sync::atomic::Ordering;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use vector::{app::Application, extra_context::ExtraContext};
 
 #[cfg(unix)]
 fn main() -> ExitCode {
-    #[cfg(all(unix, feature = "tikv-jemallocator"))]
+    #[cfg(feature = "tikv-jemallocator")]
     {
         use std::sync::atomic::Ordering;
 

--- a/src/topology/running.rs
+++ b/src/topology/running.rs
@@ -1163,7 +1163,7 @@ impl RunningTopology {
         );
 
         let task_span = span.or_current();
-        #[cfg(feature = "allocation-tracing")]
+        #[cfg(unix)]
         if crate::internal_telemetry::allocations::is_allocation_tracing_enabled() {
             let group_id = crate::internal_telemetry::allocations::acquire_allocation_group_id(
                 task.id().to_string(),
@@ -1204,7 +1204,7 @@ impl RunningTopology {
         );
 
         let task_span = span.or_current();
-        #[cfg(feature = "allocation-tracing")]
+        #[cfg(unix)]
         if crate::internal_telemetry::allocations::is_allocation_tracing_enabled() {
             let group_id = crate::internal_telemetry::allocations::acquire_allocation_group_id(
                 task.id().to_string(),
@@ -1245,7 +1245,7 @@ impl RunningTopology {
         );
 
         let task_span = span.or_current();
-        #[cfg(feature = "allocation-tracing")]
+        #[cfg(unix)]
         if crate::internal_telemetry::allocations::is_allocation_tracing_enabled() {
             let group_id = crate::internal_telemetry::allocations::acquire_allocation_group_id(
                 task.id().to_string(),

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -106,7 +106,7 @@ pub fn init(
         subscriber.with(console_layer)
     };
 
-    #[cfg(feature = "allocation-tracing")]
+    #[cfg(unix)]
     let subscriber = {
         let allocation_layer = crate::internal_telemetry::allocations::AllocationLayer::new()
             .with_filter(LevelFilter::ERROR);

--- a/vdev/Cargo.toml
+++ b/vdev/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vdev"
-version = "0.3.4"
+version = "0.3.5"
 edition = "2024"
 authors = ["Vector Contributors <vector@datadoghq.com>"]
 license = "MPL-2.0"

--- a/vdev/src/app.rs
+++ b/vdev/src/app.rs
@@ -13,7 +13,7 @@ use anyhow::{Context as _, Result, bail};
 use indicatif::{ProgressBar, ProgressStyle};
 use log::LevelFilter;
 
-use crate::utils::{self, platform};
+use crate::utils;
 
 // Use the `bash` interpreter included as part of the standard `git` install for our default shell
 // if nothing is specified in the environment.
@@ -181,7 +181,7 @@ impl CommandExt for Command {
         self.arg("--no-default-features");
         self.arg("--features");
         if features.is_empty() {
-            self.arg(platform::default_features());
+            self.arg("default");
         } else {
             self.arg(features.join(","));
         }

--- a/vdev/src/commands/test.rs
+++ b/vdev/src/commands/test.rs
@@ -2,10 +2,7 @@ use anyhow::Result;
 use clap::Args;
 use std::collections::BTreeMap;
 
-use crate::{
-    testing::runner::{LocalTestRunner, TestRunner as _},
-    utils::platform,
-};
+use crate::testing::runner::{LocalTestRunner, TestRunner as _};
 
 /// Execute tests
 #[derive(Args, Debug)]
@@ -40,8 +37,7 @@ impl Cli {
         }
 
         if !args.contains(&"--features".to_string()) {
-            let features = platform::default_features();
-            args.extend(["--features".to_string(), features.to_string()]);
+            args.extend(["--features".to_string(), "default".to_string()]);
         }
 
         LocalTestRunner.test(

--- a/vdev/src/utils/platform.rs
+++ b/vdev/src/utils/platform.rs
@@ -25,11 +25,3 @@ pub fn default_target() -> String {
         format!("{ARCH}-unknown-linux-gnu")
     }
 }
-
-pub fn default_features() -> &'static str {
-    if cfg!(windows) {
-        "default-msvc"
-    } else {
-        "default"
-    }
-}

--- a/website/content/en/docs/setup/installation/manual/from-source.md
+++ b/website/content/en/docs/setup/installation/manual/from-source.md
@@ -93,7 +93,7 @@ Build Vector in release mode:
 
 ```shell
 set RUSTFLAGS=-Ctarget-feature=+crt-static
-cargo build --no-default-features --features default-msvc --release
+cargo build --no-default-features --features default --release
 ```
 
 Start Vector. After these steps, a binary `vector.exe` in `target\release` would be created. It can be started by running:

--- a/website/content/en/docs/setup/installation/manual/from-source.md
+++ b/website/content/en/docs/setup/installation/manual/from-source.md
@@ -93,7 +93,7 @@ Build Vector in release mode:
 
 ```shell
 set RUSTFLAGS=-Ctarget-feature=+crt-static
-cargo build --no-default-features --features default --release
+cargo build --release
 ```
 
 Start Vector. After these steps, a binary `vector.exe` in `target\release` would be created. It can be started by running:


### PR DESCRIPTION
## Motivation

This PR removes four Cargo features that accumulated as workarounds rather than intentional design. Left unaddressed, these patterns make the codebase harder to reason about and set a bad precedent for contributors.

**`default-msvc`** existed because `default` included unix-only deps that weren't properly gated. Rather than fixing the root cause, a parallel Windows-specific feature was invented. This is the kind of patch that compounds — every future contributor touching platform-specific behavior has to know about it and remember to keep it in sync.

**`unix = ["tikv-jemallocator", "allocation-tracing"]`** is a Cargo feature with the same name as the `cfg(unix)` target predicate. This is a naming collision with real consequences: code had to use `#[cfg(all(unix, feature = "unix"))]` — a redundant double-guard — because the feature name alone was ambiguous. When a feature name looks like a built-in cfg, readers can't tell which layer a guard belongs to.

**`enable-unix`** bundled `enable-api-client` (fully cross-platform) with `sources-dnstap` and `unix` (unix-only) under a name that implied unix-specificity for all three. `enable-api-client` was already in `default-msvc`, proving it works on Windows — it had no business being inside an "enable-unix" grouping.

**`allocation-tracing`** was activated on unix by default via `default → enable-unix → unix → allocation-tracing`. It was never an independent toggle. Whether allocation tracing actually runs has always been controlled at runtime by `--allocation-tracing` / `ALLOCATION_TRACING`. The Cargo feature added zero compile-time optionality and only forced every callsite to carry `feature = "allocation-tracing"` noise alongside the `unix` cfg guard it already needed.

The root cause enabling all of this: `dnsmsg-parser`, `dnstap-parser`, and `hickory-proto` were in `[dependencies]` rather than `[target.'cfg(unix)'.dependencies]`, an oversight from the original dnstap PR. Fixing that one mistake unblocks everything else.

## Summary

- Delete `default-msvc`, `unix`, `enable-unix`, `allocation-tracing` Cargo features
- Move `dnsmsg-parser`, `dnstap-parser`, `hickory-proto` to `[target.'cfg(unix)'.dependencies]`
- Make `tikv-jemallocator` non-optional on unix (always compiled via target dep)
- Simplify all `#[cfg(all(unix, feature = "allocation-tracing"))]` guards to `#[cfg(unix)]`
- Simplify Windows install docs: `cargo build --no-default-features --features default --release` → `cargo build --release`

**Before vs after — compiled output is identical:**

| | Unix (before) | Unix (after) | Windows (before) | Windows (after) |
|---|---|---|---|---|
| Feature set used | `default` | `default` | `default-msvc` | `default` |
| jemalloc compiled | ✓ | ✓ | ✗ | ✗ |
| Allocation tracing compiled | ✓ | ✓ | ✗ | ✗ |
| dnstap compiled | ✓ | ✓ | ✗ | ✗ |
| API client / top | ✓ | ✓ | ✓ | ✓ |

Runtime allocation tracing behavior is unchanged — still opt-in via `--allocation-tracing` / `ALLOCATION_TRACING`.

## How did you test this PR?

- `make check-clippy` passes locally on macOS.
- At each refactoring step, captured the transitive default feature set via `cargo metadata` and diffed before/after to confirm only the removed feature names disappeared — compiled output identical.
- Codex validated the diff against both `x86_64-pc-windows-msvc` and `x86_64-unknown-linux-gnu` with `--features default`.
- Windows compilation verified via `/ci-run-unit-windows` on this PR.
- [ci-run-packaging](https://github.com/vectordotdev/vector/actions/runs/28398143854/job/84142213802?pr=25690)
- 
## Change Type

- [x] Non-functional (chore, refactoring, docs)

## Is this a breaking change?

- [x] No

## Does this PR include user facing changes?

- [x] No. A maintainer will apply the `no-changelog` label to this PR.