### PR TITLE
fix(codecs): accept short-form syslog severity keywords in encoder

### DIFF
--- a/changelog.d/fix_syslog_severity_aliases.fix.md
+++ b/changelog.d/fix_syslog_severity_aliases.fix.md
@@ -1,0 +1,3 @@
+Fixed the syslog codec silently ignoring short-form severity keywords (`crit`, `emerg`, `err`, `info`, `warn`) and falling back to the default `informational`. The encoder now accepts both short-form and full-form severity names, matching the values used by VRL's `to_syslog_severity` and `to_syslog_level` functions.
+
+authors: vparfonov

--- a/lib/codecs/src/encoding/format/syslog.rs
+++ b/lib/codecs/src/encoding/format/syslog.rs
@@ -588,19 +588,24 @@ pub enum Facility {
 #[configurable_component]
 pub enum Severity {
     /// Emergency
+    #[strum(serialize = "emergency", serialize = "emerg", serialize = "panic")]
     Emergency = 0,
     /// Alert
     Alert = 1,
     /// Critical
+    #[strum(serialize = "critical", serialize = "crit")]
     Critical = 2,
     /// Error
+    #[strum(serialize = "error", serialize = "err")]
     Error = 3,
     /// Warning
+    #[strum(serialize = "warning", serialize = "warn")]
     Warning = 4,
     /// Notice
     Notice = 5,
     /// Informational
     #[default]
+    #[strum(serialize = "informational", serialize = "info")]
     Informational = 6,
     /// Debug
     Debug = 7,
@@ -743,6 +748,40 @@ mod tests {
         let severity = decanter.get_severity(&config_sev);
         assert_eq!(facility, Facility::Daemon);
         assert_eq!(severity, Severity::Critical);
+
+        //check short-form severity aliases
+        log.insert(event_path!("syslog_severity"), "crit");
+        let decanter = ConfigDecanter::new(&log);
+        assert_eq!(decanter.get_severity(&config_sev), Severity::Critical);
+
+        log.insert(event_path!("syslog_severity"), "emerg");
+        let decanter = ConfigDecanter::new(&log);
+        assert_eq!(decanter.get_severity(&config_sev), Severity::Emergency);
+
+        log.insert(event_path!("syslog_severity"), "err");
+        let decanter = ConfigDecanter::new(&log);
+        assert_eq!(decanter.get_severity(&config_sev), Severity::Error);
+
+        log.insert(event_path!("syslog_severity"), "info");
+        let decanter = ConfigDecanter::new(&log);
+        assert_eq!(decanter.get_severity(&config_sev), Severity::Informational);
+
+        log.insert(event_path!("syslog_severity"), "warn");
+        let decanter = ConfigDecanter::new(&log);
+        assert_eq!(decanter.get_severity(&config_sev), Severity::Warning);
+
+        log.insert(event_path!("syslog_severity"), "panic");
+        let decanter = ConfigDecanter::new(&log);
+        assert_eq!(decanter.get_severity(&config_sev), Severity::Emergency);
+
+        //check uppercase short-form aliases
+        log.insert(event_path!("syslog_severity"), "CRIT");
+        let decanter = ConfigDecanter::new(&log);
+        assert_eq!(decanter.get_severity(&config_sev), Severity::Critical);
+
+        log.insert(event_path!("syslog_severity"), "EMERG");
+        let decanter = ConfigDecanter::new(&log);
+        assert_eq!(decanter.get_severity(&config_sev), Severity::Emergency);
 
         //check defaults with empty config
         let empty_config =


### PR DESCRIPTION
## Summary
The syslog codec's `Severity` enum only accepts full-form keywords (`"critical"`, `"emergency"`, `"informational"`, etc.) but the VRL functions `to_syslog_severity` and `to_syslog_level` use short-form keywords (`"crit"`, `"emerg"`, `"info"`, etc.). When a short-form value reaches the syslog encoder, `FromStr` parsing fails silently and the severity falls back to the default `Informational` (6).

  This adds strum `serialize` aliases so the encoder accepts both forms:
  - `emerg` / `emergency` / `panic` → Emergency (0)
  - `crit` / `critical` → Critical (2)
  - `err` / `error` → Error (3)
  - `warn` / `warning` → Warning (4)
  - `info` / `informational` → Informational (6)

<!-- Please provide a brief summary about what this PR does.

This should help the reviewers give feedback faster and with higher quality. -->

## Vector configuration
<!-- Include Vector configuration(s) you used to test and debug your changes. -->

## How did you test this PR?
Extended the existing `test_parsing_logic` unit test in `lib/codecs/src/encoding/format/syslog.rs`
<!-- Please describe how you tested your changes. Also include any information about your setup. -->

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Closes: #<issue/PR number or link>
-->
<!--
- Related: #<issue/PR number or link>
-->

## Notes

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details on the [dd-rust-license-tool](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert, perf
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional but appreciated; letters, digits, spaces, hyphens, underscores (e.g. `kafka source`, `amazon-linux`)
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
