### PR TITLE
Add memory buffer drop_oldest mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1108,8 +1108,14 @@ test-utils = ["vector-lib/test"]
 
 # End-to-End testing-related features
 all-e2e-tests = [
+  "e2e-tests-buffer-drop-oldest",
   "e2e-tests-datadog",
   "e2e-tests-opentelemetry"
+]
+
+e2e-tests-buffer-drop-oldest = [
+  "sources-http_server",
+  "sinks-http"
 ]
 
 e2e-tests-datadog = [

--- a/changelog.d/8209_memory_buffer_drop_oldest.feature.md
+++ b/changelog.d/8209_memory_buffer_drop_oldest.feature.md
@@ -1,0 +1,3 @@
+Add `drop_oldest` support for memory buffers, allowing Vector to evict older buffered events in favor of newer events when a memory buffer is full.
+
+authors: fpytloun

--- a/lib/vector-buffers/src/buffer_usage_data.rs
+++ b/lib/vector-buffers/src/buffer_usage_data.rs
@@ -204,6 +204,13 @@ impl BufferUsageHandle {
             }
         }
     }
+
+    /// Increment the number of events dropped by `drop_oldest` for this buffer component.
+    pub fn increment_dropped_oldest_event_count_and_byte_size(&self, count: u64, byte_size: u64) {
+        if count > 0 || byte_size > 0 {
+            self.state.dropped_oldest.increment(count, byte_size);
+        }
+    }
 }
 
 #[derive(Debug, Default)]
@@ -213,6 +220,7 @@ struct BufferUsageData {
     sent: CategoryMetrics,
     dropped: CategoryMetrics,
     dropped_intentional: CategoryMetrics,
+    dropped_oldest: CategoryMetrics,
     max_size: CategoryMetrics,
 }
 
