### PR TITLE
fix(healthcheck): use documented retry defaults

### DIFF
--- a/changelog.d/health_config_defaults.fix.md
+++ b/changelog.d/health_config_defaults.fix.md
@@ -1,0 +1,3 @@
+Fix programmatic defaults for endpoint health configuration to match the documented deserialization defaults.
+
+authors: fpytloun

--- a/src/sinks/util/service/health.rs
+++ b/src/sinks/util/service/health.rs
@@ -29,7 +29,7 @@ const UNHEALTHY_AMOUNT_OF_ERRORS: usize = 5;
 /// Options for determining the health of an endpoint.
 #[serde_as]
 #[configurable_component]
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 #[serde(rename_all = "snake_case")]
 pub struct HealthConfig {
     /// Initial delay between attempts to reactivate endpoints once they become unhealthy.
@@ -52,6 +52,15 @@ const fn default_retry_initial_backoff_secs() -> u64 {
 
 const fn default_retry_max_duration_secs() -> std::time::Duration {
     Duration::from_secs(RETRY_MAX_DURATION_SECONDS_DEFAULT)
+}
+
+impl Default for HealthConfig {
+    fn default() -> Self {
+        Self {
+            retry_initial_backoff_secs: default_retry_initial_backoff_secs(),
+            retry_max_duration_secs: default_retry_max_duration_secs(),
+        }
+    }
 }
 
 impl HealthConfig {
@@ -328,5 +337,19 @@ mod tests {
 
         counters.inc_healthy();
         assert!(counters.healthy(snapshot).is_ok());
+    }
+
+    #[test]
+    fn health_config_default_matches_deserialize_defaults() {
+        let config = HealthConfig::default();
+
+        assert_eq!(
+            config.retry_initial_backoff_secs,
+            RETRY_INITIAL_BACKOFF_SECONDS_DEFAULT
+        );
+        assert_eq!(
+            config.retry_max_duration_secs,
+            Duration::from_secs(RETRY_MAX_DURATION_SECONDS_DEFAULT)
+        );
     }
 }


### PR DESCRIPTION
## Summary

This is a small follow-up split out from review feedback on #25662.

It changes `HealthConfig::default()` to match the same retry defaults already used when deserializing `HealthConfig` from config:

- `retry_initial_backoff_secs`: `1`
- `retry_max_duration_secs`: `3600s`

Without this, code paths that construct a missing health config with `HealthConfig::default()` get zero retry timing values instead of the documented/deserialized defaults.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation update
- [ ] Other

## Is this a breaking change?

- [ ] Yes
- [x] No

## How Has This Been Tested?

- `cargo fmt --all -- --check`
- `cargo test sinks::util::service::health::tests::health_config_default_matches_deserialize_defaults --lib`
- `cargo test sinks::util::service::health::tests::test_health_counters --lib`
- `./scripts/check_changelog_fragments.sh`

## Checklist

- [x] I have read the contributing guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an appropriate changelog entry
