### PR TITLE
enhancement(redis source): add pchannel pattern subscribe support

### DIFF
--- a/changelog.d/25184_redis_pchannel.enhancement.md
+++ b/changelog.d/25184_redis_pchannel.enhancement.md
@@ -1,0 +1,3 @@
+The `redis` source now supports a `pchannel` data type for subscribing to Redis channels by pattern (`PSUBSCRIBE`). When using `pchannel`, the `key` is interpreted as a glob-style channel pattern, and the new optional `redis_channel` option records the concrete channel that matched the pattern on each event.
+
+authors: divadpoc

--- a/src/sources/redis/channel.rs
+++ b/src/sources/redis/channel.rs
@@ -18,10 +18,7 @@ enum BuildError {
 }
 
 impl InputHandler {
-    pub(super) async fn subscribe(
-        mut self,
-        connection_info: ConnectionInfo,
-    ) -> crate::Result<Source> {
+    pub(super) async fn subscribe(self, connection_info: ConnectionInfo) -> crate::Result<Source> {
         let mut pubsub_conn = self
             .client
             .get_async_pubsub()
@@ -36,13 +33,37 @@ impl InputHandler {
             .context(SubscribeSnafu {})?;
         trace!(endpoint = %connection_info.endpoint.as_str(), channel = %self.key, "Subscribed to channel.");
 
-        Ok(Box::pin(async move {
+        Ok(self.run(pubsub_conn, false))
+    }
+
+    pub(super) async fn psubscribe(self, connection_info: ConnectionInfo) -> crate::Result<Source> {
+        let mut pubsub_conn = self
+            .client
+            .get_async_pubsub()
+            .await
+            .context(ConnectionSnafu {})?;
+
+        trace!(endpoint = %connection_info.endpoint.as_str(), "Connected.");
+
+        pubsub_conn
+            .psubscribe(&self.key)
+            .await
+            .context(SubscribeSnafu {})?;
+        trace!(endpoint = %connection_info.endpoint.as_str(), pattern = %self.key, "Subscribed to channel with pattern.");
+
+        Ok(self.run(pubsub_conn, true))
+    }
+
+    fn run(mut self, mut pubsub_conn: redis::aio::PubSub, with_channel: bool) -> Source {
+        Box::pin(async move {
             let shutdown = self.cx.shutdown.clone();
             let mut pubsub_stream = pubsub_conn.on_message().take_until(shutdown);
             while let Some(msg) = pubsub_stream.next().await {
+                // For pattern subscriptions, record which concrete channel matched.
+                let channel = with_channel.then(|| msg.get_channel_name().to_string());
                 match msg.get_payload::<String>() {
                     Ok(line) => {
-                        if let Err(()) = self.handle_line(line).await {
+                        if let Err(()) = self.handle_line(line, channel.as_deref()).await {
                             break;
                         }
                     }
@@ -50,6 +71,6 @@ impl InputHandler {
                 }
             }
             Ok(())
-        }))
+        })
     }
 }

--- a/src/sources/redis/channel.rs
+++ b/src/sources/redis/channel.rs
@@ -60,7 +60,10 @@ impl InputHandler {
             let mut pubsub_stream = pubsub_conn.on_message().take_until(shutdown);
             while let Some(msg) = pubsub_stream.next().await {
                 // For pattern subscriptions, record which concrete channel matched.
-                let channel = with_channel.then(|| msg.get_channel_name().to_string());
+                // Redis channel names are binary-safe, so keep the raw bytes
+                let channel: Option<Vec<u8>> = with_channel
+                    .then(|| msg.get_channel::<Vec<u8>>().ok())
+                    .flatten();
                 match msg.get_payload::<String>() {
                     Ok(line) => {
                         if let Err(()) = self.handle_line(line, channel.as_deref()).await {

--- a/src/sources/redis/list.rs
+++ b/src/sources/redis/list.rs
@@ -51,7 +51,7 @@ impl InputHandler {
                         if retry > 0 {
                             retry = 0
                         }
-                        if let Err(()) = self.handle_line(line).await {
+                        if let Err(()) = self.handle_line(line, None).await {
                             break;
                         }
                     }

--- a/src/sources/redis/mod.rs
+++ b/src/sources/redis/mod.rs
@@ -46,6 +46,12 @@ pub enum DataTypeConfig {
     ///
     /// This is based on Redis' Pub/Sub capabilities.
     Channel,
+
+    /// The `pchannel` data type.
+    ///
+    /// Pattern-based Pub/Sub subscription using Redis `PSUBSCRIBE`. The `key` is interpreted
+    /// as a glob-style channel pattern (for example, `news.*`).
+    Pchannel,
 }
 
 /// Options for the Redis `list` data type.
@@ -117,6 +123,15 @@ pub struct RedisSourceConfig {
     #[configurable(metadata(docs::examples = "redis_key"))]
     redis_key: Option<OptionalValuePath>,
 
+    /// Sets the name of the log field to use to add the matched channel to each event.
+    ///
+    /// The value is the concrete Redis channel that matched the subscribed pattern.
+    /// Only applies to the `pchannel` data type.
+    ///
+    /// By default, this is not set and the field is not automatically added.
+    #[configurable(metadata(docs::examples = "redis_channel"))]
+    redis_channel: Option<OptionalValuePath>,
+
     #[configurable(derived)]
     #[serde(default = "default_framing_message_based")]
     #[derivative(Default(value = "default_framing_message_based()"))]
@@ -159,6 +174,7 @@ impl SourceConfig for RedisSourceConfig {
             return Err("`key` cannot be empty.".into());
         }
         let redis_key = self.redis_key.clone().and_then(|k| k.path);
+        let redis_channel = self.redis_channel.clone().and_then(|k| k.path);
 
         let client = redis::Client::open(self.url.as_str()).context(ClientSnafu {})?;
         let connection_info = ConnectionInfo::from(client.get_connection_info());
@@ -176,6 +192,7 @@ impl SourceConfig for RedisSourceConfig {
             events_received: events_received.clone(),
             key: self.key.clone(),
             redis_key,
+            redis_channel,
             decoder,
             cx,
             log_namespace,
@@ -187,6 +204,7 @@ impl SourceConfig for RedisSourceConfig {
                 handler.watch(method).await
             }
             DataTypeConfig::Channel => handler.subscribe(connection_info).await,
+            DataTypeConfig::Pchannel => handler.psubscribe(connection_info).await,
         }
     }
 
@@ -199,7 +217,7 @@ impl SourceConfig for RedisSourceConfig {
             .and_then(|k| k.path)
             .map(LegacyKey::InsertIfEmpty);
 
-        let schema_definition = self
+        let mut schema_definition = self
             .decoding
             .schema_definition(log_namespace)
             .with_source_metadata(
@@ -208,8 +226,25 @@ impl SourceConfig for RedisSourceConfig {
                 &owned_value_path!("key"),
                 Kind::bytes(),
                 None,
-            )
-            .with_standard_vector_source_metadata();
+            );
+
+        if matches!(self.data_type, DataTypeConfig::Pchannel) {
+            let redis_channel_path = self
+                .redis_channel
+                .clone()
+                .and_then(|k| k.path)
+                .map(LegacyKey::InsertIfEmpty);
+
+            schema_definition = schema_definition.with_source_metadata(
+                Self::NAME,
+                redis_channel_path,
+                &owned_value_path!("channel"),
+                Kind::bytes(),
+                None,
+            );
+        }
+
+        let schema_definition = schema_definition.with_standard_vector_source_metadata();
 
         vec![SourceOutput::new_maybe_logs(
             self.decoding.output_type(),
@@ -228,13 +263,14 @@ struct InputHandler {
     pub events_received: Registered<EventsReceived>,
     pub key: String,
     pub redis_key: Option<OwnedValuePath>,
+    pub redis_channel: Option<OwnedValuePath>,
     pub decoder: Decoder,
     pub log_namespace: LogNamespace,
     pub cx: SourceContext,
 }
 
 impl InputHandler {
-    async fn handle_line(&mut self, line: String) -> Result<(), ()> {
+    async fn handle_line(&mut self, line: String, channel: Option<&str>) -> Result<(), ()> {
         let now = Utc::now();
 
         self.bytes_received.emit(ByteSize(line.len()));
@@ -269,6 +305,16 @@ impl InputHandler {
                                 path!("key"),
                                 self.key.as_str(),
                             );
+
+                            if let Some(channel) = channel {
+                                self.log_namespace.insert_source_metadata(
+                                    RedisSourceConfig::NAME,
+                                    log,
+                                    self.redis_channel.as_ref().map(LegacyKey::InsertIfEmpty),
+                                    path!("channel"),
+                                    channel,
+                                );
+                            }
                         };
 
                         event
@@ -299,6 +345,22 @@ mod test {
     #[test]
     fn generate_config() {
         crate::test_util::test_generate_config::<RedisSourceConfig>();
+    }
+
+    #[test]
+    fn pchannel_config_parses() {
+        let config: RedisSourceConfig = toml::from_str(
+            r#"
+            url = "redis://127.0.0.1:6379/0"
+            key = "news.*"
+            data_type = "pchannel"
+            redis_channel = "channel"
+            "#,
+        )
+        .unwrap();
+
+        assert!(matches!(config.data_type, DataTypeConfig::Pchannel));
+        assert!(config.redis_channel.is_some());
     }
 }
 
@@ -342,6 +404,7 @@ mod integration_test {
             url: REDIS_SERVER.to_owned(),
             key: key.clone(),
             redis_key: None,
+            redis_channel: None,
             framing: default_framing_message_based(),
             decoding: default_decoding(),
             log_namespace: Some(false),
@@ -383,6 +446,7 @@ mod integration_test {
             url: REDIS_SERVER.to_owned(),
             key: key.clone(),
             redis_key: Some(OptionalValuePath::from(owned_value_path!("remapped_key"))),
+            redis_channel: None,
             framing: default_framing_message_based(),
             decoding: default_decoding(),
             log_namespace: Some(true),
@@ -424,6 +488,7 @@ mod integration_test {
             url: REDIS_SERVER.to_owned(),
             key: key.clone(),
             redis_key: None,
+            redis_channel: None,
             framing: default_framing_message_based(),
             decoding: default_decoding(),
             log_namespace: Some(false),
@@ -457,6 +522,7 @@ mod integration_test {
             url: REDIS_SERVER.to_owned(),
             key: key.clone(),
             redis_key: None,
+            redis_channel: None,
             framing: default_framing_message_based(),
             decoding: default_decoding(),
             log_namespace: Some(false),
@@ -502,5 +568,68 @@ mod integration_test {
                 RedisSourceConfig::NAME.into()
             );
         }
+    }
+
+    #[tokio::test]
+    async fn redis_source_pchannel_consume_event() {
+        let prefix = format!("test-pchannel-{}", random_string(10));
+        let channel_a = format!("{prefix}-a");
+        let channel_b = format!("{prefix}-b");
+        let pattern = format!("{prefix}-*");
+        let text = "test message for pchannel";
+
+        // Build and spawn the source before publishing, so the pattern subscription is active.
+        let config = RedisSourceConfig {
+            data_type: DataTypeConfig::Pchannel,
+            list: None,
+            url: REDIS_SERVER.to_owned(),
+            key: pattern.clone(),
+            redis_key: None,
+            redis_channel: Some(OptionalValuePath::from(owned_value_path!("channel"))),
+            framing: default_framing_message_based(),
+            decoding: default_decoding(),
+            log_namespace: Some(false),
+        };
+
+        let (tx, rx) = SourceSender::new_test();
+        let context = SourceContext::new_test(tx, None);
+        let source = config
+            .build(context)
+            .await
+            .expect("source should not fail to build");
+
+        tokio::spawn(source);
+
+        // Briefly wait to ensure the source is subscribed.
+        tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+
+        let client = redis::Client::open(REDIS_SERVER).unwrap();
+        let mut async_conn = client
+            .get_multiplexed_async_connection()
+            .await
+            .expect("Failed to get redis async connection.");
+
+        let _: i32 = async_conn.publish(channel_a.clone(), text).await.unwrap();
+        let _: i32 = async_conn.publish(channel_b.clone(), text).await.unwrap();
+
+        let events = collect_n(rx, 2).await;
+        assert_eq!(events.len(), 2);
+
+        let mut seen_channels = std::collections::HashSet::new();
+        for event in events {
+            let log = event.as_log();
+            assert_eq!(
+                log[log_schema().message_key().unwrap().to_string()],
+                text.into()
+            );
+            assert_eq!(
+                log[log_schema().source_type_key().unwrap().to_string()],
+                RedisSourceConfig::NAME.into()
+            );
+            seen_channels.insert(log["channel"].to_string_lossy().into_owned());
+        }
+
+        assert!(seen_channels.contains(&channel_a));
+        assert!(seen_channels.contains(&channel_b));
     }
 }

--- a/src/sources/redis/mod.rs
+++ b/src/sources/redis/mod.rs
@@ -270,7 +270,7 @@ struct InputHandler {
 }
 
 impl InputHandler {
-    async fn handle_line(&mut self, line: String, channel: Option<&str>) -> Result<(), ()> {
+    async fn handle_line(&mut self, line: String, channel: Option<&[u8]>) -> Result<(), ()> {
         let now = Utc::now();
 
         self.bytes_received.emit(ByteSize(line.len()));
@@ -575,6 +575,14 @@ mod integration_test {
         let prefix = format!("test-pchannel-{}", random_string(10));
         let channel_a = format!("{prefix}-a");
         let channel_b = format!("{prefix}-b");
+        // A channel name that is not valid UTF-8. It still matches the pattern (glob matching
+        // is byte-wise) and must be preserved verbatim in the `channel` metadata rather than
+        // being lossily replaced with `?`.
+        let channel_bin = {
+            let mut name = format!("{prefix}-").into_bytes();
+            name.extend_from_slice(&[0xff, 0xfe]);
+            name
+        };
         let pattern = format!("{prefix}-*");
         let text = "test message for pchannel";
 
@@ -611,11 +619,12 @@ mod integration_test {
 
         let _: i32 = async_conn.publish(channel_a.clone(), text).await.unwrap();
         let _: i32 = async_conn.publish(channel_b.clone(), text).await.unwrap();
+        let _: i32 = async_conn.publish(channel_bin.clone(), text).await.unwrap();
 
-        let events = collect_n(rx, 2).await;
-        assert_eq!(events.len(), 2);
+        let events = collect_n(rx, 3).await;
+        assert_eq!(events.len(), 3);
 
-        let mut seen_channels = std::collections::HashSet::new();
+        let mut seen_channels: Vec<Vec<u8>> = Vec::new();
         for event in events {
             let log = event.as_log();
             assert_eq!(
@@ -626,10 +635,15 @@ mod integration_test {
                 log[log_schema().source_type_key().unwrap().to_string()],
                 RedisSourceConfig::NAME.into()
             );
-            seen_channels.insert(log["channel"].to_string_lossy().into_owned());
+            let channel = log["channel"]
+                .as_bytes()
+                .expect("channel metadata should be bytes")
+                .to_vec();
+            seen_channels.push(channel);
         }
 
-        assert!(seen_channels.contains(&channel_a));
-        assert!(seen_channels.contains(&channel_b));
+        assert!(seen_channels.contains(&channel_a.into_bytes()));
+        assert!(seen_channels.contains(&channel_b.into_bytes()));
+        assert!(seen_channels.contains(&channel_bin));
     }
 }

--- a/website/cue/reference/components/sources/generated/redis.cue
+++ b/website/cue/reference/components/sources/generated/redis.cue
@@ -13,6 +13,12 @@ generated: components: sources: redis: configuration: {
 					This is based on Redis' Pub/Sub capabilities.
 					"""
 				list: "The `list` data type."
+				pchannel: """
+					The `pchannel` data type.
+
+					Pattern-based Pub/Sub subscription using Redis `PSUBSCRIBE`. The `key` is interpreted
+					as a glob-style channel pattern (for example, `news.*`).
+					"""
 			}
 		}
 	}
@@ -534,6 +540,18 @@ generated: components: sources: redis: configuration: {
 				rpop: "Pop messages from the tail of the list."
 			}
 		}
+	}
+	redis_channel: {
+		description: """
+			Sets the name of the log field to use to add the matched channel to each event.
+
+			The value is the concrete Redis channel that matched the subscribed pattern.
+			Only applies to the `pchannel` data type.
+
+			By default, this is not set and the field is not automatically added.
+			"""
+		required: false
+		type: string: examples: ["redis_channel"]
 	}
 	redis_key: {
 		description: """


### PR DESCRIPTION
## Summary
- add a new `data_type = "pchannel"` - this ensures channel is untouched. The `key` field is then interpreted as a glob pattern (e.g.`news.*`).
- the `key` field is a single `String` . this is similar to channel, although the library would support multiple channels/patterns
- the meta data would be `redis_key` the pattern itself, `redis_channel` the actual channel (new and optional, only applicable for psubscribe, so list and channel would ignore it, as the list options are ignored for channel)

## Vector configuration
```
  redis_in:
    type: "redis"
    url: "redis://127.0.0.1:6379/0"
    data_type: "pchannel"
    key: "cap-stats-*"
    redis_channel: "channel"
    decoding:
      codec: "json"
```

## How did you test this PR?
Unit and integration tests

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Closes: #25184

## Notes

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details on the [dd-rust-license-tool](https://crates.io/crates/dd-rust-license-tool).


