### PR TITLE
feat(clickhouse sink): add drain_shaping to pace recovery from disk-buffer backlogs

### DIFF
--- a/changelog.d/clickhouse_drain_shaping.feature.md
+++ b/changelog.d/clickhouse_drain_shaping.feature.md
@@ -1,0 +1,3 @@
+Add a `drain_shaping` option to the `clickhouse` sink for pacing recovery from disk-buffer backlogs.
+
+authors: ku524

--- a/lib/vector-buffers/src/buffer_usage_data.rs
+++ b/lib/vector-buffers/src/buffer_usage_data.rs
@@ -180,6 +180,28 @@ impl BufferUsageHandle {
         }
     }
 
+    /// Increments the number of externally received events for observer consumers.
+    pub fn increment_observer_received(&self, count: u64, byte_size: u64) {
+        self.state.observer_received.increment(count, byte_size);
+    }
+
+    /// Gets the cumulative number of externally received events for observer consumers.
+    pub fn observer_received(&self) -> (u64, u64) {
+        let snapshot = self.state.observer_received.get();
+        (snapshot.event_count, snapshot.event_byte_size)
+    }
+
+    /// Sets the current occupancy for observer consumers.
+    pub fn set_occupancy(&self, count: u64, byte_size: u64) {
+        self.state.occupancy.set(count, byte_size);
+    }
+
+    /// Gets the current occupancy for observer consumers.
+    pub fn occupancy(&self) -> (u64, u64) {
+        let snapshot = self.state.occupancy.get();
+        (snapshot.event_count, snapshot.event_byte_size)
+    }
+
     /// Increments the number of events (and their total size) sent by this buffer component.
     ///
     /// This represents the events being read out of the buffer.
