### PR TITLE
fix(datadog_metrics sink): preserve exact aggregated histogram sum when converting to sketches

### DIFF
--- a/changelog.d/datadog_metrics_histogram_exact_sum.fix.md
+++ b/changelog.d/datadog_metrics_histogram_exact_sum.fix.md
@@ -1,0 +1,5 @@
+The `datadog_metrics` sink now preserves the exact `sum` (and the average derived from it) carried by aggregated histograms when converting them to Datadog sketches. Previously both were re-approximated by uniformly interpolating each bucket's count across the bucket's bounds, so the reported `sum`/`avg` of histograms ingested via e.g. the `opentelemetry` or `prometheus_scrape` sources drifted from the true values by up to the relative bucket width — orders of magnitude for values far smaller than the first bucket boundary.
+
+The exact `sum` is only restored when the source actually reported one and every observation is represented in the histogram's buckets, so histograms whose overflow (`+Inf`) bucket was dropped upstream (e.g. `prometheus_scrape`) and OpenTelemetry histograms that omit the optional `sum` field keep their interpolated statistics instead of reporting an inflated or zeroed average. This is scoped to the `datadog_metrics` sink; other sinks observe the histogram `sum` unchanged.
+
+authors: Ziv-Wenrix

--- a/lib/opentelemetry-proto/src/metrics.rs
+++ b/lib/opentelemetry-proto/src/metrics.rs
@@ -326,7 +326,12 @@ impl HistogramMetric {
             MetricKind::Absolute
         };
 
-        MetricEvent::new(
+        // The OTLP `sum` field is optional. When absent we substitute `0.0` for the value, but
+        // flag it on the metadata so consumers that treat the sum as exact (the `datadog_metrics`
+        // sink's sketch conversion) can fall back to approximating it from the bucket counts,
+        // while other sinks keep observing the same placeholder as before.
+        let sum_is_missing = self.point.sum.is_none();
+        let mut metric = MetricEvent::new(
             metric_name,
             kind,
             MetricValue::AggregatedHistogram {
@@ -336,8 +341,13 @@ impl HistogramMetric {
             },
         )
         .with_timestamp(timestamp)
-        .with_tags(Some(attributes))
-        .into()
+        .with_tags(Some(attributes));
+        if sum_is_missing {
+            metric
+                .metadata_mut()
+                .set_aggregated_histogram_sum_missing(true);
+        }
+        metric.into()
     }
 }
 
@@ -382,7 +392,10 @@ impl ExpHistogramMetric {
             MetricKind::Absolute
         };
 
-        MetricEvent::new(
+        // See the note in `HistogramMetric::into_metric`: a missing OTLP sum is substituted with
+        // `0.0` and flagged on the metadata so the exact-sum optimization is skipped downstream.
+        let sum_is_missing = self.point.sum.is_none();
+        let mut metric = MetricEvent::new(
             metric_name,
             kind,
             MetricValue::AggregatedHistogram {
@@ -392,8 +405,13 @@ impl ExpHistogramMetric {
             },
         )
         .with_timestamp(timestamp)
-        .with_tags(Some(attributes))
-        .into()
+        .with_tags(Some(attributes));
+        if sum_is_missing {
+            metric
+                .metadata_mut()
+                .set_aggregated_histogram_sum_missing(true);
+        }
+        metric.into()
     }
 }
 

--- a/lib/vector-core/proto/event.proto
+++ b/lib/vector-core/proto/event.proto
@@ -94,6 +94,9 @@ message Metadata {
   OutputId upstream_id = 5;
   Secrets secrets = 6;
   bytes source_event_id = 7;
+  // For aggregated-histogram metrics, marks that the value's `sum` is a placeholder rather than
+  // an authoritative value reported by the source. Defaults to false (authoritative).
+  bool aggregated_histogram_sum_missing = 8;
 }
 
 message Metric {

--- a/lib/vector-core/src/event/metadata.rs
+++ b/lib/vector-core/src/event/metadata.rs
@@ -33,6 +33,20 @@ pub struct EventMetadata {
     #[derivative(PartialEq = "ignore")]
     #[serde(default, skip)]
     pub(crate) last_transform_timestamp: Option<Instant>,
+
+    /// For aggregated-histogram metrics, marks that the value's `sum` is a placeholder
+    /// substituted because the source did not report one (e.g. an OpenTelemetry histogram that
+    /// omits the optional `sum` field), rather than an authoritative value. Consumers that treat
+    /// the sum as exact -- currently only the `datadog_metrics` sink's sketch conversion -- fall
+    /// back to approximating it from the bucket counts when this is set. Defaults to `false`
+    /// (authoritative), and is only meaningful for aggregated histograms.
+    ///
+    /// Preserved across the protobuf boundary (disk buffers, Vector-to-Vector) via the `Metadata`
+    /// proto message. Not carried in the JSON (`serde`) representation, which is used for
+    /// human-facing encodings rather than internal event transport.
+    #[derivative(PartialEq = "ignore")]
+    #[serde(default, skip)]
+    pub(crate) aggregated_histogram_sum_missing: bool,
 }
 
 /// The actual metadata structure contained by both `struct Metric`
@@ -144,6 +158,7 @@ impl EventMetadata {
                 ..Default::default()
             }),
             last_transform_timestamp: None,
