### PR TITLE
chore(enrichment tables): split component diffs

### DIFF
--- a/src/config/diff.rs
+++ b/src/config/diff.rs
@@ -442,4 +442,83 @@ mod tests {
             HashSet::from_iter(["memory_table".into()])
         );
     }
+
+    #[test]
+    fn diff_enrichment_tables_tracks_source_key_renames() {
+        let old_config: Config = serde_yaml::from_str::<ConfigBuilder>(indoc! {r#"
+            enrichment_tables:
+              memory_table:
+                type: "memory"
+                ttl: 10
+                inputs: []
+                source_config:
+                  source_key: "memory_table_source_old"
+                  export_interval: 50
+
+            sources:
+              test:
+                type: "test_basic"
+
+            sinks:
+              test_sink:
+                type: "test_basic"
+                inputs: ["test"]
+        "#})
+        .unwrap()
+        .build()
+        .unwrap();
+
+        let new_config: Config = serde_yaml::from_str::<ConfigBuilder>(indoc! {r#"
+            enrichment_tables:
+              memory_table:
+                type: "memory"
+                ttl: 10
+                inputs: []
+                source_config:
+                  source_key: "memory_table_source_new"
+                  export_interval: 50
+
+            sources:
+              test:
+                type: "test_basic"
+
+            sinks:
+              test_sink:
+                type: "test_basic"
+                inputs: ["test"]
+        "#})
+        .unwrap()
+        .build()
+        .unwrap();
+
+        let diff = EnrichmentTableDiff::new(
+            &old_config.enrichment_tables,
+            &new_config.enrichment_tables,
+            &Default::default(),
+        );
+
+        assert_eq!(
+            diff.tables.to_change,
+            HashSet::from_iter(["memory_table".into()])
+        );
+        assert!(diff.tables.to_add.is_empty());
+        assert!(diff.tables.to_remove.is_empty());
+
+        assert_eq!(
+            diff.sources.to_add,
+            HashSet::from_iter(["memory_table_source_new".into()])
+        );
+        assert_eq!(
+            diff.sources.to_remove,
+            HashSet::from_iter(["memory_table_source_old".into()])
+        );
+        assert!(diff.sources.to_change.is_empty());
+
+        assert_eq!(
+            diff.sinks.to_change,
+            HashSet::from_iter(["memory_table".into()])
+        );
+        assert!(diff.sinks.to_add.is_empty());
+        assert!(diff.sinks.to_remove.is_empty());
+    }
 }

--- a/src/config/diff.rs
+++ b/src/config/diff.rs
@@ -104,43 +104,39 @@ impl EnrichmentTableDiff {
         }
     }
 
-    /// Checks whether or not any enrichment table component is being changed or added.
+    /// Checks whether or not any enrichment table-derived component is being changed or added.
     pub fn any_changed_or_added(&self) -> bool {
-        self.tables.any_changed_or_added()
-            || self.sources.any_changed_or_added()
-            || self.sinks.any_changed_or_added()
+        self.sources.any_changed_or_added() || self.sinks.any_changed_or_added()
     }
 
-    /// Checks whether or not any enrichment table component is being changed or removed.
+    /// Checks whether or not any enrichment table-derived component is being changed or removed.
     pub fn any_changed_or_removed(&self) -> bool {
-        self.tables.any_changed_or_removed()
-            || self.sources.any_changed_or_removed()
-            || self.sinks.any_changed_or_removed()
+        self.sources.any_changed_or_removed() || self.sinks.any_changed_or_removed()
     }
 
-    /// Checks whether the given enrichment table component is present at all.
+    /// Checks whether the given enrichment table-derived component is present at all.
     pub fn contains(&self, id: &ComponentKey) -> bool {
-        self.tables.contains(id) || self.sources.contains(id) || self.sinks.contains(id)
+        self.sources.contains(id) || self.sinks.contains(id)
     }
 
-    /// Checks whether the given enrichment table component is present as a change or addition.
+    /// Checks whether the given enrichment table-derived component is present as a change or addition.
     pub fn contains_new(&self, id: &ComponentKey) -> bool {
-        self.tables.contains_new(id) || self.sources.contains_new(id) || self.sinks.contains_new(id)
+        self.sources.contains_new(id) || self.sinks.contains_new(id)
     }
 
-    /// Checks whether or not the given enrichment table component is changed.
+    /// Checks whether or not the given enrichment table-derived component is changed.
     pub fn is_changed(&self, key: &ComponentKey) -> bool {
-        self.tables.is_changed(key) || self.sources.is_changed(key) || self.sinks.is_changed(key)
+        self.sources.is_changed(key) || self.sinks.is_changed(key)
     }
 
-    /// Checks whether the given enrichment table component is present as an addition.
+    /// Checks whether the given enrichment table-derived component is present as an addition.
     pub fn is_added(&self, id: &ComponentKey) -> bool {
-        self.tables.is_added(id) || self.sources.is_added(id) || self.sinks.is_added(id)
+        self.sources.is_added(id) || self.sinks.is_added(id)
     }
 
-    /// Checks whether or not the given enrichment table component is removed.
+    /// Checks whether or not the given enrichment table-derived component is removed.
     pub fn is_removed(&self, key: &ComponentKey) -> bool {
-        self.tables.is_removed(key) || self.sources.is_removed(key) || self.sinks.is_removed(key)
+        self.sources.is_removed(key) || self.sinks.is_removed(key)
     }
 
     const fn flip(&mut self) {
@@ -441,6 +437,63 @@ mod tests {
             diff.sinks.to_change,
             HashSet::from_iter(["memory_table".into()])
         );
+    }
+
+    #[test]
+    fn diff_enrichment_table_component_helpers_ignore_table_config_keys() {
+        let old_config: Config = serde_yaml::from_str::<ConfigBuilder>(indoc! {r#"
+            sources:
+              test:
+                type: "test_basic"
+
+            sinks:
+              test_sink:
+                type: "test_basic"
+                inputs: ["test"]
+        "#})
+        .unwrap()
+        .build()
+        .unwrap();
+
+        let new_config: Config = serde_yaml::from_str::<ConfigBuilder>(indoc! {r#"
+            enrichment_tables:
+              file_table:
+                type: "file"
+                file:
+                  path: ./tests/data/enrichment.csv
+                  encoding:
+                    type: "csv"
+                schema:
+                  id: integer
+
+            sources:
+              test:
+                type: "test_basic"
+
+            sinks:
+              test_sink:
+                type: "test_basic"
+                inputs: ["test"]
+        "#})
+        .unwrap()
+        .build()
+        .unwrap();
+
+        let diff = EnrichmentTableDiff::new(
+            &old_config.enrichment_tables,
+            &new_config.enrichment_tables,
+            &Default::default(),
+        );
+        let table_key = ComponentKey::from("file_table");
+
+        assert_eq!(diff.tables.to_add, HashSet::from_iter([table_key.clone()]));
+        assert!(diff.sources.to_add.is_empty());
+        assert!(diff.sinks.to_add.is_empty());
+
+        assert!(!diff.any_changed_or_added());
+        assert!(!diff.contains(&table_key));
+        assert!(!diff.contains_new(&table_key));
+        assert!(!diff.is_added(&table_key));
     }
 
     #[test]

--- a/src/config/diff.rs
+++ b/src/config/diff.rs
@@ -10,9 +10,7 @@ pub struct ConfigDiff {
     pub sources: Difference,
     pub transforms: Difference,
     pub sinks: Difference,
-    /// This difference does not only contain the actual enrichment_tables keys, but also keys that
-    /// may be used for their source and sink components (if available).
-    pub enrichment_tables: Difference,
+    pub enrichment_tables: EnrichmentTableDiff,
     pub components_to_reload: HashSet<ComponentKey>,
 }
 
@@ -26,7 +24,7 @@ impl ConfigDiff {
             sources: Difference::new(&old.sources, &new.sources, &components_to_reload),
             transforms: Difference::new(&old.transforms, &new.transforms, &components_to_reload),
             sinks: Difference::new(&old.sinks, &new.sinks, &components_to_reload),
-            enrichment_tables: Difference::from_enrichment_tables(
+            enrichment_tables: EnrichmentTableDiff::new(
                 &old.enrichment_tables,
                 &new.enrichment_tables,
                 &components_to_reload,
@@ -66,6 +64,89 @@ impl ConfigDiff {
             || self.transforms.is_removed(key)
             || self.sinks.is_removed(key)
             || self.enrichment_tables.is_removed(key)
+    }
+}
+
+#[derive(Debug)]
+pub struct EnrichmentTableDiff {
+    /// Difference for the enrichment table configuration keyed by table name.
+    pub tables: Difference,
+    /// Difference for source components derived from enrichment tables.
+    pub sources: Difference,
+    /// Difference for sink components derived from enrichment tables.
+    pub sinks: Difference,
+}
+
+impl EnrichmentTableDiff {
+    fn new(
+        old: &IndexMap<ComponentKey, EnrichmentTableOuter<OutputId>>,
+        new: &IndexMap<ComponentKey, EnrichmentTableOuter<OutputId>>,
+        need_change: &HashSet<ComponentKey>,
+    ) -> Self {
+        let tables = Difference::new(old, new, need_change);
+        let sources = Difference::from_enrichment_table_components(
+            old,
+            new,
+            need_change,
+            enrichment_table_source_key,
+        );
+        let sinks = Difference::from_enrichment_table_components(
+            old,
+            new,
+            need_change,
+            enrichment_table_sink_key,
+        );
+
+        Self {
+            tables,
+            sources,
+            sinks,
+        }
+    }
+
+    /// Checks whether or not any enrichment table component is being changed or added.
+    pub fn any_changed_or_added(&self) -> bool {
+        self.tables.any_changed_or_added()
+            || self.sources.any_changed_or_added()
+            || self.sinks.any_changed_or_added()
+    }
+
+    /// Checks whether or not any enrichment table component is being changed or removed.
+    pub fn any_changed_or_removed(&self) -> bool {
+        self.tables.any_changed_or_removed()
+            || self.sources.any_changed_or_removed()
+            || self.sinks.any_changed_or_removed()
+    }
+
+    /// Checks whether the given enrichment table component is present at all.
+    pub fn contains(&self, id: &ComponentKey) -> bool {
+        self.tables.contains(id) || self.sources.contains(id) || self.sinks.contains(id)
+    }
+
+    /// Checks whether the given enrichment table component is present as a change or addition.
+    pub fn contains_new(&self, id: &ComponentKey) -> bool {
+        self.tables.contains_new(id) || self.sources.contains_new(id) || self.sinks.contains_new(id)
+    }
+
+    /// Checks whether or not the given enrichment table component is changed.
+    pub fn is_changed(&self, key: &ComponentKey) -> bool {
+        self.tables.is_changed(key) || self.sources.is_changed(key) || self.sinks.is_changed(key)
+    }
+
+    /// Checks whether the given enrichment table component is present as an addition.
+    pub fn is_added(&self, id: &ComponentKey) -> bool {
+        self.tables.is_added(id) || self.sources.is_added(id) || self.sinks.is_added(id)
+    }
+
+    /// Checks whether or not the given enrichment table component is removed.
+    pub fn is_removed(&self, key: &ComponentKey) -> bool {
+        self.tables.is_removed(key) || self.sources.is_removed(key) || self.sinks.is_removed(key)
+    }
+
+    const fn flip(&mut self) {
+        self.tables.flip();
+        self.sources.flip();
+        self.sinks.flip();
     }
 }
 
@@ -114,13 +195,17 @@ impl Difference {
         }
     }
 
-    fn from_enrichment_tables(
+    fn from_enrichment_table_components<F>(
         old: &IndexMap<ComponentKey, EnrichmentTableOuter<OutputId>>,
         new: &IndexMap<ComponentKey, EnrichmentTableOuter<OutputId>>,
         need_change: &HashSet<ComponentKey>,
-    ) -> Self {
-        let old_table_keys = extract_table_component_keys(old);
-        let new_table_keys = extract_table_component_keys(new);
+        component_key: F,
+    ) -> Self
+    where
+        F: Fn(&ComponentKey, &EnrichmentTableOuter<OutputId>) -> Option<ComponentKey>,
+    {
+        let old_table_keys = extract_table_component_keys(old, &component_key);
+        let new_table_keys = extract_table_component_keys(new, &component_key);
 
         let to_change = old_table_keys
             .intersection(&new_table_keys)
@@ -208,23 +293,37 @@ impl Difference {
 }
 
 /// Helper function to extract component keys from enrichment tables.
-fn extract_table_component_keys(
-    tables: &IndexMap<ComponentKey, EnrichmentTableOuter<OutputId>>,
-) -> HashSet<(&ComponentKey, ComponentKey)> {
+fn extract_table_component_keys<'a, F>(
+    tables: &'a IndexMap<ComponentKey, EnrichmentTableOuter<OutputId>>,
+    component_key: &F,
+) -> HashSet<(&'a ComponentKey, ComponentKey)>
+where
+    F: Fn(&ComponentKey, &EnrichmentTableOuter<OutputId>) -> Option<ComponentKey>,
+{
     tables
         .iter()
-        .flat_map(|(table_key, table)| {
-            vec![
-                table
-                    .as_source(table_key)
-                    .map(|(component_key, _)| (table_key, component_key)),
-                table
-                    .as_sink(table_key)
-                    .map(|(component_key, _)| (table_key, component_key)),
-            ]
+        .filter_map(|(table_key, table)| {
+            component_key(table_key, table).map(|component_key| (table_key, component_key))
         })
-        .flatten()
         .collect()
+}
+
+fn enrichment_table_source_key(
+    table_key: &ComponentKey,
+    table: &EnrichmentTableOuter<OutputId>,
+) -> Option<ComponentKey> {
+    table
+        .as_source(table_key)
+        .map(|(component_key, _)| component_key)
+}
+
+fn enrichment_table_sink_key(
+    table_key: &ComponentKey,
+    table: &EnrichmentTableOuter<OutputId>,
+) -> Option<ComponentKey> {
+    table
+        .as_sink(table_key)
+        .map(|(component_key, _)| component_key)
 }
 
 #[cfg(all(test, feature = "enrichment-tables-memory"))]
@@ -304,20 +403,43 @@ mod tests {
         .build()
         .unwrap();
 
-        let diff = Difference::from_enrichment_tables(
+        let diff = EnrichmentTableDiff::new(
             &old_config.enrichment_tables,
             &new_config.enrichment_tables,
             &Default::default(),
         );
 
-        assert_eq!(diff.to_add, HashSet::from_iter(["memory_table_new".into()]));
         assert_eq!(
-            diff.to_remove,
+            diff.tables.to_add,
+            HashSet::from_iter(["memory_table_new".into()])
+        );
+        assert_eq!(
+            diff.tables.to_remove,
             HashSet::from_iter(["memory_table_old".into()])
         );
         assert_eq!(
-            diff.to_change,
-            HashSet::from_iter(["memory_table".into(), "memory_table_source".into()])
+            diff.tables.to_change,
+            HashSet::from_iter(["memory_table".into()])
+        );
+
+        assert_eq!(
+            diff.sources.to_change,
+            HashSet::from_iter(["memory_table_source".into()])
+        );
+        assert!(diff.sources.to_add.is_empty());
+        assert!(diff.sources.to_remove.is_empty());
+
+        assert_eq!(
+            diff.sinks.to_add,
+            HashSet::from_iter(["memory_table_new".into()])
+        );
+        assert_eq!(
+            diff.sinks.to_remove,
+            HashSet::from_iter(["memory_table_old".into()])
+        );
+        assert_eq!(
+            diff.sinks.to_change,
+            HashSet::from_iter(["memory_table".into()])
         );
     }
 }

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -235,13 +235,10 @@ impl<'a> Builder<'a> {
                 || self.diff.enrichment_tables.tables.is_changed(name)
                 || self.diff.enrichment_tables.tables.is_added(name)
             {
-                let indexes = if !self.diff.enrichment_tables.tables.is_added(name) {
-                    // If this is an existing enrichment table, we need to store the indexes to reapply
-                    // them again post load.
-                    Some(ENRICHMENT_TABLES.index_fields(&table_name))
-                } else {
-                    None
-                };
+                // Indexes are registered dynamically by VRL lookups against the global
+                // enrichment table registry. Preserve any existing registry indexes even
+                // when this config diff sees the table as newly added.
+                let indexes = ENRICHMENT_TABLES.index_fields(&table_name);
 
                 let mut prev_state = None;
                 if !self.diff.enrichment_tables.tables.is_added(name)
@@ -263,21 +260,19 @@ impl<'a> Builder<'a> {
                     }
                 };
 
-                if let Some(indexes) = indexes {
-                    for (case, index) in indexes {
-                        match table
-                            .add_index(case, &index.iter().map(|s| s.as_ref()).collect::<Vec<_>>())
-                        {
-                            Ok(_) => (),
-                            Err(error) => {
-                                // If there is an error adding an index we do not want to use the reloaded
-                                // data, the previously loaded data will still need to be used.
-                                // Just report the error and continue.
-                                error!(message = "Unable to add index to reloaded enrichment table.",
-                                    table = ?name.to_string(),
-                                    %error);
-                                continue 'tables;
-                            }
+                for (case, index) in indexes {
+                    match table
+                        .add_index(case, &index.iter().map(|s| s.as_ref()).collect::<Vec<_>>())
+                    {
+                        Ok(_) => (),
+                        Err(error) => {
+                            // If there is an error adding an index we do not want to use the reloaded
+                            // data, the previously loaded data will still need to be used.
+                            // Just report the error and continue.
+                            error!(message = "Unable to add index to reloaded enrichment table.",
+                                table = ?name.to_string(),
+                                %error);
+                            continue 'tables;
                         }
                     }
                 }

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -232,10 +232,10 @@ impl<'a> Builder<'a> {
         'tables: for (name, table_outer) in self.config.enrichment_tables.iter() {
             let table_name = name.to_string();
             if ENRICHMENT_TABLES.needs_reload(&table_name)
-                || self.diff.enrichment_tables.is_changed(name)
-                || self.diff.enrichment_tables.is_added(name)
+                || self.diff.enrichment_tables.tables.is_changed(name)
+                || self.diff.enrichment_tables.tables.is_added(name)
             {
-                let indexes = if !self.diff.enrichment_tables.is_added(name) {
+                let indexes = if !self.diff.enrichment_tables.tables.is_added(name) {
                     // If this is an existing enrichment table, we need to store the indexes to reapply
                     // them again post load.
                     Some(ENRICHMENT_TABLES.index_fields(&table_name))
@@ -244,7 +244,7 @@ impl<'a> Builder<'a> {
                 };
 
                 let mut prev_state = None;
-                if !self.diff.enrichment_tables.is_added(name)
+                if !self.diff.enrichment_tables.tables.is_added(name)
                     && table_outer.inner.wants_previous_state()
                 {
                     prev_state = ENRICHMENT_TABLES.extract_state(&table_name);
@@ -311,7 +311,7 @@ impl<'a> Builder<'a> {
                 table_sources
                     .iter()
                     .map(|(key, source)| (key, source))
-                    .filter(|(key, _)| self.diff.enrichment_tables.contains_new(key)),
+                    .filter(|(key, _)| self.diff.enrichment_tables.sources.contains_new(key)),
             )
         {
             debug!(component_id = %key, "Building new source.");
@@ -647,7 +647,7 @@ impl<'a> Builder<'a> {
                 table_sinks
                     .iter()
                     .map(|(key, sink)| (key, sink))
-                    .filter(|(key, _)| self.diff.enrichment_tables.contains_new(key)),
+                    .filter(|(key, _)| self.diff.enrichment_tables.sinks.contains_new(key)),
             )
         {
             debug!(component_id = %key, "Building new sink.");

--- a/src/topology/running.rs
+++ b/src/topology/running.rs
@@ -422,28 +422,18 @@ impl RunningTopology {
     ) -> HashMap<ComponentKey, BuiltBuffer> {
         // First, we shutdown any changed/removed sources. This ensures that we can allow downstream
         // components to terminate naturally by virtue of the flow of events stopping.
-        if diff.sources.any_changed_or_removed() || diff.enrichment_tables.any_changed_or_removed()
+        if diff.sources.any_changed_or_removed()
+            || diff.enrichment_tables.sources.any_changed_or_removed()
         {
             let timeout = Duration::from_secs(30);
             let mut source_shutdown_handles = Vec::new();
 
-            let to_remove_table_sources = diff
-                .enrichment_tables
-                .to_remove
-                .iter()
-                .filter_map(|key| {
-                    self.config
-                        .enrichment_table(key)
-                        .and_then(|t| t.as_source(key))
-                        .map(|(key, _)| key.clone())
-                })
-                .collect::<Vec<_>>();
             let deadline = Instant::now() + timeout;
             for key in diff
                 .sources
                 .to_remove
                 .iter()
-                .chain(to_remove_table_sources.iter())
+                .chain(diff.enrichment_tables.sources.to_remove.iter())
             {
                 debug!(component_id = %key, "Removing source.");
 
@@ -455,22 +445,11 @@ impl RunningTopology {
                     .push(self.shutdown_coordinator.shutdown_source(key, deadline));
             }
 
-            let to_change_table_sources = diff
-                .enrichment_tables
-                .to_change
-                .iter()
-                .filter_map(|key| {
-                    self.config
-                        .enrichment_table(key)
-                        .and_then(|t| t.as_source(key))
-                        .map(|(key, _)| key.clone())
-                })
-                .collect::<Vec<_>>();
             for key in diff
                 .sources
                 .to_change
                 .iter()
-                .chain(to_change_table_sources.iter())
+                .chain(diff.enrichment_tables.sources.to_change.iter())
             {
                 debug!(component_id = %key, "Changing source.");
 
@@ -528,12 +507,13 @@ impl RunningTopology {
         // and to be added components.
         let removed_table_sinks = diff
             .enrichment_tables
+            .sinks
             .removed_and_changed()
-            .filter_map(|key| {
-                self.config
-                    .enrichment_table(key)
-                    .and_then(|t| t.as_sink(key))
-                    .map(|(key, s)| (key.clone(), s.resources(&key)))
+            .map(|key| {
+                (
+                    key.clone(),
+                    enrichment_table_sink_resources(&self.config, key),
+                )
             })
             .collect::<Vec<_>>();
         let remove_sink = diff
@@ -555,12 +535,13 @@ impl RunningTopology {
             .map(|key| (key, new_config.source(key).unwrap().inner.resources()));
         let added_table_sinks = diff
             .enrichment_tables
+            .sinks
             .changed_and_added()
-            .filter_map(|key| {
-                self.config
-                    .enrichment_table(key)
-                    .and_then(|t| t.as_sink(key))
-                    .map(|(key, s)| (key.clone(), s.resources(&key)))
+            .map(|key| {
+                (
+                    key.clone(),
+                    enrichment_table_sink_resources(new_config, key),
+                )
             })
             .collect::<Vec<_>>();
         let add_sink = diff
@@ -597,27 +578,19 @@ impl RunningTopology {
             .sinks
             .to_change
             .iter()
-            .chain(diff.enrichment_tables.to_change.iter().filter(|key| {
-                self.config
-                    .enrichment_table(key)
-                    .and_then(|t| t.as_sink(key))
-                    .is_some()
-            }))
+            .chain(diff.enrichment_tables.sinks.to_change.iter())
             .filter(|&key| {
                 if diff.components_to_reload.contains(key) {
                     return false;
                 }
-                self.config.sink(key).map(|s| s.buffer.clone()).or_else(|| {
-                    self.config
-                        .enrichment_table(key)
-                        .and_then(|t| t.as_sink(key))
-                        .map(|(_, s)| s.buffer)
-                }) == new_config.sink(key).map(|s| s.buffer.clone()).or_else(|| {
-                    self.config
-                        .enrichment_table(key)
-                        .and_then(|t| t.as_sink(key))
-                        .map(|(_, s)| s.buffer)
-                })
+                self.config
+                    .sink(key)
+                    .map(|s| s.buffer.clone())
+                    .or_else(|| enrichment_table_sink_buffer(&self.config, key))
+                    == new_config
+                        .sink(key)
+                        .map(|s| s.buffer.clone())
+                        .or_else(|| enrichment_table_sink_buffer(new_config, key))
             })
             .cloned()
             .collect::<HashSet<_>>();
@@ -636,11 +609,8 @@ impl RunningTopology {
                         .config
                         .sink(key)
                         .is_some_and(|s| s.buffer.has_disk_stage())
-                        || self
-                            .config
-                            .enrichment_table(key)
-                            .and_then(|t| t.as_sink(key))
-                            .is_some_and(|(_, s)| s.buffer.has_disk_stage()))
+                        || enrichment_table_sink_buffer(&self.config, key)
+                            .is_some_and(|buffer| buffer.has_disk_stage()))
             })
             .cloned()
             .collect::<HashSet<_>>();
@@ -655,12 +625,7 @@ impl RunningTopology {
             .sinks
             .to_remove
             .iter()
-            .chain(diff.enrichment_tables.to_remove.iter().filter(|key| {
-                self.config
-                    .enrichment_table(key)
-                    .and_then(|t| t.as_sink(key))
-                    .is_some()
-            }))
+            .chain(diff.enrichment_tables.sinks.to_remove.iter())
             .collect::<Vec<_>>();
         for key in &removed_sinks {
             debug!(component_id = %key, "Removing sink.");
@@ -679,12 +644,7 @@ impl RunningTopology {
             .sinks
             .to_change
             .iter()
-            .chain(diff.enrichment_tables.to_change.iter().filter(|key| {
-                self.config
-                    .enrichment_table(key)
-                    .and_then(|t| t.as_sink(key))
-                    .is_some()
-            }))
+            .chain(diff.enrichment_tables.sinks.to_change.iter())
             .collect::<Vec<_>>();
 
         for key in &sinks_to_change {
@@ -763,7 +723,7 @@ impl RunningTopology {
         &mut self,
         diff: &ConfigDiff,
         new_pieces: &mut TopologyPieces,
-        new_config: Option<&Config>,
+        _new_config: Option<&Config>,
     ) {
         debug!("Connecting changed/added component(s).");
 
@@ -788,27 +748,16 @@ impl RunningTopology {
                 self.component_type_names.remove(key);
             }
 
-            let removed_sinks = diff.enrichment_tables.to_remove.iter().filter(|key| {
-                self.config
-                    .enrichment_table(key)
-                    .and_then(|t| t.as_sink(key))
-                    .is_some()
-            });
-            for key in removed_sinks {
+            for key in &diff.enrichment_tables.sinks.to_remove {
                 // Sinks only have inputs
                 self.inputs_tap_metadata.remove(key);
                 self.component_type_names.remove(key);
             }
 
-            let removed_sources = diff.enrichment_tables.to_remove.iter().filter_map(|key| {
-                self.config
-                    .enrichment_table(key)
-                    .and_then(|t| t.as_source(key).map(|(key, _)| key))
-            });
-            for key in removed_sources {
+            for key in &diff.enrichment_tables.sources.to_remove {
                 // Sources only have outputs
-                self.outputs_tap_metadata.remove(&key);
-                self.component_type_names.remove(&key);
+                self.outputs_tap_metadata.remove(key);
+                self.component_type_names.remove(key);
             }
 
             for key in diff.sources.changed_and_added() {
@@ -820,17 +769,8 @@ impl RunningTopology {
                 }
             }
 
-            for key in diff
-                .enrichment_tables
-                .changed_and_added()
-                .filter_map(|key| {
-                    new_config
-                        .unwrap_or(&self.config)
-                        .enrichment_table(key)
-                        .and_then(|t| t.as_source(key).map(|(key, _)| key))
-                })
-            {
-                if let Some(task) = new_pieces.tasks.get(&key) {
+            for key in diff.enrichment_tables.sources.changed_and_added() {
+                if let Some(task) = new_pieces.tasks.get(key) {
                     self.outputs_tap_metadata
                         .insert(key.clone(), ("source", task.typetag().to_string()));
                     self.component_type_names
@@ -854,17 +794,8 @@ impl RunningTopology {
                 }
             }
 
-            for key in diff
-                .enrichment_tables
-                .changed_and_added()
-                .filter_map(|key| {
-                    new_config
-                        .unwrap_or(&self.config)
-                        .enrichment_table(key)
-                        .and_then(|t| t.as_sink(key).map(|(key, _)| key))
-                })
-            {
-                if let Some(task) = new_pieces.tasks.get(&key) {
+            for key in diff.enrichment_tables.sinks.changed_and_added() {
+                if let Some(task) = new_pieces.tasks.get(key) {
                     self.component_type_names
                         .insert(key.clone(), task.typetag().to_string());
                 }
@@ -885,13 +816,9 @@ impl RunningTopology {
 
         let added_changed_table_sources: Vec<ComponentKey> = diff
             .enrichment_tables
+            .sources
             .changed_and_added()
-            .filter_map(|key| {
-                new_config
-                    .unwrap_or(&self.config)
-                    .enrichment_table(key)
-                    .and_then(|t| t.as_source(key).map(|(key, _)| key))
-            })
+            .cloned()
             .collect();
         for key in &added_changed_table_sources {
             debug!(component_id = %key, "Connecting outputs for enrichment table source.");
@@ -919,13 +846,9 @@ impl RunningTopology {
         }
         let added_changed_tables: Vec<ComponentKey> = diff
             .enrichment_tables
+            .sinks
             .changed_and_added()
-            .filter_map(|key| {
-                new_config
-                    .unwrap_or(&self.config)
-                    .enrichment_table(key)
-                    .and_then(|t| t.as_sink(key).map(|(key, _)| key))
-            })
+            .cloned()
             .collect();
         for key in &added_changed_tables {
             debug!(component_id = %key, "Connecting inputs for enrichment table sink.");
@@ -1119,7 +1042,7 @@ impl RunningTopology {
             .transforms()
             .filter(|(key, _)| !diff.transforms.contains(key));
         for (transform_key, transform) in unchanged_transforms {
-            let changed_outputs = get_changed_outputs(&self.config, diff, transform.inputs.clone());
+            let changed_outputs = get_changed_outputs(diff, transform.inputs.clone());
             for output_id in changed_outputs {
                 debug!(component_id = %transform_key, fanout_id = %output_id.component, "Reattaching component input to fanout.");
 
@@ -1132,8 +1055,8 @@ impl RunningTopology {
         let unchanged_table_sinks = self
             .config
             .enrichment_tables()
-            .filter(|(key, _)| !diff.enrichment_tables.contains(key))
             .filter_map(|(key, table)| table.as_sink(key))
+            .filter(|(key, _)| !diff.enrichment_tables.sinks.contains(key))
             .collect::<Vec<_>>();
         let unchanged_sinks = self
             .config
@@ -1142,7 +1065,7 @@ impl RunningTopology {
         for (sink_key, sink) in
             unchanged_sinks.chain(unchanged_table_sinks.iter().map(|(k, v)| (k, v)))
         {
-            let changed_outputs = get_changed_outputs(&self.config, diff, sink.inputs.clone());
+            let changed_outputs = get_changed_outputs(diff, sink.inputs.clone());
             for output_id in changed_outputs {
                 debug!(component_id = %sink_key, fanout_id = %output_id.component, "Reattaching component input to fanout.");
 
@@ -1167,6 +1090,7 @@ impl RunningTopology {
 
         let changed_table_sources: Vec<&ComponentKey> = diff
             .enrichment_tables
+            .sources
             .to_change
             .iter()
             .filter(|k| new_pieces.source_tasks.contains_key(k))
@@ -1174,6 +1098,7 @@ impl RunningTopology {
 
         let added_table_sources: Vec<&ComponentKey> = diff
             .enrichment_tables
+            .sources
             .to_add
             .iter()
             .filter(|k| new_pieces.source_tasks.contains_key(k))
@@ -1211,20 +1136,18 @@ impl RunningTopology {
 
         let changed_tables: Vec<&ComponentKey> = diff
             .enrichment_tables
+            .sinks
             .to_change
             .iter()
-            .filter(|k| {
-                new_pieces.tasks.contains_key(k) && !new_pieces.source_tasks.contains_key(k)
-            })
+            .filter(|k| new_pieces.tasks.contains_key(k))
             .collect();
 
         let added_tables: Vec<&ComponentKey> = diff
             .enrichment_tables
+            .sinks
             .to_add
             .iter()
-            .filter(|k| {
-                new_pieces.tasks.contains_key(k) && !new_pieces.source_tasks.contains_key(k)
-            })
+            .filter(|k| new_pieces.tasks.contains_key(k))
             .collect();
 
         for key in changed_tables {
@@ -1499,29 +1422,14 @@ impl RunningTopology {
     }
 }
 
-fn get_changed_outputs(
-    config: &Config,
-    diff: &ConfigDiff,
-    output_ids: Inputs<OutputId>,
-) -> Vec<OutputId> {
+fn get_changed_outputs(diff: &ConfigDiff, output_ids: Inputs<OutputId>) -> Vec<OutputId> {
     let mut changed_outputs = Vec::new();
 
-    let to_change_table_sources = diff
-        .enrichment_tables
-        .to_change
-        .iter()
-        .filter_map(|key| {
-            config
-                .enrichment_table(key)
-                .and_then(|t| t.as_source(key))
-                .map(|(key, _)| key.clone())
-        })
-        .collect::<Vec<_>>();
     for source_key in diff
         .sources
         .to_change
         .iter()
-        .chain(to_change_table_sources.iter())
+        .chain(diff.enrichment_tables.sources.to_change.iter())
     {
         changed_outputs.extend(
             output_ids
@@ -1541,4 +1449,24 @@ fn get_changed_outputs(
     }
 
     changed_outputs
+}
+
+fn enrichment_table_sink_resources(config: &Config, sink_key: &ComponentKey) -> Vec<Resource> {
+    config
+        .enrichment_tables()
+        .filter_map(|(table_key, table)| table.as_sink(table_key))
+        .find(|(key, _)| key == sink_key)
+        .map(|(key, sink)| sink.resources(&key))
+        .unwrap_or_default()
+}
+
+fn enrichment_table_sink_buffer(
+    config: &Config,
+    sink_key: &ComponentKey,
+) -> Option<vector_lib::buffers::BufferConfig> {
+    config
+        .enrichment_tables()
+        .filter_map(|(table_key, table)| table.as_sink(table_key))
+        .find(|(key, _)| key == sink_key)
+        .map(|(_, sink)| sink.buffer)
 }

--- a/src/topology/running.rs
+++ b/src/topology/running.rs
@@ -329,8 +329,7 @@ impl RunningTopology {
                 .run_healthchecks(&diff, &mut new_pieces, new_config.healthchecks)
                 .await
             {
-                self.connect_diff(&diff, &mut new_pieces, Some(&new_config))
-                    .await;
+                self.connect_diff(&diff, &mut new_pieces).await;
                 self.spawn_diff(&diff, new_pieces);
                 self.config = new_config;
 
@@ -356,7 +355,7 @@ impl RunningTopology {
                 .run_healthchecks(&diff, &mut new_pieces, self.config.healthchecks)
                 .await
         {
-            self.connect_diff(&diff, &mut new_pieces, None).await;
+            self.connect_diff(&diff, &mut new_pieces).await;
             self.spawn_diff(&diff, new_pieces);
 
             info!("Old configuration restored successfully.");
@@ -723,7 +722,6 @@ impl RunningTopology {
         &mut self,
         diff: &ConfigDiff,
         new_pieces: &mut TopologyPieces,
-        _new_config: Option<&Config>,
     ) {
         debug!("Connecting changed/added component(s).");
 
@@ -1382,9 +1380,7 @@ impl RunningTopology {
         {
             return None;
         }
-        running_topology
-            .connect_diff(&diff, &mut pieces, None)
-            .await;
+        running_topology.connect_diff(&diff, &mut pieces).await;
         running_topology.spawn_diff(&diff, pieces);
 
         let (utilization_task_shutdown_trigger, utilization_shutdown_signal, _) =

--- a/src/topology/test/reload.rs
+++ b/src/topology/test/reload.rs
@@ -566,6 +566,94 @@ async fn topology_reload_preserves_enrichment_table_state() {
     }
 }
 
+#[tokio::test]
+async fn topology_reload_reuses_removed_enrichment_table_source_key() {
+    test_util::trace_init();
+
+    let table_source_key = "memory_test_source";
+    let (old_tx, old_rx) = channel();
+
+    let mut old_config = Config::builder();
+    old_config.add_source(
+        "in",
+        UnitTestSourceConfig {
+            events: vec![Event::Log(LogEvent::from("old"))],
+        },
+    );
+
+    let mut old_memory_config = MemoryConfig::default();
+    old_memory_config.source_config = Some(MemorySourceConfig {
+        export_interval: Some(NonZeroU64::new(1).unwrap()),
+        source_key: table_source_key.to_string(),
+        export_batch_size: None,
+        remove_after_export: false,
+        export_expired_items: false,
+    });
+    old_config.add_enrichment_table(
+        "memory_test",
+        &["in"],
+        EnrichmentTables::Memory(old_memory_config),
+    );
+    old_config.add_sink("old_out", &[table_source_key], oneshot_sink(old_tx));
+
+    let (new_tx, new_rx) = channel();
+    let mut new_config = Config::builder();
+    new_config.add_enrichment_table(
+        "memory_test",
+        &[],
+        EnrichmentTables::Memory(MemoryConfig::default()),
+    );
+    new_config.add_source(
+        table_source_key,
+        UnitTestSourceConfig {
+            events: vec![Event::Log(LogEvent::from("new"))],
+        },
+    );
+    new_config.add_sink("new_out", &[table_source_key], oneshot_sink(new_tx));
+
+    let (mut topology, crash) = start_topology(old_config.build().unwrap(), false).await;
+    let mut crash_stream = UnboundedReceiverStream::new(crash);
+
+    tokio::select! {
+        events = old_rx => {
+            let events = events
+                .expect("old table source must send output before reload")
+                .into_events()
+                .collect::<Vec<_>>();
+            assert!(!events.is_empty());
+        },
+        _ = tokio::time::sleep(Duration::from_secs(5)) => {
+            panic!("old table source never produced output")
+        }
+        error = crash_stream.next() => panic!("topology crashed before reload: {error:?}"),
+    }
+
+    let reload_result = tokio::time::timeout(
+        Duration::from_secs(5),
+        topology.reload_config_and_respawn(new_config.build().unwrap(), Default::default()),
+    )
+    .await;
+    assert!(
+        reload_result.is_ok(),
+        "reload stalled while reusing removed enrichment table source key"
+    );
+    reload_result.unwrap().unwrap();
+
+    tokio::select! {
+        events = new_rx => {
+            let events = events
+                .expect("new source must send output after reload")
+                .into_events()
+                .collect::<Vec<_>>();
+            assert_eq!(events.len(), 1);
+        },
+        _ = tokio::time::sleep(Duration::from_secs(5)) => {
+            panic!("new source never produced output after reload")
+        }
+        error = crash_stream.next() => panic!("topology crashed after reload: {error:?}"),
+    }
+}
+
 async fn reload_sink_test(
     old_config: Config,
     new_config: Config,


### PR DESCRIPTION
## Summary
This refactors enrichment table diffs so table config keys are tracked separately from the source and sink component keys derived from those tables.

The motivation is to make reload topology code explicit about whether it is acting on table configs, generated table sources, or generated table sinks. The previous single `enrichment_tables` diff mixed those concepts, which made the code harder to reason about and led to misleading review comments around removed or changed table sources.

The reload path also keeps preserving dynamic VRL enrichment-table lookup indexes from the global registry, even when the config diff sees the table as newly added.

## Vector configuration
N/A, refactor only.

## How did you test this PR?
- `make fmt`
- `cargo check -p vector`
- `make check-clippy`
- `cargo test -p vector --features enrichment-tables-memory config::diff::tests`
- `cargo test -p vector --features sources-prometheus,sinks-prometheus,sources-internal_metrics,sources-splunk_hec,enrichment-tables-memory topology::test::reload::topology_reload_reuses_removed_enrichment_table_source_key`
- `cargo run --no-default-features --features transforms,vrl-functions-env,vrl-functions-system,vrl-functions-network,vrl-functions-crypto -- test tests/behavior/transforms/remap.yaml`
- `target/debug/vector validate --no-environment /private/tmp/memory-table-source-config.yaml`
  - Validated a memory enrichment table config that defines `source_config.source_key`, `export_interval`, and `export_expired_items`, with downstream sinks consuming both `memory_table_export` and `memory_table_export.expired`.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: #25547
