### PR TITLE
docs(website): render deprecated enum variants with yellow deprecation box

### DIFF
--- a/src/transforms/lua/mod.rs
+++ b/src/transforms/lua/mod.rs
@@ -16,10 +16,6 @@ enum V1 {
     /// Lua transform API version 1.
     ///
     /// This version is deprecated and will be removed in a future version.
-    // TODO: The `deprecated` attribute flag is not used/can't be used for enum values like this
-    // because we don't emit the full schema for the enum value, we just gather its description. We
-    // might need to consider actually using the flag as a marker to say "append our boilerplate
-    // deprecation warning to the description of the field/enum value/etc".
     #[configurable(metadata(deprecated))]
     #[serde(rename = "1")]
     V1,

--- a/vdev/src/commands/build/component_docs/schema_enum.rs
+++ b/vdev/src/commands/build/component_docs/schema_enum.rs
@@ -2,6 +2,26 @@ use super::{SchemaContext, get_schema_metadata, schema_aware_nested_merge};
 use anyhow::{Result, bail};
 use indexmap::IndexMap;
 use serde_json::{Map, Value, json};
+
+fn enum_variant_value(ctx: &SchemaContext, schema: &Value) -> Value {
+    let desc = ctx.get_rendered_description_from_schema(schema);
+    let deprecated = schema
+        .get("deprecated")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+
+    if deprecated {
+        let mut obj = Map::new();
+        obj.insert("description".to_string(), Value::String(desc));
+        obj.insert("deprecated".to_string(), Value::Bool(true));
+        if let Some(msg) = get_schema_metadata(schema, "deprecated_message") {
+            obj.insert("deprecated_message".to_string(), msg.clone());
+        }
+        Value::Object(obj)
+    } else {
+        Value::String(desc)
+    }
+}
 use std::collections::HashSet;
 
 impl SchemaContext {
@@ -215,8 +235,7 @@ impl SchemaContext {
 
                 let mut enum_vals = Map::new();
                 for (k, v) in unique_tag_values {
-                    let desc = self.get_rendered_description_from_schema(&v);
-                    enum_vals.insert(k, Value::String(desc));
+                    enum_vals.insert(k, enum_variant_value(self, &v));
                 }
 
                 let mut resolved_tag_property_obj = Map::new();
@@ -268,8 +287,7 @@ impl SchemaContext {
                 debug!("Resolved as 'externally-tagged with only unit variants' enum schema.");
                 let mut enum_vals = Map::new();
                 for (k, v) in tag_values {
-                    let desc = self.get_rendered_description_from_schema(&v);
-                    enum_vals.insert(k, Value::String(desc));
+                    enum_vals.insert(k, enum_variant_value(self, &v));
                 }
                 return Ok(json!({ "_resolved": { "type": { "string": { "enum": enum_vals } } } }));
             }
@@ -397,8 +415,7 @@ impl SchemaContext {
                     let mut enum_map = Map::new();
                     for const_obj in &const_arr {
                         if let Some(value) = const_obj.get("value").and_then(|v| v.as_str()) {
-                            let desc = self.get_rendered_description_from_schema(const_obj);
-                            enum_map.insert(value.to_string(), Value::String(desc));
+                            enum_map.insert(value.to_string(), enum_variant_value(self, const_obj));
                         }
                     }
                     if !enum_map.is_empty() {

--- a/vdev/src/commands/build/component_docs/schema_enum.rs
+++ b/vdev/src/commands/build/component_docs/schema_enum.rs
@@ -5,10 +5,15 @@ use serde_json::{Map, Value, json};
 
 fn enum_variant_value(ctx: &SchemaContext, schema: &Value) -> Value {
     let desc = ctx.get_rendered_description_from_schema(schema);
+    // Check both the top-level `deprecated` flag (#[configurable(deprecated)]) and the
+    // metadata form (#[configurable(metadata(deprecated))]).
     let deprecated = schema
         .get("deprecated")
         .and_then(Value::as_bool)
-        .unwrap_or(false);
+        .unwrap_or(false)
+        || get_schema_metadata(schema, "deprecated")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
 
     if deprecated {
         let mut obj = Map::new();

--- a/website/cue/reference.cue
+++ b/website/cue/reference.cue
@@ -79,7 +79,20 @@ _values: {
 //                 json: "Encodes the data via application/json"
 //                 text: "Encodes the data via text/plain"
 //                }
-#Enum: [Name=_]: string
+//
+// Deprecated variants use an object form:
+//
+//                enum: {
+//                 v1: { description: "legacy endpoint", deprecated: true }
+//                 v2: "current endpoint"
+//                }
+#EnumVariant: string | {
+	description:         string
+	deprecated?:         bool
+	deprecated_message?: string
+}
+
+#Enum: [Name=_]: #EnumVariant
 
 #EnvVars: #Schema & {[Type=string]: {
 	common:   true

--- a/website/cue/reference/components/sinks/generated/datadog_metrics.cue
+++ b/website/cue/reference/components/sinks/generated/datadog_metrics.cue
@@ -295,11 +295,14 @@ generated: components: sinks: datadog_metrics: configuration: {
 		type: string: {
 			default: "v2"
 			enum: {
-				v1: """
-					Use the v1 series endpoint (`/api/v1/series`).
+				v1: {
+					deprecated: true
+					description: """
+						Use the v1 series endpoint (`/api/v1/series`).
 
-					This is a legacy endpoint. Prefer `v2` unless you have a specific reason to use v1.
-					"""
+						This is a legacy endpoint. Prefer `v2` unless you have a specific reason to use v1.
+						"""
+				}
 				v2: """
 					Use the v2 series endpoint (`/api/v2/series`).
 

--- a/website/layouts/partials/data.html
+++ b/website/layouts/partials/data.html
@@ -1693,11 +1693,48 @@
     <tbody>
       {{ range $k, $v := . }}
         <tr>
-          <td>
+          <td class="align-top">
             <code>{{ $k }}</code>
           </td>
-          <td>
-            {{ $v | markdownify }}
+          <td class="align-top [&>p:first-child]:mt-0">
+            {{ if and (reflect.IsMap $v) $v.deprecated }}
+              <div class="mb-3 border-2 rounded-md border-yellow-400 flex flex-col space-y-1.5 py-2 px-3">
+                <span>
+                  {{ partial "heading.html" (dict "text" "Deprecated" "level" 4 "toc_hide" true) }}
+                </span>
+                <div class="flex space-x-5 items-center">
+                  <div class="flex-shrink-0">
+                    {{/* Heroicon: outline/exclamation-circle */}}
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      class="text-yellow-500 h-5 w-5"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                    >
+                      <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                      />
+                    </svg>
+                  </div>
+                  <div class="prose dark:prose-dark max-w-none leading-snug">
+                    {{ if $v.deprecated_message }}
+                      {{ $v.deprecated_message | markdownify }}
+                    {{ else }}
+                      This option is deprecated.
+                    {{ end }}
+                  </div>
+                </div>
+              </div>
+            {{ end }}
+            {{ if reflect.IsMap $v }}
+              {{ $v.description | markdownify }}
+            {{ else }}
+              {{ $v | markdownify }}
+            {{ end }}
           </td>
         </tr>
       {{ end }}


### PR DESCRIPTION
## Summary

Deprecated enum variant values were not surfacing any deprecation signal on the docs site. For example, `series_api_version: v1` on the `datadog_metrics` sink has been deprecated since 0.56.0, but nothing on the docs page communicated that to users.

Deprecated enum variants now render with the same yellow \"Deprecated\" box used for deprecated fields (e.g. `token` on the `splunk_hec` source), including the deprecation message when one is provided.

## Vector configuration

N/A — website-only change.

## How did you test this PR?

Verified locally with `hugo server`.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.