### PR TITLE
fix(metric sinks): release normalizer finalizers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1109,7 +1109,8 @@ test-utils = ["vector-lib/test"]
 # End-to-End testing-related features
 all-e2e-tests = [
   "e2e-tests-datadog",
-  "e2e-tests-opentelemetry"
+  "e2e-tests-opentelemetry",
+  "e2e-tests-prometheus"
 ]
 
 e2e-tests-datadog = [
@@ -1128,6 +1129,14 @@ e2e-tests-opentelemetry = [
   "sinks-file",
   "codecs-opentelemetry",
   "dep:prost-reflect"
+]
+
+e2e-tests-prometheus = [
+  "sources-demo_logs",
+  "sources-internal_metrics",
+  "transforms-log_to_metric",
+  "sinks-prometheus",
+  "vector-lib/antithesis-disk-asserts"
 ]
 
 vector-api-tests = [

--- a/changelog.d/metric_normalizer_finalizers.fix.md
+++ b/changelog.d/metric_normalizer_finalizers.fix.md
@@ -1,0 +1,3 @@
+Fix metric normalization retaining delivery finalizers in cached state, which could prevent sink buffers from being acknowledged and reclaimed for metric sinks such as `prometheus_remote_write`.
+
+authors: fpytloun

--- a/src/sinks/util/buffer/metrics/normalize.rs
+++ b/src/sinks/util/buffer/metrics/normalize.rs
@@ -691,10 +691,10 @@ impl MetricSet {
                     metric = metric.with_value(new_value);
                 }
                 // Insert the updated stored value, or as store a new reference value (if the Metric changed type)
-                self.insert(metric.clone(), timestamp);
+                self.insert_normalization_state(metric.clone(), timestamp);
             }
             None => {
-                self.insert(metric.clone(), timestamp);
+                self.insert_normalization_state(metric.clone(), timestamp);
             }
         }
         metric.into_absolute()
@@ -738,13 +738,13 @@ impl MetricSet {
                     Some(metric.into_incremental())
                 } else {
                     // Metric changed type, store this and emit nothing
-                    self.insert(metric, timestamp);
+                    self.insert_normalization_state(metric, timestamp);
                     None
                 }
             }
             None => {
                 // No reference so store this and emit nothing
-                self.insert(metric, timestamp);
+                self.insert_normalization_state(metric, timestamp);
                 None
             }
         }
