### PR TITLE
chore(ci): consolidate docker dependabot entries using directories

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -92,52 +92,11 @@ updates:
         patterns:
           - "*"
   - package-ecosystem: "docker"
-    directory: "/distribution/docker/alpine"
-    schedule:
-      interval: "monthly"
-      time: "04:00" # UTC
-    labels:
-      - "domain: releasing"
-      - "no-changelog"
-    commit-message:
-      prefix: "chore(deps)"
-    open-pull-requests-limit: 100
-    groups:
-      docker-images:
-        patterns:
-          - "*"
-  - package-ecosystem: "docker"
-    directory: "/distribution/docker/debian"
-    schedule:
-      interval: "monthly"
-      time: "04:00" # UTC
-    labels:
-      - "domain: releasing"
-      - "no-changelog"
-    commit-message:
-      prefix: "chore(deps)"
-    open-pull-requests-limit: 100
-    groups:
-      docker-images:
-        patterns:
-          - "*"
-  - package-ecosystem: "docker"
-    directory: "/distribution/docker/distroless-static"
-    schedule:
-      interval: "monthly"
-      time: "04:00" # UTC
-    labels:
-      - "domain: releasing"
-      - "no-changelog"
-    commit-message:
-      prefix: "chore(deps)"
-    open-pull-requests-limit: 100
-    groups:
-      docker-images:
-        patterns:
-          - "*"
-  - package-ecosystem: "docker"
-    directory: "/distribution/docker/distroless-libc"
+    directories:
+      - "/distribution/docker/alpine"
+      - "/distribution/docker/debian"
+      - "/distribution/docker/distroless-static"
+      - "/distribution/docker/distroless-libc"
     schedule:
       interval: "monthly"
       time: "04:00" # UTC


### PR DESCRIPTION
## Summary

Consolidate the four separate `package-ecosystem: docker` entries in `.github/dependabot.yml` into a single entry using the `directories` key. This reduces 41 lines of duplication while preserving identical behavior — same schedule, labels, commit-message prefix, PR limit, and grouping for all four Docker image directories.

## Vector configuration

N/A

## How did you test this PR?

Reviewed the Dependabot `directories` docs to confirm the key is supported for `package-ecosystem: docker`. No functional change — dependabot will continue scanning the same four paths.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.