### PR TITLE
enhancement(socket source): add multicast_interface option for UDP multicast group joining

### DIFF
--- a/changelog.d/socket_udp_multicast_interface.enhancement.md
+++ b/changelog.d/socket_udp_multicast_interface.enhancement.md
@@ -1,0 +1,3 @@
+The `socket` source (UDP mode) now supports a `multicast_interface` option that controls which local network interface is used when joining multicast groups. This is useful on hosts with multiple interfaces and on macOS, where specifying `0.0.0.0` only joins on the default interface (unlike Linux, which joins on all interfaces).
+
+authors: thomasqueirozb

--- a/src/sources/socket/mod.rs
+++ b/src/sources/socket/mod.rs
@@ -397,10 +397,16 @@ mod test {
             .expect("Failed to bind UDP socket to OS-assigned port")
     }
 
-    pub fn bind_unused_udp_any() -> UdpSocket {
-        // Bind to port 0 to let the OS assign an available port
-        UdpSocket::bind((IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0))
-            .expect("Failed to bind UDP socket to OS-assigned port")
+    /// Bind a UDP socket suitable for sending multicast packets through the loopback interface.
+    /// Sets `IP_MULTICAST_IF` to loopback so packets route through `lo` regardless of the
+    /// system's default multicast route, necessary for reliable local testing on macOS.
+    pub fn bind_unused_udp_multicast() -> UdpSocket {
+        let socket = UdpSocket::bind((IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0))
+            .expect("Failed to bind UDP socket to OS-assigned port");
+        socket2::SockRef::from(&socket)
+            .set_multicast_if_v4(&Ipv4Addr::LOCALHOST)
+            .expect("Failed to set multicast interface to loopback");
+        socket
     }
 
     fn get_gelf_payload(message: &str) -> String {
@@ -1371,13 +1377,16 @@ mod test {
                 SocketAddr::new(IpAddr::V4(multicast_ip_address), socket_address.port());
             let mut config = UdpConfig::from_address(socket_address.into());
             config.multicast_groups = vec![multicast_ip_address];
+            // Use loopback as the multicast interface so local test packets are delivered
+            // on all platforms. Without this, macOS joins on the default network interface
+            // (e.g. en0) instead of loopback, and the sender's packets never arrive.
+            config.multicast_interface = Some(Ipv4Addr::LOCALHOST);
             init_udp_with_config(tx, config).await;
 
-            // We must send packets to the same interface the `socket_address` is bound to
-            // in order to receive the multicast packets the `from` socket sends.
-            // To do so, we use the `IPADDR_ANY` address
+            // Bind sender with loopback as the outgoing multicast interface so packets
+            // route through lo, matching the interface the receiver joined on.
             send_lines_udp_from(
-                bind_unused_udp_any(),
+                bind_unused_udp_multicast(),
                 multicast_socket_address,
                 ["test".to_string()],
             );
@@ -1405,9 +1414,10 @@ mod test {
                 .collect::<Vec<SocketAddr>>();
             let mut config = UdpConfig::from_address(socket_address.into());
             config.multicast_groups = multicast_ip_addresses;
+            config.multicast_interface = Some(Ipv4Addr::LOCALHOST);
             init_udp_with_config(tx, config).await;
 
-            let mut from = bind_unused_udp_any();
+            let mut from = bind_unused_udp_multicast();
             for multicast_ip_socket_address in multicast_ip_socket_addresses {
                 from = send_lines_udp_from(
                     from,
@@ -1435,11 +1445,13 @@ mod test {
                 SocketAddr::new(IpAddr::V4(multicast_ip_address), socket_address.port());
             let mut config = UdpConfig::from_address(socket_address.into());
             config.multicast_groups = vec![multicast_ip_address];
+            config.multicast_interface = Some(Ipv4Addr::LOCALHOST);
             init_udp_with_config(tx, config).await;
 
-            // Send packet to multicast address
+            // Send packet to multicast address using loopback as the outgoing interface
+            // so it routes through lo, matching the interface the receiver joined on.
             let _ = send_lines_udp_from(
-                bind_unused_udp_any(),
+                bind_unused_udp_multicast(),
                 multicast_socket_address,
                 ["test".to_string()],
             );

--- a/src/sources/socket/udp.rs
+++ b/src/sources/socket/udp.rs
@@ -58,6 +58,23 @@ pub struct UdpConfig {
     #[configurable(metadata(docs::examples = "['224.0.0.2', '224.0.0.4']"))]
     pub(super) multicast_groups: Vec<Ipv4Addr>,
 
+    /// The IPv4 interface address used when joining multicast groups.
+    ///
+    /// Specifies which local network interface to use for receiving multicast traffic.
+    /// When not set, defaults to the socket's binding address (e.g. `0.0.0.0` lets the OS
+    /// pick the default multicast-capable interface).
+    ///
+    /// Set this explicitly when the host has multiple interfaces and you need to control
+    /// which one receives multicast traffic. For example, `127.0.0.1` restricts multicast
+    /// reception to the loopback interface.
+    ///
+    /// On macOS, specifying `0.0.0.0` only joins on the default network interface (typically
+    /// the primary Ethernet or Wi-Fi interface), unlike Linux which joins on all interfaces.
+    /// If multicast traffic is expected on a specific interface (including loopback), set this
+    /// field explicitly.
+    #[serde(default)]
+    pub(super) multicast_interface: Option<Ipv4Addr>,
+
     /// The maximum buffer size of incoming messages.
     ///
     /// Messages larger than this are truncated.
@@ -136,6 +153,7 @@ impl UdpConfig {
         Self {
             address,
             multicast_groups: Vec::new(),
+            multicast_interface: None,
             max_length: default_max_length(),
             host_key: None,
             port_key: default_port_key(),
@@ -185,7 +203,7 @@ pub(super) fn udp(
                 }
             };
             for group_addr in config.multicast_groups {
-                let interface = *listen_addr.ip();
+                let interface = config.multicast_interface.unwrap_or(*listen_addr.ip());
                 socket
                     .join_multicast_v4(group_addr, interface)
                     .map_err(|error| {

--- a/src/sources/socket/udp.rs
+++ b/src/sources/socket/udp.rs
@@ -61,15 +61,14 @@ pub struct UdpConfig {
     /// The IPv4 interface address used when joining multicast groups.
     ///
     /// Specifies which local network interface to use for receiving multicast traffic.
-    /// When not set, defaults to the socket's binding address (e.g. `0.0.0.0` lets the OS
-    /// pick the default multicast-capable interface).
+    /// When not set, defaults to the socket's binding address.
     ///
     /// Set this explicitly when the host has multiple interfaces and you need to control
     /// which one receives multicast traffic. For example, `127.0.0.1` restricts multicast
     /// reception to the loopback interface.
     ///
     /// On macOS, specifying `0.0.0.0` only joins on the default network interface (typically
-    /// the primary Ethernet or Wi-Fi interface), unlike Linux which joins on all interfaces.
+    /// the primary Ethernet or Wi-Fi interface), unlike Linux, which joins on all interfaces.
     /// If multicast traffic is expected on a specific interface (including loopback), set this
     /// field explicitly.
     #[serde(default)]

--- a/website/cue/reference/components/sources/generated/socket.cue
+++ b/website/cue/reference/components/sources/generated/socket.cue
@@ -594,6 +594,27 @@ generated: components: sources: socket: configuration: {
 			items: type: string: examples: ["['224.0.0.2', '224.0.0.4']"]
 		}
 	}
+	multicast_interface: {
+		description: """
+			The IPv4 interface address used when joining multicast groups.
+
+			Specifies which local network interface to use for receiving multicast traffic.
+			When not set, defaults to the socket's binding address (e.g. `0.0.0.0` lets the OS
+			pick the default multicast-capable interface).
+
+			Set this explicitly when the host has multiple interfaces and you need to control
+			which one receives multicast traffic. For example, `127.0.0.1` restricts multicast
+			reception to the loopback interface.
+
+			On macOS, specifying `0.0.0.0` only joins on the default network interface (typically
+			the primary Ethernet or Wi-Fi interface), unlike Linux which joins on all interfaces.
+			If multicast traffic is expected on a specific interface (including loopback), set this
+			field explicitly.
+			"""
+		relevant_when: "mode = \"udp\""
+		required:      false
+		type: string: {}
+	}
 	path: {
 		description: """
 			The Unix socket path.

--- a/website/cue/reference/components/sources/generated/socket.cue
+++ b/website/cue/reference/components/sources/generated/socket.cue
@@ -599,15 +599,14 @@ generated: components: sources: socket: configuration: {
 			The IPv4 interface address used when joining multicast groups.
 
 			Specifies which local network interface to use for receiving multicast traffic.
-			When not set, defaults to the socket's binding address (e.g. `0.0.0.0` lets the OS
-			pick the default multicast-capable interface).
+			When not set, defaults to the socket's binding address.
 
 			Set this explicitly when the host has multiple interfaces and you need to control
 			which one receives multicast traffic. For example, `127.0.0.1` restricts multicast
 			reception to the loopback interface.
 
 			On macOS, specifying `0.0.0.0` only joins on the default network interface (typically
-			the primary Ethernet or Wi-Fi interface), unlike Linux which joins on all interfaces.
+			the primary Ethernet or Wi-Fi interface), unlike Linux, which joins on all interfaces.
 			If multicast traffic is expected on a specific interface (including loopback), set this
 			field explicitly.
 			"""


### PR DESCRIPTION
## Summary

Adds a `multicast_interface` option to the UDP `socket` source that controls which local IPv4 interface is used when joining multicast groups via `IP_ADD_MEMBERSHIP`.

On macOS, `join_multicast_v4` with `0.0.0.0` only joins on the default network interface (e.g. `en0`), unlike Linux which joins on all interfaces. This caused the three multicast UDP tests to time out locally on macOS. The new option lets callers pin the interface explicitly (e.g. `127.0.0.1` for loopback), and the tests now use a loopback-pinned sender socket alongside the loopback interface join to ensure reliable local delivery on all platforms.

## Vector configuration

```yaml
sources:
  my_udp:
    type: socket
    mode: udp
    address: "0.0.0.0:9000"
    multicast_groups:
      - "224.0.0.2"
    multicast_interface: "192.168.1.10"  # optional; pin to a specific interface
```

## How did you test this PR?

Ran the three previously timing-out multicast tests locally on macOS:

```
cargo nextest run -p vector --features sources-socket --no-default-features -E 'test(multicast)'
```

All four multicast tests now pass.

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

NA