@@ -753,6 +753,11 @@ impl MetricSet {
     fn insert(&mut self, metric: Metric, timestamp: Option<Instant>) {
         let (series, entry) = MetricEntry::from_metric(metric, timestamp);
         self.insert_with_tracking(series, entry);
+    }
+
+    fn insert_normalization_state(&mut self, mut metric: Metric, timestamp: Option<Instant>) {
+        metric.metadata_mut().take_finalizers();
+        self.insert(metric, timestamp);
     }
 
     pub fn insert_update(&mut self, metric: Metric) {
@@ -809,12 +814,33 @@ impl Default for MetricSet {
 
 #[cfg(test)]
 mod tests {
-    use vector_lib::event::metric::{MetricKind, MetricValue};
+    use vector_lib::event::{
+        BatchNotifier, BatchStatus, EventStatus, Finalizable,
+        metric::{MetricKind, MetricValue},
+    };
 
     use super::*;
 
     fn counter(name: &str, value: f64, kind: MetricKind) -> Metric {
         Metric::new(name, kind, MetricValue::Counter { value })
+    }
+
+    fn counter_with_receiver(
+        name: &str,
+        value: f64,
+        kind: MetricKind,
+    ) -> (Metric, vector_lib::event::BatchStatusReceiver) {
+        let (batch, receiver) = BatchNotifier::new_with_receiver();
+        (
+            counter(name, value, kind).with_batch_notifier(&batch),
+            receiver,
+        )
+    }
+
+    fn deliver_metric(mut metric: Metric) {
+        let mut finalizers = metric.take_finalizers();
+        finalizers.update_status(EventStatus::Delivered);
+        finalizers.update_sources();
     }
 
     // Verifies that the default (no capacity policy) path uses IndexMap and that
@@ -857,5 +883,57 @@ mod tests {
             ..Default::default()
         });
         assert!(matches!(set.inner, MetricSetInner::Bounded(_)));
+    }
+
+    #[test]
+    fn make_absolute_does_not_retain_finalizers_in_state() {
+        let mut set = MetricSet::default();
+        let (metric, mut receiver) = counter_with_receiver("hits", 1.0, MetricKind::Incremental);
+
+        let normalized = set.make_absolute(metric).unwrap();
+        deliver_metric(normalized);
+
+        assert_eq!(receiver.try_recv(), Ok(BatchStatus::Delivered));
+        assert!(
+            set.into_metrics()
+                .into_iter()
+                .all(|metric| metric.metadata().finalizers().is_empty())
+        );
+    }
+
+    #[test]
+    fn make_incremental_releases_finalizers_when_metric_is_not_emitted() {
+        let mut set = MetricSet::default();
+        let (metric, mut receiver) = counter_with_receiver("hits", 1.0, MetricKind::Absolute);
+
+        assert!(set.make_incremental(metric).is_none());
+
+        assert_eq!(receiver.try_recv(), Ok(BatchStatus::Delivered));
+        assert!(
+            set.into_metrics()
+                .into_iter()
+                .all(|metric| metric.metadata().finalizers().is_empty())
+        );
+    }
+
+    #[test]
+    fn make_incremental_does_not_retain_finalizers_in_updated_state() {
+        let mut set = MetricSet::default();
+        let (first, mut first_receiver) = counter_with_receiver("hits", 1.0, MetricKind::Absolute);
+        let (second, mut second_receiver) =
+            counter_with_receiver("hits", 3.0, MetricKind::Absolute);
+
+        assert!(set.make_incremental(first).is_none());
+        assert_eq!(first_receiver.try_recv(), Ok(BatchStatus::Delivered));
+
+        let normalized = set.make_incremental(second).unwrap();
+        deliver_metric(normalized);
+
+        assert_eq!(second_receiver.try_recv(), Ok(BatchStatus::Delivered));
+        assert!(
+            set.into_metrics()
+                .into_iter()
+                .all(|metric| metric.metadata().finalizers().is_empty())
+        );
     }
 }

--- a/tests/e2e/mod.rs
+++ b/tests/e2e/mod.rs
@@ -3,3 +3,5 @@
 mod datadog;
 #[cfg(feature = "e2e-tests-opentelemetry")]
 mod opentelemetry;
+#[cfg(feature = "e2e-tests-prometheus")]
+mod prometheus;

--- a/tests/e2e/prometheus-remote-write/config/compose.yaml
+++ b/tests/e2e/prometheus-remote-write/config/compose.yaml
@@ -1,0 +1,47 @@
+name: prometheus-remote-write-vector-e2e
+services:
+  remote-write-receiver:
+    container_name: prometheus-remote-write-receiver
+    image: python:3.12-alpine
+    init: true
+    ports:
+      - "${PROM_REMOTE_WRITE_RECEIVER_PORT:-19091}:8080"
+    command:
+      - "python"
+      - "-u"
+      - "/receiver.py"
+    volumes:
+      - type: bind
+        source: ../data/receiver.py
+        target: /receiver.py
+        read_only: true
+
+  vector:
+    container_name: vector-prometheus-remote-write-e2e
+    image: ${CONFIG_VECTOR_IMAGE}
+    init: true
+    depends_on:
+      remote-write-receiver:
+        condition: service_started
+    environment:
+      - VECTOR_LOG=${VECTOR_LOG:-info}
+      - FEATURES=e2e-tests-prometheus
+      - VECTOR_DISK_V2_MAX_DATA_FILE_SIZE=262144
+    command: ["vector", "-c", "/etc/vector/vector.yaml"]
+    volumes:
+      - type: bind
+        source: ../data/vector.yaml
+        target: /etc/vector/vector.yaml
+        read_only: true
+      - type: volume
+        source: vector_target
+        target: /var/lib/vector
+
+volumes:
+  vector_target:
+    external: true
+
+networks:
+  default:
+    name: ${VECTOR_NETWORK}
+    external: true

--- a/tests/e2e/prometheus-remote-write/config/test.yaml
+++ b/tests/e2e/prometheus-remote-write/config/test.yaml
@@ -1,0 +1,17 @@
+features:
+  - e2e-tests-prometheus
+
+test: "e2e"
+
+test_filter: "prometheus::remote_write::"
+
+runner:
+  needs_docker_socket: true
+
+matrix: {}
+
+paths:
+  - "src/sinks/prometheus/**"
+  - "src/sinks/util/buffer/metrics/**"
+  - "tests/e2e/prometheus-remote-write/**"
+  - "tests/e2e/prometheus/**"

--- a/tests/e2e/prometheus-remote-write/data/receiver.py
+++ b/tests/e2e/prometheus-remote-write/data/receiver.py
@@ -1,0 +1,44 @@
+import json
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+
+stats = {"requests": 0, "bytes": 0}
+
+
+def write_stats():
+    with open("/tmp/stats.json", "w", encoding="utf-8") as stats_file:
+        json.dump(stats, stats_file)
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_POST(self):
+        length = int(self.headers.get("content-length", "0"))
+        if length:
+            self.rfile.read(length)
+
+        stats["requests"] += 1
+        stats["bytes"] += length
+        write_stats()
+
+        self.send_response(204)
+        self.end_headers()
+
+    def do_GET(self):
+        if self.path != "/stats":
+            self.send_response(404)
+            self.end_headers()
+            return
+
+        body = json.dumps(stats).encode("utf-8")
+        self.send_response(200)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format, *args):
+        return
+
+
+write_stats()
+ThreadingHTTPServer(("0.0.0.0", 8080), Handler).serve_forever()

