### PR TITLE
chore(http client): Make `HttpClient` generic over connector

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -16,7 +16,7 @@ use http::{
 use hyper::{
     body::{Body, HttpBody},
     client,
-    client::{Client, HttpConnector},
+    client::{Client, HttpConnector, connect::Connect},
 };
 use hyper_openssl::HttpsConnector;
 use hyper_proxy::ProxyConnector;
@@ -73,15 +73,22 @@ impl HttpError {
 }
 
 pub type HttpClientFuture = <HttpClient as Service<http::Request<Body>>>::Future;
-type HttpProxyConnector = ProxyConnector<HttpsConnector<HttpConnector>>;
+pub type HttpProxyConnector = ProxyConnector<HttpsConnector<HttpConnector>>;
 
-pub struct HttpClient<B = Body> {
-    client: Client<HttpProxyConnector, B>,
+/// An HTTP client generic over the underlying connector `C`.
+///
+/// `C` defaults to [`HttpProxyConnector`], the proxy-aware TLS connector built from Vector's
+/// [`MaybeTlsSettings`]/[`ProxyConfig`]. Callers that need a custom connector can supply
+/// their own via [`HttpClient::new_with_connector`].
+pub struct HttpClient<B = Body, C = HttpProxyConnector> {
+    client: Client<C, B>,
     user_agent: HeaderValue,
-    proxy_connector: HttpProxyConnector,
+    // Proxy-header injection only applies when the client owns a `ProxyConnector`. A custom
+    // connector supplied via `new_with_connector` sets this to `None`.
+    proxy_connector: Option<HttpProxyConnector>,
 }
 
-impl<B> HttpClient<B>
+impl<B> HttpClient<B, HttpProxyConnector>
 where
     B: fmt::Debug + HttpBody + Send + 'static,
     B::Data: Send,
@@ -90,7 +97,7 @@ where
     pub fn new(
         tls_settings: impl Into<MaybeTlsSettings>,
         proxy_config: &ProxyConfig,
-    ) -> Result<HttpClient<B>, HttpError> {
+    ) -> Result<Self, HttpError> {
         HttpClient::new_with_custom_client(tls_settings, proxy_config, &mut Client::builder())
     }
 
@@ -98,20 +105,39 @@ where
         tls_settings: impl Into<MaybeTlsSettings>,
         proxy_config: &ProxyConfig,
         client_builder: &mut client::Builder,
-    ) -> Result<HttpClient<B>, HttpError> {
+    ) -> Result<Self, HttpError> {
         let proxy_connector = build_proxy_connector(tls_settings.into(), proxy_config)?;
         let client = client_builder.build(proxy_connector.clone());
 
-        let app_name = crate::get_app_name();
-        let version = crate::get_version();
-        let user_agent = HeaderValue::from_str(&format!("{app_name}/{version}"))
-            .expect("Invalid header value for user-agent!");
-
         Ok(HttpClient {
             client,
-            user_agent,
-            proxy_connector,
+            user_agent: default_user_agent(),
+            proxy_connector: Some(proxy_connector),
         })
+    }
+}
+
+impl<B, C> HttpClient<B, C>
+where
+    B: fmt::Debug + HttpBody + Send + 'static,
+    B::Data: Send,
+    B::Error: Into<crate::Error>,
+    C: Connect + Clone + Send + Sync + 'static,
+{
+    /// Build an `HttpClient` from a pre-constructed connector.
+    ///
+    /// Proxy-header injection is disabled for custom connectors (`proxy_connector` is always `None`).
+    /// It only matters for the case of a plaintext-`http` request sent through an HTTP proxy, where
+    /// `Proxy-Authorization` must ride on the request itself. HTTPS-through-proxy is unaffected:
+    /// proxy auth happens during the CONNECT handshake inside the connector.
+    pub fn new_with_connector(connector: C, client_builder: &mut client::Builder) -> Self {
+        let client = client_builder.build(connector);
+
+        HttpClient {
+            client,
+            user_agent: default_user_agent(),
+            proxy_connector: None,
+        }
     }
 
     pub fn send(
@@ -161,7 +187,10 @@ where
     }
 
     fn maybe_add_proxy_headers(&self, request: &mut Request<B>) {
-        if let Some(proxy_headers) = self.proxy_connector.http_headers(request.uri()) {
+        let Some(proxy_connector) = &self.proxy_connector else {
+            return;
+        };
+        if let Some(proxy_headers) = proxy_connector.http_headers(request.uri()) {
             for (k, v) in proxy_headers {
                 let request_headers = request.headers_mut();
                 if !request_headers.contains_key(k) {
@@ -170,6 +199,13 @@ where
             }
         }
     }
+}
+
+fn default_user_agent() -> HeaderValue {
+    let app_name = crate::get_app_name();
+    let version = crate::get_version();
+    HeaderValue::from_str(&format!("{app_name}/{version}"))
+        .expect("Invalid header value for user-agent!")
 }
 
 pub fn build_proxy_connector(
@@ -227,11 +263,12 @@ fn default_request_headers<B>(request: &mut Request<B>, user_agent: &HeaderValue
     }
 }
 
-impl<B> Service<Request<B>> for HttpClient<B>
+impl<B, C> Service<Request<B>> for HttpClient<B, C>
 where
     B: fmt::Debug + HttpBody + Send + 'static,
     B::Data: Send,
     B::Error: Into<crate::Error> + Send,
+    C: Connect + Clone + Send + Sync + 'static,
 {
     type Response = http::Response<Body>;
     type Error = HttpError;
@@ -246,7 +283,7 @@ where
     }
 }
 
-impl<B> Clone for HttpClient<B> {
+impl<B, C: Clone> Clone for HttpClient<B, C> {
     fn clone(&self) -> Self {
         Self {
             client: self.client.clone(),
@@ -256,7 +293,7 @@ impl<B> Clone for HttpClient<B> {
     }
 }
 
-impl<B> fmt::Debug for HttpClient<B> {
+impl<B, C> fmt::Debug for HttpClient<B, C> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("HttpClient")
             .field("client", &self.client)

--- a/src/sinks/datadog/logs/config.rs
+++ b/src/sinks/datadog/logs/config.rs
@@ -7,6 +7,8 @@ use vector_lib::{
 };
 use vrl::value::Kind;
 
+use hyper::{Body, client::connect::Connect};
+
 use super::{service::LogApiRetry, sink::LogSinkBuilder};
 use crate::{
     common::datadog,
@@ -107,12 +109,15 @@ impl DatadogLogsConfig {
             .to_string()
     }
 
-    pub fn build_processor(
+    pub fn build_processor<C>(
         &self,
         dd_common: &DatadogCommonConfig,
-        client: HttpClient,
+        client: HttpClient<Body, C>,
         dd_evp_origin: String,
-    ) -> crate::Result<VectorSink> {
+    ) -> crate::Result<VectorSink>
+    where
+        C: Connect + Clone + Send + Sync + 'static,
+    {
         let default_api_key: Arc<str> = Arc::from(dd_common.default_api_key.inner());
         let request_limits = self.request.tower.into_settings();
 

--- a/src/sinks/datadog/logs/service.rs
+++ b/src/sinks/datadog/logs/service.rs
@@ -10,7 +10,7 @@ use http::{
     HeaderValue, Request, Uri,
     header::{CONTENT_ENCODING, CONTENT_LENGTH, CONTENT_TYPE},
 };
-use hyper::Body;
+use hyper::{Body, client::connect::Connect};
 use tower::Service;
 use tracing::Instrument;
 use vector_lib::{
@@ -20,7 +20,7 @@ use vector_lib::{
 };
 
 use crate::{
-    http::HttpClient,
+    http::{HttpClient, HttpProxyConnector},
     sinks::{
         datadog::DatadogApiError,
         util::{
@@ -97,16 +97,19 @@ impl DriverResponse for LogApiResponse {
 /// composed within a Tower "stack", such that we can easily and transparently
 /// provide retries, concurrency limits, rate limits, and more.
 #[derive(Debug, Clone)]
-pub struct LogApiService {
-    client: HttpClient,
+pub struct LogApiService<C = HttpProxyConnector> {
+    client: HttpClient<Body, C>,
     uri: Uri,
     user_provided_headers: BTreeMap<OrderedHeaderName, HeaderValue>,
     dd_evp_headers: BTreeMap<OrderedHeaderName, HeaderValue>,
 }
 
-impl LogApiService {
+impl<C> LogApiService<C>
+where
+    C: Connect + Clone + Send + Sync + 'static,
+{
     pub fn new(
-        client: HttpClient,
+        client: HttpClient<Body, C>,
         uri: Uri,
         headers: BTreeMap<String, String>,
         dd_evp_origin: String,
@@ -130,7 +133,10 @@ impl LogApiService {
     }
 }
 
-impl Service<LogApiRequest> for LogApiService {
+impl<C> Service<LogApiRequest> for LogApiService<C>
+where
+    C: Connect + Clone + Send + Sync + 'static,
+{
     type Response = LogApiResponse;
     type Error = DatadogApiError;
     type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;

--- a/src/sinks/datadog/mod.rs
+++ b/src/sinks/datadog/mod.rs
@@ -1,6 +1,6 @@
 use futures_util::FutureExt;
 use http::{Request, StatusCode, Uri};
-use hyper::body::Body;
+use hyper::{body::Body, client::connect::Connect};
 use snafu::Snafu;
 use vector_lib::{
     config::AcknowledgementsConfig, configurable::configurable_component,
@@ -137,7 +137,10 @@ pub struct DatadogCommonConfig {
 impl DatadogCommonConfig {
     /// Returns a `Healthcheck` which is a future that will be used to ensure the
     /// `<site>/api/v1/validate` endpoint is reachable.
-    pub fn build_healthcheck(&self, client: HttpClient) -> crate::Result<Healthcheck> {
+    pub fn build_healthcheck<C>(&self, client: HttpClient<Body, C>) -> crate::Result<Healthcheck>
+    where
+        C: Connect + Clone + Send + Sync + 'static,
+    {
         let validate_endpoint = self.get_api_endpoint("/api/v1/validate")?;
 
         let api_key: String = self.default_api_key.clone().into();
@@ -155,11 +158,14 @@ impl DatadogCommonConfig {
 }
 
 /// Makes a GET HTTP request to `<site>/api/v1/validate` using the provided client and API key.
-async fn build_healthcheck_future(
-    client: HttpClient,
+async fn build_healthcheck_future<C>(
+    client: HttpClient<Body, C>,
     validate_endpoint: Uri,
     api_key: String,
-) -> crate::Result<()> {
+) -> crate::Result<()>
+where
+    C: Connect + Clone + Send + Sync + 'static,
+{
     let request = Request::get(validate_endpoint)
         .header("DD-API-KEY", api_key)
         .body(hyper::Body::empty())


### PR DESCRIPTION
## Summary
This PR makes the `HttpClient` generic over the connector (`hyper::client::connect::Connect`) so it can be customized to support use cases that are not relevant to the broader OSS community.

## Change Type
Non-functional refactoring.

## Is this a breaking change?
This is a non-functional change. Call sites remain unchanged and the current connector remains the default one.

## Does this PR include user facing changes?
No.