### PR TITLE
chore(vector-core): remove blanket allows

### DIFF
--- a/lib/vector-core/src/event/proto.rs
+++ b/lib/vector-core/src/event/proto.rs
@@ -215,6 +215,8 @@ impl From<Metric> for super::Metric {
 
         let namespace = (!metric.namespace.is_empty()).then_some(metric.namespace);
 
+        // Sign can never be lost as ts.nanos is always non negative (per proto spec)
+        #[allow(clippy::cast_sign_loss)]
         let timestamp = metric.timestamp.map(|ts| {
             chrono::Utc
                 .timestamp_opt(ts.seconds, ts.nanos as u32)
@@ -422,6 +424,9 @@ impl From<super::Metric> for WithMetadata<Metric> {
         let name = series.name.name;
         let namespace = series.name.namespace.unwrap_or_default();
 
+        // Value never wraps as timestamp_subsec_nanos returns a value <= 1_999_999_999 
+        // (as per chrono leap-second specs), which is below i32::MAX
+        #[allow(clippy::cast_possible_wrap)]
         let timestamp = data.time.timestamp.map(|ts| prost_types::Timestamp {
             seconds: ts.timestamp(),
             nanos: ts.timestamp_subsec_nanos() as i32,
@@ -699,6 +704,8 @@ impl From<Metadata> for EventMetadata {
 fn decode_value(input: Value) -> Option<super::Value> {
     match input.kind {
         Some(value::Kind::RawBytes(data)) => Some(super::Value::Bytes(data)),
+        // Sign is never lost as ts.nanos is always non negative (per proto spec)
+        #[allow(clippy::cast_sign_loss)]
         Some(value::Kind::Timestamp(ts)) => Some(super::Value::Timestamp(
             chrono::Utc
                 .timestamp_opt(ts.seconds, ts.nanos as u32)
@@ -739,6 +746,9 @@ fn encode_value(value: super::Value) -> Value {
         kind: match value {
             super::Value::Bytes(b) => Some(value::Kind::RawBytes(b)),
             super::Value::Regex(regex) => Some(value::Kind::RawBytes(regex.as_bytes())),
+            // Value never wraps as timestamp_subsec_nanos returns a value <= 1_999_999_999 
+            // (as per chrono leap-second specs), which is below i32::MAX
+            #[allow(clippy::cast_possible_wrap)]
             super::Value::Timestamp(ts) => Some(value::Kind::Timestamp(prost_types::Timestamp {
                 seconds: ts.timestamp(),
                 nanos: ts.timestamp_subsec_nanos() as i32,

--- a/lib/vector-core/src/event/proto.rs
+++ b/lib/vector-core/src/event/proto.rs
@@ -424,7 +424,7 @@ impl From<super::Metric> for WithMetadata<Metric> {
         let name = series.name.name;
         let namespace = series.name.namespace.unwrap_or_default();
 
-        // Value never wraps as timestamp_subsec_nanos returns a value <= 1_999_999_999 
+        // Value never wraps as timestamp_subsec_nanos returns a value <= 1_999_999_999
         // (as per chrono leap-second specs), which is below i32::MAX
         #[allow(clippy::cast_possible_wrap)]
         let timestamp = data.time.timestamp.map(|ts| prost_types::Timestamp {
@@ -746,7 +746,7 @@ fn encode_value(value: super::Value) -> Value {
         kind: match value {
             super::Value::Bytes(b) => Some(value::Kind::RawBytes(b)),
             super::Value::Regex(regex) => Some(value::Kind::RawBytes(regex.as_bytes())),
-            // Value never wraps as timestamp_subsec_nanos returns a value <= 1_999_999_999 
+            // Value never wraps as timestamp_subsec_nanos returns a value <= 1_999_999_999
             // (as per chrono leap-second specs), which is below i32::MAX
             #[allow(clippy::cast_possible_wrap)]
             super::Value::Timestamp(ts) => Some(value::Kind::Timestamp(prost_types::Timestamp {

--- a/lib/vector-core/src/lib.rs
+++ b/lib/vector-core/src/lib.rs
@@ -16,8 +16,6 @@
 #![deny(unused_extern_crates)]
 #![deny(unused_assignments)]
 #![deny(unused_comparisons)]
-#![allow(clippy::cast_possible_wrap)]
-#![allow(clippy::cast_sign_loss)]
 #![allow(clippy::default_trait_access)] // triggers on generated prost code
 #![allow(clippy::float_cmp)]
 #![allow(clippy::match_wildcard_for_single_variants)]

--- a/lib/vector-core/src/metrics/ddsketch.rs
+++ b/lib/vector-core/src/metrics/ddsketch.rs
@@ -580,9 +580,12 @@ impl AgentDDSketch {
                 remainder += fkn - fkn.trunc();
             }
 
-            // SAFETY: This integer cast is intentional: we want to get the non-fractional part, as
-            // we've captured the fractional part in the above conditional.
-            #[allow(clippy::cast_possible_truncation)]
+            // SAFETY: 
+            // [TRUNCATION] This integer cast is intentional: we want to get the non-fractional part, as
+            // we've captured the fractional part in the above conditional. 
+            // [SIGN LOSS] fkn is always non-negative because it is computed from sketch bounds and a count, 
+            // which are both non-negative
+            #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
             let mut kn = fkn as u32;
             if remainder > 1.0 {
                 kn += 1;

--- a/lib/vector-core/src/metrics/ddsketch.rs
+++ b/lib/vector-core/src/metrics/ddsketch.rs
@@ -580,10 +580,10 @@ impl AgentDDSketch {
                 remainder += fkn - fkn.trunc();
             }
 
-            // SAFETY: 
+            // SAFETY:
             // [TRUNCATION] This integer cast is intentional: we want to get the non-fractional part, as
-            // we've captured the fractional part in the above conditional. 
-            // [SIGN LOSS] fkn is always non-negative because it is computed from sketch bounds and a count, 
+            // we've captured the fractional part in the above conditional.
+            // [SIGN LOSS] fkn is always non-negative because it is computed from sketch bounds and a count,
             // which are both non-negative
             #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
             let mut kn = fkn as u32;

--- a/lib/vector-core/src/metrics/storage.rs
+++ b/lib/vector-core/src/metrics/storage.rs
@@ -92,7 +92,7 @@ impl Histogram {
         let log = value.max(Self::MIN_BUCKET).log2().ceil();
         // Offset it based on the minimum bucket's exponent. The result will be non-negative thanks
         // to the `.max` above, so we can coerce it directly to `usize`.
-        #[allow(clippy::cast_possible_truncation)] // The log will always be smaller than `usize`.
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)] // The log will always be smaller than `usize`.
         let index = (log - Self::MIN_BUCKET_EXP) as usize;
         // Now bound the value for values larger than the largest bucket.
         index.min(Self::BUCKETS - 1)

--- a/lib/vector-core/src/metrics/storage.rs
+++ b/lib/vector-core/src/metrics/storage.rs
@@ -92,7 +92,8 @@ impl Histogram {
         let log = value.max(Self::MIN_BUCKET).log2().ceil();
         // Offset it based on the minimum bucket's exponent. The result will be non-negative thanks
         // to the `.max` above, so we can coerce it directly to `usize`.
-        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)] // The log will always be smaller than `usize`.
+        // The log will always be smaller than `usize`.
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
         let index = (log - Self::MIN_BUCKET_EXP) as usize;
         // Now bound the value for values larger than the largest bucket.
         index.min(Self::BUCKETS - 1)


### PR DESCRIPTION
## Summary
Removes two blanket #![allow(...)] attributes from lib/vector-core/src/lib.rs:
- clippy::cast_possible_wrap
- clippy::cast_sign_loss

These two statements were suppressing lints across the entire vector-core crate. The contents of this PR replace them with specific suppressions at 6 locations (comments with justification/explanations were also modified or added at each location).

## Vector configuration
N/A (no behavior changes).

## How did you test this PR?
- make check-clippy passes
- make check-fmt passes
- cargo vdev test:  3002/3005 tests pass, 3 failures seemed to be preexisting environment related issues unrelated to this change 

## Change Type
- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?
- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References
Related: #23659 

## Notes
- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details on the [dd-rust-license-tool](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert, perf
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional but appreciated; letters, digits, spaces, hyphens, underscores (e.g. `kafka source`, `amazon-linux`)
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