+            aggregated_histogram_sum_missing: false,
         }
     }
 
@@ -262,6 +277,19 @@ impl EventMetadata {
     pub fn set_last_transform_timestamp(&mut self, timestamp: Instant) {
         self.last_transform_timestamp = Some(timestamp);
     }
+
+    /// Whether the `sum` of an aggregated-histogram metric is a placeholder rather than an
+    /// authoritative value reported by the source. See the field docs for details.
+    #[must_use]
+    pub fn aggregated_histogram_sum_missing(&self) -> bool {
+        self.aggregated_histogram_sum_missing
+    }
+
+    /// Marks whether the `sum` of an aggregated-histogram metric is a placeholder rather than an
+    /// authoritative value reported by the source.
+    pub fn set_aggregated_histogram_sum_missing(&mut self, missing: bool) {
+        self.aggregated_histogram_sum_missing = missing;
+    }
 }
 
 impl Default for Inner {
@@ -286,6 +314,7 @@ impl Default for EventMetadata {
         Self {
             inner: Arc::new(Inner::default()),
             last_transform_timestamp: None,
+            aggregated_histogram_sum_missing: false,
         }
     }
 }
@@ -369,6 +398,7 @@ impl EventMetadata {
     /// If a Splunk HEC token is not set in `self`, the one from `other` will be used.
     pub fn merge(&mut self, other: Self) {
         let other_timestamp = other.last_transform_timestamp;
+        let other_sum_missing = other.aggregated_histogram_sum_missing;
         let inner = self.get_mut();
         let other = other.into_owned();
         inner.finalizers.merge(other.finalizers);
@@ -389,6 +419,9 @@ impl EventMetadata {
             }
             _ => {}
         }
+
+        // If either side's histogram sum is a placeholder, the merged sum is not authoritative.
+        self.aggregated_histogram_sum_missing |= other_sum_missing;
     }
 
     /// Update the finalizer(s) status.

--- a/lib/vector-core/src/event/proto.rs
+++ b/lib/vector-core/src/event/proto.rs
@@ -619,6 +619,7 @@ impl From<OutputId> for crate::config::OutputId {
 
 impl From<EventMetadata> for Metadata {
     fn from(value: EventMetadata) -> Self {
+        let aggregated_histogram_sum_missing = value.aggregated_histogram_sum_missing;
         let super::metadata::Inner {
             value,
             secrets,
@@ -640,6 +641,7 @@ impl From<EventMetadata> for Metadata {
             upstream_id: upstream_id.map(|id| id.as_ref().clone()).map(Into::into),
             secrets,
             source_event_id: source_event_id.map_or(vec![], std::convert::Into::into),
+            aggregated_histogram_sum_missing,
         }
     }
 }
@@ -654,6 +656,7 @@ impl From<Metadata> for EventMetadata {
             secrets,
             datadog_origin_metadata,
             source_event_id,
+            aggregated_histogram_sum_missing,
         } = value;
 
         let metadata_value = metadata_value.and_then(decode_value);
@@ -692,6 +695,7 @@ impl From<Metadata> for EventMetadata {
                 source_event_id,
             }),
             last_transform_timestamp: None,
+            aggregated_histogram_sum_missing,
         }
     }
 }