@@ -229,6 +237,7 @@ impl BufferUsageData {
         let sent = self.sent.get();
         let dropped = self.dropped.get();
         let dropped_intentional = self.dropped_intentional.get();
+        let dropped_oldest = self.dropped_oldest.get();
         let max_size = self.max_size.get();
 
         BufferUsageSnapshot {
@@ -238,8 +247,12 @@ impl BufferUsageData {
             sent_byte_size: sent.event_byte_size,
             dropped_event_count: dropped.event_count,
             dropped_event_byte_size: dropped.event_byte_size,
-            dropped_event_count_intentional: dropped_intentional.event_count,
-            dropped_event_byte_size_intentional: dropped_intentional.event_byte_size,
+            dropped_event_count_intentional: dropped_intentional
+                .event_count
+                .saturating_add(dropped_oldest.event_count),
+            dropped_event_byte_size_intentional: dropped_intentional
+                .event_byte_size
+                .saturating_add(dropped_oldest.event_byte_size),
             max_size_bytes: max_size.event_byte_size,
             max_size_events: max_size
                 .event_count
@@ -275,6 +288,9 @@ impl BufferUsageData {
 
         let dropped_intentional = self.dropped_intentional.consume();
         current_metrics.add_left(dropped_intentional);
+
+        let dropped_oldest = self.dropped_oldest.consume();
+        current_metrics.add_left(dropped_oldest);
 
         let current = current_metrics.current();
 
@@ -321,6 +337,19 @@ impl BufferUsageData {
                 reason: "drop_newest",
                 count: dropped_intentional.event_count,
                 byte_size: dropped_intentional.event_byte_size,
+                total_count: current.event_count,
+                total_byte_size: current.event_byte_size,
+            });
+        }
+
+        if dropped_oldest.has_updates() {
+            emit(BufferEventsDropped {
+                buffer_id: buffer_id.to_string(),
+                idx: self.idx,
+                intentional: true,
+                reason: "drop_oldest",
+                count: dropped_oldest.event_count,
+                byte_size: dropped_oldest.event_byte_size,
                 total_count: current.event_count,
                 total_byte_size: current.event_byte_size,
             });

--- a/lib/vector-buffers/src/config.rs
+++ b/lib/vector-buffers/src/config.rs
@@ -28,6 +28,8 @@ pub enum BufferBuildError {
     FailedToBuildTopology { source: TopologyError },
     #[snafu(display("`max_events` must be greater than zero"))]
     InvalidMaxEvents,
+    #[snafu(display("`when_full = \"drop_oldest\"` is only supported for memory buffers"))]
+    DropOldestRequiresMemory,
 }
 
 #[derive(Deserialize, Serialize)]
@@ -316,6 +318,9 @@ impl BufferType {
                 when_full,
                 max_size,
             } => {
+                if when_full == WhenFull::DropOldest {
+                    return Err(BufferBuildError::DropOldestRequiresMemory);
+                }
                 let data_dir = data_dir.ok_or(BufferBuildError::RequiresDataDir)?;
                 builder.stage(DiskV2Buffer::new(id, data_dir, max_size), when_full);
             }
@@ -425,7 +430,10 @@ impl BufferConfig {
 mod test {
     use std::num::{NonZeroU64, NonZeroUsize};
 
-    use crate::{BufferConfig, BufferType, MemoryBufferSize, WhenFull};
+    use tracing::Span;
+
+    use super::BufferBuildError;
+    use crate::{BufferConfig, BufferType, MemoryBufferSize, WhenFull, test::SizedRecord};
 
     fn check_single_stage(source: &str, expected: BufferType) {
         let config: BufferConfig = serde_yaml::from_str(source).unwrap();
@@ -552,6 +560,17 @@ max_events: 42
         check_single_stage(
             r"
           type: memory
+          when_full: drop_oldest
+          ",
+            BufferType::Memory {
+                size: MemoryBufferSize::MaxEvents(NonZeroUsize::new(500).unwrap()),
+                when_full: WhenFull::DropOldest,
+            },
+        );
+
+        check_single_stage(
+            r"
+          type: memory
           when_full: overflow
           ",
             BufferType::Memory {
@@ -570,5 +589,20 @@ max_events: 42
                 when_full: WhenFull::Block,
             },
         );
+    }
+
+    #[tokio::test]
+    async fn build_rejects_drop_oldest_for_disk() {
+        let config = BufferConfig::Single(BufferType::DiskV2 {
+            max_size: NonZeroU64::new(1024).unwrap(),
+            when_full: WhenFull::DropOldest,
+        });
+
+        let error = config
+            .build::<SizedRecord>(None, String::from("test"), Span::none())
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, BufferBuildError::DropOldestRequiresMemory));
     }
 }

--- a/lib/vector-buffers/src/lib.rs
+++ b/lib/vector-buffers/src/lib.rs
@@ -63,6 +63,13 @@ pub enum WhenFull {
     /// slowdown in the acceptance/consumption of events.
     DropNewest,
 
+    /// Drops the oldest buffered event to make room for the new event.
+    ///
+    /// The oldest buffered event will be intentionally dropped when free space is required. This
+    /// mode is typically used when preserving the most recent events is more important than
+    /// preserving older buffered events.
+    DropOldest,
+
     /// Overflows to the next stage in the buffer topology.
     ///
     /// If the current buffer stage is full, attempt to send this event to the next buffer stage.
@@ -81,10 +88,10 @@ impl Arbitrary for WhenFull {
         // TODO: We explicitly avoid generating "overflow" as a possible value because nothing yet
         // supports handling it, and will be defaulted to using "block" if they encounter
         // "overflow".  Thus, there's no reason to emit it here... yet.
-        if bool::arbitrary(g) {
-            WhenFull::Block
-        } else {
-            WhenFull::DropNewest
+        match usize::arbitrary(g) % 3 {
+            0 => WhenFull::Block,
+            1 => WhenFull::DropNewest,
+            _ => WhenFull::DropOldest,
         }
     }
 }

--- a/lib/vector-buffers/src/test/variant.rs
+++ b/lib/vector-buffers/src/test/variant.rs
@@ -105,11 +105,15 @@ impl Arbitrary for Variant {
         let max_size = NonZeroU16::arbitrary(g).into();
         let size = MemoryBufferSize::MaxEvents(max_events);
 
-        let when_full = WhenFull::arbitrary(g);
-
         if use_memory_buffer {
+            let when_full = WhenFull::arbitrary(g);
             Variant::Memory { size, when_full }
         } else {
+            let when_full = if bool::arbitrary(g) {
+                WhenFull::Block
+            } else {
+                WhenFull::DropNewest
+            };
             Variant::DiskV2 {
                 max_size,
                 when_full,

--- a/lib/vector-buffers/src/topology/builder.rs
+++ b/lib/vector-buffers/src/topology/builder.rs
@@ -28,6 +28,11 @@ pub trait IntoBuffer<T: Bufferable>: Send {
         false
     }
 
+    /// Gets whether this stage supports `WhenFull::DropOldest`.
+    fn supports_drop_oldest(&self) -> bool {
+        true
+    }
+
     /// Converts this value into a sender and receiver pair suitable for use in a buffer topology.
     async fn into_buffer_parts(
         self: Box<Self>,
@@ -46,6 +51,8 @@ pub enum TopologyError {
     NextStageNotUsed { stage_idx: usize },
     #[snafu(display("last stage in buffer topology cannot be set to overflow mode"))]
     OverflowWhenLast,
+    #[snafu(display("stage {} does not support drop_oldest mode", stage_idx))]
+    DropOldestNotSupported { stage_idx: usize },
     #[snafu(display("failed to build individual stage {}: {}", stage_idx, source))]
     FailedToBuildStage {
         stage_idx: usize,
@@ -127,6 +134,11 @@ impl<T: Bufferable> TopologyBuilder<T> {
                 WhenFull::Block | WhenFull::DropNewest | WhenFull::DropOldest => {
                     if current_stage.is_some() {
                         return Err(TopologyError::NextStageNotUsed { stage_idx });
+                    }
+                    if stage.when_full == WhenFull::DropOldest
+                        && !stage.untransformed.supports_drop_oldest()
+                    {
+                        return Err(TopologyError::DropOldestNotSupported { stage_idx });
                     }
                 }
             }
@@ -257,7 +269,10 @@ impl<T: Bufferable> Default for TopologyBuilder<T> {
 
 #[cfg(test)]
 mod tests {
-    use std::num::NonZeroUsize;
+    use std::{
+        num::{NonZeroU64, NonZeroUsize},
+        path::PathBuf,
+    };
 
     use tracing::Span;
 
@@ -268,7 +283,7 @@ mod tests {
             builder::TopologyError,
             test_util::{Sample, assert_current_send_capacity},
         },
-        variants::MemoryBuffer,
+        variants::{DiskV2Buffer, MemoryBuffer},
     };
 
     #[tokio::test]
@@ -311,6 +326,24 @@ mod tests {
 
         let (mut sender, _) = result.unwrap();
         assert_current_send_capacity(&mut sender, Some(1), None);
+    }
+
+    #[tokio::test]
+    async fn single_stage_topology_disk_drop_oldest() {
+        let mut builder = TopologyBuilder::<Sample>::default();
+        builder.stage(
+            DiskV2Buffer::new(
+                String::from("test"),
+                PathBuf::from("/tmp/vector-drop-oldest-test"),
+                NonZeroU64::new(1).unwrap(),
+            ),
+            WhenFull::DropOldest,
+        );
+        let result = builder.build(String::from("test"), Span::none()).await;
+        match result {
+            Err(TopologyError::DropOldestNotSupported { stage_idx }) => assert_eq!(stage_idx, 0),
+            r => panic!("unexpected build result: {r:?}"),
+        }
     }
 
     #[tokio::test]

--- a/lib/vector-buffers/src/topology/builder.rs
+++ b/lib/vector-buffers/src/topology/builder.rs
@@ -40,7 +40,7 @@ pub enum TopologyError {
     #[snafu(display("buffer topology cannot be empty"))]
     EmptyTopology,
     #[snafu(display(
-        "stage {} configured with block/drop newest behavior in front of subsequent stage",
+        "stage {} configured with block/drop behavior in front of subsequent stage",
         stage_idx
     ))]
     NextStageNotUsed { stage_idx: usize },
@@ -76,15 +76,15 @@ impl<T: Bufferable> TopologyBuilder<T> {
     /// an overflow buffer is added to the topology after this, then the specified "when full"
     /// behavior will be ignored and will be set to "overflow" mode.
     ///
-    /// Callers can configure what to do when a buffer is full by setting `when_full`.  Three modes
-    /// are available -- block, drop newest, and overflow -- which are documented in more detail by
-    /// [`BufferSender`].
+    /// Callers can configure what to do when a buffer is full by setting `when_full`.  Four modes
+    /// are available -- block, drop newest, drop oldest, and overflow -- which are documented in
+    /// more detail by [`BufferSender`].
     ///
     /// Two notes about what modes are not valid in certain scenarios:
     /// - the innermost stage (the last stage given to the builder) cannot be set to "overflow" mode,
     ///   as there is no other stage to overflow to
-    /// - a stage cannot use the "block" or "drop newest" mode when there is a subsequent stage, and
-    ///   must user the "overflow" mode
+    /// - a stage cannot use the "block", "drop newest", or "drop oldest" mode when there is a
+    ///   subsequent stage, and must user the "overflow" mode
     ///
     /// Any occurrence of either of these scenarios will result in an error during build.
     pub fn stage<S>(&mut self, stage: S, when_full: WhenFull) -> &mut Self
@@ -122,9 +122,9 @@ impl<T: Bufferable> TopologyBuilder<T> {
                         return Err(TopologyError::OverflowWhenLast);
                     }
                 }
-                // If there's already an inner stage, then blocking or dropping the newest events
+                // If there's already an inner stage, then blocking or dropping events
                 // doesn't no sense.  Overflowing is the only valid transition to another stage.
-                WhenFull::Block | WhenFull::DropNewest => {
+                WhenFull::Block | WhenFull::DropNewest | WhenFull::DropOldest => {
                     if current_stage.is_some() {
                         return Err(TopologyError::NextStageNotUsed { stage_idx });
                     }
@@ -177,9 +177,9 @@ impl<T: Bufferable> TopologyBuilder<T> {
 impl<T: Bufferable> TopologyBuilder<T> {
     /// Creates a memory-only buffer topology.
     ///
-    /// The overflow mode (i.e. `WhenFull`) can be configured to either block or drop the newest
-    /// values, but cannot be configured to use overflow mode.  If overflow mode is selected, it
-    /// will be changed to blocking mode.
+    /// The overflow mode (i.e. `WhenFull`) can be configured to block, drop the newest values, or
+    /// drop the oldest values, but cannot be configured to use overflow mode. If overflow mode is
+    /// selected, it will be changed to blocking mode.
     ///
     /// This is a convenience method for `vector` as it is used for inter-transform channels, and we
     /// can simplifying needing to require callers to do all the boilerplate to create the builder,
@@ -216,9 +216,9 @@ impl<T: Bufferable> TopologyBuilder<T> {
     /// like channel capacity left, which cannot be done on in-memory v1 buffers as they use the
     /// more abstract `Sink`-based adapters.
     ///
-    /// The overflow mode (i.e. `WhenFull`) can be configured to either block or drop the newest
-    /// values, but cannot be configured to use overflow mode.  If overflow mode is selected, it
-    /// will be changed to blocking mode.
+    /// The overflow mode (i.e. `WhenFull`) can be configured to block, drop the newest values, or
+    /// drop the oldest values, but cannot be configured to use overflow mode. If overflow mode is
+    /// selected, it will be changed to blocking mode.
     ///
     /// This is a convenience method for `vector` as it is used for inter-transform channels, and we
     /// can simplifying needing to require callers to do all the boilerplate to create the builder,
@@ -300,6 +300,20 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn single_stage_topology_drop_oldest() {
+        let mut builder = TopologyBuilder::<Sample>::default();
+        builder.stage(
+            MemoryBuffer::with_max_events(NonZeroUsize::new(1).unwrap()),
+            WhenFull::DropOldest,
+        );
+        let result = builder.build(String::from("test"), Span::none()).await;
+        assert!(result.is_ok());
+
+        let (mut sender, _) = result.unwrap();
+        assert_current_send_capacity(&mut sender, Some(1), None);
+    }
+
+    #[tokio::test]
     async fn single_stage_topology_overflow() {
         let mut builder = TopologyBuilder::<Sample>::default();
         builder.stage(
@@ -337,6 +351,24 @@ mod tests {
         builder.stage(
             MemoryBuffer::with_max_events(NonZeroUsize::new(1).unwrap()),
             WhenFull::DropNewest,
+        );
+        builder.stage(
+            MemoryBuffer::with_max_events(NonZeroUsize::new(1).unwrap()),
+            WhenFull::Block,
+        );
+        let result = builder.build(String::from("test"), Span::none()).await;
+        match result {
+            Err(TopologyError::NextStageNotUsed { stage_idx }) => assert_eq!(stage_idx, 0),
+            r => panic!("unexpected build result: {r:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn two_stage_topology_drop_oldest() {
+        let mut builder = TopologyBuilder::<Sample>::default();
+        builder.stage(
+            MemoryBuffer::with_max_events(NonZeroUsize::new(1).unwrap()),
+            WhenFull::DropOldest,
         );
         builder.stage(
             MemoryBuffer::with_max_events(NonZeroUsize::new(1).unwrap()),

--- a/lib/vector-buffers/src/topology/channel/limited_queue.rs
+++ b/lib/vector-buffers/src/topology/channel/limited_queue.rs
@@ -4,14 +4,11 @@ use std::{
     num::NonZeroUsize,
     pin::Pin,
     sync::{
-        Arc,
+        Arc, Mutex,
         atomic::{AtomicUsize, Ordering},
     },
     time::Instant,
 };
-
-#[cfg(test)]
-use std::sync::Mutex;
 
 use async_stream::stream;
 use crossbeam_queue::{ArrayQueue, SegQueue};
@@ -57,6 +54,12 @@ pub enum TrySendError<T> {
 pub struct DropOldestSendError<T> {
     pub error: TrySendError<T>,
     pub dropped: Vec<T>,
+}
+
+enum DropOldestStep<T> {
+    Acquired(OwnedSemaphorePermit),
+    Dropped(T),
+    Empty,
 }
 
 impl<T> TrySendError<T> {
@@ -239,6 +242,7 @@ impl Metrics {
 #[derive(Debug)]
 struct Inner<T> {
     data: Arc<dyn QueueImpl<(OwnedSemaphorePermit, T)>>,
+    queue_lock: Arc<Mutex<()>>,
     limit: MemoryBufferSize,
     limiter: Arc<Semaphore>,
     read_waker: Arc<Notify>,
@@ -250,6 +254,7 @@ impl<T> Clone for Inner<T> {
     fn clone(&self) -> Self {
         Self {
             data: self.data.clone(),
+            queue_lock: self.queue_lock.clone(),
             limit: self.limit,
             limiter: self.limiter.clone(),
             read_waker: self.read_waker.clone(),
@@ -271,6 +276,7 @@ impl<T: Send + Sync + Debug + 'static> Inner<T> {
         match limit {
             MemoryBufferSize::MaxEvents(max_events) => Inner {
                 data: Arc::new(ArrayQueue::new(max_events.get())),
+                queue_lock: Arc::new(Mutex::new(())),
                 limit,
                 limiter: Arc::new(Semaphore::new(max_events.get())),
                 read_waker,
@@ -279,6 +285,7 @@ impl<T: Send + Sync + Debug + 'static> Inner<T> {
             },
             MemoryBufferSize::MaxSize(max_bytes) => Inner {
                 data: Arc::new(SegQueue::new()),
+                queue_lock: Arc::new(Mutex::new(())),
                 limit,
                 limiter: Arc::new(Semaphore::new(max_bytes.get())),
                 read_waker,
@@ -301,6 +308,7 @@ impl<T: Send + Sync + Debug + 'static> Inner<T> {
             let utilization = size.max(self.used_capacity());
             metrics.record(utilization, Instant::now());
         }
+        let _guard = self.queue_lock.lock().unwrap();
         self.data.push((permits, item));
         self.read_waker.notify_one();
     }
@@ -312,6 +320,11 @@ impl<T> Inner<T> {
     }
 
     fn pop_and_record(&self) -> Option<T> {
+        let _guard = self.queue_lock.lock().unwrap();
+        self.pop_and_record_locked()
+    }
+
+    fn pop_and_record_locked(&self) -> Option<T> {
         self.data.pop().map(|(permit, item)| {
             if let Some(metrics) = &self.metrics {
                 // Compute remaining utilization from the semaphore state. Since our permits haven't
@@ -325,6 +338,24 @@ impl<T> Inner<T> {
             drop(permit);
             item
         })
+    }
+
+    fn try_acquire_or_pop_oldest(
+        &self,
+        permits_required: u32,
+    ) -> Result<DropOldestStep<T>, TryAcquireError> {
+        let _guard = self.queue_lock.lock().unwrap();
+        match self
+            .limiter
+            .clone()
+            .try_acquire_many_owned(permits_required)
+        {
+            Ok(permits) => Ok(DropOldestStep::Acquired(permits)),
+            Err(TryAcquireError::NoPermits) => Ok(self
+                .pop_and_record_locked()
+                .map_or(DropOldestStep::Empty, DropOldestStep::Dropped)),
+            Err(error @ TryAcquireError::Closed) => Err(error),
+        }
     }
 }
 
@@ -428,71 +459,23 @@ impl<T: InMemoryBufferable> LimitedSender<T> {
         let mut dropped = Vec::new();
 
         loop {
-            match self
-                .inner
-                .limiter
-                .clone()
-                .try_acquire_many_owned(permits_required)
-            {
-                Ok(permits) => {
+            match self.inner.try_acquire_or_pop_oldest(permits_required) {
+                Ok(DropOldestStep::Acquired(permits)) => {
                     self.inner.send_with_permits(size, permits, item);
                     trace!("Attempt to send item after dropping oldest queued items succeeded.");
                     return Ok(dropped);
                 }
-                Err(TryAcquireError::NoPermits) => {
+                Ok(DropOldestStep::Dropped(mut dropped_item)) => {
+                    dropped_item
+                        .take_finalizers()
+                        .update_status(EventStatus::Rejected);
+                    dropped.push(dropped_item);
+                }
+                Ok(DropOldestStep::Empty) => {
                     let notified = self.inner.read_waker.notified();
-                    match self
-                        .inner
-                        .limiter
-                        .clone()
-                        .try_acquire_many_owned(permits_required)
-                    {
-                        Ok(permits) => {
-                            self.inner.send_with_permits(size, permits, item);
-                            trace!(
-                                "Attempt to send item after rechecking available capacity succeeded."
-                            );
-                            return Ok(dropped);
-                        }
-                        Err(TryAcquireError::NoPermits) => {
-                            if let Some(mut dropped_item) = self.inner.pop_and_record() {
-                                dropped_item
-                                    .take_finalizers()
-                                    .update_status(EventStatus::Rejected);
-                                dropped.push(dropped_item);
-                            } else {
-                                match self
-                                    .inner
-                                    .limiter
-                                    .clone()
-                                    .try_acquire_many_owned(permits_required)
-                                {
-                                    Ok(permits) => {
-                                        self.inner.send_with_permits(size, permits, item);
-                                        trace!(
-                                            "Attempt to send item after queue drained succeeded."
-                                        );
-                                        return Ok(dropped);
-                                    }
-                                    Err(TryAcquireError::NoPermits) => tokio::select! {
-                                        () = notified => {}
-                                        () = tokio::task::yield_now() => {}
-                                    },
-                                    Err(TryAcquireError::Closed) => {
-                                        return Err(DropOldestSendError {
-                                            error: TrySendError::Disconnected(item),
-                                            dropped,
-                                        });
-                                    }
-                                }
-                            }
-                        }
-                        Err(TryAcquireError::Closed) => {
-                            return Err(DropOldestSendError {
-                                error: TrySendError::Disconnected(item),
-                                dropped,
-                            });
-                        }
+                    tokio::select! {
+                        () = notified => {}
+                        () = tokio::task::yield_now() => {}
                     }
                 }
                 Err(TryAcquireError::Closed) => {
@@ -500,6 +483,9 @@ impl<T: InMemoryBufferable> LimitedSender<T> {
                         error: TrySendError::Disconnected(item),
                         dropped,
                     });
+                }
+                Err(TryAcquireError::NoPermits) => {
+                    unreachable!("try_acquire_or_pop_oldest handles missing permits internally")
                 }
             }
         }

--- a/lib/vector-buffers/src/topology/channel/limited_queue.rs
+++ b/lib/vector-buffers/src/topology/channel/limited_queue.rs
@@ -52,6 +52,12 @@ pub enum TrySendError<T> {
     Disconnected(T),
 }
 
+#[derive(Debug)]
+pub struct DropOldestSendError<T> {
+    pub error: TrySendError<T>,
+    pub dropped: Vec<T>,
+}
+
 impl<T> TrySendError<T> {
     pub fn into_inner(self) -> T {
         match self {
@@ -408,11 +414,10 @@ impl<T: InMemoryBufferable> LimitedSender<T> {
     ///
     /// # Errors
     ///
-    /// If the receiver has disconnected (does not exist anymore), then
-    /// `Err(TrySendError::Disconnected)` will be returned with the given `item`. If the channel has
-    /// insufficient total capacity for the item, then `Err(TrySendError::InsufficientCapacity)`
-    /// will be returned with the given `item`.
-    pub async fn send_drop_oldest(&mut self, item: T) -> Result<Vec<T>, TrySendError<T>> {
+    /// If the receiver has disconnected, then an error will be returned with the given `item` and
+    /// any queued items that were already evicted. If the channel has insufficient total capacity
+    /// for the item, then an error will be returned with the given `item`.
+    pub async fn send_drop_oldest(&mut self, item: T) -> Result<Vec<T>, DropOldestSendError<T>> {
         // Calculate how many permits we need, and try to acquire them all without waiting. If there
         // is not enough space, evict queued items until we have enough room for the new item.
         let (size, permits_required) = self.calc_required_permits(&item);
@@ -432,13 +437,40 @@ impl<T: InMemoryBufferable> LimitedSender<T> {
                 }
                 Err(TryAcquireError::NoPermits) => {
                     let notified = self.inner.read_waker.notified();
-                    if let Some(dropped_item) = self.inner.pop_and_record() {
-                        dropped.push(dropped_item);
-                    } else {
-                        notified.await;
+                    match self
+                        .inner
+                        .limiter
+                        .clone()
+                        .try_acquire_many_owned(permits_required)
+                    {
+                        Ok(permits) => {
+                            self.inner.send_with_permits(size, permits, item);
+                            trace!(
+                                "Attempt to send item after rechecking available capacity succeeded."
+                            );
+                            return Ok(dropped);
+                        }
+                        Err(TryAcquireError::NoPermits) => {
+                            if let Some(dropped_item) = self.inner.pop_and_record() {
+                                dropped.push(dropped_item);
+                            } else {
+                                notified.await;
+                            }
+                        }
+                        Err(TryAcquireError::Closed) => {
+                            return Err(DropOldestSendError {
+                                error: TrySendError::Disconnected(item),
+                                dropped,
+                            });
+                        }
                     }
                 }
-                Err(TryAcquireError::Closed) => return Err(TrySendError::Disconnected(item)),
+                Err(TryAcquireError::Closed) => {
+                    return Err(DropOldestSendError {
+                        error: TrySendError::Disconnected(item),
+                        dropped,
+                    });
+                }
             }
         }
     }

--- a/lib/vector-buffers/src/topology/channel/limited_queue.rs
+++ b/lib/vector-buffers/src/topology/channel/limited_queue.rs
@@ -454,7 +454,29 @@ impl<T: InMemoryBufferable> LimitedSender<T> {
                             if let Some(dropped_item) = self.inner.pop_and_record() {
                                 dropped.push(dropped_item);
                             } else {
-                                notified.await;
+                                match self
+                                    .inner
+                                    .limiter
+                                    .clone()
+                                    .try_acquire_many_owned(permits_required)
+                                {
+                                    Ok(permits) => {
+                                        self.inner.send_with_permits(size, permits, item);
+                                        trace!(
+                                            "Attempt to send item after queue drained succeeded."
+                                        );
+                                        return Ok(dropped);
+                                    }
+                                    Err(TryAcquireError::NoPermits) => {
+                                        notified.await;
+                                    }
+                                    Err(TryAcquireError::Closed) => {
+                                        return Err(DropOldestSendError {
+                                            error: TrySendError::Disconnected(item),
+                                            dropped,
+                                        });
+                                    }
+                                }
                             }
                         }
                         Err(TryAcquireError::Closed) => {

--- a/lib/vector-buffers/src/topology/channel/limited_queue.rs
+++ b/lib/vector-buffers/src/topology/channel/limited_queue.rs
@@ -18,6 +18,7 @@ use crossbeam_queue::{ArrayQueue, SegQueue};
 use futures::Stream;
 use metrics::{Gauge, Histogram};
 use tokio::sync::{Notify, OwnedSemaphorePermit, Semaphore, TryAcquireError};
+use vector_common::finalization::{EventStatus, Finalizable};
 use vector_common::internal_event::{GaugeName, HistogramName};
 use vector_common::stats::TimeEwmaGauge;
 use vector_common::{gauge, histogram};
@@ -417,7 +418,10 @@ impl<T: InMemoryBufferable> LimitedSender<T> {
     /// If the receiver has disconnected, then an error will be returned with the given `item` and
     /// any queued items that were already evicted. If the channel has insufficient total capacity
     /// for the item, then an error will be returned with the given `item`.
-    pub async fn send_drop_oldest(&mut self, item: T) -> Result<Vec<T>, DropOldestSendError<T>> {
+    pub async fn send_drop_oldest(&mut self, item: T) -> Result<Vec<T>, DropOldestSendError<T>>
+    where
+        T: Finalizable,
+    {
         // Calculate how many permits we need, and try to acquire them all without waiting. If there
         // is not enough space, evict queued items until we have enough room for the new item.
         let (size, permits_required) = self.calc_required_permits(&item);
@@ -451,7 +455,10 @@ impl<T: InMemoryBufferable> LimitedSender<T> {
                             return Ok(dropped);
                         }
                         Err(TryAcquireError::NoPermits) => {
-                            if let Some(dropped_item) = self.inner.pop_and_record() {
+                            if let Some(mut dropped_item) = self.inner.pop_and_record() {
+                                dropped_item
+                                    .take_finalizers()
+                                    .update_status(EventStatus::Rejected);
                                 dropped.push(dropped_item);
                             } else {
                                 match self
@@ -467,9 +474,10 @@ impl<T: InMemoryBufferable> LimitedSender<T> {
                                         );
                                         return Ok(dropped);
                                     }
-                                    Err(TryAcquireError::NoPermits) => {
-                                        notified.await;
-                                    }
+                                    Err(TryAcquireError::NoPermits) => tokio::select! {
+                                        () = notified => {}
+                                        () = tokio::task::yield_now() => {}
+                                    },
                                     Err(TryAcquireError::Closed) => {
                                         return Err(DropOldestSendError {
                                             error: TrySendError::Disconnected(item),

--- a/lib/vector-buffers/src/topology/channel/limited_queue.rs
+++ b/lib/vector-buffers/src/topology/channel/limited_queue.rs
@@ -285,7 +285,7 @@ impl<T: Send + Sync + Debug + 'static> Inner<T> {
     ///
     /// The `size` value is the true utilization contribution of `item`, which may exceed the number
     /// of permits acquired for oversized payloads.
-    fn send_with_permits(&mut self, size: usize, permits: OwnedSemaphorePermit, item: T) {
+    fn send_with_permits(&self, size: usize, permits: OwnedSemaphorePermit, item: T) {
         if let Some(metrics) = &self.metrics {
             // For normal items, capacity - available_permits() exactly represents the total queued
             // utilization (including this item's just-acquired permits). For oversized items that
@@ -401,6 +401,47 @@ impl<T: InMemoryBufferable> LimitedSender<T> {
             Err(TryAcquireError::Closed) => Err(TrySendError::Disconnected(item)),
         }
     }
+
+    /// Sends an item into the channel, evicting the oldest queued items as needed.
+    ///
+    /// Returns the queued items that were dropped to make room for `item`.
+    ///
+    /// # Errors
+    ///
+    /// If the receiver has disconnected (does not exist anymore), then
+    /// `Err(TrySendError::Disconnected)` will be returned with the given `item`. If the channel has
+    /// insufficient total capacity for the item, then `Err(TrySendError::InsufficientCapacity)`
+    /// will be returned with the given `item`.
+    pub async fn send_drop_oldest(&mut self, item: T) -> Result<Vec<T>, TrySendError<T>> {
+        // Calculate how many permits we need, and try to acquire them all without waiting. If there
+        // is not enough space, evict queued items until we have enough room for the new item.
+        let (size, permits_required) = self.calc_required_permits(&item);
+        let mut dropped = Vec::new();
+
+        loop {
+            match self
+                .inner
+                .limiter
+                .clone()
+                .try_acquire_many_owned(permits_required)
+            {
+                Ok(permits) => {
+                    self.inner.send_with_permits(size, permits, item);
+                    trace!("Attempt to send item after dropping oldest queued items succeeded.");
+                    return Ok(dropped);
+                }
+                Err(TryAcquireError::NoPermits) => {
+                    let notified = self.inner.read_waker.notified();
+                    if let Some(dropped_item) = self.inner.pop_and_record() {
+                        dropped.push(dropped_item);
+                    } else {
+                        notified.await;
+                    }
+                }
+                Err(TryAcquireError::Closed) => return Err(TrySendError::Disconnected(item)),
+            }
+        }
+    }
 }
 
 impl<T> Clone for LimitedSender<T> {
@@ -500,6 +541,7 @@ mod tests {
     use std::num::NonZeroUsize;
 
     use rand::{Rng as _, SeedableRng as _, rngs::SmallRng};
+    use tokio::time::{Duration, timeout};
     use tokio_test::{assert_pending, assert_ready, task::spawn};
     use vector_common::byte_size_of::ByteSizeOf;
 
@@ -653,6 +695,64 @@ mod tests {
         // Channel should have no more data
         let mut recv = spawn(async { rx.next().await });
         assert_pending!(recv.poll());
+    }
+
+    #[tokio::test]
+    async fn send_drop_oldest_by_byte_size_evicts_until_new_item_fits() {
+        let small = Sample::new_with_heap_allocated_values(10);
+        let large = Sample::new_with_heap_allocated_values(20);
+        let small_size = small.allocated_bytes();
+        let max_allowed_bytes = small_size * 3;
+
+        let limit = MemoryBufferSize::MaxSize(NonZeroUsize::new(max_allowed_bytes).unwrap());
+        let (mut tx, mut rx) = limited(limit, None, None);
+
+        for _ in 0..3 {
+            tx.try_send(small.clone()).expect("send should succeed");
+        }
+        assert_eq!(0, tx.available_capacity());
+
+        let dropped = tx
+            .send_drop_oldest(large.clone())
+            .await
+            .expect("drop oldest send should succeed");
+        assert_eq!(dropped.len(), 2);
+        assert!(
+            dropped
+                .iter()
+                .all(|item| item.allocated_bytes() == small_size)
+        );
+        assert_eq!(0, tx.available_capacity());
+
+        assert_eq!(Some(small), rx.next().await);
+        assert_eq!(Some(large), rx.next().await);
+        assert_eq!(max_allowed_bytes, rx.available_capacity());
+    }
+
+    #[tokio::test]
+    async fn send_drop_oldest_waits_for_in_flight_permits() {
+        let buffer_size = MemoryBufferSize::MaxEvents(NonZeroUsize::new(1).unwrap());
+        let (tx, mut rx) = limited(buffer_size, None, None);
+        let queued = Sample::new_with_heap_allocated_values(5);
+        let sent = Sample::new_with_heap_allocated_values(10);
+        let permit = tx.inner.limiter.clone().try_acquire_many_owned(1).unwrap();
+        let mut sending_tx = tx.clone();
+        let sent_clone = sent.clone();
+
+        let sending = tokio::spawn(async move { sending_tx.send_drop_oldest(sent_clone).await });
+        tokio::task::yield_now().await;
+        assert!(!sending.is_finished());
+
+        tx.inner.send_with_permits(1, permit, queued.clone());
+
+        let dropped = timeout(Duration::from_secs(5), sending)
+            .await
+            .expect("drop oldest send should complete")
+            .expect("join should succeed")
+            .expect("send should succeed");
+
+        assert_eq!(dropped, vec![queued]);
+        assert_eq!(Some(sent), rx.next().await);
     }
 
     #[test]

--- a/lib/vector-buffers/src/topology/channel/sender.rs
+++ b/lib/vector-buffers/src/topology/channel/sender.rs
@@ -1,17 +1,21 @@
 // Derivative's Debug impl generates 'let _ = field.fmt(f)' which triggers this lint.
 #![allow(clippy::let_underscore_must_use)]
 
-use std::{sync::Arc, time::Instant};
+use std::{io, sync::Arc, time::Instant};
 
 use async_recursion::async_recursion;
 use derivative::Derivative;
 use tokio::sync::Mutex;
 use tracing::Span;
-use vector_common::internal_event::{InternalEventHandle, Registered, register};
+use vector_common::{
+    byte_size_of::ByteSizeOf,
+    finalization::{EventStatus, Finalizable},
+    internal_event::{InternalEventHandle, Registered, register},
+};
 
 use super::limited_queue::LimitedSender;
 use crate::{
-    BufferInstrumentation, Bufferable, WhenFull,
+    BufferInstrumentation, Bufferable, EventCount, WhenFull,
     buffer_usage_data::BufferUsageHandle,
     internal_events::BufferSendDuration,
     variants::disk_v2::{self, ProductionFilesystem},
@@ -86,6 +90,15 @@ where
         }
     }
 
+    pub(crate) async fn send_drop_oldest(&mut self, item: T) -> crate::Result<Vec<T>> {
+        match self {
+            Self::InMemory(tx) => tx.send_drop_oldest(item).await.map_err(Into::into),
+            Self::DiskV2(_) => {
+                Err(io::Error::other("drop_oldest is only supported for memory buffers").into())
+            }
+        }
+    }
+
     pub(crate) async fn flush(&mut self) -> crate::Result<()> {
         match self {
             Self::InMemory(_) => Ok(()),
@@ -115,16 +128,19 @@ where
 /// events when the internal channel is full.
 ///
 /// When creating a buffer sender/receiver pair, callers can specify the "when full" behavior of the
-/// sender.  This controls how events are handled when the internal channel is full.  Three modes
+/// sender.  This controls how events are handled when the internal channel is full.  Four modes
 /// are possible:
 /// - block
 /// - drop newest
+/// - drop oldest
 /// - overflow
 ///
 /// In "block" mode, callers are simply forced to wait until the channel has enough capacity to
 /// accept the event.  In "drop newest" mode, any event being sent when the channel is full will be
 /// dropped and proceed no further. In "overflow" mode, events will be sent to another buffer
-/// sender.  Callers can specify the overflow sender to use when constructing their buffers initially.
+/// sender.  In "drop oldest" mode, the oldest buffered events will be dropped as needed to make room
+/// for incoming events. Callers can specify the overflow sender to use when constructing their
+/// buffers initially.
 ///
 /// TODO: We should eventually rework `BufferSender`/`BufferReceiver` so that they contain a vector
 /// of the fields we already have here, but instead of cascading via calling into `overflow`, we'd
@@ -208,11 +224,10 @@ impl<T: Bufferable> BufferSender<T> {
     }
 
     #[async_recursion]
-    pub async fn send(
-        &mut self,
-        mut item: T,
-        send_reference: Option<Instant>,
-    ) -> crate::Result<()> {
+    pub async fn send(&mut self, mut item: T, send_reference: Option<Instant>) -> crate::Result<()>
+    where
+        T: Finalizable,
+    {
         if let Some(instrumentation) = self.custom_instrumentation.as_ref() {
             instrumentation.on_send(&mut item);
         }
@@ -234,6 +249,23 @@ impl<T: Bufferable> BufferSender<T> {
             WhenFull::DropNewest => {
                 if self.base.try_send(item).await?.is_some() {
                     was_dropped = true;
+                }
+            }
+            WhenFull::DropOldest => {
+                let mut dropped = self.base.send_drop_oldest(item).await?;
+                if let Some(instrumentation) = self.usage_instrumentation.as_ref()
+                    && !dropped.is_empty()
+                {
+                    let dropped_count = dropped.iter().map(EventCount::event_count).sum::<usize>();
+                    let dropped_size = dropped.iter().map(ByteSizeOf::size_of).sum::<usize>();
+                    instrumentation.increment_dropped_event_count_and_byte_size(
+                        dropped_count as u64,
+                        dropped_size as u64,
+                        true,
+                    );
+                }
+                for item in &mut dropped {
+                    item.take_finalizers().update_status(EventStatus::Rejected);
                 }
             }
             WhenFull::Overflow => {

--- a/lib/vector-buffers/src/topology/channel/sender.rs
+++ b/lib/vector-buffers/src/topology/channel/sender.rs
@@ -1,7 +1,7 @@
 // Derivative's Debug impl generates 'let _ = field.fmt(f)' which triggers this lint.
 #![allow(clippy::let_underscore_must_use)]
 
-use std::{io, sync::Arc, time::Instant};
+use std::{sync::Arc, time::Instant};
 
 use async_recursion::async_recursion;
 use derivative::Derivative;
@@ -13,7 +13,7 @@ use vector_common::{
     internal_event::{InternalEventHandle, Registered, register},
 };
 
-use super::limited_queue::LimitedSender;
+use super::limited_queue::{DropOldestSendError, LimitedSender};
 use crate::{
     BufferInstrumentation, Bufferable, EventCount, WhenFull,
     buffer_usage_data::BufferUsageHandle,
@@ -90,12 +90,16 @@ where
         }
     }
 
-    pub(crate) async fn send_drop_oldest(&mut self, item: T) -> crate::Result<Vec<T>> {
+    pub(crate) async fn send_drop_oldest(
+        &mut self,
+        item: T,
+    ) -> Result<Vec<T>, DropOldestSendError<T>> {
         match self {
-            Self::InMemory(tx) => tx.send_drop_oldest(item).await.map_err(Into::into),
-            Self::DiskV2(_) => {
-                Err(io::Error::other("drop_oldest is only supported for memory buffers").into())
-            }
+            Self::InMemory(tx) => tx.send_drop_oldest(item).await,
+            Self::DiskV2(_) => Err(DropOldestSendError {
+                error: super::limited_queue::TrySendError::Disconnected(item),
+                dropped: Vec::new(),
+            }),
         }
     }
 
@@ -252,16 +256,39 @@ impl<T: Bufferable> BufferSender<T> {
                 }
             }
             WhenFull::DropOldest => {
-                let mut dropped = self.base.send_drop_oldest(item).await?;
+                let mut dropped = match self.base.send_drop_oldest(item).await {
+                    Ok(dropped) => dropped,
+                    Err(mut error) => {
+                        if let Some(instrumentation) = self.usage_instrumentation.as_ref()
+                            && !error.dropped.is_empty()
+                        {
+                            let dropped_count = error
+                                .dropped
+                                .iter()
+                                .map(EventCount::event_count)
+                                .sum::<usize>();
+                            let dropped_size =
+                                error.dropped.iter().map(ByteSizeOf::size_of).sum::<usize>();
+                            instrumentation.increment_dropped_oldest_event_count_and_byte_size(
+                                dropped_count as u64,
+                                dropped_size as u64,
+                            );
+                        }
+                        for item in &mut error.dropped {
+                            item.take_finalizers().update_status(EventStatus::Rejected);
+                        }
+
+                        return Err(error.error.into());
+                    }
+                };
                 if let Some(instrumentation) = self.usage_instrumentation.as_ref()
                     && !dropped.is_empty()
                 {
                     let dropped_count = dropped.iter().map(EventCount::event_count).sum::<usize>();
                     let dropped_size = dropped.iter().map(ByteSizeOf::size_of).sum::<usize>();
-                    instrumentation.increment_dropped_event_count_and_byte_size(
+                    instrumentation.increment_dropped_oldest_event_count_and_byte_size(
                         dropped_count as u64,
                         dropped_size as u64,
-                        true,
                     );
                 }
                 for item in &mut dropped {

--- a/lib/vector-buffers/src/topology/channel/sender.rs
+++ b/lib/vector-buffers/src/topology/channel/sender.rs
@@ -9,7 +9,7 @@ use tokio::sync::Mutex;
 use tracing::Span;
 use vector_common::{
     byte_size_of::ByteSizeOf,
-    finalization::{EventStatus, Finalizable},
+    finalization::Finalizable,
     internal_event::{InternalEventHandle, Registered, register},
 };
 
@@ -93,7 +93,10 @@ where
     pub(crate) async fn send_drop_oldest(
         &mut self,
         item: T,
-    ) -> Result<Vec<T>, DropOldestSendError<T>> {
+    ) -> Result<Vec<T>, DropOldestSendError<T>>
+    where
+        T: Finalizable,
+    {
         match self {
             Self::InMemory(tx) => tx.send_drop_oldest(item).await,
             Self::DiskV2(_) => Err(DropOldestSendError {
@@ -256,9 +259,9 @@ impl<T: Bufferable> BufferSender<T> {
                 }
             }
             WhenFull::DropOldest => {
-                let mut dropped = match self.base.send_drop_oldest(item).await {
+                let dropped = match self.base.send_drop_oldest(item).await {
                     Ok(dropped) => dropped,
-                    Err(mut error) => {
+                    Err(error) => {
                         if let Some(instrumentation) = self.usage_instrumentation.as_ref()
                             && !error.dropped.is_empty()
                         {
@@ -274,10 +277,6 @@ impl<T: Bufferable> BufferSender<T> {
                                 dropped_size as u64,
                             );
                         }
-                        for item in &mut error.dropped {
-                            item.take_finalizers().update_status(EventStatus::Rejected);
-                        }
-
                         return Err(error.error.into());
                     }
                 };
@@ -290,9 +289,6 @@ impl<T: Bufferable> BufferSender<T> {
                         dropped_count as u64,
                         dropped_size as u64,
                     );
-                }
-                for item in &mut dropped {
-                    item.take_finalizers().update_status(EventStatus::Rejected);
                 }
             }
             WhenFull::Overflow => {

--- a/lib/vector-buffers/src/topology/channel/tests.rs
+++ b/lib/vector-buffers/src/topology/channel/tests.rs
@@ -3,15 +3,21 @@ use std::{
     time::{Duration, Instant},
 };
 
-use tokio::{pin, sync::Barrier, time::sleep};
+use tokio::{
+    pin,
+    sync::Barrier,
+    time::{sleep, timeout},
+};
 
 use crate::{
     Bufferable, WhenFull,
+    test::SizedRecord,
     topology::{
         channel::{BufferReceiver, BufferSender},
-        test_util::{assert_current_send_capacity, build_buffer},
+        test_util::{assert_current_send_capacity, build_buffer, build_buffer_with_type},
     },
 };
+use vector_common::finalization::{BatchNotifier, BatchStatus, Finalizable};
 
 async fn assert_send_ok_with_capacities<T>(
     sender: &mut BufferSender<T>,
@@ -19,7 +25,7 @@ async fn assert_send_ok_with_capacities<T>(
     base_expected: Option<usize>,
     overflow_expected: Option<usize>,
 ) where
-    T: Bufferable,
+    T: Bufferable + Finalizable,
 {
     assert!(sender.send(value.into(), None).await.is_ok());
     assert_current_send_capacity(sender, base_expected, overflow_expected);
@@ -31,7 +37,7 @@ async fn blocking_send_and_drain_receiver<T, V>(
     send_value: V,
 ) -> Vec<V>
 where
-    T: Bufferable,
+    T: Bufferable + Finalizable,
     V: Into<T> + From<T> + Send + 'static,
 {
     // We can likely replace this with `tokio_test`-related helpers to avoid the sleeping.
@@ -135,6 +141,51 @@ async fn test_sender_drop_newest() {
 }
 
 #[tokio::test]
+async fn test_sender_drop_oldest() {
+    // Get a non-overflow buffer in "drop oldest" mode with a capacity of 3.
+    let (mut tx, rx, _) = build_buffer(3, WhenFull::DropOldest, None);
+
+    // We should be able to send three messages through unimpeded.
+    assert_current_send_capacity(&mut tx, Some(3), None);
+    assert_send_ok_with_capacities(&mut tx, 1, Some(2), None).await;
+    assert_send_ok_with_capacities(&mut tx, 2, Some(1), None).await;
+    assert_send_ok_with_capacities(&mut tx, 3, Some(0), None).await;
+
+    // Then, since we're in "drop oldest" mode, additional sends should evict the oldest buffered
+    // events to preserve the newest events.
+    assert_send_ok_with_capacities(&mut tx, 7, Some(0), None).await;
+    assert_send_ok_with_capacities(&mut tx, 8, Some(0), None).await;
+    assert_send_ok_with_capacities(&mut tx, 9, Some(0), None).await;
+
+    // Then, when we collect all of the messages from the receiver, we should only get back the
+    // newest three of them.
+    let results: Vec<u64> = drain_receiver(tx, rx).await;
+    assert_eq!(results, vec![7, 8, 9]);
+}
+
+#[tokio::test]
+async fn test_sender_drop_oldest_rejects_evicted_event() {
+    let (mut tx, rx, _) = build_buffer_with_type::<SizedRecord>(1, WhenFull::DropOldest, None);
+    let mut evicted = vec![SizedRecord::new(1)];
+    let batch_receiver = BatchNotifier::apply_to(&mut evicted);
+    let evicted = evicted.pop().expect("evicted record should exist");
+    let retained = SizedRecord::new(2);
+
+    assert_send_ok_with_capacities(&mut tx, evicted, Some(0), None).await;
+    assert_send_ok_with_capacities(&mut tx, retained.clone(), Some(0), None).await;
+
+    let status = timeout(Duration::from_secs(5), batch_receiver)
+        .await
+        .expect("evicted event should finalize");
+
+    assert_eq!(status, BatchStatus::Rejected);
+    assert_eq!(
+        drain_receiver::<SizedRecord, SizedRecord>(tx, rx).await,
+        vec![retained]
+    );
+}
+
+#[tokio::test]
 async fn test_sender_overflow_block() {
     // Get an overflow buffer, where the overflow buffer is in blocking mode, and both the base
     // and overflow buffers have a capacity of 2.
@@ -234,6 +285,33 @@ async fn test_buffer_metrics_drop_newest() {
     let mut results: Vec<u64> = drain_receiver(tx, rx).await;
     results.sort_unstable();
     assert_eq!(results, vec![7, 8]);
+
+    let snapshot = handle.snapshot();
+    assert_eq!(3, snapshot.received_event_count);
+    assert_eq!(2, snapshot.sent_event_count);
+    assert_eq!(1, snapshot.dropped_event_count_intentional);
+}
+
+#[tokio::test]
+async fn test_buffer_metrics_drop_oldest() {
+    // Get a buffer that drops the oldest items when full.
+    let (mut tx, rx, handle) = build_buffer(2, WhenFull::DropOldest, None);
+
+    // Send three items through, and make sure the buffer usage stats reflect the oldest drop.
+    assert_current_send_capacity(&mut tx, Some(2), None);
+    assert_send_ok_with_capacities(&mut tx, 7, Some(1), None).await;
+    assert_send_ok_with_capacities(&mut tx, 8, Some(0), None).await;
+    assert_send_ok_with_capacities(&mut tx, 2, Some(0), None).await;
+
+    let snapshot = handle.snapshot();
+    assert_eq!(3, snapshot.received_event_count);
+    assert_eq!(0, snapshot.sent_event_count);
+    assert_eq!(1, snapshot.dropped_event_count_intentional);
+
+    // Then, when we collect all of the messages from the receiver, the metrics should also reflect
+    // that the newest two events were retained.
+    let results: Vec<u64> = drain_receiver(tx, rx).await;
+    assert_eq!(results, vec![8, 2]);
 
     let snapshot = handle.snapshot();
     assert_eq!(3, snapshot.received_event_count);

--- a/lib/vector-buffers/src/topology/test_util.rs
+++ b/lib/vector-buffers/src/topology/test_util.rs
@@ -3,7 +3,7 @@ use std::{error, fmt, num::NonZeroUsize};
 use bytes::{Buf, BufMut};
 use vector_common::{
     byte_size_of::ByteSizeOf,
-    finalization::{AddBatchNotifier, BatchNotifier},
+    finalization::{AddBatchNotifier, BatchNotifier, EventFinalizers, Finalizable},
 };
 
 use super::builder::TopologyBuilder;
@@ -53,6 +53,12 @@ impl Sample {
 impl AddBatchNotifier for Sample {
     fn add_batch_notifier(&mut self, batch: BatchNotifier) {
         drop(batch); // We never check acknowledgements for this type
+    }
+}
+
+impl Finalizable for Sample {
+    fn take_finalizers(&mut self) -> EventFinalizers {
+        EventFinalizers::default()
     }
 }
 
@@ -146,6 +152,17 @@ pub(crate) fn build_buffer(
     BufferReceiver<Sample>,
     BufferUsageHandle,
 ) {
+    build_buffer_with_type(capacity, mode, overflow_mode)
+}
+
+pub(crate) fn build_buffer_with_type<T>(
+    capacity: usize,
+    mode: WhenFull,
+    overflow_mode: Option<WhenFull>,
+) -> (BufferSender<T>, BufferReceiver<T>, BufferUsageHandle)
+where
+    T: Bufferable,
+{
     let handle = BufferUsageHandle::noop();
     let (tx, rx) = match mode {
         WhenFull::Overflow => {

--- a/lib/vector-buffers/src/variants/disk_v2/mod.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/mod.rs
@@ -322,6 +322,10 @@ where
         true
     }
 
+    fn supports_drop_oldest(&self) -> bool {
+        false
+    }
+
     async fn into_buffer_parts(
         self: Box<Self>,
         usage_handle: BufferUsageHandle,

--- a/tests/e2e/buffer-drop-oldest/config/compose.yaml
+++ b/tests/e2e/buffer-drop-oldest/config/compose.yaml
@@ -1,0 +1,37 @@
+services:
+  collector:
+    image: docker.io/library/python:3.12-alpine
+    working_dir: /app
+    command:
+      - python
+      - /app/collector.py
+    environment:
+      - DELAY_SECONDS=2
+    volumes:
+      - type: bind
+        source: ../data/collector.py
+        target: /app/collector.py
+        read_only: true
+
+  vector:
+    depends_on:
+      - collector
+    image: ${CONFIG_VECTOR_IMAGE}
+    environment:
+      - FEATURES=e2e-tests-buffer-drop-oldest
+      - VECTOR_EXPERIMENTAL_REQUEST_BUILDER_CONCURRENCY=1
+    working_dir: /home/vector
+    command:
+      - /usr/bin/vector
+      - -vvv
+      - -c
+      - /home/vector/tests/e2e/buffer-drop-oldest/data/vector.yaml
+    volumes:
+      - type: bind
+        source: ../../../..
+        target: /home/vector
+
+networks:
+  default:
+    name: ${VECTOR_NETWORK}
+    external: true

--- a/tests/e2e/buffer-drop-oldest/config/test.yaml
+++ b/tests/e2e/buffer-drop-oldest/config/test.yaml
@@ -1,0 +1,22 @@
+features:
+  - e2e-tests-buffer-drop-oldest
+
+test: "e2e"
+
+test_filter: "buffer_drop_oldest::"
+
+runner:
+  env:
+    VECTOR_ENDPOINT: "http://vector:8080"
+    COLLECTOR_ENDPOINT: "http://collector:8081"
+    EVENT_COUNT: "50"
+    RETAINED_TAIL: "3"
+
+matrix: {}
+
+# changes to these files/paths will invoke the e2e test in CI
+# expressions are evaluated using https://github.com/micromatch/picomatch
+paths:
+  - "lib/vector-buffers/**"
+  - "tests/e2e/buffer-drop-oldest/**"
+  - "tests/e2e/buffer_drop_oldest/**"

--- a/tests/e2e/buffer-drop-oldest/data/collector.py
+++ b/tests/e2e/buffer-drop-oldest/data/collector.py
@@ -42,6 +42,13 @@ class Handler(BaseHTTPRequestHandler):
         self.end_headers()
 
     def do_POST(self):
+        if self.path == "/reset":
+            with LOCK:
+                IDS.clear()
+            self.send_response(200)
+            self.end_headers()
+            return
+
         length = int(self.headers.get("content-length", "0"))
         body = self.rfile.read(length)
         try:

--- a/tests/e2e/buffer-drop-oldest/data/collector.py
+++ b/tests/e2e/buffer-drop-oldest/data/collector.py
@@ -1,0 +1,63 @@
+import json
+import os
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+
+DELAY_SECONDS = float(os.environ.get("DELAY_SECONDS", "2"))
+IDS = []
+LOCK = threading.Lock()
+
+
+def collect_ids(value):
+    if isinstance(value, dict):
+        if isinstance(value.get("id"), int):
+            yield value["id"]
+        for child in value.values():
+            yield from collect_ids(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from collect_ids(child)
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == "/health":
+            self.send_response(200)
+            self.end_headers()
+            return
+
+        if self.path == "/ids":
+            with LOCK:
+                body = json.dumps({"ids": IDS}).encode()
+            self.send_response(200)
+            self.send_header("content-type", "application/json")
+            self.send_header("content-length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return
+
+        self.send_response(404)
+        self.end_headers()
+
+    def do_POST(self):
+        length = int(self.headers.get("content-length", "0"))
+        body = self.rfile.read(length)
+        try:
+            payload = json.loads(body)
+        except json.JSONDecodeError:
+            payload = {}
+
+        with LOCK:
+            IDS.extend(collect_ids(payload))
+
+        time.sleep(DELAY_SECONDS)
+        self.send_response(200)
+        self.end_headers()
+
+    def log_message(self, format, *args):
+        return
+
+
+ThreadingHTTPServer(("0.0.0.0", 8081), Handler).serve_forever()

--- a/tests/e2e/buffer-drop-oldest/data/vector.yaml
+++ b/tests/e2e/buffer-drop-oldest/data/vector.yaml
@@ -1,0 +1,23 @@
+sources:
+  in:
+    type: http_server
+    address: 0.0.0.0:8080
+    decoding:
+      codec: json
+
+sinks:
+  out:
+    type: http
+    inputs:
+      - in
+    uri: http://collector:8081/events
+    method: post
+    encoding:
+      codec: json
+    batch:
+      max_events: 1
+      timeout_secs: 1
+    buffer:
+      type: memory
+      max_events: 3
+      when_full: drop_oldest

--- a/tests/e2e/buffer_drop_oldest/mod.rs
+++ b/tests/e2e/buffer_drop_oldest/mod.rs
@@ -71,13 +71,16 @@ async fn wait_for_vector(client: &Client, vector: &str) {
 }
 
 async fn reset_collector(client: &Client, collector: &str) {
-    client
-        .post(format!("{collector}/reset"))
-        .send()
-        .await
-        .expect("resetting collector should succeed")
-        .error_for_status()
-        .expect("collector reset response should be successful");
+    for _ in 0..MAX_RETRIES {
+        if let Ok(response) = client.post(format!("{collector}/reset")).send().await
+            && response.error_for_status().is_ok()
+        {
+            return;
+        }
+        tokio::time::sleep(WAIT_INTERVAL).await;
+    }
+
+    panic!("collector did not become reachable at {collector}");
 }
 
 #[tokio::test]

--- a/tests/e2e/buffer_drop_oldest/mod.rs
+++ b/tests/e2e/buffer_drop_oldest/mod.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::{collections::HashSet, time::Duration};
 
 use reqwest::Client;
 use serde::Deserialize;
@@ -59,6 +59,27 @@ async fn get_collected_ids(client: &Client, collector: &str) -> Vec<usize> {
         .ids
 }
 
+async fn wait_for_vector(client: &Client, vector: &str) {
+    for _ in 0..MAX_RETRIES {
+        if client.get(vector).send().await.is_ok() {
+            return;
+        }
+        tokio::time::sleep(WAIT_INTERVAL).await;
+    }
+
+    panic!("Vector HTTP source did not become reachable at {vector}");
+}
+
+async fn reset_collector(client: &Client, collector: &str) {
+    client
+        .post(format!("{collector}/reset"))
+        .send()
+        .await
+        .expect("resetting collector should succeed")
+        .error_for_status()
+        .expect("collector reset response should be successful");
+}
+
 #[tokio::test]
 async fn retains_newest_events_when_memory_buffer_is_full() {
     trace_init();
@@ -68,6 +89,9 @@ async fn retains_newest_events_when_memory_buffer_is_full() {
     let collector = collector_endpoint();
     let event_count = event_count();
     let retained_tail = retained_tail();
+
+    wait_for_vector(&client, &vector).await;
+    reset_collector(&client, &collector).await;
 
     for id in 0..event_count {
         client
@@ -98,8 +122,9 @@ async fn retains_newest_events_when_memory_buffer_is_full() {
         expected_tail.iter().all(|id| ids.contains(id)),
         "collector should receive the newest buffered events; expected tail {expected_tail:?}, got {ids:?}"
     );
+    let unique_ids = ids.iter().copied().collect::<HashSet<_>>();
     assert!(
-        ids.len() < event_count,
-        "drop_oldest should shed some events under forced sink backpressure; got all {event_count} events: {ids:?}"
+        unique_ids.len() < event_count,
+        "drop_oldest should shed some events under forced sink backpressure; got all {event_count} unique events: {ids:?}"
     );
 }

--- a/tests/e2e/buffer_drop_oldest/mod.rs
+++ b/tests/e2e/buffer_drop_oldest/mod.rs
@@ -1,0 +1,105 @@
+use std::time::Duration;
+
+use reqwest::Client;
+use serde::Deserialize;
+use serde_json::json;
+use vector::test_util::trace_init;
+
+const DEFAULT_EVENT_COUNT: usize = 50;
+const DEFAULT_RETAINED_TAIL: usize = 3;
+const MAX_RETRIES: usize = 30;
+const WAIT_INTERVAL: Duration = Duration::from_secs(1);
+
+fn vector_endpoint() -> String {
+    std::env::var("VECTOR_ENDPOINT").unwrap_or_else(|_| "http://127.0.0.1:8080".to_string())
+}
+
+fn collector_endpoint() -> String {
+    std::env::var("COLLECTOR_ENDPOINT").unwrap_or_else(|_| "http://127.0.0.1:8081".to_string())
+}
+
+fn event_count() -> usize {
+    std::env::var("EVENT_COUNT")
+        .ok()
+        .map(|value| {
+            value
+                .parse::<usize>()
+                .expect("EVENT_COUNT should be an unsigned integer.")
+        })
+        .unwrap_or(DEFAULT_EVENT_COUNT)
+}
+
+fn retained_tail() -> usize {
+    std::env::var("RETAINED_TAIL")
+        .ok()
+        .map(|value| {
+            value
+                .parse::<usize>()
+                .expect("RETAINED_TAIL should be an unsigned integer.")
+        })
+        .unwrap_or(DEFAULT_RETAINED_TAIL)
+}
+
+#[derive(Debug, Deserialize)]
+struct CollectorResponse {
+    ids: Vec<usize>,
+}
+
+async fn get_collected_ids(client: &Client, collector: &str) -> Vec<usize> {
+    client
+        .get(format!("{collector}/ids"))
+        .send()
+        .await
+        .expect("getting collected ids should succeed")
+        .error_for_status()
+        .expect("collector ids response should be successful")
+        .json::<CollectorResponse>()
+        .await
+        .expect("collector ids response should be JSON")
+        .ids
+}
+
+#[tokio::test]
+async fn retains_newest_events_when_memory_buffer_is_full() {
+    trace_init();
+
+    let client = Client::new();
+    let vector = vector_endpoint();
+    let collector = collector_endpoint();
+    let event_count = event_count();
+    let retained_tail = retained_tail();
+
+    for id in 0..event_count {
+        client
+            .post(&vector)
+            .json(&json!({
+                "id": id,
+                "message": format!("event-{id}"),
+            }))
+            .send()
+            .await
+            .unwrap_or_else(|_| panic!("sending event {id} to Vector should succeed"))
+            .error_for_status()
+            .unwrap_or_else(|_| panic!("Vector should accept event {id}"));
+    }
+
+    let expected_tail = (event_count - retained_tail..event_count).collect::<Vec<_>>();
+
+    let mut ids = Vec::new();
+    for _ in 0..MAX_RETRIES {
+        ids = get_collected_ids(&client, &collector).await;
+        if expected_tail.iter().all(|id| ids.contains(id)) {
+            break;
+        }
+        tokio::time::sleep(WAIT_INTERVAL).await;
+    }
+
+    assert!(
+        expected_tail.iter().all(|id| ids.contains(id)),
+        "collector should receive the newest buffered events; expected tail {expected_tail:?}, got {ids:?}"
+    );
+    assert!(
+        ids.len() < event_count,
+        "drop_oldest should shed some events under forced sink backpressure; got all {event_count} events: {ids:?}"
+    );
+}

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -1,4 +1,6 @@
 #![allow(clippy::print_stderr)]
+#[cfg(feature = "e2e-tests-buffer-drop-oldest")]
+mod buffer_drop_oldest;
 #[cfg(feature = "e2e-tests-datadog")]
 mod datadog;
 #[cfg(feature = "e2e-tests-opentelemetry")]

--- a/website/content/en/docs/architecture/buffering-model.md
+++ b/website/content/en/docs/architecture/buffering-model.md
@@ -186,6 +186,18 @@ continually) or is generally not high-value, such as trace or debug logging. It 
 effectively shed load, by lowering the number of events in-flight for a topology, while
 simultaneously avoiding the blocking of upstream components.
 
+### Drop the oldest buffered event (`drop_oldest`)
+
+When configured to "drop oldest", Vector will drop the oldest buffered event as needed to make room
+for new events. This mode is supported for in-memory buffers.
+
+This behavior can be useful for streams where retaining the most recent events is more important
+than preserving older buffered events. For example, high-volume telemetry streams may prefer recent
+state over stale data when the destination is temporarily slower than the source.
+
+When a new event is larger than the available buffer capacity, Vector may drop multiple old events
+until enough capacity is available for the new event.
+
 ### Overflow to another buffer (`overflow`)
 
 {{< danger >}}

--- a/website/cue/reference/components/generated/sinks.cue
+++ b/website/cue/reference/components/generated/sinks.cue
@@ -70,6 +70,13 @@ generated: components: sinks: configuration: {
 														highest priority, and it is preferable to temporarily lose events rather than cause a
 														slowdown in the acceptance/consumption of events.
 														"""
+						drop_oldest: """
+														Drops the oldest buffered event to make room for the new event.
+
+														The oldest buffered event will be intentionally dropped when free space is required. This
+														mode is typically used when preserving the most recent events is more important than
+														preserving older buffered events.
+														"""
 					}
 				}
 			}

--- a/website/cue/reference/generated/configuration.cue
+++ b/website/cue/reference/generated/configuration.cue
@@ -828,6 +828,13 @@ generated: configuration: {
 																					highest priority, and it is preferable to temporarily lose events rather than cause a
 																					slowdown in the acceptance/consumption of events.
 																					"""
+										drop_oldest: """
+																					Drops the oldest buffered event to make room for the new event.
+
+																					The oldest buffered event will be intentionally dropped when free space is required. This
+																					mode is typically used when preserving the most recent events is more important than
+																					preserving older buffered events.
+																					"""
 									}
 									default: "block"
 								}


### PR DESCRIPTION
## Summary

Adds `when_full = "drop_oldest"` support for memory buffers.

When a memory buffer is full, the new mode evicts the oldest queued event(s) to make room for newer events. Evicted events are finalized as rejected so source acknowledgements do not hang or incorrectly report success.

Disk buffers explicitly reject `drop_oldest` for now because disk eviction needs separate ledger/read/ack semantics.

Fixes #8209.

## Changes

- Add `WhenFull::DropOldest` and generated config/schema docs.
- Implement memory-buffer oldest-event eviction with usage accounting.
- Reject `drop_oldest` for disk buffers during buffer construction.
- Add unit coverage for ordering, byte-size eviction, finalization status, and in-flight permit behavior.
- Add a Docker Compose E2E scenario that verifies newest events survive under sink backpressure.

## Validation

- `cargo test -p vector-buffers drop_oldest`
- `cargo test -p vector-buffers`
- `cargo clippy -p vector-buffers --all-targets -- -D warnings`
- `cargo test --test e2e --features e2e-tests-buffer-drop-oldest --no-run`
- `cargo test --test e2e --features all-e2e-tests --no-run`
- `cargo vdev e2e test buffer-drop-oldest`
- `./scripts/check_changelog_fragments.sh`
- `make check-generated-docs`
