### PR TITLE
enhancement(sources): pre-size HTTP request body buffer from Content-Length

### DIFF
--- a/changelog.d/presize_http_request_body_buffer.enhancement.md
+++ b/changelog.d/presize_http_request_body_buffer.enhancement.md
@@ -1,0 +1,3 @@
+The HTTP-based sources (e.g. `http_server`, `opentelemetry`) now pre-size the request-body buffer from the `Content-Length` header, collecting each body in a single allocation instead of growing an unsized buffer. This removes a per-request reallocation/copy cost on the ingestion path and restores throughput on high-volume HTTP sources, while keeping the streaming decompressed-size cap.
+
+authors: armleth

--- a/changelog.d/presize_http_request_body_buffer.enhancement.md
+++ b/changelog.d/presize_http_request_body_buffer.enhancement.md
@@ -1,3 +1,0 @@
-The HTTP-based sources (e.g. `http_server`, `opentelemetry`) now pre-size the request-body buffer from the `Content-Length` header, collecting each body in a single allocation instead of growing an unsized buffer. This removes a per-request reallocation/copy cost on the ingestion path and restores throughput on high-volume HTTP sources, while keeping the streaming decompressed-size cap.
-
-authors: armleth

--- a/src/sources/util/http/encoding.rs
+++ b/src/sources/util/http/encoding.rs
@@ -60,13 +60,12 @@ pub(crate) fn limited_body(max_body_size: usize) -> BoxedFilter<(Bytes,)> {
                     max_body_size,
                 )))
             } else {
-                Ok(())
+                Ok(declared)
             }
         })
-        .untuple_one()
         .and(warp::body::stream())
-        .and_then(move |body| async move {
-            collect_body_with_limit(body, max_body_size)
+        .and_then(move |declared: Option<u64>, body| async move {
+            collect_body_with_limit(body, max_body_size, declared)
                 .await
                 .map_err(warp::reject::custom)
         })
@@ -183,14 +182,25 @@ fn decompress_snappy(
     feature = "sources-opentelemetry",
     test
 ))]
-async fn collect_body_with_limit<S, B>(body: S, max_body_size: usize) -> Result<Bytes, ErrorMessage>
+async fn collect_body_with_limit<S, B>(
+    body: S,
+    max_body_size: usize,
+    declared_len: Option<u64>,
+) -> Result<Bytes, ErrorMessage>
 where
     S: futures_util::Stream<Item = Result<B, warp::Error>>,
     B: Buf,
 {
     futures_util::pin_mut!(body);
 
-    let mut bytes = BytesMut::new();
+    // Pre-size from the Content-Length header (capped at the limit) so the body is collected with
+    // a single allocation and one copy per chunk, matching the previous `warp::body::bytes()`
+    // cost. Without this the buffer starts empty and grows by repeated realloc+recopy on every
+    // request, which shows up as a per-request throughput/CPU regression on high-volume sources.
+    let capacity = declared_len
+        .and_then(|len| usize::try_from(len).ok())
+        .map_or(0, |len| len.min(max_body_size));
+    let mut bytes = BytesMut::with_capacity(capacity);
     while let Some(chunk) = body.next().await {
         let chunk = chunk.map_err(|error| {
             ErrorMessage::new(
@@ -368,7 +378,7 @@ mod tests {
             Ok::<_, warp::Error>(Bytes::from_static(b" world")),
         ]);
 
-        let collected = collect_body_with_limit(body, 11).await.unwrap();
+        let collected = collect_body_with_limit(body, 11, Some(11)).await.unwrap();
         assert_eq!(collected, Bytes::from_static(b"hello world"));
     }
 
@@ -379,7 +389,7 @@ mod tests {
             Ok::<_, warp::Error>(Bytes::from_static(b" world")),
         ]);
 
-        let err = collect_body_with_limit(body, 5)
+        let err = collect_body_with_limit(body, 5, None)
             .await
             .expect_err("should reject");
         assert_eq!(err.status_code(), StatusCode::PAYLOAD_TOO_LARGE);

--- a/src/sources/util/http/encoding.rs
+++ b/src/sources/util/http/encoding.rs
@@ -193,10 +193,6 @@ where
 {
     futures_util::pin_mut!(body);
 
-    // Pre-size from the Content-Length header (capped at the limit) so the body is collected with
-    // a single allocation and one copy per chunk, matching the previous `warp::body::bytes()`
-    // cost. Without this the buffer starts empty and grows by repeated realloc+recopy on every
-    // request, which shows up as a per-request throughput/CPU regression on high-volume sources.
     let capacity = declared_len
         .and_then(|len| usize::try_from(len).ok())
         .map_or(0, |len| len.min(max_body_size));

--- a/src/sources/util/http/encoding.rs
+++ b/src/sources/util/http/encoding.rs
@@ -177,6 +177,15 @@ fn decompress_snappy(
     Ok(decoded.into())
 }
 
+/// Cap on the initial buffer allocation when pre-sizing from a `Content-Length` header.
+/// Prevents stalling clients from reserving large amounts of memory before sending any bytes.
+#[cfg(any(
+    feature = "sources-utils-http-prelude",
+    feature = "sources-opentelemetry",
+    test
+))]
+const MAX_INITIAL_BODY_CAPACITY: usize = 8 * 1024 * 1024; // 8 MiB
+
 #[cfg(any(
     feature = "sources-utils-http-prelude",
     feature = "sources-opentelemetry",
@@ -195,7 +204,7 @@ where
 
     let capacity = declared_len
         .and_then(|len| usize::try_from(len).ok())
-        .map_or(0, |len| len.min(max_body_size));
+        .map_or(0, |len| len.min(max_body_size).min(MAX_INITIAL_BODY_CAPACITY));
     let mut bytes = BytesMut::with_capacity(capacity);
     while let Some(chunk) = body.next().await {
         let chunk = chunk.map_err(|error| {


### PR DESCRIPTION
## Summary
Follow-up to #25488.

We detected some performance regression that seems to come from #25488. The issue seems to be that we collect the body into a `BytesMut` created empty, with no pre-defined capacity. As the body streams in, the buffer grows (up to the 100 MiB cap), and each time it needs more room we have to allocate again (and possibly copy all the already-buffered data), as the capacity grows by `max(previous_capacity * 2, requested_size)`.

With this change, we pre-sizes the buffer from the `Content-Length` header (capped at the limit), restoring a single-allocation body collection.

## Change
- `limited_body` threads the parsed `Content-Length` through instead of discarding it.
- `collect_body_with_limit` allocates `BytesMut::with_capacity(content_length.min(limit))` instead of `BytesMut::new()`.

No behavior change.