### PR TITLE
fix(vrl): preserve large integer precision in VRL Playground

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13461,6 +13461,7 @@ dependencies = [
  "getrandom 0.4.2",
  "gloo-utils",
  "serde",
+ "serde_json",
  "vector-vrl-functions",
  "vrl",
  "wasm-bindgen",

--- a/changelog.d/vrl_playground_large_int_precision.fix.md
+++ b/changelog.d/vrl_playground_large_int_precision.fix.md
@@ -1,0 +1,3 @@
+Fixed the VRL Playground truncating large integers (such as `xxhash` and `seahash` results) to their least-significant digits. Results are now serialized with full precision instead of being coerced to JavaScript floating-point numbers.
+
+authors: stigglor

--- a/lib/vector-vrl/web-playground/Cargo.toml
+++ b/lib/vector-vrl/web-playground/Cargo.toml
@@ -22,6 +22,7 @@ default = ["vrl/stdlib"]
 wasm-bindgen = "0.2"
 vrl.workspace = true
 serde.workspace = true
+serde_json.workspace = true
 web-sys = { version = "0.3", features = ["Window", "Performance"] }
 gloo-utils = { version = "0.2", features = ["serde"] }
 vector-vrl-functions.workspace = true

--- a/lib/vector-vrl/web-playground/public/index.js
+++ b/lib/vector-vrl/web-playground/public/index.js
@@ -173,6 +173,13 @@ export class VrlWebPlayground {
   }
 
   _formatRunResult(runResult) {
+    // Prefer the full-precision JSON serialized on the Rust side. The wasm result is
+    // marshaled into JS through JSON.parse, which coerces integers beyond the safe integer
+    // range for f64 (e.g. XXH64/seahash hashes, nanosecond timestamps) into lossy f64s.
+    // Rendering the pre-serialized string keeps those integers exact.
+    if (typeof runResult?.output === "string") {
+      return { text: runResult.output, isJson: true };
+    }
     if (runResult?.target_value != null) {
       const isJson = typeof runResult.target_value === "object";
       const text = isJson ? JSON.stringify(runResult.target_value, null, "\t") : String(runResult.target_value);

--- a/lib/vector-vrl/web-playground/src/lib.rs
+++ b/lib/vector-vrl/web-playground/src/lib.rs
@@ -35,9 +35,29 @@ impl Input {
 // and the execution time.
 #[derive(Deserialize, Serialize)]
 pub struct VrlCompileResult {
+    // Full-precision JSON rendering of `target_value`, produced on the Rust side.
+    //
+    // The result is marshaled into JS via `JsValue::from_serde`, which serializes to a
+    // JSON string and then calls JS `JSON.parse`. `JSON.parse` coerces every number into
+    // an f64, so any integer beyond the safe integer range for f64 (e.g. an XXH64/seahash hash or a
+    // nanosecond timestamp) loses its low-order digits. Serializing the event here and
+    // rendering this string verbatim in the UI keeps large integers exact.
+    pub output: String,
     pub runtime_result: Value,
     pub target_value: Value,
     pub elapsed_time: Option<f64>,
+}
+
+// Serialize a `Value` to pretty JSON using tab indentation, matching the layout the
+// playground previously produced with `JSON.stringify(value, null, "\t")`.
+fn to_pretty_json(value: &Value) -> String {
+    let mut buf = Vec::new();
+    let formatter = serde_json::ser::PrettyFormatter::with_indent(b"\t");
+    let mut serializer = serde_json::Serializer::with_formatter(&mut buf, formatter);
+    match value.serialize(&mut serializer) {
+        Ok(()) => String::from_utf8(buf).unwrap_or_default(),
+        Err(_) => String::new(),
+    }
 }
 
 #[derive(Deserialize, Serialize, Default)]
@@ -127,7 +147,8 @@ fn compile(
 
     match result {
         Ok(runtime_result) => Ok(VrlCompileResult {
-            runtime_result,                   // This is the value of the last expression.
+            output: to_pretty_json(&target_value.value), // Full-precision JSON for display.
+            runtime_result, // This is the value of the last expression.
             target_value: target_value.value, // The value of the final event
             elapsed_time,
         }),
@@ -164,4 +185,36 @@ pub fn vrl_version() -> String {
 #[wasm_bindgen]
 pub fn vrl_link() -> String {
     built_info::VRL_LINK.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    // `compile`/`run_vrl` can't be exercised here: they call `web_sys::window()`, which
+    // panics on non-wasm targets, so they need a `wasm-bindgen-test` harness. These tests
+    // instead cover `to_pretty_json`, which is where the precision fix lives.
+    use super::*;
+    use vrl::value::ObjectMap;
+
+    // A scalar integer larger than f64's safe range must serialize to its exact digits.
+    // JS `JSON.parse` (used when marshaling the wasm result) would round these; see
+    // https://github.com/vectordotdev/vrl/issues/1535.
+    #[test]
+    fn to_pretty_json_preserves_large_integers() {
+        // An XXH64 hash (`xxhash("foo", "XXH64")`).
+        assert_eq!(
+            to_pretty_json(&Value::from(3_728_699_739_546_630_719_i64)),
+            "3728699739546630719"
+        );
+        // A seahash whose `u64 as i64` reinterpretation wrapped negative (`seahash("bar")`).
+        assert_eq!(
+            to_pretty_json(&Value::from(-2_796_170_501_982_571_315_i64)),
+            "-2796170501982571315"
+        );
+    }
+
+    // An empty event renders the same as before (`JSON.stringify({}, null, "\t")`).
+    #[test]
+    fn to_pretty_json_renders_empty_object() {
+        assert_eq!(to_pretty_json(&Value::Object(ObjectMap::new())), "{}");
+    }
 }

--- a/lib/vector-vrl/web-playground/src/lib.rs
+++ b/lib/vector-vrl/web-playground/src/lib.rs
@@ -35,13 +35,7 @@ impl Input {
 // and the execution time.
 #[derive(Deserialize, Serialize)]
 pub struct VrlCompileResult {
-    // Full-precision JSON rendering of `target_value`, produced on the Rust side.
-    //
-    // The result is marshaled into JS via `JsValue::from_serde`, which serializes to a
-    // JSON string and then calls JS `JSON.parse`. `JSON.parse` coerces every number into
-    // an f64, so any integer beyond the safe integer range for f64 (e.g. an XXH64/seahash hash or a
-    // nanosecond timestamp) loses its low-order digits. Serializing the event here and
-    // rendering this string verbatim in the UI keeps large integers exact.
+    // Pre-serialized target_value to avoid f64 precision loss in JS JSON.parse.
     pub output: String,
     pub runtime_result: Value,
     pub target_value: Value,
@@ -50,14 +44,13 @@ pub struct VrlCompileResult {
 
 // Serialize a `Value` to pretty JSON using tab indentation, matching the layout the
 // playground previously produced with `JSON.stringify(value, null, "\t")`.
-fn to_pretty_json(value: &Value) -> String {
+fn to_pretty_json(value: &Value) -> Result<String, serde_json::Error> {
     let mut buf = Vec::new();
     let formatter = serde_json::ser::PrettyFormatter::with_indent(b"\t");
     let mut serializer = serde_json::Serializer::with_formatter(&mut buf, formatter);
-    match value.serialize(&mut serializer) {
-        Ok(()) => String::from_utf8(buf).unwrap_or_default(),
-        Err(_) => String::new(),
-    }
+    value.serialize(&mut serializer)?;
+    // `serde_json` only ever writes valid UTF-8.
+    Ok(String::from_utf8(buf).expect("serde_json emits valid UTF-8"))
 }
 
 #[derive(Deserialize, Serialize, Default)]
@@ -146,12 +139,23 @@ fn compile(
         };
 
     match result {
-        Ok(runtime_result) => Ok(VrlCompileResult {
-            output: to_pretty_json(&target_value.value), // Full-precision JSON for display.
-            runtime_result, // This is the value of the last expression.
-            target_value: target_value.value, // The value of the final event
-            elapsed_time,
-        }),
+        Ok(runtime_result) => {
+            // Full-precision JSON for display.
+            let output = to_pretty_json(&target_value.value).map_err(|err| {
+                let msg = format!("failed to serialize result: {err}");
+                VrlDiagnosticResult {
+                    msg_colorized: msg.clone(),
+                    msg,
+                    ..Default::default()
+                }
+            })?;
+            Ok(VrlCompileResult {
+                output,
+                runtime_result, // This is the value of the last expression.
+                target_value: target_value.value, // The value of the final event
+                elapsed_time,
+            })
+        }
         Err(err) => Err(VrlDiagnosticResult::new_runtime_error(&input.program, err)),
     }
 }
@@ -190,8 +194,7 @@ pub fn vrl_link() -> String {
 #[cfg(test)]
 mod tests {
     // `compile`/`run_vrl` can't be exercised here: they call `web_sys::window()`, which
-    // panics on non-wasm targets, so they need a `wasm-bindgen-test` harness. These tests
-    // instead cover `to_pretty_json`, which is where the precision fix lives.
+    // panics on non-wasm targets, so they need a `wasm-bindgen-test` harness.
     use super::*;
     use vrl::value::ObjectMap;
 
@@ -202,12 +205,12 @@ mod tests {
     fn to_pretty_json_preserves_large_integers() {
         // An XXH64 hash (`xxhash("foo", "XXH64")`).
         assert_eq!(
-            to_pretty_json(&Value::from(3_728_699_739_546_630_719_i64)),
+            to_pretty_json(&Value::from(3_728_699_739_546_630_719_i64)).unwrap(),
             "3728699739546630719"
         );
         // A seahash whose `u64 as i64` reinterpretation wrapped negative (`seahash("bar")`).
         assert_eq!(
-            to_pretty_json(&Value::from(-2_796_170_501_982_571_315_i64)),
+            to_pretty_json(&Value::from(-2_796_170_501_982_571_315_i64)).unwrap(),
             "-2796170501982571315"
         );
     }
@@ -215,6 +218,6 @@ mod tests {
     // An empty event renders the same as before (`JSON.stringify({}, null, "\t")`).
     #[test]
     fn to_pretty_json_renders_empty_object() {
-        assert_eq!(to_pretty_json(&Value::Object(ObjectMap::new())), "{}");
+        assert_eq!(to_pretty_json(&Value::Object(ObjectMap::new())).unwrap(), "{}");
     }
 }

--- a/lib/vector-vrl/web-playground/src/lib.rs
+++ b/lib/vector-vrl/web-playground/src/lib.rs
@@ -218,6 +218,9 @@ mod tests {
     // An empty event renders the same as before (`JSON.stringify({}, null, "\t")`).
     #[test]
     fn to_pretty_json_renders_empty_object() {
-        assert_eq!(to_pretty_json(&Value::Object(ObjectMap::new())).unwrap(), "{}");
+        assert_eq!(
+            to_pretty_json(&Value::Object(ObjectMap::new())).unwrap(),
+            "{}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

The VRL Playground displayed large integers with trailing zeros. For
example, xxhash("foo", "XXH64") showed 3728699739546630700 instead of
3728699739546630719.

Run results cross the WASM/JS boundary via JsValue::from_serde, which
calls JSON.parse in JavaScript. JSON.parse stores every number as an f64,
so any integer beyond the safe integer range for f64 loses precision.
This affects any large integer result, including xxhash and seahash
hashes, not the hashing functions themselves.

The fix serializes the event to full precision JSON in Rust and renders
that string directly, so the value no longer passes through JSON.parse.

## Vector configuration

Not applicable. This is a VRL Playground change with no Vector config.

## How did you test this PR?

Added unit tests for the new serialization covering large positive and
negative integers, and empty object rendering.

Built the playground with wasm-pack and drove the generated wasm module
directly. xxhash("foo", "XXH64") returned 3728699739546630719 and
seahash("foobar") returned 5348458858952426560, while
the previous path returned 3728699739546630700 and 5348458858952426000.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: https://github.com/vectordotdev/vrl/issues/1535