--- a/tests/e2e/prometheus-remote-write/data/vector.yaml
+++ b/tests/e2e/prometheus-remote-write/data/vector.yaml
@@ -1,0 +1,46 @@
+data_dir: /var/lib/vector
+
+sources:
+  demo_logs:
+    type: demo_logs
+    format: json
+    interval: 0.0
+    count: 4000
+  internal_metrics:
+    type: internal_metrics
+
+transforms:
+  received_logs:
+    type: log_to_metric
+    inputs:
+      - demo_logs
+    metrics:
+      - type: counter
+        field: message
+        name: received_logs_total
+        namespace: e2e
+        tags:
+          source: demo_logs
+
+sinks:
+  remote_write:
+    type: prometheus_remote_write
+    inputs:
+      - received_logs
+    endpoint: http://remote-write-receiver:8080/write
+    healthcheck:
+      enabled: false
+    buffer:
+      type: disk
+      max_size: 268435488
+      when_full: block
+    batch:
+      aggregate: false
+      max_events: 100
+      timeout_secs: 1
+    expire_metrics_secs: 60
+  internal_metrics_exporter:
+    type: prometheus_exporter
+    inputs:
+      - internal_metrics
+    address: 0.0.0.0:9598

--- a/tests/e2e/prometheus/mod.rs
+++ b/tests/e2e/prometheus/mod.rs
@@ -1,0 +1,1 @@
+mod remote_write;