@@ -214,6 +236,8 @@ struct BufferUsageData {
     dropped: CategoryMetrics,
     dropped_intentional: CategoryMetrics,
     max_size: CategoryMetrics,
+    observer_received: CategoryMetrics,
+    occupancy: CategoryMetrics,
 }
 
 impl BufferUsageData {
@@ -343,6 +367,50 @@ pub struct BufferUsageSnapshot {
     pub max_size_events: usize,
 }
 
+/// Read-only buffer usage view for rate-shaping consumers.
+#[derive(Clone, Debug)]
+pub struct BufferUsageObserver {
+    stages: Vec<Arc<BufferUsageData>>,
+}
+
+impl BufferUsageObserver {
+    fn sum<F>(&self, snapshot: F) -> (u64, u64)
+    where
+        F: Fn(&BufferUsageData) -> CategorySnapshot,
+    {
+        self.stages
+            .iter()
+            .fold((0, 0), |(event_count, byte_size), stage| {
+                let snapshot = snapshot(stage);
+                (
+                    event_count.saturating_add(snapshot.event_count),
+                    byte_size.saturating_add(snapshot.event_byte_size),
+                )
+            })
+    }
+
+    /// Gets the cumulative external ingress volume from the outermost stage.
+    pub fn received(&self) -> (u64, u64) {
+        self.stages
+            .iter()
+            .find(|stage| stage.idx == 0)
+            .map_or((0, 0), |stage| {
+                let snapshot = stage.observer_received.get();
+                (snapshot.event_count, snapshot.event_byte_size)
+            })
+    }
+
+    /// Gets the current occupancy across all stages.
+    pub fn occupancy(&self) -> (u64, u64) {
+        self.sum(|stage| stage.occupancy.get())
+    }
+
+    /// Gets the maximum configured size across all stages.
+    pub fn max_size(&self) -> (u64, u64) {
+        self.sum(|stage| stage.max_size.get())
+    }
+}
+
 /// Builder for tracking buffer usage metrics.
 ///
 /// While building a buffer topology, `BufferUsage` can be utilized to create metrics storage for each individual buffer
@@ -376,6 +444,13 @@ impl BufferUsage {
 
         self.stages.push(data);
         handle
+    }
+
+    /// Creates a read-only observer over the configured buffer stages.
+    pub fn observer(&self) -> BufferUsageObserver {
+        BufferUsageObserver {
+            stages: self.stages.clone(),
+        }
     }
 
     /// Installs a reporter for the configured stages which periodically reports buffer usage metrics.
@@ -415,6 +490,8 @@ impl BufferUsage {
 
 #[cfg(test)]
 mod tests {
+    use metrics_util::debugging::{DebugValue, DebuggingRecorder};
+
     use super::*;
 
     #[test]
@@ -504,5 +581,67 @@ mod tests {
         let current = metrics.current();
         assert_eq!(current.event_count, 10);
         assert_eq!(current.event_byte_size, 1000);
+    }
+
+    #[test]
+    fn report_emits_existing_received_metrics_without_observer_accounting() {
+        let data = BufferUsageData::new(0);
+        let mut metrics = ReporterCurrentMetrics::default();
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+
+        data.received.increment(3, 300);
+        metrics::with_local_recorder(&recorder, || {
+            data.report(&mut metrics, "test");
+        });
+
+        let snapshot = snapshotter.snapshot().into_vec();
+        let received_events = snapshot.iter().find_map(|(key, _, _, value)| {
+            (key.key().name() == "buffer_received_events_total").then_some(value)
+        });
+        let received_bytes = snapshot.iter().find_map(|(key, _, _, value)| {
+            (key.key().name() == "buffer_received_bytes_total").then_some(value)
+        });
+
+        assert_eq!(received_events, Some(&DebugValue::Counter(3)));
+        assert_eq!(received_bytes, Some(&DebugValue::Counter(300)));
+        assert_eq!(data.observer_received.get().event_count, 0);
+        assert_eq!(data.observer_received.get().event_byte_size, 0);
+    }
+
+    #[test]
+    fn observer_received_accumulates_and_does_not_consume() {
+        let mut usage = BufferUsage::from_span(tracing::Span::none());
+        let handle = usage.add_stage(0);
+        handle.increment_observer_received(3, 300);
+        handle.increment_observer_received(2, 250);
+        assert_eq!(handle.observer_received(), (5, 550));
+        assert_eq!(handle.observer_received(), (5, 550));
+    }
+
+    #[test]
+    fn occupancy_reflects_last_set_value() {
+        let mut usage = BufferUsage::from_span(tracing::Span::none());
+        let handle = usage.add_stage(0);
+        handle.set_occupancy(10, 1000);
+        assert_eq!(handle.occupancy(), (10, 1000));
+        handle.set_occupancy(4, 400);
+        assert_eq!(handle.occupancy(), (4, 400));
+    }
+
+    #[test]
+    fn observer_received_is_ingress_only_occupancy_is_summed() {
+        let mut usage = BufferUsage::from_span(tracing::Span::none());
+        let ingress = usage.add_stage(0);
+        let overflow = usage.add_stage(1);
+        let observer = usage.observer();
+
+        ingress.increment_observer_received(2, 200);
+        overflow.increment_observer_received(9, 900);
+        ingress.set_occupancy(1, 100);
+        overflow.set_occupancy(2, 250);
+
+        assert_eq!(observer.received(), (2, 200));
+        assert_eq!(observer.occupancy(), (3, 350));
     }
 }

--- a/lib/vector-buffers/src/config.rs
+++ b/lib/vector-buffers/src/config.rs
@@ -12,7 +12,7 @@ use vector_common::{config::ComponentKey, finalization::Finalizable};
 use vector_config::configurable_component;
 
 use crate::{
-    Bufferable, WhenFull,
+    BufferUsageObserver, Bufferable, WhenFull,
     topology::{
         builder::{TopologyBuilder, TopologyError},
         channel::{BufferReceiver, BufferSender},
@@ -378,6 +378,33 @@ impl BufferConfig {
             .any(|stage| matches!(stage, BufferType::DiskV2 { .. }))
     }
 
+    /// Validates that this buffer can support drain shaping.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when any stage is not a blocking disk buffer.
+    pub fn validate_for_drain_shaping(&self) -> Result<(), String> {
+        for stage in self.stages() {
+            match stage {
+                BufferType::Memory { .. } => {
+                    return Err(
+                        "drain_shaping requires disk buffers; memory buffers are unsupported"
+                            .to_string(),
+                    );
+                }
+                BufferType::DiskV2 { when_full, .. } if *when_full != WhenFull::Block => {
+                    return Err(
+                        "drain_shaping requires when_full = \"block\" on every buffer stage"
+                            .to_string(),
+                    );
+                }
+                BufferType::DiskV2 { .. } => {}
+            }
+        }
+
+        Ok(())
+    }
+
     /// Gets all of the configured stages for this buffer.
     pub fn stages(&self) -> &[BufferType] {
         match self {
@@ -408,6 +435,32 @@ impl BufferConfig {
     where
         T: Bufferable + Clone + Finalizable,
     {
+        let (sender, receiver, _observer) = self
+            .build_with_observer(data_dir, buffer_id, span, false)
+            .await?;
+        Ok((sender, receiver))
+    }
+
+    /// Builds the buffer components and read-only usage observer represented by this configuration.
+    ///
+    /// The observer is always returned, but its hot-path accounting is only enabled when `observe`
+    /// is true.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any configured stage is invalid, a required data directory is missing,
+    /// or the underlying topology cannot be built.
+    #[allow(clippy::needless_pass_by_value)]
+    pub async fn build_with_observer<T>(
+        &self,
+        data_dir: Option<PathBuf>,
+        buffer_id: String,
+        span: Span,
+        observe: bool,
+    ) -> Result<(BufferSender<T>, BufferReceiver<T>, BufferUsageObserver), BufferBuildError>
+    where
+        T: Bufferable + Clone + Finalizable,
+    {
         let mut builder = TopologyBuilder::default();
 
         for stage in self.stages() {
@@ -415,7 +468,7 @@ impl BufferConfig {
         }
 
         builder
-            .build(buffer_id, span)
+            .build_with_observer(buffer_id, span, observe)
             .await
             .context(FailedToBuildTopologySnafu)
     }
@@ -466,6 +519,33 @@ max_events: 42
 ";
         let error = serde_yaml::from_str::<BufferConfig>(source).unwrap_err();
         assert_eq!(error.to_string(), BUFFER_CONFIG_NO_MATCH_ERR);
+    }
+
+    #[test]
+    fn drain_shaping_validation_requires_disk_block_stages() {
+        let memory = BufferConfig::Single(BufferType::Memory {
+            size: MemoryBufferSize::MaxEvents(NonZeroUsize::new(10).unwrap()),
+            when_full: WhenFull::Block,
+        });
+        assert_eq!(
+            memory.validate_for_drain_shaping().unwrap_err(),
+            "drain_shaping requires disk buffers; memory buffers are unsupported"
+        );
+
+        let disk_drop_newest = BufferConfig::Single(BufferType::DiskV2 {
+            max_size: NonZeroU64::new(300_000_000).unwrap(),
+            when_full: WhenFull::DropNewest,
+        });
+        assert_eq!(
+            disk_drop_newest.validate_for_drain_shaping().unwrap_err(),
+            "drain_shaping requires when_full = \"block\" on every buffer stage"
+        );
+
+        let disk_block = BufferConfig::Single(BufferType::DiskV2 {
+            max_size: NonZeroU64::new(300_000_000).unwrap(),
+            when_full: WhenFull::Block,
+        });
+        disk_block.validate_for_drain_shaping().unwrap();
     }
 
     #[test]

--- a/lib/vector-buffers/src/lib.rs
+++ b/lib/vector-buffers/src/lib.rs
@@ -15,6 +15,7 @@
 extern crate tracing;
 
 mod buffer_usage_data;
+pub use buffer_usage_data::BufferUsageObserver;
 
 pub mod config;
 pub use config::{BufferConfig, BufferType, MemoryBufferSize};

--- a/lib/vector-buffers/src/topology/builder.rs
+++ b/lib/vector-buffers/src/topology/builder.rs
@@ -7,7 +7,7 @@ use tracing::Span;
 use super::channel::{ChannelMetricMetadata, ReceiverAdapter, SenderAdapter};
 use crate::{
     Bufferable, WhenFull,
-    buffer_usage_data::{BufferUsage, BufferUsageHandle},
+    buffer_usage_data::{BufferUsage, BufferUsageHandle, BufferUsageObserver},
     config::MemoryBufferSize,
     topology::channel::{BufferReceiver, BufferSender, limited},
 };
@@ -32,6 +32,7 @@ pub trait IntoBuffer<T: Bufferable>: Send {
     async fn into_buffer_parts(
         self: Box<Self>,
         usage_handle: BufferUsageHandle,
+        observe: bool,
     ) -> Result<(SenderAdapter<T>, ReceiverAdapter<T>), Box<dyn Error + Send + Sync>>;
 }
 
@@ -109,6 +110,23 @@ impl<T: Bufferable> TopologyBuilder<T> {
         buffer_id: String,
         span: Span,
     ) -> Result<(BufferSender<T>, BufferReceiver<T>), TopologyError> {
+        let (sender, receiver, _observer) =
+            self.build_with_observer(buffer_id, span, false).await?;
+        Ok((sender, receiver))
+    }
+
+    /// Consumes this builder, returning the sender, receiver, and read-only usage observer.
+    ///
+    /// # Errors
+    ///
+    /// If there was a configuration error with one of the stages, an error variant will be returned
+    /// explaining the issue.
+    pub async fn build_with_observer(
+        self,
+        buffer_id: String,
+        span: Span,
+        observe: bool,
+    ) -> Result<(BufferSender<T>, BufferReceiver<T>, BufferUsageObserver), TopologyError> {
         // We pop stages off in reverse order to build from the inside out.
         let mut buffer_usage = BufferUsage::from_span(span.clone());
         let mut current_stage = None;
@@ -139,7 +157,7 @@ impl<T: Bufferable> TopologyBuilder<T> {
             let provides_instrumentation = stage.untransformed.provides_instrumentation();
             let (sender, receiver) = stage
                 .untransformed
-                .into_buffer_parts(usage_handle.clone())
+                .into_buffer_parts(usage_handle.clone(), observe)
                 .await
                 .context(FailedToBuildStageSnafu { stage_idx })?;
 
@@ -155,6 +173,9 @@ impl<T: Bufferable> TopologyBuilder<T> {
             };
 
             sender.with_send_duration_instrumentation(stage_idx, &span);
+            if observe && stage_idx == 0 {
+                sender.with_observer(usage_handle.clone());
+            }
             if !provides_instrumentation {
                 sender.with_usage_instrumentation(usage_handle.clone());
                 receiver.with_usage_instrumentation(usage_handle);
@@ -168,9 +189,10 @@ impl<T: Bufferable> TopologyBuilder<T> {
         // Install the buffer usage handler since we successfully created the buffer topology.  This
         // spawns it in the background and periodically emits aggregated metrics about each of the
         // buffer stages.
+        let observer = buffer_usage.observer();
         buffer_usage.install(buffer_id.as_str());
 
-        Ok((sender, receiver))
+        Ok((sender, receiver, observer))
     }
 }
 

--- a/lib/vector-buffers/src/topology/channel/limited_queue.rs
+++ b/lib/vector-buffers/src/topology/channel/limited_queue.rs
@@ -5,7 +5,7 @@ use std::{
     pin::Pin,
     sync::{
         Arc,
-        atomic::{AtomicUsize, Ordering},
+        atomic::{AtomicU64, AtomicUsize, Ordering},
     },
     time::Instant,
 };
@@ -22,7 +22,7 @@ use vector_common::internal_event::{GaugeName, HistogramName};
 use vector_common::stats::TimeEwmaGauge;
 use vector_common::{gauge, histogram};
 
-use crate::{InMemoryBufferable, config::MemoryBufferSize};
+use crate::{InMemoryBufferable, buffer_usage_data::BufferUsageHandle, config::MemoryBufferSize};
 
 pub const DEFAULT_EWMA_HALF_LIFE_SECONDS: f64 = 5.0;
 
@@ -237,6 +237,9 @@ struct Inner<T> {
     read_waker: Arc<Notify>,
     metrics: Option<Metrics>,
     capacity: NonZeroUsize,
+    usage_handle: Option<BufferUsageHandle>,
+    queued_events: Arc<AtomicU64>,
+    queued_native: Arc<AtomicU64>,
 }
 
 impl<T> Clone for Inner<T> {
@@ -248,19 +251,25 @@ impl<T> Clone for Inner<T> {
             read_waker: self.read_waker.clone(),
             metrics: self.metrics.clone(),
             capacity: self.capacity,
+            usage_handle: self.usage_handle.clone(),
+            queued_events: self.queued_events.clone(),
+            queued_native: self.queued_native.clone(),
         }
     }
 }
 
-impl<T: Send + Sync + Debug + 'static> Inner<T> {
+impl<T: InMemoryBufferable + Send + Sync + Debug + 'static> Inner<T> {
     fn new(
         limit: MemoryBufferSize,
         metric_metadata: Option<ChannelMetricMetadata>,
         ewma_half_life_seconds: Option<f64>,
+        usage_handle: Option<BufferUsageHandle>,
     ) -> Self {
         let read_waker = Arc::new(Notify::new());
         let metrics =
             metric_metadata.map(|metadata| Metrics::new(limit, metadata, ewma_half_life_seconds));
+        let queued_events = Arc::new(AtomicU64::new(0));
+        let queued_native = Arc::new(AtomicU64::new(0));
         match limit {
             MemoryBufferSize::MaxEvents(max_events) => Inner {
                 data: Arc::new(ArrayQueue::new(max_events.get())),
@@ -269,6 +278,9 @@ impl<T: Send + Sync + Debug + 'static> Inner<T> {
                 read_waker,
                 metrics,
                 capacity: max_events,
+                usage_handle,
+                queued_events,
+                queued_native,
             },
             MemoryBufferSize::MaxSize(max_bytes) => Inner {
                 data: Arc::new(SegQueue::new()),
@@ -277,6 +289,9 @@ impl<T: Send + Sync + Debug + 'static> Inner<T> {
                 read_waker,
                 metrics,
                 capacity: max_bytes,
+                usage_handle,
+                queued_events,
+                queued_native,
             },
         }
     }
@@ -286,6 +301,7 @@ impl<T: Send + Sync + Debug + 'static> Inner<T> {
     /// The `size` value is the true utilization contribution of `item`, which may exceed the number
     /// of permits acquired for oversized payloads.
     fn send_with_permits(&mut self, size: usize, permits: OwnedSemaphorePermit, item: T) {
+        let event_count = item.event_count() as u64;
         if let Some(metrics) = &self.metrics {
             // For normal items, capacity - available_permits() exactly represents the total queued
             // utilization (including this item's just-acquired permits). For oversized items that
@@ -295,13 +311,31 @@ impl<T: Send + Sync + Debug + 'static> Inner<T> {
             metrics.record(utilization, Instant::now());
         }
         self.data.push((permits, item));
+        if let Some(handle) = &self.usage_handle {
+            let ordering = Ordering::Relaxed;
+            let events = self
+                .queued_events
+                .fetch_add(event_count, ordering)
+                .saturating_add(event_count);
+            let native_size = size as u64;
+            let native = self
+                .queued_native
+                .fetch_add(native_size, ordering)
+                .saturating_add(native_size);
+            handle.set_occupancy(events, native);
+        }
         self.read_waker.notify_one();
     }
-}
 
-impl<T> Inner<T> {
     fn used_capacity(&self) -> usize {
         self.capacity.get() - self.limiter.available_permits()
+    }
+
+    fn native_size(&self, item: &T) -> usize {
+        match self.limit {
+            MemoryBufferSize::MaxSize(_) => item.allocated_bytes(),
+            MemoryBufferSize::MaxEvents(_) => item.event_count(),
+        }
     }
 
     fn pop_and_record(&self) -> Option<T> {
@@ -312,6 +346,20 @@ impl<T> Inner<T> {
                 // permits.
                 let utilization = self.used_capacity().saturating_sub(permit.num_permits());
                 metrics.record(utilization, Instant::now());
+            }
+            if let Some(handle) = &self.usage_handle {
+                let ordering = Ordering::Relaxed;
+                let event_count = item.event_count() as u64;
+                let events = self
+                    .queued_events
+                    .fetch_sub(event_count, ordering)
+                    .saturating_sub(event_count);
+                let native_size = self.native_size(&item) as u64;
+                let native = self
+                    .queued_native
+                    .fetch_sub(native_size, ordering)
+                    .saturating_sub(native_size);
+                handle.set_occupancy(events, native);
             }
             // Release permits after recording so a waiting sender cannot enqueue a new item
             // before this pop's utilization measurement is taken.
@@ -429,7 +477,7 @@ pub struct LimitedReceiver<T> {
     inner: Inner<T>,
 }
 
-impl<T: Send + 'static> LimitedReceiver<T> {
+impl<T: InMemoryBufferable + Send + 'static> LimitedReceiver<T> {
     /// Gets the number of items that this channel could accept.
     pub fn available_capacity(&self) -> usize {
         self.inner.limiter.available_permits()
@@ -484,7 +532,16 @@ pub fn limited<T: InMemoryBufferable + fmt::Debug>(
     metric_metadata: Option<ChannelMetricMetadata>,
     ewma_half_life_seconds: Option<f64>,
 ) -> (LimitedSender<T>, LimitedReceiver<T>) {
-    let inner = Inner::new(limit, metric_metadata, ewma_half_life_seconds);
+    limited_with_usage_handle(limit, metric_metadata, ewma_half_life_seconds, None)
+}
+
+pub fn limited_with_usage_handle<T: InMemoryBufferable + fmt::Debug>(
+    limit: MemoryBufferSize,
+    metric_metadata: Option<ChannelMetricMetadata>,
+    ewma_half_life_seconds: Option<f64>,
+    usage_handle: Option<BufferUsageHandle>,
+) -> (LimitedSender<T>, LimitedReceiver<T>) {
+    let inner = Inner::new(limit, metric_metadata, ewma_half_life_seconds, usage_handle);
 
     let sender = LimitedSender {
         inner: inner.clone(),

--- a/lib/vector-buffers/src/topology/channel/limited_queue.rs
+++ b/lib/vector-buffers/src/topology/channel/limited_queue.rs
@@ -310,8 +310,11 @@ impl<T: InMemoryBufferable + Send + Sync + Debug + 'static> Inner<T> {
             let utilization = size.max(self.used_capacity());
             metrics.record(utilization, Instant::now());
         }
-        self.data.push((permits, item));
         if let Some(handle) = &self.usage_handle {
+            // Increment the observed counters before the item becomes visible to poppers. If the
+            // push happened first, a receiver already polling could pop the item and run the
+            // `fetch_sub` path before this `fetch_add`, underflowing the atomics toward `u64::MAX`
+            // and making the observer report a near-full buffer.
             let ordering = Ordering::Relaxed;
             let events = self
                 .queued_events
@@ -324,6 +327,7 @@ impl<T: InMemoryBufferable + Send + Sync + Debug + 'static> Inner<T> {
                 .saturating_add(native_size);
             handle.set_occupancy(events, native);
         }
+        self.data.push((permits, item));
         self.read_waker.notify_one();
     }
 

--- a/lib/vector-buffers/src/topology/channel/mod.rs
+++ b/lib/vector-buffers/src/topology/channel/mod.rs
@@ -4,10 +4,12 @@ mod sender;
 
 pub use limited_queue::{
     BufferChannelKind, ChannelMetricMetadata, DEFAULT_EWMA_HALF_LIFE_SECONDS, LimitedReceiver,
-    LimitedSender, SendError, limited,
+    LimitedSender, SendError, limited, limited_with_usage_handle,
 };
 pub use receiver::*;
 pub use sender::*;
 
+#[cfg(test)]
+mod observer_tests;
 #[cfg(test)]
 mod tests;

--- a/lib/vector-buffers/src/topology/channel/observer_tests.rs
+++ b/lib/vector-buffers/src/topology/channel/observer_tests.rs
@@ -1,0 +1,220 @@
+use std::{
+    num::{NonZeroU64, NonZeroUsize},
+    path::Path,
+};
+
+use tracing::Span;
+use vector_common::{byte_size_of::ByteSizeOf, finalization::Finalizable};
+
+use crate::{
+    BufferUsageObserver, Bufferable, WhenFull,
+    config::MemoryBufferSize,
+    test::{MultiEventRecord, SizedRecord, acknowledge, with_temp_dir},
+    topology::{
+        builder::TopologyBuilder,
+        channel::{BufferReceiver, BufferSender},
+    },
+    variants::{DiskV2Buffer, MemoryBuffer},
+};
+
+type ObservedBuffer<T> = (BufferSender<T>, BufferReceiver<T>, BufferUsageObserver);
+
+async fn build_memory_buffer_with_observer<T: Bufferable>(
+    max_events: NonZeroUsize,
+) -> ObservedBuffer<T> {
+    let mut builder = TopologyBuilder::default();
+    builder.stage(MemoryBuffer::with_max_events(max_events), WhenFull::Block);
+    builder
+        .build_with_observer(String::from("observer-test"), Span::none(), true)
+        .await
+        .expect("memory topology should build")
+}
+
+async fn build_byte_size_memory_buffer_with_observer<T: Bufferable>(
+    max_bytes: NonZeroUsize,
+) -> ObservedBuffer<T> {
+    let mut builder = TopologyBuilder::default();
+    builder.stage(
+        MemoryBuffer::new(MemoryBufferSize::MaxSize(max_bytes)),
+        WhenFull::Block,
+    );
+    builder
+        .build_with_observer(String::from("observer-test"), Span::none(), true)
+        .await
+        .expect("byte-size memory topology should build")
+}
+
+async fn build_overflow_buffer_with_observer<T>() -> ObservedBuffer<T>
+where
+    T: Bufferable,
+{
+    let mut builder = TopologyBuilder::default();
+    builder.stage(
+        MemoryBuffer::with_max_events(NonZeroUsize::new(1).unwrap()),
+        WhenFull::Overflow,
+    );
+    builder.stage(
+        MemoryBuffer::with_max_events(NonZeroUsize::new(100).unwrap()),
+        WhenFull::Block,
+    );
+    builder
+        .build_with_observer(String::from("observer-test"), Span::none(), true)
+        .await
+        .expect("overflow topology should build")
+}
+
+async fn build_disk_buffer_with_observer_in<T>(dir: &Path) -> ObservedBuffer<T>
+where
+    T: Bufferable + Clone + Finalizable,
+{
+    let mut builder = TopologyBuilder::default();
+    builder.stage(
+        DiskV2Buffer::new(
+            String::from("observer-test"),
+            dir.to_path_buf(),
+            NonZeroU64::new(300_000_000).unwrap(),
+        ),
+        WhenFull::Block,
+    );
+    builder
+        .build_with_observer(String::from("observer-test"), Span::none(), true)
+        .await
+        .expect("disk topology should build")
+}
+
+async fn build_memory_buffer_with_observe<T: Bufferable>(observe: bool) -> ObservedBuffer<T> {
+    let mut builder = TopologyBuilder::default();
+    builder.stage(
+        MemoryBuffer::with_max_events(NonZeroUsize::new(100).unwrap()),
+        WhenFull::Block,
+    );
+    builder
+        .build_with_observer(String::from("observer-test"), Span::none(), observe)
+        .await
+        .expect("memory topology should build")
+}
+
+#[tokio::test]
+async fn observe_flag_controls_observer_received_accounting() {
+    let (mut observed_tx, _observed_rx, observed) =
+        build_memory_buffer_with_observe::<SizedRecord>(true).await;
+    let observed_record = SizedRecord::new(7);
+    let expected = observed_record.size_of() as u64;
+    observed_tx.send(observed_record, None).await.unwrap();
+    assert_eq!(observed.received(), (1, expected));
+
+    let (mut unobserved_tx, _unobserved_rx, unobserved) =
+        build_memory_buffer_with_observe::<SizedRecord>(false).await;
+    unobserved_tx.send(SizedRecord::new(7), None).await.unwrap();
+    assert_eq!(unobserved.received(), (0, 0));
+}
+
+#[tokio::test]
+async fn observer_received_counts_size_of_once_on_memory() {
+    let (mut tx, mut rx, observer) =
+        build_memory_buffer_with_observer::<SizedRecord>(NonZeroUsize::new(100).unwrap()).await;
+    let record = SizedRecord::new(7);
+    let expected = record.size_of() as u64;
+
+    tx.send(record, None).await.unwrap();
+
+    assert_eq!(observer.received(), (1, expected));
+    let _ = rx.next().await;
+    assert_eq!(observer.received(), (1, expected));
+}
+
+#[tokio::test]
+async fn observer_received_counts_size_of_once_on_disk() {
+    with_temp_dir(|dir| {
+        let data_dir = dir.to_path_buf();
+
+        async move {
+            let (mut tx, _rx, observer) =
+                build_disk_buffer_with_observer_in::<SizedRecord>(&data_dir).await;
+            let record = SizedRecord::new(7);
+            let expected = record.size_of() as u64;
+
+            tx.send(record, None).await.unwrap();
+
+            assert_eq!(observer.received(), (1, expected));
+        }
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn observer_received_not_double_counted_on_overflow() {
+    let (mut tx, _rx, observer) = build_overflow_buffer_with_observer::<SizedRecord>().await;
+
+    tx.send(SizedRecord::new(1), None).await.unwrap();
+    tx.send(SizedRecord::new(1), None).await.unwrap();
+
+    assert_eq!(observer.received().0, 2);
+}
+
+#[tokio::test]
+async fn occupancy_tracks_event_count_on_memory() {
+    let (mut tx, mut rx, observer) =
+        build_memory_buffer_with_observer::<MultiEventRecord>(NonZeroUsize::new(100).unwrap())
+            .await;
+
+    tx.send(MultiEventRecord::new(3), None).await.unwrap();
+    tx.send(MultiEventRecord::new(2), None).await.unwrap();
+    assert_eq!(observer.occupancy().0, 5);
+
+    let _ = rx.next().await;
+    assert_eq!(observer.occupancy().0, 2);
+}
+
+#[tokio::test]
+async fn occupancy_tracks_fill_on_disk() {
+    with_temp_dir(|dir| {
+        let data_dir = dir.to_path_buf();
+
+        async move {
+            let (mut tx, mut rx, observer) =
+                build_disk_buffer_with_observer_in::<SizedRecord>(&data_dir).await;
+
+            tx.send(SizedRecord::new(1), None).await.unwrap();
+            tx.flush().await.unwrap();
+            assert!(observer.occupancy().1 > 0);
+
+            let record = rx.next().await.unwrap();
+            acknowledge(record).await;
+            drop(tx);
+            while rx.next().await.is_some() {}
+            assert_eq!(observer.occupancy().1, 0);
+        }
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn occupancy_seeded_after_restart_with_existing_data() {
+    with_temp_dir(|dir| {
+        let data_dir = dir.to_path_buf();
+
+        async move {
+            {
+                let (mut tx, _rx, _observer) =
+                    build_disk_buffer_with_observer_in::<SizedRecord>(&data_dir).await;
+                tx.send(SizedRecord::new(1), None).await.unwrap();
+                tx.flush().await.unwrap();
+            }
+
+            let (_tx, _rx, observer) =
+                build_disk_buffer_with_observer_in::<SizedRecord>(&data_dir).await;
+            assert!(observer.occupancy().1 > 0);
+        }
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn max_size_reports_bytes_for_byte_capacity_buffer() {
+    let cap = NonZeroUsize::new(1_000_000).unwrap();
+    let (_tx, _rx, observer) =
+        build_byte_size_memory_buffer_with_observer::<SizedRecord>(cap).await;
+
+    assert_eq!(observer.max_size().1, 1_000_000);
+}

--- a/lib/vector-buffers/src/topology/channel/sender.rs
+++ b/lib/vector-buffers/src/topology/channel/sender.rs
@@ -138,6 +138,7 @@ pub struct BufferSender<T: Bufferable> {
     overflow: Option<Box<BufferSender<T>>>,
     when_full: WhenFull,
     usage_instrumentation: Option<BufferUsageHandle>,
+    observer: Option<BufferUsageHandle>,
     #[derivative(Debug = "ignore")]
     send_duration: Option<Registered<BufferSendDuration>>,
     #[derivative(Debug = "ignore")]
@@ -152,6 +153,7 @@ impl<T: Bufferable> BufferSender<T> {
             overflow: None,
             when_full,
             usage_instrumentation: None,
+            observer: None,
             send_duration: None,
             custom_instrumentation: None,
         }
@@ -164,6 +166,7 @@ impl<T: Bufferable> BufferSender<T> {
             overflow: Some(Box::new(overflow)),
             when_full: WhenFull::Overflow,
             usage_instrumentation: None,
+            observer: None,
             send_duration: None,
             custom_instrumentation: None,
         }
@@ -182,6 +185,11 @@ impl<T: Bufferable> BufferSender<T> {
     /// Configures this sender to instrument the items passing through it.
     pub fn with_usage_instrumentation(&mut self, handle: BufferUsageHandle) {
         self.usage_instrumentation = Some(handle);
+    }
+
+    /// Configures this sender to update the read-only usage observer.
+    pub fn with_observer(&mut self, handle: BufferUsageHandle) {
+        self.observer = Some(handle);
     }
 
     /// Configures this sender to instrument the send duration.
@@ -219,6 +227,7 @@ impl<T: Bufferable> BufferSender<T> {
         let item_sizing = self
             .usage_instrumentation
             .as_ref()
+            .or(self.observer.as_ref())
             .map(|_| (item.event_count(), item.size_of()));
 
         let mut was_dropped = false;
@@ -228,6 +237,11 @@ impl<T: Bufferable> BufferSender<T> {
         {
             instrumentation
                 .increment_received_event_count_and_byte_size(item_count as u64, item_size as u64);
+        }
+        if let Some(observer) = self.observer.as_ref()
+            && let Some((item_count, item_size)) = item_sizing
+        {
+            observer.increment_observer_received(item_count as u64, item_size as u64);
         }
         match self.when_full {
             WhenFull::Block => self.base.send(item).await?,

--- a/lib/vector-buffers/src/variants/disk_v2/ledger.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/ledger.rs
@@ -554,7 +554,7 @@ where
             );
     }
 
-    fn set_observed_occupancy(&self) {
+    pub(super) fn set_observed_occupancy(&self) {
         if self.occupancy_enabled {
             self.usage_handle
                 .set_occupancy(self.get_total_records(), self.get_total_buffer_size());

--- a/lib/vector-buffers/src/variants/disk_v2/ledger.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/ledger.rs
@@ -231,6 +231,8 @@ where
     last_flush: AtomicCell<Instant>,
     // Tracks usage data about the buffer.
     usage_handle: BufferUsageHandle,
+    // Enables the drain-shaping observer's current occupancy mirror.
+    occupancy_enabled: bool,
 }
 
 impl<FS> Ledger<FS>
@@ -412,6 +414,7 @@ where
     /// Tracks the statistics of a successful write.
     pub fn track_write(&self, event_count: u64, record_size: u64) {
         self.increment_total_buffer_size(record_size);
+        self.set_observed_occupancy();
         self.usage_handle
             .increment_received_event_count_and_byte_size(event_count, record_size);
     }
@@ -419,6 +422,7 @@ where
     /// Tracks the statistics of multiple successful reads.
     pub fn track_reads(&self, event_count: u64, total_record_size: u64) {
         self.decrement_total_buffer_size(total_record_size);
+        self.set_observed_occupancy();
         self.usage_handle
             .increment_sent_event_count_and_byte_size(event_count, total_record_size);
     }
@@ -550,6 +554,13 @@ where
             );
     }
 
+    fn set_observed_occupancy(&self) {
+        if self.occupancy_enabled {
+            self.usage_handle
+                .set_occupancy(self.get_total_records(), self.get_total_buffer_size());
+        }
+    }
+
     pub fn track_dropped_events(&self, count: u64) {
         // We don't know how many bytes are represented by dropped events because we never actually had a chance to read
         // them, so we have to use a byte size of 0 here.
@@ -583,6 +594,7 @@ where
     pub(super) async fn load_or_create(
         config: DiskBufferConfig<FS>,
         usage_handle: BufferUsageHandle,
+        observe: bool,
     ) -> Result<Ledger<FS>, LedgerLoadCreateError> {
         // Create our containing directory if it doesn't already exist.
         fs::create_dir_all(&config.data_dir)
@@ -671,6 +683,7 @@ where
             unacked_reader_file_id_offset: AtomicU16::new(0),
             last_flush: AtomicCell::new(Instant::now()),
             usage_handle,
+            occupancy_enabled: observe,
         };
         ledger.update_buffer_size().await?;
 
@@ -733,6 +746,7 @@ where
         }
 
         self.increment_total_buffer_size(total_buffer_size);
+        self.set_observed_occupancy();
 
         Ok(())
     }

--- a/lib/vector-buffers/src/variants/disk_v2/mod.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/mod.rs
@@ -243,12 +243,13 @@ where
     pub(crate) async fn from_config_inner<FS>(
         config: DiskBufferConfig<FS>,
         usage_handle: BufferUsageHandle,
+        observe: bool,
     ) -> Result<(BufferWriter<T, FS>, BufferReader<T, FS>, Arc<Ledger<FS>>), BufferError<T>>
     where
         FS: Filesystem + fmt::Debug + Clone + 'static,
         FS::File: Unpin,
     {
-        let ledger = Ledger::load_or_create(config, usage_handle)
+        let ledger = Ledger::load_or_create(config, usage_handle, observe)
             .await
             .context(LedgerSnafu)?;
         let ledger = Arc::new(ledger);
@@ -286,12 +287,13 @@ where
     pub async fn from_config<FS>(
         config: DiskBufferConfig<FS>,
         usage_handle: BufferUsageHandle,
+        observe: bool,
     ) -> Result<(BufferWriter<T, FS>, BufferReader<T, FS>), BufferError<T>>
     where
         FS: Filesystem + fmt::Debug + Clone + 'static,
         FS::File: Unpin,
     {
-        let (writer, reader, _) = Self::from_config_inner(config, usage_handle).await?;
+        let (writer, reader, _) = Self::from_config_inner(config, usage_handle, observe).await?;
 
         Ok((writer, reader))
     }
@@ -325,12 +327,14 @@ where
     async fn into_buffer_parts(
         self: Box<Self>,
         usage_handle: BufferUsageHandle,
+        observe: bool,
     ) -> Result<(SenderAdapter<T>, ReceiverAdapter<T>), Box<dyn Error + Send + Sync>> {
         let (writer, reader) = build_disk_v2_buffer(
             usage_handle,
             &self.data_dir,
             self.id.as_str(),
             self.max_size,
+            observe,
         )
         .await?;
 
@@ -343,6 +347,7 @@ async fn build_disk_v2_buffer<T>(
     data_dir: &Path,
     id: &str,
     max_size: NonZeroU64,
+    observe: bool,
 ) -> Result<
     (
         BufferWriter<T, ProductionFilesystem>,
@@ -372,7 +377,7 @@ where
         None => builder,
     };
     let config = builder.build()?;
-    Buffer::from_config(config, usage_handle)
+    Buffer::from_config(config, usage_handle, observe)
         .await
         .map_err(Into::into)
 }

--- a/lib/vector-buffers/src/variants/disk_v2/reader.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/reader.rs
@@ -970,6 +970,12 @@ where
 
         self.ready_to_read = true;
 
+        // `update_buffer_size` published the full on-disk size to the observer before
+        // this seek ran; the seek above drew the tracked buffer size back down to the
+        // unread tail by deleting or reading already-acknowledged records, so refresh
+        // the observed occupancy to match instead of leaving the stale startup value.
+        self.ledger.set_observed_occupancy();
+
         Ok(())
     }
 

--- a/lib/vector-buffers/src/variants/disk_v2/tests/acknowledgements.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/tests/acknowledgements.rs
@@ -27,7 +27,7 @@ async fn ack_updates_ledger_correctly() {
             let config = DiskBufferConfigBuilder::from_path(data_dir)
                 .build()
                 .expect("creating buffer should not fail");
-            let ledger = Ledger::load_or_create(config, usage_handle)
+            let ledger = Ledger::load_or_create(config, usage_handle, false)
                 .await
                 .expect("ledger should not fail to load/create");
             assert_eq!(ledger.consume_pending_acks(), 0);
@@ -59,7 +59,7 @@ async fn ack_wakes_reader() {
             let config = DiskBufferConfigBuilder::from_path(data_dir)
                 .build()
                 .expect("creating buffer should not fail");
-            let ledger = Ledger::load_or_create(config, usage_handle)
+            let ledger = Ledger::load_or_create(config, usage_handle, false)
                 .await
                 .expect("ledger should not fail to load/create");
 

--- a/lib/vector-buffers/src/variants/disk_v2/tests/basic.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/tests/basic.rs
@@ -166,7 +166,7 @@ async fn initial_size_correct_with_multievents() {
                 .build()
                 .expect("creating buffer config should not fail");
             let usage_handle = BufferUsageHandle::noop();
-            let ledger = Ledger::load_or_create(config, usage_handle)
+            let ledger = Ledger::load_or_create(config, usage_handle, false)
                 .await
                 .expect("ledger should not fail to load/create");
             let ledger = Arc::new(ledger);

--- a/lib/vector-buffers/src/variants/disk_v2/tests/initialization.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/tests/initialization.rs
@@ -5,7 +5,9 @@ use tracing::Instrument;
 
 use crate::{
     test::{SizedRecord, acknowledge, install_tracing_helpers, with_temp_dir},
-    variants::disk_v2::tests::{create_default_buffer_v2, set_file_length},
+    variants::disk_v2::tests::{
+        create_default_buffer_v2, create_default_buffer_v2_observed, set_file_length,
+    },
 };
 
 #[tokio::test]
@@ -85,6 +87,71 @@ async fn reader_doesnt_block_from_partial_write_on_last_record() {
     });
 
     let parent = trace_span!("reader_doesnt_block_from_partial_write_on_last_record");
+    fut.instrument(parent.or_current()).await;
+}
+
+#[tokio::test]
+async fn reopen_refreshes_observed_occupancy_after_seek() {
+    // On restart, `update_buffer_size` publishes the full on-disk size to the observer, then
+    // `seek_to_next_record` draws the tracked size back down to the unread tail by skipping
+    // already-acknowledged records. The observed occupancy must reflect that post-seek size, not
+    // the stale whole-file value, otherwise drain shaping treats a nearly drained buffer as
+    // saturated and throttles recovery unnecessarily.
+    let _a = install_tracing_helpers();
+
+    let fut = with_temp_dir(|dir| {
+        let data_dir = dir.to_path_buf();
+
+        async move {
+            // Write two records, acknowledge the first, and leave the second unacknowledged so the
+            // reopened buffer seeks back to it as an unread tail.
+            let (mut writer, mut reader, ledger, _usage) =
+                create_default_buffer_v2_observed::<_, SizedRecord>(data_dir.clone()).await;
+            writer
+                .write_record(SizedRecord::new(64))
+                .await
+                .expect("should not fail to write");
+            writer
+                .write_record(SizedRecord::new(68))
+                .await
+                .expect("should not fail to write");
+            writer.flush().await.expect("flush should not fail");
+            writer.close();
+
+            // Reading the second record pumps the first record's acknowledgement into the ledger.
+            // It is intentionally neither bound nor acknowledged: dropping it immediately keeps it
+            // from pinning the buffer past the reopen, while leaving it unacknowledged means the
+            // reopened reader must seek back to it as an unread tail on disk.
+            let first_read = reader
+                .next()
+                .await
+                .expect("should not fail to read record")
+                .expect("should contain first record");
+            acknowledge(first_read).await;
+            reader
+                .next()
+                .await
+                .expect("should not fail to read record")
+                .expect("should contain second record");
+            ledger.flush().expect("should not fail to flush ledger");
+            drop(reader);
+            drop(writer);
+            drop(ledger);
+
+            // Reopen: load publishes the full on-disk size, then the seek draws it back down to
+            // the unread tail and must refresh the observed occupancy to match.
+            let (_writer, _reader, ledger, usage) =
+                create_default_buffer_v2_observed::<_, SizedRecord>(data_dir).await;
+
+            assert_eq!(
+                usage.occupancy(),
+                (ledger.get_total_records(), ledger.get_total_buffer_size()),
+                "observed occupancy must match the post-seek buffer size, not the stale whole-file size"
+            );
+        }
+    });
+
+    let parent = trace_span!("reopen_refreshes_observed_occupancy_after_seek");
     fut.instrument(parent.or_current()).await;
 }
 

--- a/lib/vector-buffers/src/variants/disk_v2/tests/mod.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/tests/mod.rs
@@ -206,7 +206,7 @@ where
         .build()
         .expect("creating buffer should not fail");
     let usage_handle = BufferUsageHandle::noop();
-    Buffer::from_config_inner(config, usage_handle)
+    Buffer::from_config_inner(config, usage_handle, false)
         .await
         .expect("should not fail to create buffer")
 }
@@ -228,7 +228,7 @@ where
         .build()
         .expect("creating buffer should not fail");
     let usage_handle = BufferUsageHandle::noop();
-    let (writer, reader, ledger) = Buffer::from_config_inner(config, usage_handle.clone())
+    let (writer, reader, ledger) = Buffer::from_config_inner(config, usage_handle.clone(), false)
         .await
         .expect("should not fail to create buffer");
     (writer, reader, ledger, usage_handle)
@@ -278,7 +278,7 @@ where
         .expect("creating buffer should not fail");
     let usage_handle = BufferUsageHandle::noop();
 
-    Buffer::from_config_inner(config, usage_handle)
+    Buffer::from_config_inner(config, usage_handle, false)
         .await
         .expect("should not fail to create buffer")
 }
@@ -302,7 +302,7 @@ where
         .expect("creating buffer should not fail");
     let usage_handle = BufferUsageHandle::noop();
 
-    Buffer::from_config_inner(config, usage_handle)
+    Buffer::from_config_inner(config, usage_handle, false)
         .await
         .expect("should not fail to create buffer")
 }
@@ -331,7 +331,7 @@ where
         .expect("creating buffer should not fail");
     let usage_handle = BufferUsageHandle::noop();
 
-    Buffer::from_config_inner(config, usage_handle)
+    Buffer::from_config_inner(config, usage_handle, false)
         .await
         .expect("should not fail to create buffer")
 }
@@ -355,7 +355,7 @@ where
         .expect("creating buffer should not fail");
     let usage_handle = BufferUsageHandle::noop();
 
-    Buffer::from_config_inner(config, usage_handle)
+    Buffer::from_config_inner(config, usage_handle, false)
         .await
         .expect("should not fail to create buffer")
 }

--- a/lib/vector-buffers/src/variants/disk_v2/tests/mod.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/tests/mod.rs
@@ -234,6 +234,30 @@ where
     (writer, reader, ledger, usage_handle)
 }
 
+/// Creates a disk v2 buffer in observe mode, returning the buffer usage handle so tests can read
+/// the occupancy published to observer consumers (drain shaping).
+pub(crate) async fn create_default_buffer_v2_observed<P, R>(
+    data_dir: P,
+) -> (
+    BufferWriter<R, FilesystemUnderTest>,
+    BufferReader<R, FilesystemUnderTest>,
+    Arc<Ledger<FilesystemUnderTest>>,
+    BufferUsageHandle,
+)
+where
+    P: AsRef<Path>,
+    R: Bufferable,
+{
+    let config = DiskBufferConfigBuilder::from_path(data_dir)
+        .build()
+        .expect("creating buffer should not fail");
+    let usage_handle = BufferUsageHandle::noop();
+    let (writer, reader, ledger) = Buffer::from_config_inner(config, usage_handle.clone(), true)
+        .await
+        .expect("should not fail to create buffer");
+    (writer, reader, ledger, usage_handle)
+}
+
 /// Creates a disk v2 buffer that is sized such that only a fixed number of data files are allowed.
 ///
 /// We do this based on limiting the maximum buffer size, knowing that if the maximum data file size is N, and we want

--- a/lib/vector-buffers/src/variants/disk_v2/tests/model/mod.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/tests/model/mod.rs
@@ -872,7 +872,7 @@ proptest! {
 
             let usage_handle = BufferUsageHandle::noop();
             let (writer, reader, ledger) =
-                Buffer::<Record>::from_config_inner(config, usage_handle)
+                Buffer::<Record>::from_config_inner(config, usage_handle, false)
                     .await
                     .expect("should not fail to build buffer");
 

--- a/lib/vector-buffers/src/variants/in_memory.rs
+++ b/lib/vector-buffers/src/variants/in_memory.rs
@@ -8,7 +8,7 @@ use crate::{
     config::MemoryBufferSize,
     topology::{
         builder::IntoBuffer,
-        channel::{ReceiverAdapter, SenderAdapter, limited},
+        channel::{ReceiverAdapter, SenderAdapter, limited_with_usage_handle},
     },
 };
 
@@ -37,15 +37,17 @@ where
     async fn into_buffer_parts(
         self: Box<Self>,
         usage_handle: BufferUsageHandle,
+        observe: bool,
     ) -> Result<(SenderAdapter<T>, ReceiverAdapter<T>), Box<dyn Error + Send + Sync>> {
-        let (max_bytes, max_size) = match self.capacity {
+        let (max_bytes, max_events) = match self.capacity {
             MemoryBufferSize::MaxEvents(max_events) => (None, Some(max_events.get())),
-            MemoryBufferSize::MaxSize(max_size) => (None, Some(max_size.get())),
+            MemoryBufferSize::MaxSize(max_bytes) => (Some(max_bytes.get() as u64), None),
         };
 
-        usage_handle.set_buffer_limits(max_bytes, max_size);
+        usage_handle.set_buffer_limits(max_bytes, max_events);
 
-        let (tx, rx) = limited(self.capacity, None, None);
+        let occupancy_handle = observe.then_some(usage_handle.clone());
+        let (tx, rx) = limited_with_usage_handle(self.capacity, None, None, occupancy_handle);
         Ok((tx.into(), rx.into()))
     }
 }

--- a/src/config/sink.rs
+++ b/src/config/sink.rs
@@ -5,7 +5,7 @@ use dyn_clone::DynClone;
 use serde::Serialize;
 use serde_with::serde_as;
 use vector_lib::{
-    buffers::{BufferConfig, BufferType},
+    buffers::{BufferConfig, BufferType, BufferUsageObserver},
     config::{AcknowledgementsConfig, GlobalOptions, Input},
     configurable::{
         Configurable, GenerateError, Metadata, NamedComponent,
@@ -266,6 +266,11 @@ pub trait SinkConfig: DynClone + NamedComponent + core::fmt::Debug + Send + Sync
         Vec::new()
     }
 
+    /// Returns whether the sink needs live buffer usage observation.
+    fn requires_buffer_observation(&self) -> bool {
+        false
+    }
+
     /// Gets the acknowledgements configuration for this sink.
     fn acknowledgements(&self) -> &AcknowledgementsConfig;
 }
@@ -278,6 +283,7 @@ pub struct SinkContext {
     pub globals: GlobalOptions,
     pub enrichment_tables: vector_lib::enrichment::TableRegistry,
     pub metrics_storage: MetricsStorage,
+    pub buffer_usage_observer: Option<BufferUsageObserver>,
     pub proxy: ProxyConfig,
     pub schema: schema::Options,
     pub app_name: String,
@@ -295,6 +301,7 @@ impl Default for SinkContext {
             globals: Default::default(),
             enrichment_tables: Default::default(),
             metrics_storage: Default::default(),
+            buffer_usage_observer: None,
             proxy: Default::default(),
             schema: Default::default(),
             app_name: crate::get_app_name().to_string(),
@@ -311,5 +318,49 @@ impl SinkContext {
 
     pub const fn proxy(&self) -> &ProxyConfig {
         &self.proxy
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SinkConfig, SinkContext};
+
+    #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
+    struct DefaultObservationSink;
+
+    impl vector_lib::configurable::NamedComponent for DefaultObservationSink {
+        fn get_component_name(&self) -> &'static str {
+            "default_observation_sink"
+        }
+    }
+
+    #[typetag::serde(name = "default_observation_sink")]
+    #[async_trait::async_trait]
+    impl SinkConfig for DefaultObservationSink {
+        async fn build(
+            &self,
+            _cx: SinkContext,
+        ) -> crate::Result<(vector_lib::sink::VectorSink, crate::sinks::Healthcheck)> {
+            unreachable!("default observation test does not build the sink")
+        }
+
+        fn input(&self) -> vector_lib::config::Input {
+            vector_lib::config::Input::all()
+        }
+
+        fn acknowledgements(&self) -> &vector_lib::config::AcknowledgementsConfig {
+            &vector_lib::config::AcknowledgementsConfig::DEFAULT
+        }
+    }
+
+    #[test]
+    fn sink_context_default_has_no_buffer_usage_observer() {
+        assert!(SinkContext::default().buffer_usage_observer.is_none());
+    }
+
+    #[test]
+    fn default_sink_config_does_not_require_buffer_observation() {
+        let config = DefaultObservationSink;
+        assert!(!config.requires_buffer_observation());
     }
 }

--- a/src/sinks/clickhouse/config.rs
+++ b/src/sinks/clickhouse/config.rs
@@ -1,6 +1,6 @@
 //! Configuration for the `Clickhouse` sink.
 
-use std::fmt;
+use std::{fmt, sync::Arc};
 
 use http::{Request, StatusCode, Uri};
 use hyper::Body;
@@ -10,13 +10,17 @@ use vector_lib::codecs::encoding::format::SchemaProvider;
 use super::{
     request_builder::ClickhouseRequestBuilder,
     service::{ClickhouseRetryLogic, ClickhouseServiceRequestBuilder},
-    sink::{ClickhouseSink, PartitionKey},
+    sink::{ClickhouseSink, DrainShapingInputs, PartitionKey},
 };
 use crate::{
     http::{Auth, HttpClient, MaybeAuth},
     sinks::{
         prelude::*,
-        util::{RealtimeSizeBasedDefaultBatchSettings, UriSerde, http::HttpService},
+        util::{
+            RealtimeSizeBasedDefaultBatchSettings, UriSerde,
+            drain_shaping::{BufferUsageSource, DrainShapingConfig},
+            http::HttpService,
+        },
     },
 };
 
@@ -136,6 +140,17 @@ pub struct ClickhouseConfig {
     #[serde(default)]
     pub request: TowerRequestConfig,
 
+    /// Backlog-aware pacing for ClickHouse insert requests.
+    ///
+    /// When enabled, Vector caps original request submission from a backed-up disk buffer to
+    /// reduce recovery floods. This requires static `database` and `table` values, and a disk
+    /// buffer with `when_full` set to `block`; memory buffers are unsupported. Retries are not
+    /// debited by this cap, so use `request.adaptive_concurrency` and
+    /// `request.retry_max_duration_secs` to bound retry behavior.
+    #[configurable(derived)]
+    #[serde(default)]
+    pub drain_shaping: DrainShapingConfig,
+
     #[configurable(derived)]
     pub tls: Option<TlsConfig>,
 
@@ -239,11 +254,9 @@ impl SinkConfig for ClickhouseConfig {
 
         let batch_settings = self.batch.into_batcher_settings()?;
 
-        let database = self.database.clone().unwrap_or_else(|| {
-            "default"
-                .try_into()
-                .expect("'default' should be a valid template")
-        });
+        let database = self.database.clone().unwrap_or_else(default_database);
+        let static_partition_key = !database.is_dynamic() && !self.table.is_dynamic();
+        self.drain_shaping.validate(static_partition_key)?;
 
         // Resolve the encoding strategy (format + encoder) based on configuration
         let (format, encoder_kind) = self
@@ -254,6 +267,10 @@ impl SinkConfig for ClickhouseConfig {
             compression: self.compression,
             encoder: (self.encoding.clone(), encoder_kind),
         };
+        let source = cx
+            .buffer_usage_observer
+            .clone()
+            .map(|observer| Arc::new(observer) as Arc<dyn BufferUsageSource>);
 
         let sink = ClickhouseSink::new(
             batch_settings,
@@ -262,6 +279,7 @@ impl SinkConfig for ClickhouseConfig {
             self.table.clone(),
             format,
             request_builder,
+            DrainShapingInputs::new(source, self.drain_shaping),
         );
 
         let healthcheck = Box::pin(healthcheck(client, endpoint, auth));
@@ -275,6 +293,10 @@ impl SinkConfig for ClickhouseConfig {
 
     fn acknowledgements(&self) -> &AcknowledgementsConfig {
         &self.acknowledgements
+    }
+
+    fn requires_buffer_observation(&self) -> bool {
+        self.drain_shaping.enabled
     }
 }
 
@@ -388,6 +410,12 @@ impl ClickhouseConfig {
 
         Ok(())
     }
+}
+
+fn default_database() -> Template {
+    "default"
+        .try_into()
+        .expect("'default' should be a valid template")
 }
 
 fn get_healthcheck_uri(endpoint: &Uri) -> String {
@@ -538,5 +566,42 @@ mod tests {
                 "format should match configured value"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn drain_shaping_rejects_dynamic_table() {
+        let mut config = create_test_config(Format::JsonEachRow, None);
+        config.table = "{{ .table }}".try_into().unwrap();
+        config.drain_shaping.enabled = true;
+        config.drain_shaping.min_drain_bytes_per_sec = 1;
+
+        let error = match config.build(SinkContext::default()).await {
+            Ok(_) => panic!("build unexpectedly succeeded"),
+            Err(error) => error.to_string(),
+        };
+
+        assert!(
+            error.contains("static partition key"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn drain_shaping_accepts_static_table_with_default_database() {
+        let mut config = create_test_config(Format::JsonEachRow, None);
+        config.database = None;
+        config.drain_shaping.enabled = true;
+        config.drain_shaping.min_drain_bytes_per_sec = 1;
+
+        let (_sink, _healthcheck) = config.build(SinkContext::default()).await.unwrap();
+    }
+
+    #[test]
+    fn drain_shaping_controls_buffer_observation_requirement() {
+        let mut config = create_test_config(Format::JsonEachRow, None);
+        assert!(!config.requires_buffer_observation());
+
+        config.drain_shaping.enabled = true;
+        assert!(config.requires_buffer_observation());
     }
 }

--- a/src/sinks/clickhouse/integration_tests.rs
+++ b/src/sinks/clickhouse/integration_tests.rs
@@ -1,10 +1,12 @@
 use std::{
     convert::Infallible,
     net::SocketAddr,
+    num::NonZeroU64,
     sync::{
-        Arc,
-        atomic::{AtomicBool, Ordering},
+        Arc, Mutex,
+        atomic::{AtomicBool, AtomicUsize, Ordering},
     },
+    time::Instant as StdInstant,
 };
 
 use chrono::{TimeZone, Utc};
@@ -12,12 +14,13 @@ use futures::{
     future::{ok, ready},
     stream,
 };
-use http::StatusCode;
+use http::{Method, StatusCode};
 use ordered_float::NotNan;
 use serde::Deserialize;
 use serde_json::Value;
-use tokio::time::{Duration, timeout};
+use tokio::time::{Duration, sleep, timeout};
 use vector_lib::{
+    buffers::{BufferConfig, BufferType, WhenFull},
     codecs::encoding::ArrowStreamSerializerConfig,
     event::{BatchNotifier, BatchStatus, BatchStatusReceiver, Event, LogEvent},
     lookup::PathPrefix,
@@ -26,14 +29,17 @@ use warp::Filter;
 
 use crate::{
     codecs::{TimestampFormat, Transformer},
-    config::{SinkConfig, SinkContext, log_schema},
+    config::{SinkConfig, SinkContext, SinkOuter, log_schema, unit_test::UnitTestSourceConfig},
     sinks::{
         clickhouse::config::{ClickhouseBatchEncoding, ClickhouseConfig},
-        util::{BatchConfig, Compression, TowerRequestConfig},
+        util::{
+            BatchConfig, Compression, Concurrency, TowerRequestConfig,
+            drain_shaping::DrainShapingConfig, retries::JitterMode,
+        },
     },
     test_util::{
         components::{SINK_TAGS, init_test, run_and_assert_sink_compliance},
-        random_table_name, trace_init,
+        random_table_name, start_topology, trace_init,
     },
 };
 use vector_lib::metrics::Controller;
@@ -397,6 +403,235 @@ async fn templated_table() {
             "table \"{table}\"'s event should have been delivered"
         );
     }
+}
+
+#[tokio::test]
+async fn drain_shaping_bounds_recovery_request_rate() {
+    trace_init();
+
+    let table = random_table_name();
+    let host = clickhouse_address();
+    let client = ClickhouseClient::new(host.clone());
+    client
+        .create_table(&table, "host String, timestamp String, message String")
+        .await;
+
+    let proxy = start_clickhouse_recovery_proxy(host).await;
+    let event_count = 8;
+    let mut batch = BatchConfig::default();
+    batch.max_events = Some(1);
+
+    let clickhouse = ClickhouseConfig {
+        endpoint: proxy.endpoint.parse().unwrap(),
+        table: table.clone().try_into().unwrap(),
+        compression: Compression::None,
+        batch,
+        request: TowerRequestConfig {
+            concurrency: Concurrency::None,
+            retry_attempts: 10,
+            retry_initial_backoff_secs: NonZeroU64::new(1).unwrap(),
+            retry_jitter_mode: JitterMode::None,
+            ..Default::default()
+        },
+        drain_shaping: DrainShapingConfig {
+            enabled: true,
+            factor: 1.1,
+            min_drain_bytes_per_sec: 1_000_000,
+            max_requests_per_sec: Some(2.0),
+            ewma_alpha: 1.0,
+            sample_interval_secs: 0.1,
+            engage_min_bytes: 1,
+            burst_bytes: 0,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let data_dir = tempfile::tempdir().unwrap();
+    let mut topology_config = crate::config::Config::builder();
+    topology_config.set_data_dir(data_dir.path());
+    topology_config.add_source(
+        "in",
+        UnitTestSourceConfig {
+            events: (0..event_count).map(make_numbered_event).collect(),
+        },
+    );
+
+    let mut sink = SinkOuter::new(vec!["in".to_string()], clickhouse);
+    sink.buffer = BufferConfig::Single(BufferType::DiskV2 {
+        max_size: NonZeroU64::new(268_435_488).unwrap(),
+        when_full: WhenFull::Block,
+    });
+    topology_config.add_sink_outer("out", sink);
+
+    let (topology, _) = start_topology(topology_config.build().unwrap(), false).await;
+    proxy.wait_for_failed_insert().await;
+    sleep(Duration::from_millis(500)).await;
+
+    proxy.available();
+    wait_for_clickhouse_rows(&client, &table, event_count).await;
+    topology.stop().await;
+
+    let successful_inserts = proxy.successful_inserts();
+    assert_eq!(event_count, successful_inserts.len());
+    let insert_gaps = successful_inserts
+        .windows(2)
+        .map(|window| window[1].duration_since(window[0]))
+        .collect::<Vec<_>>();
+    let minimum_shaped_gap = Duration::from_millis(350);
+    let first_shaped_gap = insert_gaps
+        .iter()
+        .position(|gap| *gap >= minimum_shaped_gap)
+        .expect("expected recovery to eventually enter shaped drain mode");
+    let shaped_gaps = &insert_gaps[first_shaped_gap..];
+    assert!(
+        shaped_gaps.len() >= 3 && shaped_gaps.iter().all(|gap| *gap >= minimum_shaped_gap),
+        "expected recovered INSERTs to stay under the configured request cap after the initial retry/startup burst; gaps: {insert_gaps:?}; timestamps: {successful_inserts:?}"
+    );
+}
+
+struct ClickhouseRecoveryProxy {
+    endpoint: String,
+    unavailable: Arc<AtomicBool>,
+    failed_inserts: Arc<AtomicUsize>,
+    successful_inserts: Arc<Mutex<Vec<StdInstant>>>,
+    _port_guard: crate::test_util::addr::PortGuard,
+}
+
+impl ClickhouseRecoveryProxy {
+    fn available(&self) {
+        self.unavailable.store(false, Ordering::SeqCst);
+    }
+
+    async fn wait_for_failed_insert(&self) {
+        timeout(Duration::from_secs(10), async {
+            loop {
+                if self.failed_inserts.load(Ordering::SeqCst) > 0 {
+                    return;
+                }
+
+                sleep(Duration::from_millis(50)).await;
+            }
+        })
+        .await
+        .expect("timed out waiting for the sink to build a disk-buffered backlog");
+    }
+
+    fn successful_inserts(&self) -> Vec<StdInstant> {
+        self.successful_inserts.lock().unwrap().clone()
+    }
+}
+
+async fn start_clickhouse_recovery_proxy(upstream: String) -> ClickhouseRecoveryProxy {
+    let (port_guard, address) = crate::test_util::addr::next_addr();
+    let endpoint = format!("http://{address}");
+    let upstream = upstream.trim_end_matches('/').to_string();
+    let unavailable = Arc::new(AtomicBool::new(true));
+    let failed_inserts = Arc::new(AtomicUsize::new(0));
+    let successful_inserts = Arc::new(Mutex::new(Vec::new()));
+    let client = reqwest::Client::new();
+
+    let routes = warp::method()
+        .and(warp::path::full())
+        .and(warp::query::raw().or(warp::any().map(String::new)).unify())
+        .and(warp::body::bytes())
+        .and_then({
+            let unavailable = Arc::clone(&unavailable);
+            let failed_inserts = Arc::clone(&failed_inserts);
+            let successful_inserts = Arc::clone(&successful_inserts);
+            move |method: Method, path: warp::path::FullPath, query: String, body: bytes::Bytes| {
+                let client = client.clone();
+                let upstream = upstream.clone();
+                let unavailable = Arc::clone(&unavailable);
+                let failed_inserts = Arc::clone(&failed_inserts);
+                let successful_inserts = Arc::clone(&successful_inserts);
+                async move {
+                    let is_insert = query.contains("INSERT");
+                    if unavailable.load(Ordering::SeqCst) {
+                        if is_insert {
+                            failed_inserts.fetch_add(1, Ordering::SeqCst);
+                        }
+
+                        return Ok::<_, Infallible>(clickhouse_proxy_response(
+                            StatusCode::SERVICE_UNAVAILABLE,
+                            bytes::Bytes::from_static(b"unavailable"),
+                        ));
+                    }
+
+                    let mut target = format!("{}{}", upstream, path.as_str());
+                    if !query.is_empty() {
+                        target.push('?');
+                        target.push_str(&query);
+                    }
+
+                    let method = reqwest::Method::from_bytes(method.as_str().as_bytes()).unwrap();
+                    match client.request(method, target).body(body).send().await {
+                        Ok(response) => {
+                            let status = StatusCode::from_u16(response.status().as_u16())
+                                .expect("reqwest status code should be valid http status");
+                            let body = response
+                                .bytes()
+                                .await
+                                .unwrap_or_else(|_| bytes::Bytes::new());
+                            if is_insert && status.is_success() {
+                                successful_inserts.lock().unwrap().push(StdInstant::now());
+                            }
+
+                            Ok(clickhouse_proxy_response(status, body))
+                        }
+                        Err(error) => Ok(clickhouse_proxy_response(
+                            StatusCode::BAD_GATEWAY,
+                            bytes::Bytes::from(error.to_string()),
+                        )),
+                    }
+                }
+            }
+        });
+
+    tokio::spawn(warp::serve(routes).bind(address));
+    crate::test_util::wait_for_tcp(address).await;
+
+    ClickhouseRecoveryProxy {
+        endpoint,
+        unavailable,
+        failed_inserts,
+        successful_inserts,
+        _port_guard: port_guard,
+    }
+}
+
+fn clickhouse_proxy_response(
+    status: StatusCode,
+    body: impl Into<bytes::Bytes>,
+) -> warp::reply::Response {
+    let mut response = warp::reply::Response::new(hyper::Body::from(body.into()));
+    *response.status_mut() = status;
+    response
+}
+
+fn make_numbered_event(index: usize) -> Event {
+    let mut event = LogEvent::from(format!("raw log line {index}"));
+    event.insert("host", format!("example-{index}.com"));
+    event.into()
+}
+
+async fn wait_for_clickhouse_rows(client: &ClickhouseClient, table: &str, expected_rows: usize) {
+    timeout(Duration::from_secs(20), async {
+        loop {
+            let output = client.select_all(table).await;
+            assert!(
+                output.rows <= expected_rows,
+                "ClickHouse received more rows than Vector sent"
+            );
+            if output.rows == expected_rows {
+                return;
+            }
+
+            sleep(Duration::from_millis(100)).await;
+        }
+    })
+    .await
+    .expect("timed out waiting for ClickHouse rows to reconcile");
 }
 
 fn make_event() -> (Event, BatchStatusReceiver) {

--- a/src/sinks/clickhouse/sink.rs
+++ b/src/sinks/clickhouse/sink.rs
@@ -1,7 +1,15 @@
 //! Implementation of the `clickhouse` sink.
 
+use std::sync::Arc;
+
 use super::{config::Format, request_builder::ClickhouseRequestBuilder};
-use crate::sinks::{prelude::*, util::http::HttpRequest};
+use crate::sinks::{
+    prelude::*,
+    util::{
+        drain_shaping::{BufferUsageSource, DrainShapingConfig, DrainShapingExt},
+        http::HttpRequest,
+    },
+};
 
 pub struct ClickhouseSink<S> {
     batch_settings: BatcherSettings,
@@ -10,6 +18,22 @@ pub struct ClickhouseSink<S> {
     table: Template,
     format: Format,
     request_builder: ClickhouseRequestBuilder,
+    source: Option<Arc<dyn BufferUsageSource>>,
+    drain_shaping: DrainShapingConfig,
+}
+
+pub(super) struct DrainShapingInputs {
+    source: Option<Arc<dyn BufferUsageSource>>,
+    config: DrainShapingConfig,
+}
+
+impl DrainShapingInputs {
+    pub(super) fn new(
+        source: Option<Arc<dyn BufferUsageSource>>,
+        config: DrainShapingConfig,
+    ) -> Self {
+        Self { source, config }
+    }
 }
 
 impl<S> ClickhouseSink<S>
@@ -19,13 +43,14 @@ where
     S::Response: DriverResponse + Send + 'static,
     S::Error: std::fmt::Debug + Into<crate::Error> + Send,
 {
-    pub const fn new(
+    pub fn new(
         batch_settings: BatcherSettings,
         service: S,
         database: Template,
         table: Template,
         format: Format,
         request_builder: ClickhouseRequestBuilder,
+        drain_shaping: DrainShapingInputs,
     ) -> Self {
         Self {
             batch_settings,
@@ -34,11 +59,15 @@ where
             table,
             format,
             request_builder,
+            source: drain_shaping.source,
+            drain_shaping: drain_shaping.config,
         }
     }
 
     async fn run_inner(self: Box<Self>, input: BoxStream<'_, Event>) -> Result<(), ()> {
         let batch_settings = self.batch_settings;
+        let source = self.source;
+        let drain_shaping = self.drain_shaping;
 
         input
             .batched_partitioned(
@@ -47,6 +76,11 @@ where
                 |_| batch_settings.as_byte_size_config(),
             )
             .filter_map(|(key, batch)| async move { key.map(move |k| (k, batch)) })
+            .drain_shaping(
+                source,
+                drain_shaping,
+                |(_, events): &(PartitionKey, Vec<Event>)| events.size_of(),
+            )
             .request_builder(
                 default_request_builder_concurrency_limit(),
                 self.request_builder,
@@ -132,5 +166,67 @@ impl Partitioner for KeyPartitioner {
             table,
             format: self.format,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{num::NonZeroUsize, sync::Arc, time::Duration};
+
+    use super::*;
+    use crate::sinks::util::drain_shaping::{BufferUsageSource, DrainShapingConfig};
+
+    struct TestBufferUsageSource;
+
+    impl BufferUsageSource for TestBufferUsageSource {
+        fn received(&self) -> (u64, u64) {
+            (0, 0)
+        }
+
+        fn occupancy(&self) -> (u64, u64) {
+            (0, 0)
+        }
+
+        fn max_size(&self) -> (u64, u64) {
+            (0, 0)
+        }
+    }
+
+    #[test]
+    fn sink_stores_drain_shaping_source_and_config() {
+        let source: Arc<dyn BufferUsageSource> = Arc::new(TestBufferUsageSource);
+        let drain_shaping = DrainShapingConfig {
+            enabled: true,
+            min_drain_bytes_per_sec: 1,
+            ..Default::default()
+        };
+        let service = tower::service_fn(|_request: HttpRequest<PartitionKey>| async {
+            unreachable!("service is not called by this construction test")
+        });
+        let request_builder = ClickhouseRequestBuilder {
+            compression: Compression::None,
+            encoder: (
+                Transformer::default(),
+                vector_lib::codecs::EncoderKind::Framed(Box::default()),
+            ),
+        };
+
+        let sink = ClickhouseSink {
+            batch_settings: BatcherSettings::new(
+                Duration::from_secs(1),
+                NonZeroUsize::new(1).unwrap(),
+                NonZeroUsize::new(1).unwrap(),
+            ),
+            service,
+            database: "default".try_into().unwrap(),
+            table: "events".try_into().unwrap(),
+            format: Format::JsonEachRow,
+            request_builder,
+            source: Some(source),
+            drain_shaping,
+        };
+
+        assert!(sink.source.is_some());
+        assert!(sink.drain_shaping.enabled);
     }
 }

--- a/src/sinks/util/drain_shaping.rs
+++ b/src/sinks/util/drain_shaping.rs
@@ -1,0 +1,836 @@
+use std::{
+    collections::VecDeque,
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll, ready},
+    time::Duration,
+};
+
+use futures_util::Stream;
+use pin_project::pin_project;
+use tokio::time::{Instant, Sleep, sleep};
+use vector_lib::{buffers::BufferUsageObserver, configurable::configurable_component};
+
+const MIN_SLEEP: Duration = Duration::from_millis(1);
+
+/// Read-only buffer usage source for drain shaping.
+pub trait BufferUsageSource: Send + Sync {
+    /// Gets cumulative ingress volume as `(events, bytes)`.
+    fn received(&self) -> (u64, u64);
+
+    /// Gets current buffer occupancy as `(events, bytes)`.
+    fn occupancy(&self) -> (u64, u64);
+
+    /// Gets configured maximum buffer size as `(events, bytes)`.
+    fn max_size(&self) -> (u64, u64);
+}
+
+impl BufferUsageSource for BufferUsageObserver {
+    fn received(&self) -> (u64, u64) {
+        self.received()
+    }
+
+    fn occupancy(&self) -> (u64, u64) {
+        self.occupancy()
+    }
+
+    fn max_size(&self) -> (u64, u64) {
+        self.max_size()
+    }
+}
+
+/// Backlog-aware output pacing.
+///
+/// When enabled, Vector estimates the byte rate entering the sink buffer and caps original
+/// output submissions to `max(estimated_input_rate * factor, min_drain_bytes_per_sec)` after
+/// enough buffered bytes accumulate.
+#[configurable_component]
+#[derive(Clone, Copy, Debug)]
+#[serde(default, deny_unknown_fields)]
+pub struct DrainShapingConfig {
+    /// Enables backlog-aware output pacing.
+    pub enabled: bool,
+
+    /// Multiplier applied to the estimated input byte rate while the buffer has a backlog.
+    pub factor: f64,
+
+    /// Minimum drain budget in bytes per second while pacing is active.
+    ///
+    /// Set this above the expected sustained input rate to ensure a full disk buffer can drain
+    /// after restart, when no recent input-rate history exists.
+    #[configurable(metadata(docs::type_unit = "bytes"))]
+    pub min_drain_bytes_per_sec: u64,
+
+    /// Optional maximum number of original requests submitted per second.
+    ///
+    /// This caps submissions before request retries. It does not debit retry attempts made by
+    /// the request service.
+    pub max_requests_per_sec: Option<f64>,
+
+    /// Exponential moving average alpha used for input byte-rate estimation.
+    pub ewma_alpha: f64,
+
+    /// Buffer usage sample interval in seconds.
+    pub sample_interval_secs: f64,
+
+    /// Minimum buffered bytes before pacing engages.
+    ///
+    /// Below this absolute backlog threshold, the sink submits requests without delay.
+    #[configurable(metadata(docs::type_unit = "bytes"))]
+    pub engage_min_bytes: u64,
+
+    /// Buffer fill ratio above which input-rate estimation freezes.
+    ///
+    /// Freezing prevents a full `when_full = "block"` buffer from coupling the observed input
+    /// rate to the shaped output rate.
+    pub saturation_high_mark: f64,
+
+    /// Buffer fill ratio below which frozen input-rate estimation resumes.
+    pub saturation_low_mark: f64,
+
+    /// Recent input-rate window, in seconds, used to seed the frozen estimate.
+    pub freeze_window_secs: f64,
+
+    /// Additional byte burst budget allowed above steady-state pacing.
+    #[configurable(metadata(docs::type_unit = "bytes"))]
+    pub burst_bytes: u64,
+}
+
+impl Default for DrainShapingConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            factor: 1.1,
+            min_drain_bytes_per_sec: 0,
+            max_requests_per_sec: None,
+            ewma_alpha: 0.1,
+            sample_interval_secs: 0.5,
+            engage_min_bytes: 1_048_576,
+            saturation_high_mark: 0.9,
+            saturation_low_mark: 0.75,
+            freeze_window_secs: 30.0,
+            burst_bytes: 0,
+        }
+    }
+}
+
+impl DrainShapingConfig {
+    /// Validates drain shaping settings.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when enabled settings cannot guarantee bounded, lossless pacing.
+    pub fn validate(&self, static_partition_key: bool) -> crate::Result<()> {
+        if !self.enabled {
+            return Ok(());
+        }
+
+        if !static_partition_key {
+            return Err("drain_shaping requires a static partition key".into());
+        }
+
+        if !self.factor.is_finite() || self.factor < 1.0 {
+            return Err("drain_shaping.factor must be finite and >= 1".into());
+        }
+
+        if self.min_drain_bytes_per_sec == 0 {
+            return Err("drain_shaping.min_drain_bytes_per_sec must be greater than 0".into());
+        }
+
+        if !self.ewma_alpha.is_finite() || self.ewma_alpha <= 0.0 || self.ewma_alpha > 1.0 {
+            return Err("drain_shaping.ewma_alpha must be finite and in (0, 1]".into());
+        }
+
+        if !self.sample_interval_secs.is_finite() || self.sample_interval_secs <= 0.0 {
+            return Err("drain_shaping.sample_interval_secs must be finite and > 0".into());
+        }
+
+        if !self.freeze_window_secs.is_finite() || self.freeze_window_secs <= 0.0 {
+            return Err("drain_shaping.freeze_window_secs must be finite and > 0".into());
+        }
+
+        if !self.saturation_low_mark.is_finite()
+            || !self.saturation_high_mark.is_finite()
+            || self.saturation_low_mark < 0.0
+            || self.saturation_low_mark >= self.saturation_high_mark
+            || self.saturation_high_mark > 1.0
+        {
+            return Err("drain_shaping saturation marks must satisfy 0 <= low < high <= 1".into());
+        }
+
+        if let Some(max_requests_per_sec) = self.max_requests_per_sec
+            && (!max_requests_per_sec.is_finite() || max_requests_per_sec <= 0.0)
+        {
+            return Err("drain_shaping.max_requests_per_sec must be finite and > 0".into());
+        }
+
+        Ok(())
+    }
+}
+
+/// Stream adapter that paces sink output based on observed buffer ingress and occupancy.
+#[pin_project]
+pub struct DrainShaper<S, F>
+where
+    S: Stream,
+{
+    #[pin]
+    inner: S,
+    size_of: F,
+    source: Option<Arc<dyn BufferUsageSource>>,
+    config: DrainShapingConfig,
+    pending: Option<S::Item>,
+    last_received_bytes: u64,
+    last_sample: Instant,
+    input_ewma: f64,
+    frozen: bool,
+    freeze_anchor: f64,
+    recent: VecDeque<(Instant, f64)>,
+    byte_tokens: f64,
+    request_tokens: f64,
+    last_refill: Instant,
+    #[pin]
+    delay: Option<Sleep>,
+}
+
+impl<S, F> DrainShaper<S, F>
+where
+    S: Stream,
+{
+    /// Creates a drain-shaping stream adapter.
+    pub fn new(
+        inner: S,
+        source: Option<Arc<dyn BufferUsageSource>>,
+        config: DrainShapingConfig,
+        size_of: F,
+    ) -> Self {
+        let now = Instant::now();
+        let last_received_bytes = source
+            .as_ref()
+            .map(|source| source.received().1)
+            .unwrap_or_default();
+
+        Self {
+            inner,
+            size_of,
+            source,
+            config,
+            pending: None,
+            last_received_bytes,
+            last_sample: now,
+            input_ewma: 0.0,
+            frozen: false,
+            freeze_anchor: 0.0,
+            recent: VecDeque::new(),
+            byte_tokens: config.burst_bytes as f64,
+            request_tokens: if config.max_requests_per_sec.is_some() {
+                1.0
+            } else {
+                0.0
+            },
+            last_refill: now,
+            delay: None,
+        }
+    }
+}
+
+impl<S, F> Stream for DrainShaper<S, F>
+where
+    S: Stream,
+    F: Fn(&S::Item) -> usize,
+{
+    type Item = S::Item;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let mut this = self.project();
+
+        if !this.config.enabled || this.source.is_none() {
+            return this.inner.poll_next(cx);
+        }
+
+        let source = Arc::clone(this.source.as_ref().expect("source checked above"));
+
+        loop {
+            if this.pending.is_none() {
+                match ready!(this.inner.as_mut().poll_next(cx)) {
+                    Some(item) => *this.pending = Some(item),
+                    None => return Poll::Ready(None),
+                }
+            }
+
+            if let Some(delay) = this.delay.as_mut().as_pin_mut() {
+                ready!(delay.poll(cx));
+                this.delay.set(None);
+            }
+
+            let now = Instant::now();
+            update_estimator(
+                *this.config,
+                &*source,
+                EstimatorState {
+                    last_received_bytes: this.last_received_bytes,
+                    last_sample: this.last_sample,
+                    input_ewma: this.input_ewma,
+                    frozen: this.frozen,
+                    freeze_anchor: this.freeze_anchor,
+                    recent: this.recent,
+                },
+                now,
+            );
+
+            if source.occupancy().1 < this.config.engage_min_bytes {
+                return Poll::Ready(this.pending.take());
+            }
+
+            let rate = effective_rate(
+                *this.config,
+                *this.input_ewma,
+                *this.frozen,
+                *this.freeze_anchor,
+            );
+            refill(
+                *this.config,
+                this.byte_tokens,
+                this.request_tokens,
+                this.last_refill,
+                rate,
+                now,
+            );
+
+            if *this.byte_tokens >= 0.0 && request_ok(*this.config, *this.request_tokens) {
+                let item = this.pending.take().expect("pending item checked above");
+                *this.byte_tokens -= (this.size_of)(&item) as f64;
+                debit_request(*this.config, this.request_tokens);
+                return Poll::Ready(Some(item));
+            }
+
+            this.delay.set(Some(sleep(time_until_emittable(
+                *this.config,
+                *this.byte_tokens,
+                *this.request_tokens,
+                rate,
+            ))));
+        }
+    }
+}
+
+/// Extension trait for applying drain shaping to streams.
+pub trait DrainShapingExt: Stream + Sized {
+    /// Wraps the stream in a [`DrainShaper`].
+    fn drain_shaping<F>(
+        self,
+        source: Option<Arc<dyn BufferUsageSource>>,
+        config: DrainShapingConfig,
+        size_of: F,
+    ) -> DrainShaper<Self, F>
+    where
+        F: Fn(&Self::Item) -> usize,
+    {
+        DrainShaper::new(self, source, config, size_of)
+    }
+}
+
+impl<S> DrainShapingExt for S where S: Stream + Sized {}
+
+struct EstimatorState<'a> {
+    last_received_bytes: &'a mut u64,
+    last_sample: &'a mut Instant,
+    input_ewma: &'a mut f64,
+    frozen: &'a mut bool,
+    freeze_anchor: &'a mut f64,
+    recent: &'a mut VecDeque<(Instant, f64)>,
+}
+
+fn update_estimator(
+    config: DrainShapingConfig,
+    source: &dyn BufferUsageSource,
+    state: EstimatorState<'_>,
+    now: Instant,
+) {
+    let elapsed = now.duration_since(*state.last_sample);
+    if elapsed < Duration::from_secs_f64(config.sample_interval_secs) {
+        return;
+    }
+
+    let received_bytes = source.received().1;
+    let rate =
+        received_bytes.saturating_sub(*state.last_received_bytes) as f64 / elapsed.as_secs_f64();
+    *state.last_received_bytes = received_bytes;
+    *state.last_sample = now;
+
+    trim_recent(
+        state.recent,
+        now,
+        Duration::from_secs_f64(config.freeze_window_secs),
+    );
+
+    let was_frozen = *state.frozen;
+    let fill_ratio = fill_ratio(source);
+    if *state.frozen {
+        if fill_ratio < config.saturation_low_mark {
+            *state.frozen = false;
+        }
+    } else if fill_ratio >= config.saturation_high_mark {
+        *state.frozen = true;
+        *state.freeze_anchor = recent_window_max(state.recent, *state.input_ewma);
+    }
+
+    if *state.frozen {
+        return;
+    }
+
+    if was_frozen {
+        *state.input_ewma = rate;
+    } else {
+        *state.input_ewma =
+            (config.ewma_alpha * rate) + ((1.0 - config.ewma_alpha) * *state.input_ewma);
+    }
+    state.recent.push_back((now, rate));
+}
+
+fn fill_ratio(source: &dyn BufferUsageSource) -> f64 {
+    let max_bytes = source.max_size().1;
+    if max_bytes == 0 {
+        return 0.0;
+    }
+
+    source.occupancy().1 as f64 / max_bytes as f64
+}
+
+fn trim_recent(recent: &mut VecDeque<(Instant, f64)>, now: Instant, window: Duration) {
+    while let Some((sampled_at, _)) = recent.front() {
+        if now.duration_since(*sampled_at) <= window {
+            break;
+        }
+
+        recent.pop_front();
+    }
+}
+
+fn recent_window_max(recent: &VecDeque<(Instant, f64)>, input_ewma: f64) -> f64 {
+    recent
+        .iter()
+        .map(|(_, rate)| *rate)
+        .fold(input_ewma, f64::max)
+}
+
+fn effective_rate(
+    config: DrainShapingConfig,
+    input_ewma: f64,
+    frozen: bool,
+    freeze_anchor: f64,
+) -> f64 {
+    let estimate = if frozen { freeze_anchor } else { input_ewma };
+    (estimate * config.factor).max(config.min_drain_bytes_per_sec as f64)
+}
+
+fn refill(
+    config: DrainShapingConfig,
+    byte_tokens: &mut f64,
+    request_tokens: &mut f64,
+    last_refill: &mut Instant,
+    rate: f64,
+    now: Instant,
+) {
+    let elapsed = now.duration_since(*last_refill).as_secs_f64();
+    if elapsed == 0.0 {
+        return;
+    }
+
+    *byte_tokens = (*byte_tokens + (rate * elapsed)).min(config.burst_bytes as f64);
+    if let Some(max_requests_per_sec) = config.max_requests_per_sec {
+        *request_tokens = (*request_tokens + (max_requests_per_sec * elapsed)).min(1.0);
+    }
+    *last_refill = now;
+}
+
+fn request_ok(config: DrainShapingConfig, request_tokens: f64) -> bool {
+    match config.max_requests_per_sec {
+        Some(_) => request_tokens >= 1.0,
+        None => true,
+    }
+}
+
+fn debit_request(config: DrainShapingConfig, request_tokens: &mut f64) {
+    if config.max_requests_per_sec.is_some() {
+        *request_tokens -= 1.0;
+    }
+}
+
+fn time_until_emittable(
+    config: DrainShapingConfig,
+    byte_tokens: f64,
+    request_tokens: f64,
+    rate: f64,
+) -> Duration {
+    let byte_wait = if byte_tokens < 0.0 {
+        (-byte_tokens) / rate.max(f64::MIN_POSITIVE)
+    } else {
+        0.0
+    };
+    let request_wait = match config.max_requests_per_sec {
+        Some(max_requests_per_sec) if request_tokens < 1.0 => {
+            (1.0 - request_tokens) / max_requests_per_sec
+        }
+        _ => 0.0,
+    };
+
+    Duration::from_secs_f64(byte_wait.max(request_wait)).max(MIN_SLEEP)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        sync::{
+            Arc,
+            atomic::{AtomicU64, Ordering::Relaxed},
+        },
+        task::Poll,
+        time::Duration,
+    };
+
+    use futures::{StreamExt, stream};
+    use tokio::time::{self, Instant};
+    use vector_lib::buffers::BufferUsageObserver;
+
+    use super::{BufferUsageSource, DrainShapingConfig, DrainShapingExt};
+
+    #[derive(Debug)]
+    struct TestBufferUsageSource {
+        received_bytes: AtomicU64,
+        occupancy_bytes: AtomicU64,
+        max_bytes: AtomicU64,
+    }
+
+    impl TestBufferUsageSource {
+        fn new(max_bytes: u64) -> Arc<Self> {
+            Arc::new(Self {
+                received_bytes: AtomicU64::new(0),
+                occupancy_bytes: AtomicU64::new(0),
+                max_bytes: AtomicU64::new(max_bytes),
+            })
+        }
+
+        fn set_received_bytes(&self, bytes: u64) {
+            self.received_bytes.store(bytes, Relaxed);
+        }
+
+        fn set_occupancy_bytes(&self, bytes: u64) {
+            self.occupancy_bytes.store(bytes, Relaxed);
+        }
+    }
+
+    impl BufferUsageSource for TestBufferUsageSource {
+        fn received(&self) -> (u64, u64) {
+            (0, self.received_bytes.load(Relaxed))
+        }
+
+        fn occupancy(&self) -> (u64, u64) {
+            (0, self.occupancy_bytes.load(Relaxed))
+        }
+
+        fn max_size(&self) -> (u64, u64) {
+            (0, self.max_bytes.load(Relaxed))
+        }
+    }
+
+    fn valid_enabled_config() -> DrainShapingConfig {
+        DrainShapingConfig {
+            enabled: true,
+            factor: 1.1,
+            min_drain_bytes_per_sec: 1024,
+            max_requests_per_sec: None,
+            ewma_alpha: 0.1,
+            sample_interval_secs: 0.5,
+            engage_min_bytes: 1,
+            saturation_high_mark: 0.9,
+            saturation_low_mark: 0.75,
+            freeze_window_secs: 30.0,
+            burst_bytes: 0,
+        }
+    }
+
+    fn stream_enabled_config() -> DrainShapingConfig {
+        DrainShapingConfig {
+            enabled: true,
+            factor: 1.0,
+            min_drain_bytes_per_sec: 1,
+            max_requests_per_sec: None,
+            ewma_alpha: 1.0,
+            sample_interval_secs: 1.0,
+            engage_min_bytes: 1,
+            saturation_high_mark: 0.9,
+            saturation_low_mark: 0.75,
+            freeze_window_secs: 10.0,
+            burst_bytes: 0,
+        }
+    }
+
+    fn shaped_source(source: &Arc<TestBufferUsageSource>) -> Arc<dyn BufferUsageSource> {
+        let cloned_source: Arc<TestBufferUsageSource> = Arc::clone(source);
+        cloned_source
+    }
+
+    fn assert_invalid(config: DrainShapingConfig, expected: &str) {
+        let error = config.validate(true).unwrap_err().to_string();
+        assert!(
+            error.contains(expected),
+            "expected {error:?} to contain {expected:?}"
+        );
+    }
+
+    #[test]
+    fn buffer_usage_observer_implements_buffer_usage_source() {
+        fn assert_source<T: BufferUsageSource>() {}
+
+        assert_source::<BufferUsageObserver>();
+    }
+
+    #[test]
+    fn disabled_config_is_valid_noop() {
+        assert!(DrainShapingConfig::default().validate(false).is_ok());
+    }
+
+    #[test]
+    fn enabled_config_accepts_valid_static_partition_key() {
+        valid_enabled_config().validate(true).unwrap();
+    }
+
+    #[test]
+    fn enabled_config_rejects_dynamic_partition_key() {
+        let error = valid_enabled_config()
+            .validate(false)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("static partition key"));
+    }
+
+    #[test]
+    fn enabled_config_rejects_invalid_factor() {
+        let mut config = valid_enabled_config();
+        config.factor = 0.99;
+        assert_invalid(config, "factor");
+
+        let mut config = valid_enabled_config();
+        config.factor = f64::INFINITY;
+        assert_invalid(config, "factor");
+
+        let mut config = valid_enabled_config();
+        config.factor = f64::NAN;
+        assert_invalid(config, "factor");
+    }
+
+    #[test]
+    fn enabled_config_rejects_invalid_floor() {
+        let mut config = valid_enabled_config();
+        config.min_drain_bytes_per_sec = 0;
+        assert_invalid(config, "min_drain_bytes_per_sec");
+    }
+
+    #[test]
+    fn enabled_config_rejects_invalid_ewma_alpha() {
+        let mut config = valid_enabled_config();
+        config.ewma_alpha = 0.0;
+        assert_invalid(config, "ewma_alpha");
+
+        let mut config = valid_enabled_config();
+        config.ewma_alpha = 1.01;
+        assert_invalid(config, "ewma_alpha");
+
+        let mut config = valid_enabled_config();
+        config.ewma_alpha = f64::NAN;
+        assert_invalid(config, "ewma_alpha");
+    }
+
+    #[test]
+    fn enabled_config_rejects_invalid_sample_interval() {
+        let mut config = valid_enabled_config();
+        config.sample_interval_secs = 0.0;
+        assert_invalid(config, "sample_interval_secs");
+
+        let mut config = valid_enabled_config();
+        config.sample_interval_secs = f64::INFINITY;
+        assert_invalid(config, "sample_interval_secs");
+    }
+
+    #[test]
+    fn enabled_config_rejects_invalid_freeze_window() {
+        let mut config = valid_enabled_config();
+        config.freeze_window_secs = 0.0;
+        assert_invalid(config, "freeze_window_secs");
+
+        let mut config = valid_enabled_config();
+        config.freeze_window_secs = f64::INFINITY;
+        assert_invalid(config, "freeze_window_secs");
+    }
+
+    #[test]
+    fn enabled_config_rejects_invalid_saturation_marks() {
+        let mut config = valid_enabled_config();
+        config.saturation_low_mark = -0.1;
+        assert_invalid(config, "saturation");
+
+        let mut config = valid_enabled_config();
+        config.saturation_low_mark = 0.9;
+        config.saturation_high_mark = 0.9;
+        assert_invalid(config, "saturation");
+
+        let mut config = valid_enabled_config();
+        config.saturation_high_mark = 1.01;
+        assert_invalid(config, "saturation");
+    }
+
+    #[test]
+    fn enabled_config_rejects_invalid_request_cap() {
+        let mut config = valid_enabled_config();
+        config.max_requests_per_sec = Some(0.0);
+        assert_invalid(config, "max_requests_per_sec");
+
+        let mut config = valid_enabled_config();
+        config.max_requests_per_sec = Some(f64::NAN);
+        assert_invalid(config, "max_requests_per_sec");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn disabled_passthrough_no_delay() {
+        let source = TestBufferUsageSource::new(1_000);
+        source.set_occupancy_bytes(900);
+        let config = DrainShapingConfig {
+            enabled: false,
+            ..stream_enabled_config()
+        };
+        let start = Instant::now();
+        let mut shaped = Box::pin(stream::iter([10, 20, 30]).drain_shaping(
+            Some(shaped_source(&source)),
+            config,
+            |item| *item as usize,
+        ));
+
+        assert_eq!(shaped.next().await, Some(10));
+        assert_eq!(shaped.next().await, Some(20));
+        assert_eq!(shaped.next().await, Some(30));
+        assert_eq!(shaped.next().await, None);
+        assert_eq!(Instant::now(), start);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn eof_not_delayed_by_debt() {
+        let source = TestBufferUsageSource::new(10_000);
+        source.set_occupancy_bytes(5_000);
+        let mut shaped = Box::pin(stream::iter([1_000]).drain_shaping(
+            Some(shaped_source(&source)),
+            stream_enabled_config(),
+            |item| *item as usize,
+        ));
+        let start = Instant::now();
+
+        assert_eq!(shaped.next().await, Some(1_000));
+        assert_eq!(shaped.next().await, None);
+        assert_eq!(Instant::now(), start);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn caps_rate_to_input_times_factor_under_backlog() {
+        let source = TestBufferUsageSource::new(10_000);
+        source.set_occupancy_bytes(5_000);
+        let config = DrainShapingConfig {
+            factor: 2.0,
+            ..stream_enabled_config()
+        };
+        let mut shaped = Box::pin(stream::iter([100, 100, 100]).drain_shaping(
+            Some(shaped_source(&source)),
+            config,
+            |item| *item as usize,
+        ));
+        let start = Instant::now();
+
+        assert_eq!(shaped.next().await, Some(100));
+        source.set_received_bytes(100);
+        time::advance(Duration::from_secs(1)).await;
+        assert_eq!(shaped.next().await, Some(100));
+
+        let mut third = shaped.next();
+        assert_eq!(futures::poll!(&mut third), Poll::Pending);
+        time::advance(Duration::from_millis(499)).await;
+        assert_eq!(futures::poll!(&mut third), Poll::Pending);
+        time::advance(Duration::from_millis(1)).await;
+        assert_eq!(futures::poll!(&mut third), Poll::Ready(Some(100)));
+        assert_eq!(Instant::now() - start, Duration::from_millis(1500));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn engage_passthrough_below_threshold() {
+        let source = TestBufferUsageSource::new(10_000);
+        source.set_occupancy_bytes(999);
+        let config = DrainShapingConfig {
+            engage_min_bytes: 1_000,
+            ..stream_enabled_config()
+        };
+        let start = Instant::now();
+        let mut shaped = Box::pin(stream::iter([500, 500]).drain_shaping(
+            Some(shaped_source(&source)),
+            config,
+            |item| *item as usize,
+        ));
+
+        assert_eq!(shaped.next().await, Some(500));
+        assert_eq!(shaped.next().await, Some(500));
+        assert_eq!(shaped.next().await, None);
+        assert_eq!(Instant::now(), start);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn freeze_prevents_runaway_when_saturated() {
+        let source = TestBufferUsageSource::new(1_000);
+        source.set_occupancy_bytes(800);
+        let mut shaped = Box::pin(
+            stream::iter([100, 100, 100, 100, 100, 100, 100, 100]).drain_shaping(
+                Some(shaped_source(&source)),
+                stream_enabled_config(),
+                |item| *item as usize,
+            ),
+        );
+
+        assert_eq!(shaped.next().await, Some(100));
+        source.set_received_bytes(100);
+        time::advance(Duration::from_secs(1)).await;
+        assert_eq!(shaped.next().await, Some(100));
+
+        source.set_occupancy_bytes(950);
+        source.set_received_bytes(10_100);
+        time::advance(Duration::from_secs(1)).await;
+        assert_eq!(shaped.next().await, Some(100));
+
+        let mut fourth = shaped.next();
+        assert_eq!(futures::poll!(&mut fourth), Poll::Pending);
+        time::advance(Duration::from_millis(999)).await;
+        assert_eq!(futures::poll!(&mut fourth), Poll::Pending);
+        time::advance(Duration::from_millis(1)).await;
+        assert_eq!(futures::poll!(&mut fourth), Poll::Ready(Some(100)));
+
+        source.set_occupancy_bytes(800);
+        source.set_received_bytes(20_100);
+        time::advance(Duration::from_secs(1)).await;
+        assert_eq!(shaped.next().await, Some(100));
+
+        let mut sixth = shaped.next();
+        assert_eq!(futures::poll!(&mut sixth), Poll::Pending);
+        time::advance(Duration::from_millis(999)).await;
+        assert_eq!(futures::poll!(&mut sixth), Poll::Pending);
+        time::advance(Duration::from_millis(1)).await;
+        assert_eq!(futures::poll!(&mut sixth), Poll::Ready(Some(100)));
+
+        source.set_occupancy_bytes(700);
+        source.set_received_bytes(30_100);
+        time::advance(Duration::from_secs(1)).await;
+        assert_eq!(shaped.next().await, Some(100));
+
+        let mut eighth = shaped.next();
+        assert_eq!(futures::poll!(&mut eighth), Poll::Pending);
+        time::advance(Duration::from_millis(9)).await;
+        assert_eq!(futures::poll!(&mut eighth), Poll::Pending);
+        time::advance(Duration::from_millis(1)).await;
+        assert_eq!(futures::poll!(&mut eighth), Poll::Ready(Some(100)));
+    }
+}

--- a/src/sinks/util/drain_shaping.rs
+++ b/src/sinks/util/drain_shaping.rs
@@ -279,7 +279,20 @@ where
                 now,
             );
 
-            if source.occupancy().1 < this.config.engage_min_bytes {
+            // Base the engagement decision on the backlog when the batch was formed, not after
+            // `inner.poll_next` already pulled it out of the buffer. A single large or final batch
+            // can drop the observed occupancy below `engage_min_bytes` as it is read, and that
+            // batch must still be paced rather than bypassed, so add the pending batch back.
+            let pending_bytes = this
+                .pending
+                .as_ref()
+                .map_or(0, |item| (this.size_of)(item) as u64);
+            if source
+                .occupancy()
+                .1
+                .saturating_add(pending_bytes)
+                < this.config.engage_min_bytes
+            {
                 return Poll::Ready(this.pending.take());
             }
 
@@ -778,7 +791,9 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn engage_passthrough_below_threshold() {
         let source = TestBufferUsageSource::new(10_000);
-        source.set_occupancy_bytes(999);
+        // Occupancy plus the pending batch (400 + 500) stays below engage_min_bytes, so pacing
+        // does not engage and both items pass through without delay.
+        source.set_occupancy_bytes(400);
         let config = DrainShapingConfig {
             engage_min_bytes: 1_000,
             ..stream_enabled_config()
@@ -896,5 +911,30 @@ mod tests {
             effective_rate(config, input_ewma, frozen, freeze_anchor),
             20_000.0,
         );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn engages_when_drained_batch_was_backlogged() {
+        // `inner.poll_next` pulls the batch out of the buffer before the engagement check runs, so
+        // a large or final batch can leave the observed occupancy at 0 even though the backlog was
+        // present when the request was formed. Adding the pending batch back keeps it paced.
+        let source = TestBufferUsageSource::new(10_000);
+        source.set_occupancy_bytes(0);
+        let config = DrainShapingConfig {
+            engage_min_bytes: 1_000,
+            ..stream_enabled_config()
+        };
+        let mut shaped = Box::pin(stream::iter([5_000, 5_000]).drain_shaping(
+            Some(shaped_source(&source)),
+            config,
+            |item| *item as usize,
+        ));
+
+        // First batch: occupancy(0) + pending(5_000) >= engage_min_bytes, so pacing engages. With
+        // burst 0 it still emits once on debt but exhausts the byte budget.
+        assert_eq!(shaped.next().await, Some(5_000));
+        // The second batch must wait rather than bypass, since the backlog was paced.
+        let mut second = shaped.next();
+        assert_eq!(futures::poll!(&mut second), Poll::Pending);
     }
 }

--- a/src/sinks/util/drain_shaping.rs
+++ b/src/sinks/util/drain_shaping.rs
@@ -373,7 +373,19 @@ fn update_estimator(
         }
     } else if fill_ratio >= config.saturation_high_mark {
         *state.frozen = true;
-        *state.freeze_anchor = recent_window_max(state.recent, *state.input_ewma);
+        // With no pre-saturation history (e.g. restart on top of an already-full
+        // buffer) `recent` is empty and `input_ewma` is still 0, so anchoring on those
+        // alone collapses the cap to `min_drain_bytes_per_sec` and discards the rate we
+        // just measured. Seed with that rate only in this case. During a normal
+        // saturation `recent` already holds pre-saturation samples and deliberately
+        // excludes the inflated, drain-coupled current sample, which we keep doing to
+        // avoid runaway.
+        let seed = if state.recent.is_empty() {
+            (*state.input_ewma).max(rate)
+        } else {
+            *state.input_ewma
+        };
+        *state.freeze_anchor = recent_window_max(state.recent, seed);
     }
 
     if *state.frozen {
@@ -482,6 +494,7 @@ fn time_until_emittable(
 #[cfg(test)]
 mod tests {
     use std::{
+        collections::VecDeque,
         sync::{
             Arc,
             atomic::{AtomicU64, Ordering::Relaxed},
@@ -494,7 +507,10 @@ mod tests {
     use tokio::time::{self, Instant};
     use vector_lib::buffers::BufferUsageObserver;
 
-    use super::{BufferUsageSource, DrainShapingConfig, DrainShapingExt};
+    use super::{
+        BufferUsageSource, DrainShapingConfig, DrainShapingExt, EstimatorState, effective_rate,
+        update_estimator,
+    };
 
     #[derive(Debug)]
     struct TestBufferUsageSource {
@@ -832,5 +848,53 @@ mod tests {
         assert_eq!(futures::poll!(&mut eighth), Poll::Pending);
         time::advance(Duration::from_millis(1)).await;
         assert_eq!(futures::poll!(&mut eighth), Poll::Ready(Some(100)));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn freeze_anchor_uses_measured_rate_when_history_empty() {
+        // Restart with an already-saturated disk buffer: no pre-saturation recent
+        // history and `input_ewma` still 0. The first sample both measures the input
+        // rate and trips the freeze on the same call. The frozen anchor must reflect
+        // that just-measured rate; collapsing to 0 would throttle recovery down to
+        // `min_drain_bytes_per_sec` until the buffer fell below the low mark.
+        let source = TestBufferUsageSource::new(1_000);
+        source.set_occupancy_bytes(950); // >= saturation_high_mark from the start
+        source.set_received_bytes(10_000);
+
+        let config = DrainShapingConfig {
+            factor: 2.0,
+            ..stream_enabled_config()
+        };
+
+        let start = Instant::now();
+        let mut last_received_bytes = 0;
+        let mut last_sample = start;
+        let mut input_ewma = 0.0;
+        let mut frozen = false;
+        let mut freeze_anchor = 0.0;
+        let mut recent = VecDeque::new();
+
+        time::advance(Duration::from_secs(1)).await;
+        let source_dyn = shaped_source(&source);
+        update_estimator(
+            config,
+            &*source_dyn,
+            EstimatorState {
+                last_received_bytes: &mut last_received_bytes,
+                last_sample: &mut last_sample,
+                input_ewma: &mut input_ewma,
+                frozen: &mut frozen,
+                freeze_anchor: &mut freeze_anchor,
+                recent: &mut recent,
+            },
+            Instant::now(),
+        );
+
+        assert!(frozen);
+        assert_eq!(freeze_anchor, 10_000.0);
+        assert_eq!(
+            effective_rate(config, input_ewma, frozen, freeze_anchor),
+            20_000.0,
+        );
     }
 }

--- a/src/sinks/util/mod.rs
+++ b/src/sinks/util/mod.rs
@@ -7,6 +7,7 @@ pub mod buffer;
 pub mod builder;
 pub mod compressor;
 pub mod datagram;
+pub mod drain_shaping;
 pub mod encoding;
 pub mod http;
 pub mod metadata;

--- a/src/test_util/mock/sinks/basic.rs
+++ b/src/test_util/mock/sinks/basic.rs
@@ -1,8 +1,11 @@
+use std::sync::{Arc, Mutex};
+
 use async_trait::async_trait;
 use futures_util::{FutureExt, StreamExt, stream::BoxStream};
 use snafu::Snafu;
 use tokio::sync::oneshot;
 use vector_lib::{
+    buffers::BufferUsageObserver,
     config::{AcknowledgementsConfig, Input},
     configurable::configurable_component,
     event::Event,
@@ -28,6 +31,12 @@ pub struct BasicSinkConfig {
 
     /// Dummy field used for generating unique configurations to trigger reloads.
     data: Option<String>,
+
+    #[serde(skip)]
+    requires_buffer_observation: bool,
+
+    #[serde(skip)]
+    captured_buffer_usage_observers: Option<Arc<Mutex<Vec<Option<BufferUsageObserver>>>>>,
 }
 
 impl_generate_config_from_default!(BasicSinkConfig);
@@ -41,11 +50,13 @@ enum Mode {
 }
 
 impl BasicSinkConfig {
-    pub const fn new(sink: SourceSender, healthy: bool) -> Self {
+    pub fn new(sink: SourceSender, healthy: bool) -> Self {
         Self {
             sink: Mode::Normal(sink),
             healthy,
             data: None,
+            requires_buffer_observation: false,
+            captured_buffer_usage_observers: None,
         }
     }
 
@@ -54,7 +65,22 @@ impl BasicSinkConfig {
             sink: Mode::Normal(sink),
             healthy,
             data: Some(data.into()),
+            requires_buffer_observation: false,
+            captured_buffer_usage_observers: None,
         }
+    }
+
+    pub fn with_buffer_observation(mut self, requires_buffer_observation: bool) -> Self {
+        self.requires_buffer_observation = requires_buffer_observation;
+        self
+    }
+
+    pub fn with_captured_buffer_usage_observers(
+        mut self,
+        captured_buffer_usage_observers: Arc<Mutex<Vec<Option<BufferUsageObserver>>>>,
+    ) -> Self {
+        self.captured_buffer_usage_observers = Some(captured_buffer_usage_observers);
+        self
     }
 }
 
@@ -67,7 +93,14 @@ enum HealthcheckError {
 #[async_trait]
 #[typetag::serde(name = "test_basic")]
 impl SinkConfig for BasicSinkConfig {
-    async fn build(&self, _cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
+    async fn build(&self, cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
+        if let Some(captured_buffer_usage_observers) = &self.captured_buffer_usage_observers {
+            captured_buffer_usage_observers
+                .lock()
+                .unwrap()
+                .push(cx.buffer_usage_observer.clone());
+        }
+
         // If this sink is set to not be healthy, just send the healthcheck error immediately over
         // the oneshot.. otherwise, pass the sender to the sink so it can send it only once it has
         // started running, so that tests can request the topology be healthy before proceeding.
@@ -92,6 +125,10 @@ impl SinkConfig for BasicSinkConfig {
 
     fn input(&self) -> Input {
         Input::all()
+    }
+
+    fn requires_buffer_observation(&self) -> bool {
+        self.requires_buffer_observation
     }
 
     fn acknowledgements(&self) -> &AcknowledgementsConfig {

--- a/src/test_util/mod.rs
+++ b/src/test_util/mod.rs
@@ -36,7 +36,7 @@ use tokio_stream::wrappers::TcpListenerStream;
 use tokio_stream::wrappers::UnixListenerStream;
 use tokio_util::codec::{Encoder, FramedRead, FramedWrite, LinesCodec};
 use vector_lib::{
-    buffers::topology::channel::LimitedReceiver,
+    buffers::{InMemoryBufferable, topology::channel::LimitedReceiver},
     event::{
         BatchNotifier, BatchStatusReceiver, Event, EventArray, LogEvent, Metric, MetricKind,
         MetricTags, MetricValue,
@@ -439,7 +439,7 @@ where
     }
 }
 
-pub async fn collect_limited<T: Send + 'static>(mut rx: LimitedReceiver<T>) -> Vec<T> {
+pub async fn collect_limited<T: InMemoryBufferable>(mut rx: LimitedReceiver<T>) -> Vec<T> {
     let mut items = Vec::new();
     while let Some(item) = rx.next().await {
         items.push(item);
@@ -447,7 +447,10 @@ pub async fn collect_limited<T: Send + 'static>(mut rx: LimitedReceiver<T>) -> V
     items
 }
 
-pub async fn collect_n_limited<T: Send + 'static>(mut rx: LimitedReceiver<T>, n: usize) -> Vec<T> {
+pub async fn collect_n_limited<T: InMemoryBufferable>(
+    mut rx: LimitedReceiver<T>,
+    n: usize,
+) -> Vec<T> {
     let mut items = Vec::new();
     while items.len() < n {
         match rx.next().await {

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -631,7 +631,13 @@ impl<'a> Builder<'a> {
             self.errors.append(&mut err);
         };
 
-        let (tx, rx) = match self.buffers.remove(key) {
+        let observe = sink.inner.requires_buffer_observation();
+        if observe && let Err(error) = sink.buffer.validate_for_drain_shaping() {
+            self.errors.push(format!("Sink \"{key}\": {error}"));
+            return;
+        }
+
+        let (tx, rx, buffer_usage_observer) = match self.buffers.remove(key) {
             Some(buffer) => buffer,
             _ => {
                 let buffer_type = match sink.buffer.stages().first().expect("cant ever be empty") {
@@ -641,10 +647,11 @@ impl<'a> Builder<'a> {
                 let buffer_span = error_span!("sink", buffer_type);
                 let buffer = sink
                     .buffer
-                    .build(
+                    .build_with_observer(
                         self.config.global.data_dir.clone(),
                         key.to_string(),
                         buffer_span,
+                        observe,
                     )
                     .await;
                 match buffer {
@@ -652,7 +659,11 @@ impl<'a> Builder<'a> {
                         self.errors.push(format!("Sink \"{key}\": {error}"));
                         return;
                     }
-                    Ok((tx, rx)) => (tx, Arc::new(Mutex::new(Some(rx.into_stream())))),
+                    Ok((tx, rx, observer)) => (
+                        tx,
+                        Arc::new(Mutex::new(Some(rx.into_stream()))),
+                        Some(observer),
+                    ),
                 }
             }
         };
@@ -662,6 +673,7 @@ impl<'a> Builder<'a> {
             globals: self.config.global.clone(),
             enrichment_tables: enrichment_tables.clone(),
             metrics_storage: METRICS_STORAGE.clone(),
+            buffer_usage_observer: buffer_usage_observer.clone(),
             proxy: ProxyConfig::merge_with_env(&self.config.global.proxy, sink.proxy()),
             schema: self.config.schema,
             app_name: crate::get_app_name().to_string(),
@@ -683,6 +695,7 @@ impl<'a> Builder<'a> {
             .utilization_registry
             .add_component(key.clone(), gauge!(GaugeName::Utilization));
         let component_key = key.clone();
+        let task_buffer_usage_observer = buffer_usage_observer.clone();
         let sink = async move {
             debug!("Sink starting.");
 
@@ -715,7 +728,7 @@ impl<'a> Builder<'a> {
             .await
             .map(|_| {
                 debug!("Sink finished normally.");
-                TaskOutput::Sink(rx)
+                TaskOutput::Sink(rx, task_buffer_usage_observer)
             })
             .map_err(|_| {
                 debug!("Sink finished with an error.");

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -26,7 +26,10 @@ use std::{
 
 use futures::{Future, FutureExt};
 use tokio::sync::mpsc;
-use vector_lib::buffers::topology::channel::{BufferReceiverStream, BufferSender};
+use vector_lib::buffers::{
+    BufferUsageObserver,
+    topology::channel::{BufferReceiverStream, BufferSender},
+};
 
 use self::task::{Task, TaskError, TaskResult};
 pub use self::{
@@ -45,6 +48,7 @@ type TaskHandle = tokio::task::JoinHandle<TaskResult>;
 type BuiltBuffer = (
     BufferSender<EventArray>,
     Arc<Mutex<Option<BufferReceiverStream<EventArray>>>>,
+    Option<BufferUsageObserver>,
 );
 
 pub(super) fn take_healthchecks(

--- a/src/topology/running.rs
+++ b/src/topology/running.rs
@@ -12,7 +12,7 @@ use tokio::{
 };
 use tracing::Instrument;
 use vector_lib::{
-    buffers::topology::channel::BufferSender,
+    buffers::{BufferConfig, topology::channel::BufferSender},
     shutdown::ShutdownSignal,
     tap::topology::{TapOutput, TapResource, WatchRx, WatchTx},
     trigger::DisabledTrigger,
@@ -567,17 +567,7 @@ impl RunningTopology {
                 if diff.components_to_reload.contains(key) {
                     return false;
                 }
-                self.config.sink(key).map(|s| s.buffer.clone()).or_else(|| {
-                    self.config
-                        .enrichment_table(key)
-                        .and_then(|t| t.as_sink(key))
-                        .map(|(_, s)| s.buffer)
-                }) == new_config.sink(key).map(|s| s.buffer.clone()).or_else(|| {
-                    self.config
-                        .enrichment_table(key)
-                        .and_then(|t| t.as_sink(key))
-                        .map(|(_, s)| s.buffer)
-                })
+                can_reuse_sink_buffer(&self.config, new_config, key)
             })
             .cloned()
             .collect::<HashSet<_>>();
@@ -700,12 +690,15 @@ impl RunningTopology {
                     // buffer) than it is to pass around info about which sinks are having their
                     // buffers reused and treat them differently at other stages.
                     let tx = buffer_tx.remove(key).unwrap();
-                    let rx = match buffer {
-                        TaskOutput::Sink(rx) => rx.into_inner(),
+                    let (rx, observer) = match buffer {
+                        TaskOutput::Sink(rx, observer) => (rx.into_inner(), observer),
                         _ => unreachable!(),
                     };
 
-                    buffers.insert((*key).clone(), (tx, Arc::new(Mutex::new(Some(rx)))));
+                    buffers.insert(
+                        (*key).clone(),
+                        (tx, Arc::new(Mutex::new(Some(rx))), observer),
+                    );
                 }
             }
         }
@@ -1412,6 +1405,27 @@ impl RunningTopology {
     }
 }
 
+fn sink_reuse_state(config: &Config, key: &ComponentKey) -> Option<(BufferConfig, bool)> {
+    config
+        .sink(key)
+        .map(|sink| {
+            (
+                sink.buffer.clone(),
+                sink.inner.requires_buffer_observation(),
+            )
+        })
+        .or_else(|| {
+            config
+                .enrichment_table(key)
+                .and_then(|table| table.as_sink(key))
+                .map(|(_, sink)| (sink.buffer, sink.inner.requires_buffer_observation()))
+        })
+}
+
+fn can_reuse_sink_buffer(old_config: &Config, new_config: &Config, key: &ComponentKey) -> bool {
+    sink_reuse_state(old_config, key) == sink_reuse_state(new_config, key)
+}
+
 fn get_changed_outputs(diff: &ConfigDiff, output_ids: Inputs<OutputId>) -> Vec<OutputId> {
     let mut changed_outputs = Vec::new();
 
@@ -1434,4 +1448,46 @@ fn get_changed_outputs(diff: &ConfigDiff, output_ids: Inputs<OutputId>) -> Vec<O
     }
 
     changed_outputs
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroU64;
+
+    use vector_lib::buffers::{BufferConfig, BufferType, WhenFull};
+
+    use super::can_reuse_sink_buffer;
+    use crate::{
+        config::{ComponentKey, Config},
+        test_util::mock::{basic_sink, basic_source},
+    };
+
+    fn config_with_observation_mode(requires_buffer_observation: bool) -> Config {
+        let sink_key = ComponentKey::from("out");
+        let (_output, sink) = basic_sink(1);
+        let mut config_builder = Config::builder();
+        config_builder.add_source("in", basic_source().1);
+        config_builder.add_sink(
+            "out",
+            &["in"],
+            sink.with_buffer_observation(requires_buffer_observation),
+        );
+        config_builder.sinks[&sink_key].buffer = BufferConfig::Single(BufferType::DiskV2 {
+            max_size: NonZeroU64::new(300_000_000).unwrap(),
+            when_full: WhenFull::Block,
+        });
+        config_builder.build().unwrap()
+    }
+
+    #[test]
+    fn buffer_reuse_requires_same_observation_mode() {
+        let disabled = config_with_observation_mode(false);
+        let enabled = config_with_observation_mode(true);
+        let still_enabled = config_with_observation_mode(true);
+        let sink_key = ComponentKey::from("out");
+
+        assert!(!can_reuse_sink_buffer(&disabled, &enabled, &sink_key));
+        assert!(!can_reuse_sink_buffer(&enabled, &disabled, &sink_key));
+        assert!(can_reuse_sink_buffer(&enabled, &still_enabled, &sink_key));
+    }
 }

--- a/src/topology/task.rs
+++ b/src/topology/task.rs
@@ -9,7 +9,10 @@ use futures::{FutureExt, future::BoxFuture};
 use pin_project::pin_project;
 use snafu::Snafu;
 use tokio::task::JoinError;
-use vector_lib::{buffers::topology::channel::BufferReceiverStream, event::EventArray};
+use vector_lib::{
+    buffers::{BufferUsageObserver, topology::channel::BufferReceiverStream},
+    event::EventArray,
+};
 
 use crate::{config::ComponentKey, utilization::Utilization};
 
@@ -18,7 +21,10 @@ pub(crate) enum TaskOutput {
     Source,
     Transform,
     /// Buffer of sink
-    Sink(Utilization<BufferReceiverStream<EventArray>>),
+    Sink(
+        Utilization<BufferReceiverStream<EventArray>>,
+        Option<BufferUsageObserver>,
+    ),
     Healthcheck,
 }
 

--- a/src/topology/test/mod.rs
+++ b/src/topology/test/mod.rs
@@ -1,7 +1,9 @@
 use std::{
+    collections::HashMap,
     iter,
+    num::NonZeroU64,
     sync::{
-        Arc,
+        Arc, Mutex,
         atomic::{AtomicBool, AtomicUsize, Ordering},
     },
 };
@@ -11,6 +13,7 @@ use tokio::{
     task::yield_now,
     time::{Duration, sleep},
 };
+use tracing::Span;
 use vector_lib::{
     buffers::{BufferConfig, BufferType, WhenFull},
     config::{ComponentKey, OutputId},
@@ -149,6 +152,67 @@ async fn topology_shutdown_while_active() {
     // We expect the pump to fail with an error since we shut down the source it was sending to
     // while it was running.
     assert!(pump_handle.await.unwrap().is_err());
+}
+
+#[tokio::test]
+async fn reused_buffer_observer_is_forwarded_to_sink_context() {
+    trace_init();
+
+    let data_dir = tempfile::tempdir().unwrap();
+    let sink_key = ComponentKey::from("out");
+    let buffer_config = BufferConfig::Single(BufferType::DiskV2 {
+        max_size: NonZeroU64::new(300_000_000).unwrap(),
+        when_full: WhenFull::Block,
+    });
+    let (sender, receiver, observer) = buffer_config
+        .build_with_observer(
+            Some(data_dir.path().to_path_buf()),
+            sink_key.to_string(),
+            Span::none(),
+            true,
+        )
+        .await
+        .unwrap();
+    let mut reusable_sender = sender.clone();
+
+    let captured_buffer_usage_observers = Arc::new(Mutex::new(Vec::new()));
+    let (_output, sink) = basic_sink(1);
+    let sink = sink
+        .with_buffer_observation(true)
+        .with_captured_buffer_usage_observers(Arc::clone(&captured_buffer_usage_observers));
+
+    let mut config_builder = Config::builder();
+    config_builder.global.data_dir = Some(data_dir.path().to_path_buf());
+    config_builder.add_source("in", basic_source().1);
+    config_builder.add_sink("out", &["in"], sink);
+    config_builder.sinks[&sink_key].buffer = buffer_config;
+    let config = config_builder.build().unwrap();
+    let diff = ConfigDiff::initial(&config);
+    let mut buffers = HashMap::new();
+    buffers.insert(
+        sink_key,
+        (
+            sender,
+            Arc::new(Mutex::new(Some(receiver.into_stream()))),
+            Some(observer),
+        ),
+    );
+
+    let _pieces = TopologyPiecesBuilder::new(&config, &diff)
+        .with_buffers(buffers)
+        .build()
+        .await
+        .unwrap();
+
+    let captured_observer = captured_buffer_usage_observers.lock().unwrap()[0]
+        .clone()
+        .expect("reused observer should be available to the sink");
+
+    reusable_sender
+        .send(EventArray::from(LogEvent::from("observed")), None)
+        .await
+        .unwrap();
+    assert_eq!(captured_observer.received().0, 1);
 }
 
 #[tokio::test]

--- a/website/cue/reference/components/sinks/generated/clickhouse.cue
+++ b/website/cue/reference/components/sinks/generated/clickhouse.cue
@@ -334,6 +334,103 @@ generated: components: sinks: clickhouse: configuration: {
 		required:    false
 		type: bool: default: false
 	}
+	drain_shaping: {
+		description: """
+			Backlog-aware pacing for ClickHouse insert requests.
+
+			When enabled, Vector caps original request submission from a backed-up disk buffer to
+			reduce recovery floods. This requires static `database` and `table` values, and a disk
+			buffer with `when_full` set to `block`; memory buffers are unsupported. Retries are not
+			debited by this cap, so use `request.adaptive_concurrency` and
+			`request.retry_max_duration_secs` to bound retry behavior.
+			"""
+		required: false
+		type: object: options: {
+			burst_bytes: {
+				description: "Additional byte burst budget allowed above steady-state pacing."
+				required:    false
+				type: uint: {
+					default: 0
+					unit:    "bytes"
+				}
+			}
+			enabled: {
+				description: "Enables backlog-aware output pacing."
+				required:    false
+				type: bool: default: false
+			}
+			engage_min_bytes: {
+				description: """
+					Minimum buffered bytes before pacing engages.
+
+					Below this absolute backlog threshold, the sink submits requests without delay.
+					"""
+				required: false
+				type: uint: {
+					default: 1048576
+					unit:    "bytes"
+				}
+			}
+			ewma_alpha: {
+				description: "Exponential moving average alpha used for input byte-rate estimation."
+				required:    false
+				type: float: default: 0.1
+			}
+			factor: {
+				description: "Multiplier applied to the estimated input byte rate while the buffer has a backlog."
+				required:    false
+				type: float: default: 1.1
+			}
+			freeze_window_secs: {
+				description: "Recent input-rate window, in seconds, used to seed the frozen estimate."
+				required:    false
+				type: float: default: 30.0
+			}
+			max_requests_per_sec: {
+				description: """
+					Optional maximum number of original requests submitted per second.
+
+					This caps submissions before request retries. It does not debit retry attempts made by
+					the request service.
+					"""
+				required: false
+				type: float: {}
+			}
+			min_drain_bytes_per_sec: {
+				description: """
+					Minimum drain budget in bytes per second while pacing is active.
+
+					Set this above the expected sustained input rate to ensure a full disk buffer can drain
+					after restart, when no recent input-rate history exists.
+					"""
+				required: false
+				type: uint: {
+					default: 0
+					unit:    "bytes"
+				}
+			}
+			sample_interval_secs: {
+				description: "Buffer usage sample interval in seconds."
+				required:    false
+				type: float: default: 0.5
+			}
+			saturation_high_mark: {
+				description: """
+					Buffer fill ratio above which input-rate estimation freezes.
+
+					Freezing prevents a full `when_full = "block"` buffer from coupling the observed input
+					rate to the shaped output rate.
+					"""
+				required: false
+				type: float: default: 0.9
+			}
+			saturation_low_mark: {
+				description: "Buffer fill ratio below which frozen input-rate estimation resumes."
+				required:    false
+				type: float: default: 0.75
+			}
+		}
+	}
 	encoding: {
 		description: "Transformations to prepare an event for serialization."
 		required:    false


### PR DESCRIPTION
## Summary

Adds an opt-in `drain_shaping` option to the `clickhouse` sink that paces output while recovering from a backed-up disk buffer. When ClickHouse becomes unavailable, the disk buffer absorbs the backlog; on recovery Vector normally drains it as fast as the service accepts, which can re-overwhelm a fragile ClickHouse (e.g. "too many parts" / merge backlog) exactly when it is recovering. `drain_shaping` caps the *original* request submission rate to `max(EWMA(input_byte_rate) * factor, min_drain_bytes_per_sec)` once a backlog exists, so the buffer drains only slightly faster than data arrives. Lossless, opt-in, default-off.

### Why existing mechanisms don't cover this

- **Buffer backpressure (`when_full: block`)** slows the *source* when the buffer fills — it bounds input, not the *output* rate to the downstream. On recovery the buffer is already full; backpressure does not pace the drain.
- **Adaptive Request Concurrency** reacts to downstream RTT/errors and is blind to buffer fill and incoming rate; ClickHouse accepts inserts at low latency while degrading internally, so ARC ramps up and floods it.
- **`request.rate_limit_num`** is a static, config-time cap; it neither adapts to input nor distinguishes recovery from steady state.

## Vector configuration

```yaml
sinks:
  clickhouse:
    type: clickhouse
    inputs: ["in"]
    endpoint: "http://clickhouse:8123"
    database: logs          # static (required when drain_shaping is enabled)
    table: events           # static
    buffer:
      type: disk            # disk required
      max_size: 268435488
      when_full: block      # required
    drain_shaping:
      enabled: true
      factor: 1.1                    # drain ~10% above input once backlogged
      min_drain_bytes_per_sec: 5000000
      max_requests_per_sec: 50       # optional part-rate ceiling
```

## How did you test this PR?

- **Unit:** `vector-buffers` (observer accounting gated; existing buffer metrics preserved; config-reload buffer reuse + observe-mode toggle), the `DrainShaper` adapter (passthrough / EOF / rate cap / engage / freeze, with `tokio::time` paused), and `clickhouse` config (static-key validation, observation flag). `cargo nextest run -p vector-buffers -p vector` is green.
- **Integration (Docker):** `drain_shaping_bounds_recovery_request_rate` drives an outage via a proxy, accrues a disk backlog, and asserts the recovered INSERT rate stays bounded by the configured cap after the initial retry/startup burst.

## Change Type

- [x] New feature

## Is this a breaking change?

- [x] No — opt-in; `enabled: false` (default) is a strict no-op.

## Does this PR include user facing changes?

- [x] Yes. Changelog fragment added (`changelog.d/clickhouse_drain_shaping.feature.md`).

## Side effects / blast radius

- **Default-off = zero cost.** Buffer-usage accounting is gated behind the sink opting in (`requires_buffer_observation()`); disabled, there is no added hot-path work and existing buffer metrics are unchanged (covered by a test).
- **Cross-cutting but behavior-preserving:** adds `BufferUsageObserver` to `vector-buffers`, a `buffer_usage_observer` field on `SinkContext`, and threads it through `BuiltBuffer` / `TaskOutput::Sink`. This compiles across all sinks but is `None` / no-op for any sink that doesn't opt in. Config-reload buffer reuse now also keys on the observe-mode, so toggling `drain_shaping` rebuilds the disk buffer (lossless — reopens the same data dir).
- **Validated, fail-fast scope (v1):** enabling requires a static `database` / `table`, a disk buffer, and `when_full: block`; invalid combinations fail at config build with a clear error (no silent misbehavior). Memory buffers and templated keys are rejected (documented follow-ups).
- **Retries:** the cap bounds *original* submissions, not retry attempts; documented to rely on `request.adaptive_concurrency` + `request.retry_max_duration_secs`.
- **No new dependencies** (`Cargo.lock` unchanged).

## References

- Related: #25704