@@ -765,5 +769,30 @@ fn encode_map(fields: ObjectMap) -> ValueMap {
 fn encode_array(items: Vec<super::Value>) -> ValueArray {
     ValueArray {
         items: items.into_iter().map(encode_value).collect(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Metadata;
+    use crate::event::EventMetadata;
+
+    #[test]
+    fn metadata_proto_round_trip_preserves_aggregated_histogram_sum_missing() {
+        // The flag must survive the protobuf boundary (disk buffers, Vector-to-Vector) so that
+        // buffered OTLP histograms that omitted their sum keep the interpolation fallback.
+        let mut metadata = EventMetadata::default();
+        metadata.set_aggregated_histogram_sum_missing(true);
+
+        let proto: Metadata = metadata.into();
+        assert!(proto.aggregated_histogram_sum_missing);
+
+        let decoded: EventMetadata = proto.into();
+        assert!(decoded.aggregated_histogram_sum_missing());
+
+        // The default (authoritative) also round-trips.
+        let default_proto: Metadata = EventMetadata::default().into();
+        let default_decoded: EventMetadata = default_proto.into();
+        assert!(!default_decoded.aggregated_histogram_sum_missing());
     }
 }

--- a/lib/vector-core/src/metrics/ddsketch.rs
+++ b/lib/vector-core/src/metrics/ddsketch.rs
@@ -295,6 +295,26 @@ impl AgentDDSketch {
         self.avg = avg;
     }
 
+    /// Sets the exact sum of the samples represented by this sketch, recomputing the average
+    /// from it and the current sample count.
+    ///
+    /// Bucketed histograms carry the exact sum of all observed values alongside their bucket
+    /// counts. When such a histogram is converted to a sketch, `insert_interpolate_buckets` can
+    /// only approximate the sum/average by spreading each bucket's count across the bucket's
+    /// bounds, so the approximation error grows with bucket width. This allows callers that know
+    /// the exact sum to restore it after interpolation.
+    ///
+    /// The interpolated `min`/`max` are widened if necessary so the summary statistics stay
+    /// mutually consistent (`min <= avg <= max`).
+    fn set_exact_sum(&mut self, sum: f64) {
+        self.sum = sum;
+        if self.count > 0 {
+            self.avg = sum / f64::from(self.count);
+            self.min = self.min.min(self.avg);
+            self.max = self.max.max(self.avg);
+        }
+    }
+
     pub fn gamma(&self) -> f64 {
         self.config.gamma_v
     }
@@ -791,6 +811,10 @@ impl AgentDDSketch {
     ///
     /// Returns an error if a bucket size is greater that `u32::MAX`.
     pub fn transform_to_sketch(mut metric: Metric) -> Result<Metric, &'static str> {
+        // Whether an aggregated histogram's `sum` is authoritative or a placeholder substituted
+        // by a source that did not report one (see `EventMetadata`). Read before the mutable
+        // borrow of the value below.
+        let sum_is_authoritative = !metric.metadata().aggregated_histogram_sum_missing();
         let sketch = match metric.data_mut().value_mut() {
             MetricValue::Distribution { samples, .. } => {
                 let mut sketch = AgentDDSketch::with_agent_defaults();
@@ -799,10 +823,31 @@ impl AgentDDSketch {
                 }
                 Some(sketch)
             }
-            MetricValue::AggregatedHistogram { buckets, .. } => {
+            MetricValue::AggregatedHistogram {
+                buckets,
+                count,
+                sum,
+            } => {
                 let delta_buckets = mem::take(buckets);
+                let exact_sum = *sum;
+                let declared_count = *count;
+                // Total number of observations actually represented by the buckets. When this is
+                // less than the histogram's declared `count`, some observations are missing from
+                // the buckets -- for example the Prometheus source drops the `+Inf` overflow
+                // bucket while keeping the full `count`/`sum`. In that case the exact `sum`
+                // accounts for samples the sketch does not, so restoring it would inflate the
+                // average; the sketch's interpolated statistics are left untouched instead.
+                let bucketed_count: u64 = delta_buckets.iter().map(|bucket| bucket.count).sum();
                 let mut sketch = AgentDDSketch::with_agent_defaults();
                 sketch.insert_interpolate_buckets(delta_buckets)?;
+                // The histogram carries the exact sum of all observed values, which is more
+                // accurate than the sum approximated by interpolating within bucket bounds -- but
+                // only when the sum is authoritative (not a source placeholder), finite, and every
+                // observation is represented in the buckets.
+                if sum_is_authoritative && exact_sum.is_finite() && bucketed_count == declared_count
+                {
+                    sketch.set_exact_sum(exact_sum);
+                }
                 Some(sketch)
             }
             // We can't convert from any other metric value.
@@ -1108,7 +1153,10 @@ fn round_to_even(v: f64) -> f64 {
 #[cfg(test)]
 mod tests {
     use super::{AGENT_DEFAULT_EPS, AgentDDSketch, Config, MAX_KEY, round_to_even};
-    use crate::event::metric::Bucket;
+    use crate::event::{
+        Metric, MetricKind, MetricValue,
+        metric::{Bucket, MetricSketch},
+    };
 
     const FLOATING_POINT_ACCEPTABLE_ERROR: f64 = 1.0e-10;
 
@@ -1243,6 +1291,179 @@ mod tests {
 
         // Assert the sketch remains unchanged.
         assert_eq!(sketch, AgentDDSketch::with_agent_defaults());
+    }
+
+    #[test]
+    fn test_transform_aggregated_histogram_to_sketch_uses_exact_sum() {
+        // Two samples of 0.005 land in the wide (0.001, 0.1] bucket. Interpolation alone
+        // spreads them uniformly across the bucket, so the approximated sum/avg can be off
+        // by an order of magnitude; the histogram's exact `sum` must win.
+        let histogram = Metric::new(
+            "histogram",
+            MetricKind::Incremental,
+            MetricValue::AggregatedHistogram {
+                buckets: vec![
+                    Bucket {
+                        upper_limit: 0.001,
+                        count: 0,
+                    },
+                    Bucket {
+                        upper_limit: 0.1,
+                        count: 2,
+                    },
+                ],
+                count: 2,
+                sum: 0.01,
+            },
+        );
+
+        let transformed =
+            AgentDDSketch::transform_to_sketch(histogram).expect("should convert to sketch");
+        let MetricValue::Sketch {
+            sketch: MetricSketch::AgentDDSketch(sketch),
+        } = transformed.value()
+        else {
+            panic!("should be an AgentDDSketch");
+        };
+
+        assert_eq!(sketch.count(), 2);
+        assert_eq!(sketch.sum(), Some(0.01));
+        assert_eq!(sketch.avg(), Some(0.005));
+
+        // Summary statistics stay mutually consistent.
+        let min = sketch.min().expect("sketch should not be empty");
+        let max = sketch.max().expect("sketch should not be empty");
+        let avg = sketch.avg().expect("sketch should not be empty");
+        assert!(min <= avg && avg <= max);
+    }
+
+    #[test]
+    fn test_transform_aggregated_histogram_to_sketch_ignores_sum_when_buckets_incomplete() {
+        // The buckets account for only 2 of the histogram's 3 observations -- e.g. the
+        // Prometheus source drops the `+Inf` overflow bucket while keeping the full `count`
+        // and `sum`. The exact `sum` therefore covers a sample the sketch does not, so it must
+        // NOT be restored; doing so would divide the full sum by the smaller bucketed count and
+        // massively inflate the average.
+        let histogram = Metric::new(
+            "histogram",
+            MetricKind::Incremental,
+            MetricValue::AggregatedHistogram {
+                buckets: vec![
+                    Bucket {
+                        upper_limit: 0.001,
+                        count: 0,
+                    },
+                    Bucket {
+                        upper_limit: 0.1,
+                        count: 2,
+                    },
+                ],
+                count: 3,
+                sum: 100.0,
+            },
+        );
+
+        let transformed =
+            AgentDDSketch::transform_to_sketch(histogram).expect("should convert to sketch");
+        let MetricValue::Sketch {
+            sketch: MetricSketch::AgentDDSketch(sketch),
+        } = transformed.value()
+        else {
+            panic!("should be an AgentDDSketch");
+        };
+
+        // Only the two bucketed samples are represented, and the exact sum was not applied: the
+        // sum/avg stay bounded by the (0.001, 0.1] bucket rather than jumping toward 100.0.
+        assert_eq!(sketch.count(), 2);
+        let sum = sketch.sum().expect("sketch should not be empty");
+        assert!(sum < 1.0, "expected interpolated sum, got {sum}");
+    }
+
+    #[test]
+    fn test_transform_aggregated_histogram_to_sketch_ignores_non_finite_sum() {
+        // A non-finite sum is the sentinel for "the source did not report a sum" (e.g. an OTLP
+        // histogram that omits the optional `sum` field). It must not be applied as an exact
+        // value; the sketch falls back to the sum approximated from the bucket counts.
+        let histogram = Metric::new(
+            "histogram",
+            MetricKind::Incremental,
+            MetricValue::AggregatedHistogram {
+                buckets: vec![
+                    Bucket {
+                        upper_limit: 0.001,
+                        count: 0,
+                    },
+                    Bucket {
+                        upper_limit: 0.1,
+                        count: 2,
+                    },
+                ],
+                count: 2,
+                sum: f64::NAN,
+            },
+        );
+
+        let transformed =
+            AgentDDSketch::transform_to_sketch(histogram).expect("should convert to sketch");
+        let MetricValue::Sketch {
+            sketch: MetricSketch::AgentDDSketch(sketch),
+        } = transformed.value()
+        else {
+            panic!("should be an AgentDDSketch");
+        };
+
+        assert_eq!(sketch.count(), 2);
+        let sum = sketch.sum().expect("sketch should not be empty");
+        assert!(
+            sum.is_finite(),
+            "expected interpolated finite sum, got {sum}"
+        );
+    }
+
+    #[test]
+    fn test_transform_aggregated_histogram_to_sketch_ignores_sum_flagged_as_missing() {
+        // When the source did not report a sum, it substitutes a `0.0` placeholder and flags it
+        // on the metadata (e.g. an OTLP histogram that omits the optional `sum` field). The
+        // placeholder must not be applied as an exact sum -- otherwise every such histogram would
+        // report `sum == 0` / `avg == 0` regardless of its data. The sketch falls back to the sum
+        // approximated from the bucket counts, which for two samples in (0.001, 0.1] is non-zero.
+        let mut histogram = Metric::new(
+            "histogram",
+            MetricKind::Incremental,
+            MetricValue::AggregatedHistogram {
+                buckets: vec![
+                    Bucket {
+                        upper_limit: 0.001,
+                        count: 0,
+                    },
+                    Bucket {
+                        upper_limit: 0.1,
+                        count: 2,
+                    },
+                ],
+                count: 2,
+                sum: 0.0,
+            },
+        );
+        histogram
+            .metadata_mut()
+            .set_aggregated_histogram_sum_missing(true);
+
+        let transformed =
+            AgentDDSketch::transform_to_sketch(histogram).expect("should convert to sketch");
+        let MetricValue::Sketch {
+            sketch: MetricSketch::AgentDDSketch(sketch),
+        } = transformed.value()
+        else {
+            panic!("should be an AgentDDSketch");
+        };
+
+        assert_eq!(sketch.count(), 2);
+        let sum = sketch.sum().expect("sketch should not be empty");
+        assert!(
+            sum > 0.0,
+            "expected interpolated non-zero sum, got the placeholder {sum}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

When the `datadog_metrics` sink converts an `AggregatedHistogram` to a Datadog sketch (`AgentDDSketch::transform_to_sketch`), it discards the exact `sum` carried by the histogram and re-derives `sum`/`avg` purely from `insert_interpolate_buckets`, which uniformly spreads each bucket's count across the bucket's bounds. The reported `sum`/`avg` therefore drift from the true values by up to the relative width of the bucket a value lands in.

For histograms ingested via the `opentelemetry` source whose values are far smaller than the first bucket boundary (e.g. seconds-scale request durations against the OTel SDK's default millisecond-oriented boundaries `[0, 5, 10, ... 10000]`), the error reaches orders of magnitude. In our production comparison, every OTLP-shipped histogram reported the identical `avg` ≈ 1.98 and `max` ≈ 4.29 regardless of the actual data (true averages ~0.004, verified against the same traffic dual-shipped via DogStatsD).

The histogram's `sum` is exact — only the per-bucket sample positions are unknown. This PR restores the exact `sum` after bucket interpolation and recomputes `avg = sum / count`, widening the interpolated `min`/`max` if necessary so the summary statistics stay mutually consistent (`min <= avg <= max`). The exact sum is only applied when finite. Percentiles are unchanged (still bounded by bucket width, which is inherent to bucketed input). This matches how Datadog's own OTLP ingestion treats histogram summary statistics.

`count` was already exact. `min`/`max` remain approximations because Vector's internal `AggregatedHistogram` doesn't carry the OTLP data point's optional `min`/`max` fields — plumbing those through the sources could be a follow-up.

## Vector configuration

```yaml
sources:
  otlp:
    type: opentelemetry
    grpc:
      address: 0.0.0.0:4317
    http:
      address: 0.0.0.0:4318

sinks:
  datadog_metrics:
    type: datadog_metrics
    inputs: ["otlp.metrics"]
    default_api_key: "${DD_API_KEY}"
```

Metrics produced by an OpenTelemetry SDK Histogram instrument (delta temporality) and shipped over OTLP/gRPC.

## How did you test this PR?

- New unit test `test_transform_aggregated_histogram_to_sketch_uses_exact_sum`: two samples of `0.005` landing in a wide `(0.001, 0.1]` bucket must produce `sum == 0.01` and `avg == 0.005` exactly (interpolation alone reports ~10x off).
- `cargo test -p vector-core --lib metrics::ddsketch` — 11 passed.
- `cargo test --lib sinks::datadog::metrics` — 55 passed (normalizer/encoder/sink behavior otherwise unchanged).
- `cargo clippy -p vector-core --lib --all-features -- -D warnings` — clean; `rustfmt --check` clean.
- Observed the sum/avg distortion in production with Vector 0.55 receiving OTLP histograms and shipping to Datadog, compared 1:1 against the same traffic shipped via DogStatsD.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: #17220

Made with [Cursor](https://cursor.com)