--- a/tests/e2e/prometheus/remote_write.rs
+++ b/tests/e2e/prometheus/remote_write.rs
@@ -1,0 +1,107 @@
+use std::time::Duration;
+
+use serde::Deserialize;
+use vector::test_util::trace_init;
+
+#[derive(Debug, Deserialize)]
+struct ReceiverStats {
+    requests: u64,
+    bytes: u64,
+}
+
+async fn read_receiver_stats(client: &reqwest::Client) -> Option<ReceiverStats> {
+    client
+        .get("http://prometheus-remote-write-receiver:8080/stats")
+        .send()
+        .await
+        .ok()?
+        .json::<ReceiverStats>()
+        .await
+        .ok()
+}
+
+async fn read_remote_write_buffer_bytes(client: &reqwest::Client) -> Option<f64> {
+    let metrics = client
+        .get("http://vector:9598/metrics")
+        .send()
+        .await
+        .ok()?
+        .text()
+        .await
+        .ok()?;
+
+    metrics.lines().find_map(|line| {
+        if line.starts_with("vector_buffer_byte_size")
+            && line.contains(r#"component_id="remote_write""#)
+        {
+            line.split_whitespace().nth(1)?.parse::<f64>().ok()
+        } else {
+            None
+        }
+    })
+}
+
+#[tokio::test]
+async fn disk_buffer_is_reclaimed_after_successful_delivery() {
+    trace_init();
+
+    let client = reqwest::Client::new();
+    let mut last_requests = 0;
+    let mut stable_samples = 0;
+    let mut stats = None;
+
+    for _ in 0..60 {
+        match read_receiver_stats(&client).await {
+            Some(current) => {
+                if current.requests >= 10 && current.requests == last_requests {
+                    stable_samples += 1;
+                } else {
+                    stable_samples = 0;
+                }
+
+                last_requests = current.requests;
+                stats = Some(current);
+
+                if stable_samples >= 3 {
+                    break;
+                }
+            }
+            None => {}
+        }
+
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+
+    let stats = stats.expect("remote-write receiver should become reachable");
+    assert!(
+        stats.requests >= 10,
+        "expected at least 10 remote-write requests, got {stats:?}"
+    );
+    assert!(
+        stats.bytes > 0,
+        "remote-write receiver should receive non-empty payloads"
+    );
+
+    // Give the disk buffer reader a short window to finalize delivered records
+    // and reclaim rotated data files. The E2E vector service sets
+    // VECTOR_DISK_V2_MAX_DATA_FILE_SIZE low so finalizer retention shows up
+    // without generating a large amount of traffic.
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    let mut buffer_bytes = None;
+    for _ in 0..30 {
+        buffer_bytes = read_remote_write_buffer_bytes(&client).await;
+
+        if matches!(buffer_bytes, Some(bytes) if bytes < 2.0 * 1024.0 * 1024.0) {
+            break;
+        }
+
+        tokio::time::sleep(Duration::from_secs(1)).await;
+    }
+
+    let buffer_bytes = buffer_bytes.expect("remote_write buffer metrics should be exposed");
+    assert!(
+        buffer_bytes < 2.0 * 1024.0 * 1024.0,
+        "remote_write disk buffer was not reclaimed; buffer_byte_size={buffer_bytes}"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes metric normalization retaining delivery finalizers in cached reference state.

`MetricSet::make_absolute` and `MetricSet::make_incremental` keep prior metric values so they can normalize future samples. Before this change, the cached reference metrics also retained delivery finalizers. For metric sinks using disk buffers, that could keep successfully sent records from being acknowledged and reclaimed.

This PR strips finalizers only from metrics retained as long-lived normalization reference state. Batch aggregation via `insert_update` is left unchanged so output metrics still carry the finalizers needed for normal delivery acknowledgement.

The fix is in the shared metric normalizer and applies to all sinks/transforms using `MetricSet::make_absolute` / `make_incremental`, including `prometheus_remote_write`, `aws_cloudwatch_metrics`, `datadog`, `statsd`, `sematext`, `influxdb`, `greptimedb`, `gcp stackdriver`, `appsignal`, and `incremental_to_absolute`. The E2E test uses `prometheus_remote_write` because it provides a compact reproduction of disk-buffer reclamation after successful metric delivery.

## Vector configuration

Added an E2E configuration under `tests/e2e/prometheus-remote-write/`:

```yaml
sources:
  demo_logs:
    type: demo_logs
    format: json
    interval: 0.0
    count: 4000
  internal_metrics:
    type: internal_metrics

transforms:
  received_logs:
    type: log_to_metric
    inputs: [demo_logs]
    metrics:
      - type: counter
        field: message
        name: received_logs_total
        namespace: e2e

sinks:
  remote_write:
    type: prometheus_remote_write
    inputs: [received_logs]
    endpoint: http://remote-write-receiver:8080/write
    buffer:
      type: disk
      max_size: 268435488
      when_full: block
  internal_metrics_exporter:
    type: prometheus_exporter
    inputs: [internal_metrics]
    address: 0.0.0.0:9598
```

## How did you test this PR?

- Reproduced the bug locally by temporarily restoring the old normalization-state insert behavior while keeping the new regression tests. The tests failed with the batch receiver still pending (`Err(Empty)`), showing cached normalizer state retained finalizers.
- `cargo fmt --all -- --check`
- `cargo test --no-default-features --features sinks-prometheus --lib sinks::util::buffer::metrics::normalize -- --nocapture`
- `cargo test --no-default-features --features sinks-prometheus --lib sinks::prometheus::remote_write -- --nocapture`
- `cargo clippy --no-default-features --features sinks-prometheus --lib -- -D warnings -A clippy::manual_option_zip`
  - The allow is for an unrelated pre-existing lint in `src/config/loading/secret.rs`.
- `cargo vdev e2e test prometheus-remote-write`
  - Local environment needed a Docker CLI shim from `docker compose` to `docker-compose` because only the standalone compose binary is available locally.
- `./scripts/check_changelog_fragments.sh`
- `git diff --check`

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Closes: #25424
- Related: #24655
