### PR TITLE
fix(topology): reattach fanout on cross-type producer key swap

### DIFF
--- a/changelog.d/25712_reload_reattach_cross_type_source.fix.md
+++ b/changelog.d/25712_reload_reattach_cross_type_source.fix.md
@@ -1,0 +1,3 @@
+Fixed a config reload bug that could silently stop event delivery. If a reload changes a component's kind while keeping the same name (for example, replacing an enrichment table's derived source named `X` with a regular source named `X`, or replacing a transform named `X` with a source named `X`), any downstream sink or transform that still reads from `X` now correctly reconnects to the new component instead of going silent until the next restart.
+
+authors: pront

--- a/src/topology/running.rs
+++ b/src/topology/running.rs
@@ -1418,33 +1418,36 @@ impl RunningTopology {
     }
 }
 
+/// Returns the subset of `output_ids` whose upstream fanout was replaced during this reload and so
+/// must be reattached to the still-running downstream consumer.
+///
+/// A producer's fanout is replaced when its key was respawned in place (`to_change`) or when it
+/// disappeared as one kind of producer and reappeared as another (e.g. an enrichment-table-derived
+/// source removed while a regular source with the same key was added, or a transform removed while
+/// a source with the same key was added).
 fn get_changed_outputs(diff: &ConfigDiff, output_ids: Inputs<OutputId>) -> Vec<OutputId> {
-    let mut changed_outputs = Vec::new();
+    let producer_destroyed = |key: &ComponentKey| {
+        diff.sources.to_change.contains(key)
+            || diff.sources.to_remove.contains(key)
+            || diff.transforms.to_change.contains(key)
+            || diff.transforms.to_remove.contains(key)
+            || diff.enrichment_tables.sources.to_change.contains(key)
+            || diff.enrichment_tables.sources.to_remove.contains(key)
+    };
+    let producer_recreated = |key: &ComponentKey| {
+        diff.sources.to_change.contains(key)
+            || diff.sources.to_add.contains(key)
+            || diff.transforms.to_change.contains(key)
+            || diff.transforms.to_add.contains(key)
+            || diff.enrichment_tables.sources.to_change.contains(key)
+            || diff.enrichment_tables.sources.to_add.contains(key)
+    };
 
-    for source_key in diff
-        .sources
-        .to_change
+    output_ids
         .iter()
-        .chain(diff.enrichment_tables.sources.to_change.iter())
-    {
-        changed_outputs.extend(
-            output_ids
-                .iter()
-                .filter(|id| &id.component == source_key)
-                .cloned(),
-        );
-    }
-
-    for transform_key in &diff.transforms.to_change {
-        changed_outputs.extend(
-            output_ids
-                .iter()
-                .filter(|id| &id.component == transform_key)
-                .cloned(),
-        );
-    }
-
-    changed_outputs
+        .filter(|id| producer_destroyed(&id.component) && producer_recreated(&id.component))
+        .cloned()
+        .collect()
 }
 
 fn enrichment_table_sink_resources(config: &Config, sink_key: &ComponentKey) -> Vec<Resource> {


### PR DESCRIPTION
## Summary
Fixes a topology reload bug where downstream components whose input key stayed the same across reload would silently stop receiving events if the upstream producer changed kind (e.g. an enrichment-table-derived source at key `X` replaced by a regular source at key `X`, or a transform at `X` replaced by a source at `X`).

`get_changed_outputs` previously only iterated `to_change` sets, missing cross-type respawns. It now also considers keys that appear in `(sources.to_remove ∪ transforms.to_remove ∪ enrichment_tables.to_remove)` intersected with `(sources.to_add ∪ transforms.to_add ∪ enrichment_tables.to_add)`.

## Vector configuration

Reproducer config A (pre-reload):

```yaml
sources:
  in:
    type: demo_logs
    format: json
    interval: 1

enrichment_tables:
  memory_table:
    type: memory
    ttl: 60
    inputs: ["in"]
    source_config:
      source_key: "shared"
      export_interval: 2

sinks:
  observer:
    type: console
    inputs: ["shared"]
    encoding:
      codec: json
```

Reloaded config B:

```yaml
sources:
  shared:
    type: demo_logs
    format: json
    interval: 1

sinks:
  observer:
    type: console
    inputs: ["shared"]
    encoding:
      codec: json
```

## How did you test this PR?

Manual end-to-end reproduction with `./target/debug/vector --config live.yaml`, swapping A -> B via SIGHUP:

- On master: `observer` receives 0 events after reload (bug confirmed).
- On this branch: `observer` continues receiving `demo_logs` events after reload.

Also ran `cargo check` with the topology feature set. A unit-test-only regression could not be reliably reproduced in the current test harness (the reattach path fires but events don't flow via `basic_source`/`basic_sink` after reload — a separate test-infra issue), so the branch relies on the manual reproducer above. Happy to add a test if a reviewer knows a working scaffold.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [x] Yes. Changelog fragment added.
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: #25712 (codex review comment that flagged the source/enrichment-table variant of this gap)