### PR TITLE
feat(duckdb sink): add DuckDB sink

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,9 +303,9 @@ dependencies = [
 
 [[package]]
 name = "arbitrary"
-version = "1.3.2"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 dependencies = [
  "derive_arbitrary",
 ]
@@ -556,6 +556,7 @@ version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f633dbfdf39c039ada1bf9e34c694816eb71fbb7dc78f613993b7245e078a1ed"
 dependencies = [
+ "bitflags 2.10.0",
  "serde",
  "serde_core",
 ]
@@ -2179,9 +2180,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.14.0"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytecheck"
@@ -2649,10 +2650,11 @@ dependencies = [
 
 [[package]]
 name = "comfy-table"
-version = "7.2.2"
+version = "7.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
+checksum = "4a65ebfec4fb190b6f90e944a817d60499ee0744e582530e2c9900a22e591d9a"
 dependencies = [
+ "crossterm 0.28.1",
  "unicode-segmentation",
  "unicode-width 0.2.0",
 ]
@@ -3048,6 +3050,19 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags 2.10.0",
+ "crossterm_winapi",
+ "parking_lot",
+ "rustix 0.38.40",
+ "winapi",
+]
 
 [[package]]
 name = "crossterm"
@@ -3500,9 +3515,9 @@ dependencies = [
 
 [[package]]
 name = "derive_arbitrary"
-version = "1.3.2"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2 1.0.106",
  "quote 1.0.45",
@@ -3756,6 +3771,25 @@ name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "duckdb"
+version = "1.10504.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b9b997383221efd999a362448a0866c54b9a2cb7d4da8cd4903ead4df9f8eaa"
+dependencies = [
+ "arrow",
+ "cast",
+ "comfy-table",
+ "fallible-iterator 0.3.0",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libduckdb-sys",
+ "num",
+ "num-integer",
+ "rust_decimal",
+ "strum 0.27.2",
+]
 
 [[package]]
 name = "duct"
@@ -4118,6 +4152,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fancy-regex"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4193,6 +4239,16 @@ dependencies = [
  "vector-common",
  "vector-config",
  "winapi",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -6415,6 +6471,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libduckdb-sys"
+version = "1.10504.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e67523a40ee3da30411e00e243990b3760d91877202ab2f39c03ab34f8dbfc"
+dependencies = [
+ "cc",
+ "flate2",
+ "pkg-config",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "tar",
+ "vcpkg",
+ "zip",
+]
+
+[[package]]
 name = "libgit2-sys"
 version = "0.18.3+1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8268,7 +8341,7 @@ dependencies = [
  "base64 0.22.1",
  "byteorder",
  "bytes",
- "fallible-iterator",
+ "fallible-iterator 0.2.0",
  "hmac 0.13.0",
  "md-5 0.11.0",
  "memchr",
@@ -8285,7 +8358,7 @@ checksum = "851ca9db4932932d69f3ea811b1abe63087a0f740a47692619dd40d4899b68be"
 dependencies = [
  "bytes",
  "chrono",
- "fallible-iterator",
+ "fallible-iterator 0.2.0",
  "postgres-protocol",
 ]
 
@@ -9216,7 +9289,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "577c9b9f652b4c121fb25c6a391dd06406d3b092ba68827e6d2f09550edc54b3"
 dependencies = [
  "cfg-if",
- "crossterm",
+ "crossterm 0.29.0",
  "instability",
  "ratatui-core",
 ]
@@ -11434,6 +11507,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "tcp-stream"
 version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11750,7 +11834,7 @@ dependencies = [
  "async-trait",
  "byteorder",
  "bytes",
- "fallible-iterator",
+ "fallible-iterator 0.2.0",
  "futures-channel",
  "futures-util",
  "log",
@@ -12891,6 +12975,7 @@ dependencies = [
  "dirs-next",
  "dnsmsg-parser",
  "dnstap-parser",
+ "duckdb",
  "dyn-clone",
  "encoding_rs",
  "enum_dispatch",
@@ -13361,7 +13446,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "clap",
- "crossterm",
+ "crossterm 0.29.0",
  "exitcode",
  "futures",
  "futures-util",
@@ -14648,6 +14733,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix 1.1.4",
+]
+
+[[package]]
 name = "xmlparser"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14773,6 +14868,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a05c7c36fde6c09b08576c9f7fb4cda705990f73b58fe011abf7dfb24168b"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "flate2",
+ "indexmap 2.12.0",
+ "memchr",
+ "zopfli",
+]
+
+[[package]]
 name = "zlib-rs"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14783,6 +14892,18 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -393,6 +393,7 @@ csv = { version = "1.3", default-features = false }
 databend-client = { version = "0.28.0", default-features = false, features = ["rustls"], optional = true }
 derivative.workspace = true
 dirs-next = { version = "2.0.0", default-features = false, optional = true }
+duckdb = { version = "~1.10504.0", default-features = false, features = ["bundled", "appender-arrow"], optional = true }
 dyn-clone = { version = "1.0.20", default-features = false }
 encoding_rs = { version = "0.8.35", default-features = false, features = ["serde"] }
 enum_dispatch = { version = "0.3.13", default-features = false }
@@ -952,6 +953,7 @@ sinks-datadog_logs = []
 sinks-datadog_metrics = ["protobuf-build", "dep:prost", "dep:prost-reflect"]
 sinks-datadog_traces = ["protobuf-build", "dep:prost", "dep:rmpv", "dep:rmp-serde", "dep:serde_bytes"]
 sinks-doris = ["sqlx/mysql"]
+sinks-duckdb = ["dep:duckdb", "codecs-arrow"]
 sinks-elasticsearch = ["transforms-metric_to_log"]
 sinks-file = ["dep:async-compression"]
 sinks-gcp = ["sinks-gcp-chronicle", "dep:base64", "gcp"]
@@ -1005,6 +1007,7 @@ all-integration-tests = [
   "dnstap-integration-tests",
   "docker-logs-integration-tests",
   "doris-integration-tests",
+  "duckdb-integration-tests",
   "es-integration-tests",
   "eventstoredb_metrics-integration-tests",
   "fluent-integration-tests",
@@ -1074,6 +1077,7 @@ datadog-metrics-integration-tests = ["sinks-datadog_metrics", "dep:prost"]
 datadog-traces-integration-tests = ["sources-datadog_agent", "sinks-datadog_traces", "axum/tokio"]
 docker-logs-integration-tests = ["sources-docker_logs"]
 doris-integration-tests = ["sinks-doris"]
+duckdb-integration-tests = ["sinks-duckdb"]
 es-integration-tests = ["sinks-elasticsearch", "aws-core"]
 eventstoredb_metrics-integration-tests = ["sources-eventstoredb_metrics"]
 fluent-integration-tests = ["docker", "sources-fluent"]

--- a/changelog.d/duckdb_sink.feature.md
+++ b/changelog.d/duckdb_sink.feature.md
@@ -1,0 +1,3 @@
+Add a DuckDB sink for writing log events into existing DuckDB tables.
+
+authors: dannote

--- a/lib/vector-common/src/internal_event/metric_name.rs
+++ b/lib/vector-common/src/internal_event/metric_name.rs
@@ -131,6 +131,7 @@ pub enum HistogramName {
     HttpClientErrorRttSeconds,
     SourceBufferUtilization,
     TransformBufferUtilization,
+    DuckdbRequestStageDurationSeconds,
 }
 
 impl HistogramName {
@@ -166,6 +167,7 @@ impl HistogramName {
             Self::HttpClientErrorRttSeconds => "http_client_error_rtt_seconds",
             Self::SourceBufferUtilization => "source_buffer_utilization",
             Self::TransformBufferUtilization => "transform_buffer_utilization",
+            Self::DuckdbRequestStageDurationSeconds => "duckdb_request_stage_duration_seconds",
         }
     }
 }

--- a/src/internal_events/duckdb.rs
+++ b/src/internal_events/duckdb.rs
@@ -1,0 +1,47 @@
+use std::time::Duration;
+
+use vector_lib::{
+    NamedInternalEvent, histogram,
+    internal_event::{HistogramName, InternalEvent},
+};
+
+#[derive(Debug, NamedInternalEvent)]
+pub struct DuckdbRequestProcessed {
+    pub rows: usize,
+    pub encode_duration: Duration,
+    pub lock_wait_duration: Duration,
+    pub transaction_begin_duration: Duration,
+    pub appender_create_duration: Duration,
+    pub append_duration: Duration,
+    pub flush_duration: Duration,
+    pub commit_duration: Duration,
+    pub total_duration: Duration,
+}
+
+impl InternalEvent for DuckdbRequestProcessed {
+    fn emit(self) {
+        trace!(
+            message = "DuckDB sink request processed.",
+            rows = self.rows,
+            encode_duration_secs = self.encode_duration.as_secs_f64(),
+            lock_wait_duration_secs = self.lock_wait_duration.as_secs_f64(),
+            transaction_begin_duration_secs = self.transaction_begin_duration.as_secs_f64(),
+            appender_create_duration_secs = self.appender_create_duration.as_secs_f64(),
+            append_duration_secs = self.append_duration.as_secs_f64(),
+            flush_duration_secs = self.flush_duration.as_secs_f64(),
+            commit_duration_secs = self.commit_duration.as_secs_f64(),
+            total_duration_secs = self.total_duration.as_secs_f64(),
+        );
+
+        let histogram = |stage: &'static str| histogram!(HistogramName::DuckdbRequestStageDurationSeconds, "stage" => stage);
+
+        histogram("encode").record(self.encode_duration.as_secs_f64());
+        histogram("lock_wait").record(self.lock_wait_duration.as_secs_f64());
+        histogram("transaction_begin").record(self.transaction_begin_duration.as_secs_f64());
+        histogram("appender_create").record(self.appender_create_duration.as_secs_f64());
+        histogram("append").record(self.append_duration.as_secs_f64());
+        histogram("flush").record(self.flush_duration.as_secs_f64());
+        histogram("commit").record(self.commit_duration.as_secs_f64());
+        histogram("total").record(self.total_duration.as_secs_f64());
+    }
+}

--- a/src/internal_events/mod.rs
+++ b/src/internal_events/mod.rs
@@ -48,6 +48,8 @@ mod dnstap;
 mod docker_logs;
 #[cfg(feature = "sinks-doris")]
 mod doris;
+#[cfg(feature = "sinks-duckdb")]
+mod duckdb;
 mod encoding_transcode;
 #[cfg(feature = "sources-eventstoredb_metrics")]
 mod eventstoredb_metrics;
@@ -204,6 +206,8 @@ pub(crate) use self::dnstap::*;
 pub(crate) use self::docker_logs::*;
 #[cfg(feature = "sinks-doris")]
 pub(crate) use self::doris::*;
+#[cfg(feature = "sinks-duckdb")]
+pub(crate) use self::duckdb::*;
 #[cfg(feature = "sources-eventstoredb_metrics")]
 pub(crate) use self::eventstoredb_metrics::*;
 #[cfg(feature = "sources-exec")]

--- a/src/sinks/duckdb/config.rs
+++ b/src/sinks/duckdb/config.rs
@@ -1,0 +1,162 @@
+use std::sync::{Arc, Mutex};
+
+use futures::FutureExt;
+use tower::ServiceBuilder;
+use vector_lib::{
+    config::AcknowledgementsConfig,
+    configurable::{component::GenerateConfig, configurable_component},
+    sink::VectorSink,
+};
+
+use super::{
+    schema::fetch_table_schema,
+    service::{
+        DuckdbRetryLogic, DuckdbService, build_serializer, default_database, open_connection,
+    },
+    sink::DuckdbSink,
+};
+use crate::{
+    config::{Input, SinkConfig, SinkContext},
+    sinks::{
+        Healthcheck,
+        util::{
+            BatchConfig, RealtimeSizeBasedDefaultBatchSettings, ServiceBuilderExt,
+            TowerRequestConfig,
+        },
+    },
+};
+
+/// Configuration for the `duckdb` sink.
+#[configurable_component(sink("duckdb", "Deliver log data to a DuckDB database."))]
+#[derive(Clone, Default, Debug)]
+#[serde(deny_unknown_fields)]
+pub struct DuckdbConfig {
+    /// The DuckDB database endpoint.
+    ///
+    /// Use a filesystem path or a `duckdb://` URI such as
+    /// `duckdb:///var/lib/vector/events.duckdb`.
+    #[configurable(metadata(docs::examples = "duckdb:///var/lib/vector/events.duckdb"))]
+    pub endpoint: String,
+
+    /// The table that data is inserted into.
+    ///
+    /// The table must already exist. Vector reads its schema at startup and encodes each batch to
+    /// match the destination table before appending it.
+    #[configurable(metadata(docs::examples = "events"))]
+    pub table: String,
+
+    /// The DuckDB database/schema containing the table.
+    #[serde(default = "default_database")]
+    #[configurable(metadata(docs::examples = "main"))]
+    pub database: String,
+
+    /// Event batching behavior.
+    #[configurable(derived)]
+    #[serde(default)]
+    pub batch: BatchConfig<RealtimeSizeBasedDefaultBatchSettings>,
+
+    #[configurable(derived)]
+    #[serde(default)]
+    pub request: TowerRequestConfig,
+
+    #[configurable(derived)]
+    #[serde(
+        default,
+        deserialize_with = "crate::serde::bool_or_struct",
+        skip_serializing_if = "crate::serde::is_default"
+    )]
+    pub acknowledgements: AcknowledgementsConfig,
+}
+
+impl GenerateConfig for DuckdbConfig {
+    fn generate_config() -> toml::Value {
+        toml::from_str(
+            r#"endpoint = "duckdb:///var/lib/vector/events.duckdb"
+            table = "events"
+        "#,
+        )
+        .unwrap()
+    }
+}
+
+#[async_trait::async_trait]
+#[typetag::serde(name = "duckdb")]
+impl SinkConfig for DuckdbConfig {
+    async fn build(&self, _cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
+        let endpoint = self.endpoint.clone();
+        let table = self.table.clone();
+        let database = self.database.clone();
+
+        let connection = tokio::task::spawn_blocking({
+            let endpoint = endpoint.clone();
+            move || open_connection(&endpoint)
+        })
+        .await??;
+
+        let schema = fetch_table_schema(&connection, &database, &table)?;
+        let serializer = build_serializer(schema)?;
+
+        let connection = Arc::new(Mutex::new(connection));
+
+        let healthcheck =
+            healthcheck(Arc::clone(&connection), database.clone(), table.clone()).boxed();
+
+        let batch_settings = self.batch.into_batcher_settings()?;
+        let request_settings = self.request.into_settings();
+
+        let service = DuckdbService::new(connection, database, table, endpoint, serializer);
+        let service = ServiceBuilder::new()
+            .settings(request_settings, DuckdbRetryLogic)
+            .service(service);
+
+        let sink = DuckdbSink::new(service, batch_settings);
+
+        Ok((VectorSink::from_event_streamsink(sink), healthcheck))
+    }
+
+    fn input(&self) -> Input {
+        Input::log()
+    }
+
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &self.acknowledgements
+    }
+}
+
+async fn healthcheck(
+    connection: Arc<Mutex<duckdb::Connection>>,
+    database: String,
+    table: String,
+) -> crate::Result<()> {
+    tokio::task::spawn_blocking(move || -> crate::Result<()> {
+        let conn = connection
+            .lock()
+            .map_err(|_| -> crate::Error { "Connection mutex poisoned".into() })?;
+        conn.execute("SELECT 1", [])?;
+        fetch_table_schema(&conn, &database, &table)?;
+        Ok(())
+    })
+    .await?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generate_config() {
+        crate::test_util::test_generate_config::<DuckdbConfig>();
+    }
+
+    #[test]
+    fn parse_config() {
+        let cfg = serde_yaml::from_str::<DuckdbConfig>(indoc::indoc! {r#"
+            endpoint: "duckdb:///tmp/vector.duckdb"
+            table: "events"
+        "#})
+        .unwrap();
+        assert_eq!(cfg.endpoint, "duckdb:///tmp/vector.duckdb");
+        assert_eq!(cfg.table, "events");
+        assert_eq!(cfg.database, "main");
+    }
+}

--- a/src/sinks/duckdb/integration_tests.rs
+++ b/src/sinks/duckdb/integration_tests.rs
@@ -1,0 +1,623 @@
+use std::{
+    env, fs,
+    path::Path,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, AtomicU64, Ordering},
+    },
+    thread,
+    time::{Duration, Instant},
+};
+
+use chrono::{TimeZone, Utc};
+use futures::{StreamExt, stream};
+use vector_lib::{
+    event::{BatchNotifier, BatchStatus, Event, LogEvent, MetricValue},
+    metrics::{Controller, init_test as init_metrics},
+};
+
+use crate::{
+    config::{SinkConfig, SinkContext},
+    sinks::{duckdb::config::DuckdbConfig, util::test::load_sink},
+    test_util::{
+        components::{COMPONENT_ERROR_TAGS, run_and_assert_sink_error_with_events},
+        random_table_name, temp_file,
+    },
+};
+
+fn create_event(id: i32, message: &str) -> Event {
+    let mut event = LogEvent::from(message);
+    event.insert("id", id);
+    event.insert("message", message);
+    event.into()
+}
+
+fn create_stress_event(id: i64) -> Event {
+    let mut event = LogEvent::default();
+    event.insert("id", id);
+    event.insert("message", format!("message-{id}"));
+    event.insert("host", format!("host-{}", id % 16));
+    event.insert(
+        "timestamp",
+        Utc.timestamp_micros(1_700_000_000_000_000 + id)
+            .single()
+            .unwrap(),
+    );
+    event.insert("value", id as f64 * 1.25);
+    event.into()
+}
+
+fn duckdb_wal_path(path: &Path) -> std::path::PathBuf {
+    let mut wal_path = path.as_os_str().to_os_string();
+    wal_path.push(".wal");
+    wal_path.into()
+}
+
+fn file_size(path: &Path) -> u64 {
+    fs::metadata(path)
+        .map(|metadata| metadata.len())
+        .unwrap_or(0)
+}
+
+fn update_max(max: &AtomicU64, value: u64) {
+    let mut current = max.load(Ordering::Relaxed);
+    while value > current {
+        match max.compare_exchange_weak(current, value, Ordering::Relaxed, Ordering::Relaxed) {
+            Ok(_) => break,
+            Err(next) => current = next,
+        }
+    }
+}
+
+#[allow(clippy::print_stdout)]
+fn print_duckdb_file_sizes(path: &Path) {
+    let wal_path = duckdb_wal_path(path);
+    println!(
+        "duckdb file sizes: db={} bytes, wal={} bytes",
+        file_size(path),
+        file_size(&wal_path)
+    );
+}
+
+#[allow(clippy::print_stdout)]
+fn print_duckdb_stage_metrics() {
+    let Ok(controller) = Controller::get() else {
+        return;
+    };
+
+    let mut stage_metrics = controller
+        .capture_metrics()
+        .into_iter()
+        .filter_map(|metric| {
+            if metric.name() != "duckdb_request_stage_duration_seconds" {
+                return None;
+            }
+
+            let stage = metric.tags()?.get("stage")?.to_string();
+            let MetricValue::AggregatedHistogram { count, sum, .. } = metric.value() else {
+                return None;
+            };
+
+            Some((stage, *count, *sum))
+        })
+        .collect::<Vec<_>>();
+
+    stage_metrics.sort_by(|left, right| left.0.cmp(&right.0));
+
+    for (stage, count, sum) in stage_metrics {
+        if count > 0 {
+            println!(
+                "duckdb stage {stage}: count={count}, total={sum:.6}s, avg={:.6}s",
+                sum / count as f64
+            );
+        }
+    }
+}
+
+fn prepare_config() -> (DuckdbConfig, String, String) {
+    let path = temp_file().with_extension("duckdb");
+    let endpoint = path.to_string_lossy().to_string();
+    let table = random_table_name();
+
+    let conn = duckdb::Connection::open(&path).expect("open duckdb database");
+    conn.execute(
+        &format!("CREATE TABLE {table} (id INTEGER NOT NULL, message VARCHAR)"),
+        [],
+    )
+    .expect("create test table");
+    drop(conn);
+
+    let config_str = format!(
+        r#"
+            endpoint = "{endpoint}"
+            table = "{table}"
+            batch.max_events = 2
+        "#,
+    );
+    let (config, _) = load_sink::<DuckdbConfig>(&config_str).unwrap();
+
+    (config, endpoint, table)
+}
+
+#[tokio::test]
+async fn build_fails_for_missing_table() {
+    let path = temp_file().with_extension("duckdb");
+    let endpoint = path.to_string_lossy().to_string();
+    let conn = duckdb::Connection::open(&path).expect("open duckdb database");
+    conn.execute("CREATE TABLE other_table (id INTEGER)", [])
+        .expect("create table");
+    drop(conn);
+
+    let config_str = format!(
+        r#"
+            endpoint = "{endpoint}"
+            table = "missing_table"
+        "#,
+    );
+    let (config, _) = load_sink::<DuckdbConfig>(&config_str).unwrap();
+
+    let result = config.build(SinkContext::default()).await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn build_fails_for_unsupported_type() {
+    let path = temp_file().with_extension("duckdb");
+    let endpoint = path.to_string_lossy().to_string();
+    let table = random_table_name();
+    let conn = duckdb::Connection::open(&path).expect("open duckdb database");
+    conn.execute(&format!("CREATE TABLE {table} (id UUID)"), [])
+        .expect("create table");
+    drop(conn);
+
+    let config_str = format!(
+        r#"
+            endpoint = "{endpoint}"
+            table = "{table}"
+        "#,
+    );
+    let (config, _) = load_sink::<DuckdbConfig>(&config_str).unwrap();
+
+    let result = config.build(SinkContext::default()).await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn writes_to_configured_database() {
+    let path = temp_file().with_extension("duckdb");
+    let endpoint = path.to_string_lossy().to_string();
+    let table = random_table_name();
+    let conn = duckdb::Connection::open(&path).expect("open duckdb database");
+    conn.execute("CREATE SCHEMA analytics", [])
+        .expect("create schema");
+    conn.execute(
+        &format!("CREATE TABLE analytics.{table} (id INTEGER NOT NULL, message VARCHAR)"),
+        [],
+    )
+    .expect("create test table");
+    drop(conn);
+
+    let config_str = format!(
+        r#"
+            endpoint = "{endpoint}"
+            database = "analytics"
+            table = "{table}"
+            batch.max_events = 1
+        "#,
+    );
+    let (config, _) = load_sink::<DuckdbConfig>(&config_str).unwrap();
+
+    let (sink, healthcheck) = config
+        .build(SinkContext::default())
+        .await
+        .expect("sink should build successfully");
+    healthcheck.await.expect("healthcheck should pass");
+
+    sink.run(Box::pin(
+        stream::iter(vec![create_event(1, "one")]).map(Into::into),
+    ))
+    .await
+    .unwrap();
+
+    let conn = duckdb::Connection::open(endpoint).expect("open duckdb database");
+    let count: i64 = conn
+        .query_row(
+            &format!("SELECT count(*) FROM analytics.{table}"),
+            [],
+            |row| row.get(0),
+        )
+        .expect("count rows");
+    assert_eq!(count, 1);
+}
+
+#[tokio::test]
+async fn missing_required_field_rejects_batch() {
+    let (config, _endpoint, _table) = prepare_config();
+    let (sink, healthcheck) = config
+        .build(SinkContext::default())
+        .await
+        .expect("sink should build successfully");
+    healthcheck.await.expect("healthcheck should pass");
+
+    let mut event = LogEvent::from("missing id");
+    event.insert("message", "missing id");
+    let mut events = vec![Event::from(event)];
+    let receiver = BatchNotifier::apply_to(&mut events);
+
+    run_and_assert_sink_error_with_events(
+        sink,
+        stream::iter(events),
+        &["EncoderNullConstraintError", "CallError"],
+        &COMPONENT_ERROR_TAGS,
+    )
+    .await;
+    assert_eq!(receiver.await, BatchStatus::Rejected);
+}
+
+#[tokio::test]
+async fn healthcheck_passes() {
+    let (config, _endpoint, _table) = prepare_config();
+    let (_sink, healthcheck) = config
+        .build(SinkContext::default())
+        .await
+        .expect("sink should build successfully");
+    assert!(healthcheck.await.is_ok());
+}
+
+#[tokio::test]
+async fn writes_supported_scalar_types() {
+    let path = temp_file().with_extension("duckdb");
+    let endpoint = path.to_string_lossy().to_string();
+    let table = random_table_name();
+    let conn = duckdb::Connection::open(&path).expect("open duckdb database");
+    conn.execute(
+        &format!(
+            "CREATE TABLE {table} (\
+             bool_col BOOLEAN, \
+             tiny_col TINYINT, \
+             small_col SMALLINT, \
+             int_col INTEGER, \
+             big_col BIGINT, \
+            utiny_col UTINYINT, \
+             usmall_col USMALLINT, \
+             uint_col UINTEGER, \
+             ubig_col UBIGINT, \
+             float_col FLOAT, \
+             double_col DOUBLE, \
+             text_col VARCHAR, \
+             timestamp_col TIMESTAMP, \
+             decimal_col DECIMAL(10, 2), \
+             nullable_col INTEGER)"
+        ),
+        [],
+    )
+    .expect("create scalar type table");
+    drop(conn);
+
+    let config_str = format!(
+        r#"
+            endpoint = "{endpoint}"
+            table = "{table}"
+            batch.max_events = 1
+        "#,
+    );
+    let (config, _) = load_sink::<DuckdbConfig>(&config_str).unwrap();
+    let (sink, healthcheck) = config
+        .build(SinkContext::default())
+        .await
+        .expect("sink should build successfully");
+    healthcheck.await.expect("healthcheck should pass");
+
+    let mut event = LogEvent::default();
+    event.insert("bool_col", true);
+    event.insert("tiny_col", 12);
+    event.insert("small_col", 32000);
+    event.insert("int_col", 1_000_000);
+    event.insert("big_col", 9_000_000_000_i64);
+    event.insert("utiny_col", 255);
+    event.insert("usmall_col", 65_535);
+    event.insert("uint_col", 4_000_000_000_i64);
+    event.insert("ubig_col", 9_000_000_000_i64);
+    event.insert("float_col", 3.5);
+    event.insert("double_col", 7.25);
+    event.insert("text_col", "hello");
+    event.insert(
+        "timestamp_col",
+        Utc.with_ymd_and_hms(2026, 7, 1, 12, 34, 56)
+            .single()
+            .unwrap(),
+    );
+    event.insert("decimal_col", 99.99);
+
+    let mut events = vec![Event::from(event)];
+    let receiver = BatchNotifier::apply_to(&mut events);
+
+    sink.run(Box::pin(stream::iter(events).map(Into::into)))
+        .await
+        .unwrap();
+    assert_eq!(receiver.await, BatchStatus::Delivered);
+
+    let conn = duckdb::Connection::open(endpoint).expect("open duckdb database");
+    let (bool_col, int_col, text_col, nullable_is_null): (bool, i32, String, bool) = conn
+        .query_row(
+            &format!("SELECT bool_col, int_col, text_col, nullable_col IS NULL FROM {table}"),
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+        )
+        .expect("query scalar row");
+    assert!(bool_col);
+    assert_eq!(int_col, 1_000_000);
+    assert_eq!(text_col, "hello");
+    assert!(nullable_is_null);
+}
+
+#[tokio::test]
+async fn writes_events() {
+    let (config, endpoint, table) = prepare_config();
+    let (sink, healthcheck) = config
+        .build(SinkContext::default())
+        .await
+        .expect("sink should build successfully");
+    healthcheck.await.expect("healthcheck should pass");
+
+    let mut events = vec![create_event(1, "one"), create_event(2, "two")];
+    let receiver = BatchNotifier::apply_to(&mut events);
+
+    sink.run(Box::pin(stream::iter(events).map(Into::into)))
+        .await
+        .unwrap();
+    assert_eq!(receiver.await, BatchStatus::Delivered);
+
+    let conn = duckdb::Connection::open(endpoint).expect("open duckdb database");
+    let count: i64 = conn
+        .query_row(&format!("SELECT count(*) FROM {table}"), [], |row| {
+            row.get(0)
+        })
+        .expect("count rows");
+    assert_eq!(count, 2);
+
+    let message: String = conn
+        .query_row(
+            &format!("SELECT message FROM {table} WHERE id = 2"),
+            [],
+            |row| row.get(0),
+        )
+        .expect("query row");
+    assert_eq!(message, "two");
+}
+
+#[tokio::test]
+#[ignore]
+#[allow(clippy::print_stdout)]
+async fn stress_million_events() {
+    init_metrics();
+    if let Ok(controller) = Controller::get() {
+        controller.reset();
+    }
+
+    let event_count = env::var("DUCKDB_STRESS_EVENTS")
+        .ok()
+        .and_then(|value| value.parse::<i64>().ok())
+        .unwrap_or(1_000_000);
+    let batch_size = env::var("DUCKDB_STRESS_BATCH_EVENTS")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(10_000);
+
+    let path = temp_file().with_extension("duckdb");
+    let endpoint = path.to_string_lossy().to_string();
+    let table = random_table_name();
+    let conn = duckdb::Connection::open(&path).expect("open duckdb database");
+    conn.execute(
+        &format!(
+            "CREATE TABLE {table} (\
+             id BIGINT NOT NULL, \
+             message VARCHAR, \
+             host VARCHAR, \
+             timestamp TIMESTAMP, \
+             value DOUBLE)"
+        ),
+        [],
+    )
+    .expect("create stress table");
+    drop(conn);
+
+    let request_concurrency = env::var("DUCKDB_STRESS_REQUEST_CONCURRENCY")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok());
+    let concurrent_reader = env::var("DUCKDB_STRESS_CONCURRENT_READER")
+        .map(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"))
+        .unwrap_or(false);
+    let reader_holds_transaction = env::var("DUCKDB_STRESS_READER_HOLDS_TRANSACTION")
+        .map(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"))
+        .unwrap_or(false);
+    let request_concurrency_config = request_concurrency
+        .map(|concurrency| format!("request.concurrency = {concurrency}\n"))
+        .unwrap_or_default();
+
+    let config_str = format!(
+        r#"
+            endpoint = "{endpoint}"
+            table = "{table}"
+            batch.max_events = {batch_size}
+            {request_concurrency_config}
+        "#,
+    );
+    let (config, _) = load_sink::<DuckdbConfig>(&config_str).unwrap();
+    let (sink, healthcheck) = config
+        .build(SinkContext::default())
+        .await
+        .expect("sink should build successfully");
+    healthcheck.await.expect("healthcheck should pass");
+
+    let (batch, receiver) = BatchNotifier::new_with_receiver();
+    let events = stream::iter(
+        (0..event_count).map(|id| create_stress_event(id).with_batch_notifier(&batch)),
+    );
+
+    let sampler_running = Arc::new(AtomicBool::new(true));
+    let max_db_size = Arc::new(AtomicU64::new(0));
+    let max_wal_size = Arc::new(AtomicU64::new(0));
+    let sampler = {
+        let path = path.clone();
+        let wal_path = duckdb_wal_path(&path);
+        let running = Arc::clone(&sampler_running);
+        let max_db_size = Arc::clone(&max_db_size);
+        let max_wal_size = Arc::clone(&max_wal_size);
+        thread::spawn(move || {
+            while running.load(Ordering::Relaxed) {
+                update_max(&max_db_size, file_size(&path));
+                update_max(&max_wal_size, file_size(&wal_path));
+                thread::sleep(Duration::from_millis(50));
+            }
+            update_max(&max_db_size, file_size(&path));
+            update_max(&max_wal_size, file_size(&wal_path));
+        })
+    };
+
+    let reader_running = Arc::new(AtomicBool::new(true));
+    let reader = concurrent_reader.then({
+        let path = path.clone();
+        let table = table.clone();
+        let running = Arc::clone(&reader_running);
+        move || {
+            thread::spawn(move || {
+                let conn = duckdb::Connection::open(path).expect("open concurrent reader");
+                let mut queries = 0_u64;
+                let mut errors = 0_u64;
+                if reader_holds_transaction {
+                    conn.execute("BEGIN TRANSACTION", [])
+                        .expect("begin reader transaction");
+                }
+                while running.load(Ordering::Relaxed) {
+                    match conn.query_row(&format!("SELECT count(*) FROM {table}"), [], |row| {
+                        row.get::<_, i64>(0)
+                    }) {
+                        Ok(_) => queries += 1,
+                        Err(_) => errors += 1,
+                    }
+                    thread::sleep(Duration::from_millis(10));
+                }
+                if reader_holds_transaction {
+                    conn.execute("COMMIT", [])
+                        .expect("commit reader transaction");
+                }
+                (queries, errors)
+            })
+        }
+    });
+
+    let started = Instant::now();
+    sink.run(Box::pin(events.map(Into::into))).await.unwrap();
+    reader_running.store(false, Ordering::Relaxed);
+    let reader_result = reader.map(|reader| reader.join().expect("join concurrent reader"));
+    sampler_running.store(false, Ordering::Relaxed);
+    sampler.join().expect("join file size sampler");
+    drop(batch);
+    assert_eq!(receiver.await, BatchStatus::Delivered);
+    let elapsed = started.elapsed();
+
+    let conn = duckdb::Connection::open(endpoint).expect("open duckdb database");
+    let (count, min_id, max_id, distinct_id, sum_id): (i64, i64, i64, i64, i128) = conn
+        .query_row(
+            &format!("SELECT count(*), min(id), max(id), count(DISTINCT id), sum(id) FROM {table}"),
+            [],
+            |row| {
+                Ok((
+                    row.get(0)?,
+                    row.get(1)?,
+                    row.get(2)?,
+                    row.get(3)?,
+                    row.get(4)?,
+                ))
+            },
+        )
+        .expect("query stress results");
+
+    assert_eq!(count, event_count);
+    assert_eq!(min_id, 0);
+    assert_eq!(max_id, event_count - 1);
+    assert_eq!(distinct_id, event_count);
+    assert_eq!(
+        sum_id,
+        (event_count as i128 * (event_count as i128 - 1)) / 2
+    );
+
+    let events_per_second = event_count as f64 / elapsed.as_secs_f64();
+    println!(
+        "inserted {event_count} events in {:.3}s ({events_per_second:.0} events/s), batch.max_events={batch_size}, request.concurrency={}, concurrent_reader={concurrent_reader}, reader_holds_transaction={reader_holds_transaction}",
+        elapsed.as_secs_f64(),
+        request_concurrency
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| "default".to_string())
+    );
+    if let Some((queries, errors)) = reader_result {
+        println!("concurrent reader: queries={queries}, errors={errors}");
+    }
+    print_duckdb_file_sizes(&path);
+    println!(
+        "duckdb max sampled file sizes: db={} bytes, wal={} bytes",
+        max_db_size.load(Ordering::Relaxed),
+        max_wal_size.load(Ordering::Relaxed)
+    );
+    print_duckdb_stage_metrics();
+}
+
+#[tokio::test]
+#[ignore]
+async fn stress_failed_batch_is_atomic() {
+    let batch_size = 10_000;
+    let path = temp_file().with_extension("duckdb");
+    let endpoint = path.to_string_lossy().to_string();
+    let table = random_table_name();
+    let conn = duckdb::Connection::open(&path).expect("open duckdb database");
+    conn.execute(
+        &format!("CREATE TABLE {table} (id BIGINT NOT NULL, message VARCHAR)"),
+        [],
+    )
+    .expect("create atomicity table");
+    drop(conn);
+
+    let config_str = format!(
+        r#"
+            endpoint = "{endpoint}"
+            table = "{table}"
+            batch.max_events = {batch_size}
+        "#,
+    );
+    let (config, _) = load_sink::<DuckdbConfig>(&config_str).unwrap();
+    let (sink, healthcheck) = config
+        .build(SinkContext::default())
+        .await
+        .expect("sink should build successfully");
+    healthcheck.await.expect("healthcheck should pass");
+
+    let mut first_batch = (0..batch_size as i64)
+        .map(|id| create_event(id as i32, &format!("good-{id}")))
+        .collect::<Vec<_>>();
+    let first_receiver = BatchNotifier::apply_to(&mut first_batch);
+
+    let mut second_batch = (batch_size as i64..(batch_size * 2) as i64)
+        .map(|id| create_event(id as i32, &format!("bad-{id}")))
+        .collect::<Vec<_>>();
+    let mut missing_required = LogEvent::from("missing id");
+    missing_required.insert("message", "missing id");
+    second_batch[batch_size / 2] = missing_required.into();
+    let second_receiver = BatchNotifier::apply_to(&mut second_batch);
+
+    let events = first_batch.into_iter().chain(second_batch.into_iter());
+    sink.run(Box::pin(stream::iter(events).map(Into::into)))
+        .await
+        .unwrap();
+
+    assert_eq!(first_receiver.await, BatchStatus::Delivered);
+    assert_eq!(second_receiver.await, BatchStatus::Rejected);
+
+    let conn = duckdb::Connection::open(endpoint).expect("open duckdb database");
+    let count: i64 = conn
+        .query_row(&format!("SELECT count(*) FROM {table}"), [], |row| {
+            row.get(0)
+        })
+        .expect("count rows");
+    assert_eq!(count, batch_size as i64);
+}

--- a/src/sinks/duckdb/mod.rs
+++ b/src/sinks/duckdb/mod.rs
@@ -1,0 +1,12 @@
+//! The DuckDB [`vector_lib::sink::VectorSink`].
+//!
+//! This sink writes log events into an existing DuckDB table. The table schema is
+//! read from DuckDB at startup and used to encode batches as Arrow record batches,
+//! which are appended via DuckDB's appender API.
+
+pub mod config;
+#[cfg(all(test, feature = "duckdb-integration-tests"))]
+mod integration_tests;
+mod schema;
+mod service;
+mod sink;

--- a/src/sinks/duckdb/schema.rs
+++ b/src/sinks/duckdb/schema.rs
@@ -1,0 +1,153 @@
+//! DuckDB table schema fetching and Arrow schema construction.
+
+use arrow::datatypes::{DataType, Field, Schema, TimeUnit};
+use duckdb::Connection;
+use snafu::Snafu;
+
+#[derive(Debug, Snafu)]
+pub(super) enum SchemaError {
+    #[snafu(display("DuckDB error while fetching schema: {source}"))]
+    DuckDb { source: duckdb::Error },
+
+    #[snafu(display("Table '{database}.{table}' does not exist or has no columns"))]
+    EmptySchema { database: String, table: String },
+
+    #[snafu(display("Unsupported DuckDB type '{duckdb_type}' for column '{column}'"))]
+    UnsupportedType { column: String, duckdb_type: String },
+}
+
+#[derive(Debug)]
+struct ColumnInfo {
+    name: String,
+    data_type: String,
+    nullable: bool,
+}
+
+pub(super) fn fetch_table_schema(
+    conn: &Connection,
+    database: &str,
+    table: &str,
+) -> Result<Schema, SchemaError> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT column_name, data_type, is_nullable \
+             FROM information_schema.columns \
+             WHERE table_schema = ? AND table_name = ? \
+             ORDER BY ordinal_position",
+        )
+        .map_err(|source| SchemaError::DuckDb { source })?;
+
+    let columns = stmt
+        .query_map([database, table], |row| {
+            let is_nullable: String = row.get(2)?;
+            Ok(ColumnInfo {
+                name: row.get(0)?,
+                data_type: row.get(1)?,
+                nullable: is_nullable.eq_ignore_ascii_case("YES"),
+            })
+        })
+        .map_err(|source| SchemaError::DuckDb { source })?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|source| SchemaError::DuckDb { source })?;
+
+    if columns.is_empty() {
+        return Err(SchemaError::EmptySchema {
+            database: database.to_string(),
+            table: table.to_string(),
+        });
+    }
+
+    columns
+        .into_iter()
+        .map(|column| {
+            duckdb_type_to_arrow(&column.data_type)
+                .map(|data_type| Field::new(column.name.clone(), data_type, column.nullable))
+                .ok_or_else(|| SchemaError::UnsupportedType {
+                    column: column.name,
+                    duckdb_type: column.data_type,
+                })
+        })
+        .collect::<Result<Vec<_>, _>>()
+        .map(Schema::new)
+}
+
+fn duckdb_type_to_arrow(duckdb_type: &str) -> Option<DataType> {
+    let normalized = duckdb_type.trim().to_ascii_uppercase();
+    let base = normalized
+        .split_once('(')
+        .map_or(normalized.as_str(), |(base, _)| base.trim());
+
+    match base {
+        "BOOLEAN" | "BOOL" => Some(DataType::Boolean),
+        "TINYINT" => Some(DataType::Int8),
+        "SMALLINT" | "INT2" | "SHORT" => Some(DataType::Int16),
+        "INTEGER" | "INT" | "INT4" | "SIGNED" => Some(DataType::Int32),
+        "BIGINT" | "INT8" | "LONG" => Some(DataType::Int64),
+        "UTINYINT" => Some(DataType::UInt8),
+        "USMALLINT" => Some(DataType::UInt16),
+        "UINTEGER" => Some(DataType::UInt32),
+        "UBIGINT" => Some(DataType::UInt64),
+        "FLOAT" | "FLOAT4" | "REAL" => Some(DataType::Float32),
+        "DOUBLE" | "FLOAT8" => Some(DataType::Float64),
+        "VARCHAR" | "CHAR" | "BPCHAR" | "TEXT" | "STRING" => Some(DataType::Utf8),
+        "BLOB" | "BYTEA" | "BINARY" | "VARBINARY" => Some(DataType::Binary),
+        "DATE" => Some(DataType::Date32),
+        "TIME" => Some(DataType::Time64(TimeUnit::Microsecond)),
+        "TIMESTAMP" | "DATETIME" => Some(DataType::Timestamp(TimeUnit::Microsecond, None)),
+        "TIMESTAMP_MS" => Some(DataType::Timestamp(TimeUnit::Millisecond, None)),
+        "TIMESTAMP_NS" => Some(DataType::Timestamp(TimeUnit::Nanosecond, None)),
+        "TIMESTAMP_S" => Some(DataType::Timestamp(TimeUnit::Second, None)),
+        "DECIMAL" | "NUMERIC" => decimal_type_to_arrow(&normalized),
+        _ => None,
+    }
+}
+
+fn decimal_type_to_arrow(duckdb_type: &str) -> Option<DataType> {
+    let parameters = duckdb_type
+        .split_once('(')?
+        .1
+        .strip_suffix(')')?
+        .split(',')
+        .map(str::trim)
+        .collect::<Vec<_>>();
+
+    match parameters.as_slice() {
+        [precision, scale] => Some(DataType::Decimal128(
+            precision.parse().ok()?,
+            scale.parse().ok()?,
+        )),
+        [precision] => Some(DataType::Decimal128(precision.parse().ok()?, 0)),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_scalar_types() {
+        assert_eq!(duckdb_type_to_arrow("INTEGER"), Some(DataType::Int32));
+        assert_eq!(duckdb_type_to_arrow("VARCHAR"), Some(DataType::Utf8));
+        assert_eq!(duckdb_type_to_arrow("BLOB"), Some(DataType::Binary));
+        assert_eq!(duckdb_type_to_arrow("DATE"), Some(DataType::Date32));
+        assert_eq!(
+            duckdb_type_to_arrow("TIME"),
+            Some(DataType::Time64(TimeUnit::Microsecond))
+        );
+        assert_eq!(
+            duckdb_type_to_arrow("TIMESTAMP"),
+            Some(DataType::Timestamp(TimeUnit::Microsecond, None))
+        );
+        assert_eq!(
+            duckdb_type_to_arrow("DECIMAL(18, 2)"),
+            Some(DataType::Decimal128(18, 2))
+        );
+    }
+
+    #[test]
+    fn rejects_unsupported_types() {
+        assert_eq!(duckdb_type_to_arrow("STRUCT(a INTEGER)"), None);
+        assert_eq!(duckdb_type_to_arrow("UUID"), None);
+    }
+}

--- a/src/sinks/duckdb/service.rs
+++ b/src/sinks/duckdb/service.rs
@@ -1,0 +1,327 @@
+use std::{
+    num::NonZeroUsize,
+    path::Path,
+    sync::{Arc, Mutex},
+    task::{Context, Poll},
+    time::{Duration, Instant},
+};
+
+use futures::future::BoxFuture;
+use snafu::{ResultExt, Snafu};
+use tower::Service;
+use vector_lib::{
+    EstimatedJsonEncodedSizeOf,
+    codecs::encoding::{ArrowStreamSerializer, ArrowStreamSerializerConfig},
+    event::{Event, EventFinalizers, EventStatus, Finalizable},
+    request_metadata::{GroupedCountByteSize, MetaDescriptive, RequestMetadata},
+    stream::DriverResponse,
+};
+
+use crate::{
+    internal_events::{DuckdbRequestProcessed, EndpointBytesSent},
+    sinks::prelude::{RequestMetadataBuilder, RetryLogic},
+};
+
+const DUCKDB_PROTOCOL: &str = "duckdb";
+
+pub(super) fn default_database() -> String {
+    "main".to_string()
+}
+
+#[derive(Debug, Snafu)]
+pub enum DuckdbServiceError {
+    #[snafu(display("DuckDB error: {source}"))]
+    DuckDb { source: duckdb::Error },
+
+    #[snafu(display("Arrow encoding error: {source}"))]
+    ArrowEncoding {
+        source: vector_lib::codecs::encoding::format::ArrowEncodingError,
+    },
+
+    #[snafu(display("Task join error: {source}"))]
+    Join { source: tokio::task::JoinError },
+
+    #[snafu(display("Connection mutex poisoned"))]
+    MutexPoisoned,
+
+    #[snafu(display("Payload should never be zero length"))]
+    EmptyPayload,
+}
+
+#[derive(Clone)]
+pub struct DuckdbRetryLogic;
+
+impl RetryLogic for DuckdbRetryLogic {
+    type Error = DuckdbServiceError;
+    type Request = DuckdbRequest;
+    type Response = DuckdbResponse;
+
+    fn is_retriable_error(&self, error: &Self::Error) -> bool {
+        // DuckDB writes are local and synchronous. Most failures are deterministic
+        // data/schema/database errors, so do not retry by default.
+        matches!(
+            error,
+            DuckdbServiceError::Join { .. } | DuckdbServiceError::MutexPoisoned
+        )
+    }
+}
+
+#[derive(Clone)]
+pub struct DuckdbService {
+    connection: Arc<Mutex<duckdb::Connection>>,
+    database: String,
+    table: String,
+    endpoint: String,
+    serializer: ArrowStreamSerializer,
+}
+
+impl DuckdbService {
+    pub const fn new(
+        connection: Arc<Mutex<duckdb::Connection>>,
+        database: String,
+        table: String,
+        endpoint: String,
+        serializer: ArrowStreamSerializer,
+    ) -> Self {
+        Self {
+            connection,
+            database,
+            table,
+            endpoint,
+            serializer,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct DuckdbRequest {
+    pub events: Vec<Event>,
+    pub finalizers: EventFinalizers,
+    pub metadata: RequestMetadata,
+}
+
+impl TryFrom<Vec<Event>> for DuckdbRequest {
+    type Error = DuckdbServiceError;
+
+    fn try_from(mut events: Vec<Event>) -> Result<Self, Self::Error> {
+        let finalizers = events.take_finalizers();
+        let metadata_builder = RequestMetadataBuilder::from_events(&events);
+        let events_size = NonZeroUsize::new(events.estimated_json_encoded_size_of().get())
+            .ok_or(DuckdbServiceError::EmptyPayload)?;
+        let metadata = metadata_builder.with_request_size(events_size);
+        Ok(Self {
+            events,
+            finalizers,
+            metadata,
+        })
+    }
+}
+
+impl Finalizable for DuckdbRequest {
+    fn take_finalizers(&mut self) -> EventFinalizers {
+        self.finalizers.take_finalizers()
+    }
+}
+
+impl MetaDescriptive for DuckdbRequest {
+    fn get_metadata(&self) -> &RequestMetadata {
+        &self.metadata
+    }
+
+    fn metadata_mut(&mut self) -> &mut RequestMetadata {
+        &mut self.metadata
+    }
+}
+
+pub struct DuckdbResponse {
+    metadata: RequestMetadata,
+}
+
+struct DuckdbWriteTimings {
+    lock_wait_duration: Duration,
+    transaction_begin_duration: Duration,
+    appender_create_duration: Duration,
+    append_duration: Duration,
+    flush_duration: Duration,
+    commit_duration: Duration,
+}
+
+impl DriverResponse for DuckdbResponse {
+    fn event_status(&self) -> EventStatus {
+        EventStatus::Delivered
+    }
+
+    fn events_sent(&self) -> &GroupedCountByteSize {
+        self.metadata.events_estimated_json_encoded_byte_size()
+    }
+
+    fn bytes_sent(&self) -> Option<usize> {
+        Some(self.metadata.request_encoded_size())
+    }
+}
+
+impl Service<DuckdbRequest> for DuckdbService {
+    type Response = DuckdbResponse;
+    type Error = DuckdbServiceError;
+    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, request: DuckdbRequest) -> Self::Future {
+        let connection = Arc::clone(&self.connection);
+        let database = self.database.clone();
+        let table = self.table.clone();
+        let endpoint = self.endpoint.clone();
+        let serializer = self.serializer.clone();
+
+        let future = async move {
+            let total_started = Instant::now();
+            let rows = request.events.len();
+            let metadata = request.metadata;
+
+            let encode_started = Instant::now();
+            let record_batch = serializer
+                .encode_to_record_batch(&request.events)
+                .context(ArrowEncodingSnafu)?;
+            let encode_duration = encode_started.elapsed();
+
+            let write_timings = tokio::task::spawn_blocking(move || {
+                let lock_started = Instant::now();
+                let mut conn = connection
+                    .lock()
+                    .map_err(|_| DuckdbServiceError::MutexPoisoned)?;
+                let lock_wait_duration = lock_started.elapsed();
+
+                let transaction_begin_started = Instant::now();
+                let tx = conn
+                    .transaction()
+                    .map_err(|source| DuckdbServiceError::DuckDb { source })?;
+                let transaction_begin_duration = transaction_begin_started.elapsed();
+
+                let (appender_create_duration, append_duration, flush_duration) = {
+                    let appender_create_started = Instant::now();
+                    let mut appender = tx
+                        .appender_to_db(&table, &database)
+                        .map_err(|source| DuckdbServiceError::DuckDb { source })?;
+                    let appender_create_duration = appender_create_started.elapsed();
+
+                    let append_started = Instant::now();
+                    appender
+                        .append_record_batch(record_batch)
+                        .map_err(|source| DuckdbServiceError::DuckDb { source })?;
+                    let append_duration = append_started.elapsed();
+
+                    let flush_started = Instant::now();
+                    appender
+                        .flush()
+                        .map_err(|source| DuckdbServiceError::DuckDb { source })?;
+                    let flush_duration = flush_started.elapsed();
+
+                    (appender_create_duration, append_duration, flush_duration)
+                };
+
+                let commit_started = Instant::now();
+                tx.commit()
+                    .map_err(|source| DuckdbServiceError::DuckDb { source })?;
+                let commit_duration = commit_started.elapsed();
+
+                Ok(DuckdbWriteTimings {
+                    lock_wait_duration,
+                    transaction_begin_duration,
+                    appender_create_duration,
+                    append_duration,
+                    flush_duration,
+                    commit_duration,
+                })
+            })
+            .await
+            .context(JoinSnafu)??;
+
+            emit!(DuckdbRequestProcessed {
+                rows,
+                encode_duration,
+                lock_wait_duration: write_timings.lock_wait_duration,
+                transaction_begin_duration: write_timings.transaction_begin_duration,
+                appender_create_duration: write_timings.appender_create_duration,
+                append_duration: write_timings.append_duration,
+                flush_duration: write_timings.flush_duration,
+                commit_duration: write_timings.commit_duration,
+                total_duration: total_started.elapsed(),
+            });
+
+            emit!(EndpointBytesSent {
+                byte_size: metadata.request_encoded_size(),
+                protocol: DUCKDB_PROTOCOL,
+                endpoint: &endpoint,
+            });
+
+            Ok(DuckdbResponse { metadata })
+        };
+
+        Box::pin(future)
+    }
+}
+
+pub(super) fn build_serializer(
+    schema: arrow::datatypes::Schema,
+) -> Result<ArrowStreamSerializer, vector_lib::codecs::encoding::format::ArrowEncodingError> {
+    ArrowStreamSerializer::new(ArrowStreamSerializerConfig::new(schema))
+}
+
+pub(super) fn open_connection(endpoint: &str) -> Result<duckdb::Connection, duckdb::Error> {
+    match duckdb_path(endpoint) {
+        DuckdbPath::Memory => duckdb::Connection::open_in_memory(),
+        DuckdbPath::File(path) => duckdb::Connection::open(path),
+    }
+}
+
+enum DuckdbPath<'a> {
+    Memory,
+    File(&'a Path),
+}
+
+fn duckdb_path(endpoint: &str) -> DuckdbPath<'_> {
+    if endpoint == ":memory:" || endpoint == "duckdb:///:memory:" {
+        return DuckdbPath::Memory;
+    }
+
+    if let Some(path) = endpoint.strip_prefix("duckdb://") {
+        let path = if path.is_empty() { ":memory:" } else { path };
+        if path == "/:memory:" || path == ":memory:" {
+            DuckdbPath::Memory
+        } else {
+            DuckdbPath::File(Path::new(path))
+        }
+    } else {
+        DuckdbPath::File(Path::new(endpoint))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_memory_endpoint() {
+        assert!(matches!(duckdb_path(":memory:"), DuckdbPath::Memory));
+        assert!(matches!(
+            duckdb_path("duckdb:///:memory:"),
+            DuckdbPath::Memory
+        ));
+    }
+
+    #[test]
+    fn parses_file_endpoint() {
+        match duckdb_path("duckdb:///tmp/vector.duckdb") {
+            DuckdbPath::File(path) => assert_eq!(path, Path::new("/tmp/vector.duckdb")),
+            DuckdbPath::Memory => panic!("expected file path"),
+        }
+
+        match duckdb_path("relative.duckdb") {
+            DuckdbPath::File(path) => assert_eq!(path, Path::new("relative.duckdb")),
+            DuckdbPath::Memory => panic!("expected file path"),
+        }
+    }
+}

--- a/src/sinks/duckdb/sink.rs
+++ b/src/sinks/duckdb/sink.rs
@@ -1,0 +1,43 @@
+use super::service::{DuckdbRequest, DuckdbRetryLogic, DuckdbService};
+use crate::sinks::prelude::*;
+
+pub struct DuckdbSink {
+    service: Svc<DuckdbService, DuckdbRetryLogic>,
+    batch_settings: BatcherSettings,
+}
+
+impl DuckdbSink {
+    pub const fn new(
+        service: Svc<DuckdbService, DuckdbRetryLogic>,
+        batch_settings: BatcherSettings,
+    ) -> Self {
+        Self {
+            service,
+            batch_settings,
+        }
+    }
+
+    async fn run_inner(self: Box<Self>, input: BoxStream<'_, Event>) -> Result<(), ()> {
+        input
+            .batched(self.batch_settings.as_byte_size_config())
+            .filter_map(|events| async move {
+                match DuckdbRequest::try_from(events) {
+                    Ok(request) => Some(request),
+                    Err(error) => {
+                        emit!(SinkRequestBuildError { error });
+                        None
+                    }
+                }
+            })
+            .into_driver(self.service)
+            .run()
+            .await
+    }
+}
+
+#[async_trait::async_trait]
+impl StreamSink<Event> for DuckdbSink {
+    async fn run(mut self: Box<Self>, input: BoxStream<'_, Event>) -> Result<(), ()> {
+        self.run_inner(input).await
+    }
+}

--- a/src/sinks/mod.rs
+++ b/src/sinks/mod.rs
@@ -51,6 +51,8 @@ pub mod databricks_zerobus;
 pub mod datadog;
 #[cfg(feature = "sinks-doris")]
 pub mod doris;
+#[cfg(feature = "sinks-duckdb")]
+pub mod duckdb;
 #[cfg(feature = "sinks-elasticsearch")]
 pub mod elasticsearch;
 #[cfg(feature = "sinks-file")]

--- a/website/cue/reference/components/sinks/duckdb.cue
+++ b/website/cue/reference/components/sinks/duckdb.cue
@@ -1,0 +1,148 @@
+package metadata
+
+components: sinks: duckdb: {
+	title: "DuckDB"
+
+	classes: {
+		delivery:      "at_least_once"
+		development:   "beta"
+		egress_method: "batch"
+		stateful:      false
+	}
+
+	features: {
+		auto_generated:   true
+		acknowledgements: true
+		healthcheck: enabled: true
+		send: {
+			batch: {
+				enabled:      true
+				common:       false
+				max_bytes:    10_000_000
+				timeout_secs: 1.0
+			}
+			request: {
+				enabled: true
+				headers: false
+			}
+			compression: enabled: false
+			encoding: enabled:    false
+			tls: enabled:         false
+			to: {
+				service: services.duckdb
+				interface: {
+					file_system: {
+						directory: "configured DuckDB database path"
+					}
+				}
+			}
+		}
+	}
+
+	support: {
+		requirements: [
+			"""
+				The destination table must already exist before Vector starts. Vector reads the
+				DuckDB table schema at startup and encodes each batch to match that schema.
+				""",
+		]
+		warnings: []
+		notices: [
+			"""
+				The DuckDB sink is not enabled by Vector's default `sinks` feature set. Builds
+				that include this sink must enable the `sinks-duckdb` feature. The current
+				implementation uses DuckDB's bundled library through `duckdb-rs`, which adds a
+				larger native build dependency than most sinks.
+				""",
+		]
+	}
+
+	configuration: generated.components.sinks.duckdb.configuration
+
+	input: {
+		logs:    true
+		metrics: null
+		traces:  false
+	}
+
+	how_it_works: {
+		table_schema: {
+			title: "Table Schema"
+			body: """
+				The DuckDB sink writes log events to an existing DuckDB table. Vector fetches
+				the configured table schema from `information_schema.columns` during startup,
+				converts that schema to Arrow, and encodes each event batch as an Arrow
+				`RecordBatch`. The batch is then appended using DuckDB's appender API.
+
+				For example, given log events with `id`, `host`, `message`, and `timestamp`
+				fields, create a table like:
+
+				```sql
+				CREATE TABLE events (
+				    id INTEGER NOT NULL,
+				    host VARCHAR,
+				    message VARCHAR,
+				    timestamp TIMESTAMP
+				);
+				```
+
+				Then configure Vector:
+
+				```toml
+				[sinks.duckdb]
+				type = "duckdb"
+				inputs = ["my_source"]
+				endpoint = "duckdb:///var/lib/vector/events.duckdb"
+				table = "events"
+				```
+
+				Columns in the DuckDB table select the event fields that are stored. Event
+				fields not present in the destination table are ignored by the Arrow encoder.
+				If an event is missing a non-nullable table column, encoding fails for the
+				batch and the events are rejected.
+				"""
+		}
+
+		database: {
+			title: "Database/Schema"
+			body: """
+				By default, the sink writes to DuckDB's `main` database/schema. Set the
+				`database` option when the target table lives in another schema:
+
+				```toml
+				[sinks.duckdb]
+				type = "duckdb"
+				endpoint = "duckdb:///var/lib/vector/events.duckdb"
+				database = "analytics"
+				table = "events"
+				```
+				"""
+		}
+
+		type_mappings: {
+			title: "Type Mappings"
+			body:  """
+				Vector maps supported [DuckDB data types](\(urls.duckdb_data_types)) to Arrow
+				types before encoding batches.
+
+				Supported types include booleans, signed and unsigned integers, floating point
+				numbers, `VARCHAR`/`TEXT`, `BLOB`, `DATE`, `TIME`, `TIMESTAMP`, and
+				`DECIMAL`/`NUMERIC`.
+
+				Unsupported destination column types fail schema resolution during sink build
+				or healthcheck. Complex DuckDB types such as `STRUCT`, `LIST`, `MAP`, and
+				`UNION` are not yet supported.
+				"""
+		}
+
+		batching: {
+			title: "Batching and Transactions"
+			body: """
+				Events are batched using the standard sink `batch` options. Each batch is
+				encoded and appended inside a DuckDB transaction, so a successful batch commit
+				makes all events in that batch visible together. DuckDB access is performed on
+				blocking worker threads because DuckDB's Rust API is synchronous.
+				"""
+		}
+	}
+}

--- a/website/cue/reference/components/sinks/generated/duckdb.cue
+++ b/website/cue/reference/components/sinks/generated/duckdb.cue
@@ -1,0 +1,280 @@
+package metadata
+
+generated: components: sinks: duckdb: configuration: {
+	acknowledgements: {
+		description: """
+			Controls how acknowledgements are handled for this sink.
+
+			See [End-to-end Acknowledgements][e2e_acks] for more information on how event acknowledgement is handled.
+
+			[e2e_acks]: https://vector.dev/docs/architecture/end-to-end-acknowledgements/
+			"""
+		required: false
+		type: object: options: enabled: {
+			description: """
+				Controls whether or not end-to-end acknowledgements are enabled.
+
+				When enabled for a sink, any source that supports end-to-end
+				acknowledgements that is connected to that sink waits for events
+				to be acknowledged by **all connected sinks** before acknowledging them at the source.
+
+				Enabling or disabling acknowledgements at the sink level takes precedence over any global
+				[`acknowledgements`][global_acks] configuration.
+
+				[global_acks]: https://vector.dev/docs/reference/configuration/global-options/#acknowledgements
+				"""
+			required: false
+			type: bool: {}
+		}
+	}
+	batch: {
+		description: "Event batching behavior."
+		required:    false
+		type: object: options: {
+			max_bytes: {
+				description: """
+					The maximum size of a batch that is processed by a sink.
+
+					This is based on the uncompressed size of the batched events, before they are
+					serialized or compressed.
+					"""
+				required: false
+				type: uint: {
+					default: 10000000
+					unit:    "bytes"
+				}
+			}
+			max_events: {
+				description: "The maximum size of a batch before it is flushed."
+				required:    false
+				type: uint: unit: "events"
+			}
+			timeout_secs: {
+				description: "The maximum age of a batch before it is flushed."
+				required:    false
+				type: float: {
+					default: 1.0
+					unit:    "seconds"
+				}
+			}
+		}
+	}
+	database: {
+		description: "The DuckDB database/schema containing the table."
+		required:    false
+		type: string: {
+			default: "main"
+			examples: [
+				"main",
+			]
+		}
+	}
+	endpoint: {
+		description: """
+			The DuckDB database endpoint.
+
+			Use a filesystem path or a `duckdb://` URI such as
+			`duckdb:///var/lib/vector/events.duckdb`.
+			"""
+		required: true
+		type: string: examples: ["duckdb:///var/lib/vector/events.duckdb"]
+	}
+	request: {
+		description: """
+			Middleware settings for outbound requests.
+
+			Various settings can be configured, such as concurrency and rate limits, timeouts, and retry behavior.
+
+			Note that the retry backoff policy follows the Fibonacci sequence.
+			"""
+		required: false
+		type: object: options: {
+			adaptive_concurrency: {
+				description: """
+					Configuration of adaptive concurrency parameters.
+
+					These parameters typically do not require changes from the default, and incorrect values can lead to meta-stable or
+					unstable performance and sink behavior. Proceed with caution.
+					"""
+				required: false
+				type: object: options: {
+					decrease_ratio: {
+						description: """
+																The fraction of the current value to set the new concurrency limit when decreasing the limit.
+
+																Valid values are greater than `0` and less than `1`. Smaller values cause the algorithm to scale back rapidly
+																when latency increases.
+
+																**Note**: The new limit is rounded down after applying this ratio.
+																"""
+						required: false
+						type: float: default: 0.9
+					}
+					ewma_alpha: {
+						description: """
+																The weighting of new measurements compared to older measurements.
+
+																Valid values are greater than `0` and less than `1`.
+
+																ARC uses an exponentially weighted moving average (EWMA) of past RTT measurements as a reference to compare with
+																the current RTT. Smaller values cause this reference to adjust more slowly, which may be useful if a service has
+																unusually high response variability.
+																"""
+						required: false
+						type: float: default: 0.4
+					}
+					initial_concurrency: {
+						description: """
+																The initial concurrency limit to use. If not specified, the initial limit is 1 (no concurrency).
+
+																Datadog recommends setting this value to your service's average limit if you're seeing that it takes a
+																long time to ramp up adaptive concurrency after a restart. You can find this value by looking at the
+																`adaptive_concurrency_limit` metric.
+																"""
+						required: false
+						type: uint: default: 1
+					}
+					max_concurrency_limit: {
+						description: """
+																The maximum concurrency limit.
+
+																The adaptive request concurrency limit does not go above this bound. This is put in place as a safeguard.
+																"""
+						required: false
+						type: uint: default: 200
+					}
+					rtt_deviation_scale: {
+						description: """
+																Scale of RTT deviations which are not considered anomalous.
+
+																Valid values are greater than or equal to `0`, and reasonable values range from `1.0` to `3.0`.
+
+																When calculating the past RTT average, a secondary “deviation” value is also computed that indicates how variable
+																those values are. That deviation is used when comparing the past RTT average to the current measurements, so we
+																can ignore increases in RTT that are within an expected range. This factor is used to scale up the deviation to
+																an appropriate range. Larger values cause the algorithm to ignore larger increases in the RTT.
+																"""
+						required: false
+						type: float: default: 2.5
+					}
+				}
+			}
+			concurrency: {
+				description: """
+					Configuration for outbound request concurrency.
+
+					This can be set either to one of the below enum values or to a positive integer, which denotes
+					a fixed concurrency limit.
+					"""
+				required: false
+				type: {
+					string: {
+						default: "adaptive"
+						enum: {
+							adaptive: """
+															Concurrency is managed by Vector's [Adaptive Request Concurrency][arc] feature.
+
+															[arc]: https://vector.dev/docs/architecture/arc/
+															"""
+							none: """
+															A fixed concurrency of 1.
+
+															Only one request can be outstanding at any given time.
+															"""
+						}
+					}
+					uint: {}
+				}
+			}
+			rate_limit_duration_secs: {
+				description: "The time window used for the `rate_limit_num` option."
+				required:    false
+				type: uint: {
+					default: 1
+					unit:    "seconds"
+				}
+			}
+			rate_limit_num: {
+				description: "The maximum number of requests allowed within the `rate_limit_duration_secs` time window."
+				required:    false
+				type: uint: {
+					default: 9223372036854775807
+					unit:    "requests"
+				}
+			}
+			retry_attempts: {
+				description: "The maximum number of retries to make for failed requests."
+				required:    false
+				type: uint: {
+					default: 9223372036854775807
+					unit:    "retries"
+				}
+			}
+			retry_initial_backoff_secs: {
+				description: """
+					The amount of time to wait before attempting the first retry for a failed request.
+
+					After the first retry has failed, the Fibonacci sequence is used to select future backoffs.
+					"""
+				required: false
+				type: uint: {
+					default: 1
+					unit:    "seconds"
+				}
+			}
+			retry_jitter_mode: {
+				description: "The jitter mode to use for retry backoff behavior."
+				required:    false
+				type: string: {
+					default: "Full"
+					enum: {
+						Full: """
+															Full jitter.
+
+															The random delay is anywhere from 0 up to the maximum current delay calculated by the backoff
+															strategy.
+
+															Incorporating full jitter into your backoff strategy can greatly reduce the likelihood
+															of creating accidental denial of service (DoS) conditions against your own systems when
+															many clients are recovering from a failure state.
+															"""
+						None: "No jitter."
+					}
+				}
+			}
+			retry_max_duration_secs: {
+				description: "The maximum amount of time to wait between retries."
+				required:    false
+				type: uint: {
+					default: 30
+					unit:    "seconds"
+				}
+			}
+			timeout_secs: {
+				description: """
+					The time a request can take before being aborted.
+
+					Datadog highly recommends that you do not lower this value below the service's internal timeout, as this could
+					create orphaned requests, pile on retries, and result in duplicate data downstream.
+					"""
+				required: false
+				type: uint: {
+					default: 60
+					unit:    "seconds"
+				}
+			}
+		}
+	}
+	table: {
+		description: """
+			The table that data is inserted into.
+
+			The table must already exist. Vector reads its schema at startup and encodes each batch to
+			match the destination table before appending it.
+			"""
+		required: true
+		type: string: examples: [
+			"events",
+		]
+	}
+}

--- a/website/cue/reference/services/duckdb.cue
+++ b/website/cue/reference/services/duckdb.cue
@@ -1,0 +1,10 @@
+package metadata
+
+services: duckdb: {
+	name:     "DuckDB"
+	thing:    "a \(name) database"
+	url:      urls.duckdb
+	versions: null
+
+	description: "[DuckDB](\(urls.duckdb)) is an in-process analytical database management system designed for fast SQL analytics over local and embedded data."
+}

--- a/website/cue/reference/urls.cue
+++ b/website/cue/reference/urls.cue
@@ -129,6 +129,8 @@ urls: {
 	databend:                                   "https://databend.rs"
 	databend_rest:                              "https://databend.rs/doc/integrations/api/rest"
 	databend_cloud:                             "https://www.databend.com"
+	duckdb:                                     "https://duckdb.org/"
+	duckdb_data_types:                          "https://duckdb.org/docs/stable/sql/data_types/overview"
 	doris:                                      "https://doris.apache.org"
 	doris_stream_load:                          "https://doris.apache.org/docs/data-operate/import/import-way/stream-load-manual"
 	datadog:                                    "https://www.datadoghq.com"


### PR DESCRIPTION
## Summary

This PR adds an opt-in `duckdb` sink for writing log events into existing DuckDB tables.

The sink is designed around DuckDB's native table model rather than treating DuckDB as an opaque file output:

- the destination table must already exist
- Vector reads the table schema from `information_schema.columns` at startup
- supported DuckDB column types are mapped to Arrow types
- each Vector batch is encoded as an Arrow `RecordBatch`
- batches are appended with DuckDB's native appender API
- each request batch is written inside a transaction, so a failed batch is not partially committed

This avoids implicit schema inference or table creation in Vector. That felt like the safer behavior for an embedded analytical database where users may create, migrate, and query the database directly outside of Vector.

The sink is behind the `sinks-duckdb` feature and is not included in the default `sinks` feature set. The `duckdb` crate currently uses DuckDB's bundled native library in this integration, so keeping it opt-in avoids adding that native build cost to regular Vector builds.

## Vector configuration

Example configuration:

```toml
[sources.in]
type = "file"
include = ["/var/log/events.ndjson"]
read_from = "beginning"
ignore_checkpoints = true

[transforms.parse]
type = "remap"
inputs = ["in"]
source = '''
. = parse_json!(.message)
'''

[sinks.duckdb]
type = "duckdb"
inputs = ["parse"]
endpoint = "duckdb:///var/lib/vector/events.duckdb"
database = "main"
table = "events"
batch.max_events = 1000
request.concurrency = 1
```

Example destination table:

```sql
CREATE TABLE events (
  host VARCHAR,
  user_identifier VARCHAR,
  datetime VARCHAR,
  method VARCHAR,
  request VARCHAR,
  protocol VARCHAR,
  status VARCHAR,
  bytes BIGINT,
  referer VARCHAR,
  service VARCHAR
);
```

The sink also accepts plain filesystem paths as endpoints:

```toml
endpoint = "/var/lib/vector/events.duckdb"
```

## How did you test this PR?

### Unit and integration tests

Added coverage for:

- config generation and parsing
- DuckDB endpoint parsing
- table schema discovery
- DuckDB-to-Arrow scalar type mapping
- missing tables failing at build time
- unsupported DuckDB column types failing at build time
- healthcheck behavior
- writing events into DuckDB
- writing to a configured non-`main` schema
- missing non-nullable fields rejecting the batch
- supported scalar values
- ignored stress tests for high-volume ingestion and failed-batch atomicity

Ran:

```bash
PROTOC=/tmp/protoc-vector/protoc mise exec rust@1.95 -- \
  cargo check --no-default-features --features sinks-duckdb

PROTOC=/tmp/protoc-vector/protoc mise exec rust@1.95 -- \
  cargo test --no-default-features \
  --features duckdb-integration-tests \
  sinks::duckdb:: -- --nocapture

PROTOC=/tmp/protoc-vector/protoc mise exec rust@1.95 -- \
  cargo clippy --no-default-features \
  --features duckdb-integration-tests \
  --tests -- -D warnings

PROTOC=/tmp/protoc-vector/protoc mise exec rust@1.95 -- \
  cargo fmt --check

PROTOC=/tmp/protoc-vector/protoc mise exec rust@1.95 -- \
  cargo vdev check events

./scripts/check_changelog_fragments.sh

git diff --check
```

All passed.

I also checked that enabling the regular `sinks` feature set does not pull in DuckDB:

```bash
PROTOC=/tmp/protoc-vector/protoc mise exec rust@1.95 -- \
  cargo tree --no-default-features --features sinks -e features -i duckdb
```

Expected result:

```text
error: package ID specification `duckdb` did not match any packages
```

### Stress testing

The PR includes ignored stress tests that can be run manually. For example:

```bash
DUCKDB_STRESS_EVENTS=1000000 \
DUCKDB_STRESS_BATCH_EVENTS=1000 \
DUCKDB_STRESS_REQUEST_CONCURRENCY=2 \
PROTOC=/tmp/protoc-vector/protoc mise exec rust@1.95 -- \
  cargo test --release --no-default-features \
  --features duckdb-integration-tests \
  stress_million_events -- --ignored --nocapture
```

Those tests validate row counts, min/max/distinct IDs, and aggregate sums after ingestion. They also sample DuckDB database/WAL file sizes and can optionally run a concurrent reader during writes.

A separate ignored stress test verifies failed-batch atomicity by writing one valid batch followed by one invalid batch and asserting that only the valid batch is committed.

### Real pipeline testing

I also tested a realistic file ingestion pipeline using a generated 1M-line NDJSON file, about 213 MiB:

```text
file source -> remap parse_json!(.message) -> duckdb sink
```

With:

```toml
batch.max_events = 1000
request.concurrency = 2
```

The DuckDB pipeline was effectively at the same throughput as the same file/remap pipeline writing to `blackhole`:

```text
file -> remap -> duckdb:   ~193k events/s
file -> remap -> blackhole: ~195k events/s
```

That suggests the sink overhead is small for this workload; file reading and JSON parsing dominate the end-to-end pipeline.

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [x] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

Changelog fragment added:

```text
changelog.d/duckdb_sink.feature.md
```

## References

- DuckDB Appender docs: https://duckdb.org/docs/current/data/appender
- Related Arrow encoding optimization: #25734

## Notes

Users should create the destination table before starting Vector. A good initial tuning point is:

```toml
batch.max_events = 1000
request.concurrency = 1
```

`request.concurrency = 2` may help when RecordBatch encoding is a significant part of the workload, while `1` is the safer default starting point for local DuckDB writes.
