### PR TITLE
fix(tests): replace timing-based sleep+collect_ready with collect_n in firehose tests

### DIFF
--- a/src/sources/aws_kinesis_firehose/mod.rs
+++ b/src/sources/aws_kinesis_firehose/mod.rs
@@ -280,7 +280,6 @@ mod tests {
     use flate2::read::GzEncoder;
     use futures::Stream;
     use similar_asserts::assert_eq;
-    use tokio::time::{Duration, sleep};
     use vector_lib::{assert_event_data_eq, lookup::path};
     use vrl::value;
 
@@ -291,7 +290,7 @@ mod tests {
         log_event,
         test_util::{
             addr::{PortGuard, next_addr},
-            collect_ready,
+            collect_n,
             components::{SOURCE_TAGS, assert_source_compliance},
             wait_for_tcp,
         },
@@ -428,11 +427,9 @@ mod tests {
         gzip: bool,
         record_compression: Compression,
     ) -> tokio::task::JoinHandle<reqwest::Result<reqwest::Response>> {
-        let handle = tokio::spawn(async move {
+        tokio::spawn(async move {
             send(address, timestamp, records, key, gzip, record_compression).await
-        });
-        sleep(Duration::from_millis(500)).await;
-        handle
+        })
     }
 
     /// Encodes record data to mach AWS's representation: base64 encoded with an additional
@@ -530,7 +527,7 @@ mod tests {
             .await;
 
             if success {
-                let events = collect_ready(rx).await;
+                let events = collect_n(rx, 1).await;
 
                 let res = res.await.unwrap().unwrap();
                 assert_eq!(200, res.status().as_u16());
@@ -631,7 +628,7 @@ mod tests {
             .await;
 
             if success {
-                let events = collect_ready(rx).await;
+                let events = collect_n(rx, 1).await;
 
                 let res = res.await.unwrap().unwrap();
                 assert_eq!(200, res.status().as_u16());
@@ -703,7 +700,7 @@ mod tests {
             )
             .await;
 
-            let events = collect_ready(rx).await;
+            let events = collect_n(rx, 1).await;
             let res = res.await.unwrap().unwrap();
             assert_eq!(200, res.status().as_u16());
 
@@ -863,7 +860,7 @@ mod tests {
         )
         .await;
 
-        let events = collect_ready(rx).await;
+        let events = collect_n(rx, 1).await;
 
         let res = res.await.unwrap().unwrap();
         assert_eq!(406, res.status().as_u16());
@@ -907,7 +904,7 @@ mod tests {
         )
         .await;
 
-        let events = collect_ready(rx).await;
+        let events = collect_n(rx, 1).await;
         let access_key = events[0]
             .metadata()
             .secrets()
@@ -932,7 +929,7 @@ mod tests {
         )
         .await;
 
-        let events = collect_ready(rx).await;
+        let events = collect_n(rx, 1).await;
 
         assert!(
             events[0]


### PR DESCRIPTION
## Summary

The `aws_kinesis_firehose` unit tests were failing locally on macOS. The root cause was a race condition in the test helpers: `spawn_send` would spawn an HTTP request, sleep for 500ms assuming the server had processed it, then return — and the tests called `collect_ready(rx)` which only does a non-blocking snapshot poll of the channel. On a loaded local machine, 500ms was insufficient for the full round-trip, leaving `collect_ready` with an empty channel.

`new_test_finalize` fires the acknowledgement at the moment each event is yielded from the stream, so `collect_n(rx, 1)` both waits for the event to arrive and triggers the ack atomically, making the sleep unnecessary.

## Vector configuration

NA

## How did you test this PR?

```
cargo nextest run --no-default-features --features "sources-aws_kinesis_firehose" -E 'test(sources::aws_kinesis_firehose::tests)'
```

All 11 tests pass.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

NA