### PR TITLE
[Experiment] en(internal telemetry): gate allocation tracing behind a Cargo feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -577,6 +577,14 @@ default-no-api-client = ["base", "sources-dnstap", "tikv-jemallocator", "vendore
 
 tokio-console = ["dep:console-subscriber", "tokio/tracing"]
 
+# Per-component allocation tracking (wraps the global allocator with a tracing
+# wrapper that attributes every alloc/dealloc to a component group ID and emits
+# `component_allocated_bytes_total` / `component_deallocated_bytes_total` /
+# `component_allocated_bytes` internal metrics). Off by default because the
+# wrapper imposes a per-allocation atomic-load + branch even when the runtime
+# `--allocation-tracing` flag is disabled.
+allocation-tracing = []
+
 # VRL functions control features
 vrl-functions-env = ["vrl/enable_env_functions"]
 vrl-functions-system = ["vrl/enable_system_functions"]

--- a/src/api/grpc/service.rs
+++ b/src/api/grpc/service.rs
@@ -425,9 +425,9 @@ impl observability::Service for ObservabilityService {
         &self,
         _request: Request<GetAllocationTracingStatusRequest>,
     ) -> Result<Response<GetAllocationTracingStatusResponse>, Status> {
-        #[cfg(unix)]
+        #[cfg(all(unix, feature = "allocation-tracing"))]
         let enabled = crate::internal_telemetry::allocations::is_allocation_tracing_enabled();
-        #[cfg(not(unix))]
+        #[cfg(not(all(unix, feature = "allocation-tracing")))]
         let enabled = false;
         Ok(Response::new(GetAllocationTracingStatusResponse {
             enabled,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -244,12 +244,12 @@ pub struct RootOpts {
     pub no_graceful_shutdown_limit: bool,
 
     /// Set runtime allocation tracing
-    #[cfg(all(unix, feature = "tikv-jemallocator"))]
+    #[cfg(all(unix, feature = "tikv-jemallocator", feature = "allocation-tracing"))]
     #[arg(long, env = "ALLOCATION_TRACING", default_value = "false")]
     pub allocation_tracing: bool,
 
     /// Set allocation tracing reporting rate in milliseconds.
-    #[cfg(all(unix, feature = "tikv-jemallocator"))]
+    #[cfg(all(unix, feature = "tikv-jemallocator", feature = "allocation-tracing"))]
     #[arg(
         long,
         env = "ALLOCATION_TRACING_REPORTING_INTERVAL_MS",

--- a/src/internal_telemetry/mod.rs
+++ b/src/internal_telemetry/mod.rs
@@ -1,4 +1,4 @@
 #![allow(missing_docs)]
 
-#[cfg(unix)]
+#[cfg(all(unix, feature = "allocation-tracing"))]
 pub mod allocations;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,12 +44,20 @@ pub use indoc::indoc;
 // re-export codecs for convenience
 pub use vector_lib::codecs;
 
-#[cfg(all(unix, feature = "tikv-jemallocator"))]
+#[cfg(all(unix, feature = "tikv-jemallocator", feature = "allocation-tracing"))]
 #[global_allocator]
 static ALLOC: self::internal_telemetry::allocations::Allocator<tikv_jemallocator::Jemalloc> =
     self::internal_telemetry::allocations::get_grouped_tracing_allocator(
         tikv_jemallocator::Jemalloc,
     );
+
+#[cfg(all(
+    unix,
+    feature = "tikv-jemallocator",
+    not(feature = "allocation-tracing")
+))]
+#[global_allocator]
+static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 #[allow(unreachable_pub)]
 pub mod internal_telemetry;

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,7 @@ use vector::{app::Application, extra_context::ExtraContext};
 
 #[cfg(unix)]
 fn main() -> ExitCode {
-    #[cfg(all(unix, feature = "tikv-jemallocator"))]
+    #[cfg(all(unix, feature = "tikv-jemallocator", feature = "allocation-tracing"))]
     {
         use std::sync::atomic::Ordering;
 

--- a/src/topology/running.rs
+++ b/src/topology/running.rs
@@ -1163,7 +1163,7 @@ impl RunningTopology {
         );
 
         let task_span = span.or_current();
-        #[cfg(unix)]
+        #[cfg(all(unix, feature = "allocation-tracing"))]
         if crate::internal_telemetry::allocations::is_allocation_tracing_enabled() {
             let group_id = crate::internal_telemetry::allocations::acquire_allocation_group_id(
                 task.id().to_string(),
@@ -1204,7 +1204,7 @@ impl RunningTopology {
         );
 
         let task_span = span.or_current();
-        #[cfg(unix)]
+        #[cfg(all(unix, feature = "allocation-tracing"))]
         if crate::internal_telemetry::allocations::is_allocation_tracing_enabled() {
             let group_id = crate::internal_telemetry::allocations::acquire_allocation_group_id(
                 task.id().to_string(),
@@ -1245,7 +1245,7 @@ impl RunningTopology {
         );
 
         let task_span = span.or_current();
-        #[cfg(unix)]
+        #[cfg(all(unix, feature = "allocation-tracing"))]
         if crate::internal_telemetry::allocations::is_allocation_tracing_enabled() {
             let group_id = crate::internal_telemetry::allocations::acquire_allocation_group_id(
                 task.id().to_string(),

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -106,7 +106,7 @@ pub fn init(
         subscriber.with(console_layer)
     };
 
-    #[cfg(unix)]
+    #[cfg(all(unix, feature = "allocation-tracing"))]
     let subscriber = {
         let allocation_layer = crate::internal_telemetry::allocations::AllocationLayer::new()
             .with_filter(LevelFilter::ERROR);


### PR DESCRIPTION
## ⚠️ Experiment — do not merge

This branch exists to measure the cost of always compiling Vector's per-component allocation tracking into release builds. It is **not** a merge candidate. If SMP shows a meaningful win we will follow up with a real proposal; if it does not, this branch will be closed.

## Motivation

Vector's `#[global_allocator]` is `GroupedTraceableAllocator<Jemalloc>`. It is **always** compiled in for unix release builds, and on every `alloc`/`dealloc` it does a relaxed atomic load + branch on `TRACK_ALLOCATIONS` to decide whether to do the per-component bookkeeping. The runtime `--allocation-tracing` flag toggles that bool, but the wrapper itself — and therefore the load + branch — is unconditional.

Open questions this experiment is meant to answer:

1. Is the always-on `AtomicBool` check on every allocation measurable in throughput/latency across our component matrix, or is the branch predictor hiding it?
2. If it is measurable, is the per-component grouping feature worth that permanent tax, or should we move to a model where the wrapper is only present in opt-in builds (and possibly replace it with sampled jemalloc `prof.active` for users who just want heap visibility)?

See https://github.com/vectordotdev/vector/blob/master/src/internal_telemetry/allocations/allocator/tracing_allocator.rs for the hot path being measured.

## What this PR does

Wraps the entire allocation-tracing surface in `#[cfg(feature = "allocation-tracing")]`:

- `#[global_allocator]` in `src/lib.rs` (wrapped vs plain `Jemalloc`)
- init code in `src/main.rs`
- `--allocation-tracing` / `--allocation-tracing-reporting-interval-ms` CLI flags in `src/cli.rs`
- `AllocationLayer` in `src/trace.rs`
- `acquire_allocation_group_id` call sites in `src/topology/running.rs`
- `get_allocation_tracing_status` gRPC RPC in `src/api/grpc/service.rs`
- the `allocations` module itself in `src/internal_telemetry/mod.rs`

Feature is **off by default**, so the SMP comparison build runs with a plain `tikv_jemallocator::Jemalloc` and no wrapper at all. Baseline is current `master` (wrapper always on).

## How tested

- `cargo check --no-default-features --features default` (feature off): clean
- `cargo check --no-default-features --features "default,allocation-tracing"` (feature on): clean
- `cargo clippy --no-default-features --features default --lib --bin vector -- -D warnings`: clean
- SMP regression run dispatched: https://github.com/vectordotdev/vector/actions/runs/28452960292

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

(Not landing as-is; if a follow-up does land, default builds would lose the runtime `--allocation-tracing` flag and the `component_allocated_bytes_total` / `component_deallocated_bytes_total` / `component_allocated_bytes` internal metrics unless the feature is added to the release feature set.)

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

Build/Cargo-feature wiring only.