### PR TITLE
fix(tests): guarantee measurable CPU usage in component CPU metric regression tests

### DIFF
--- a/src/test_util/mock/transforms/noop.rs
+++ b/src/test_util/mock/transforms/noop.rs
@@ -26,6 +26,17 @@ pub struct NoopTransformConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     delay_ms: Option<u64>,
 
+    /// Optional per-event busy-spin duration, in milliseconds.
+    ///
+    /// Unlike `delay_ms` (which sleeps, consuming no CPU), this actively burns
+    /// CPU cycles on the calling thread. Intended for tests that need
+    /// deterministic, non-zero component CPU usage: OS-level CPU-time clocks
+    /// (e.g. Windows' `GetThreadTimes`) only update at clock-tick granularity,
+    /// so a passthrough transform's negligible real work can otherwise round
+    /// down to exactly zero.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    cpu_burn_ms: Option<u64>,
+
     /// When `true`, the transform reports `enable_concurrency() == true`, causing
     /// the topology builder to run it on the concurrent (multi-task) code path.
     ///
@@ -39,6 +50,7 @@ impl GenerateConfig for NoopTransformConfig {
         toml::Value::try_from(&Self {
             transform_type: TransformType::Function,
             delay_ms: None,
+            cpu_burn_ms: None,
             enable_concurrency: false,
         })
         .unwrap()
@@ -48,6 +60,11 @@ impl GenerateConfig for NoopTransformConfig {
 impl NoopTransformConfig {
     pub fn with_delay_ms(mut self, delay_ms: u64) -> Self {
         self.delay_ms = Some(delay_ms);
+        self
+    }
+
+    pub fn with_cpu_burn_ms(mut self, cpu_burn_ms: u64) -> Self {
+        self.cpu_burn_ms = Some(cpu_burn_ms);
         self
     }
 
@@ -80,12 +97,17 @@ impl TransformConfig for NoopTransformConfig {
 
     async fn build(&self, _: &TransformContext) -> crate::Result<Transform> {
         let delay = self.delay_ms.map(Duration::from_millis);
+        let cpu_burn = self.cpu_burn_ms.map(Duration::from_millis);
         match self.transform_type {
-            TransformType::Function => Ok(Transform::Function(Box::new(NoopTransform { delay }))),
-            TransformType::Synchronous => {
-                Ok(Transform::Synchronous(Box::new(NoopTransform { delay })))
-            }
-            TransformType::Task => Ok(Transform::Task(Box::new(NoopTransform { delay }))),
+            TransformType::Function => Ok(Transform::Function(Box::new(NoopTransform {
+                delay,
+                cpu_burn,
+            }))),
+            TransformType::Synchronous => Ok(Transform::Synchronous(Box::new(NoopTransform {
+                delay,
+                cpu_burn,
+            }))),
+            TransformType::Task => Ok(Transform::Task(Box::new(NoopTransform { delay, cpu_burn }))),
         }
     }
 
@@ -99,6 +121,7 @@ impl From<TransformType> for NoopTransformConfig {
         Self {
             transform_type,
             delay_ms: None,
+            cpu_burn_ms: None,
             enable_concurrency: false,
         }
     }
@@ -107,12 +130,27 @@ impl From<TransformType> for NoopTransformConfig {
 #[derive(Clone)]
 struct NoopTransform {
     delay: Option<Duration>,
+    cpu_burn: Option<Duration>,
+}
+
+/// Actively burns CPU on the calling thread for `duration`, unlike `sleep`
+/// which yields the thread without consuming CPU time.
+fn busy_spin(duration: Duration) {
+    let start = std::time::Instant::now();
+    let mut acc: u64 = 0;
+    while start.elapsed() < duration {
+        acc = std::hint::black_box(acc.wrapping_add(1));
+    }
+    std::hint::black_box(acc);
 }
 
 impl FunctionTransform for NoopTransform {
     fn transform(&mut self, output: &mut OutputBuffer, event: Event) {
         if let Some(delay) = self.delay {
             std::thread::sleep(delay);
+        }
+        if let Some(cpu_burn) = self.cpu_burn {
+            busy_spin(cpu_burn);
         }
         output.push(event);
     }
@@ -126,9 +164,16 @@ where
         self: Box<Self>,
         task: Pin<Box<dyn futures_util::Stream<Item = T> + Send>>,
     ) -> Pin<Box<dyn Stream<Item = T> + Send>> {
-        if let Some(delay) = self.delay {
+        let delay = self.delay;
+        let cpu_burn = self.cpu_burn;
+        if delay.is_some() || cpu_burn.is_some() {
             Box::pin(task.then(move |item| async move {
-                tokio::time::sleep(delay).await;
+                if let Some(cpu_burn) = cpu_burn {
+                    busy_spin(cpu_burn);
+                }
+                if let Some(delay) = delay {
+                    tokio::time::sleep(delay).await;
+                }
                 item
             }))
         } else {

--- a/src/topology/test/cpu_metrics.rs
+++ b/src/topology/test/cpu_metrics.rs
@@ -21,6 +21,16 @@ const EVENT_COUNT: usize = 100;
 const TRANSFORM_TYPE: &str = "test_noop";
 const TRANSFORM_KIND: &str = "transform";
 
+/// Per-event busy-spin duration used by the CPU-usage tests below.
+///
+/// OS-level thread CPU-time clocks (e.g. Windows' `GetThreadTimes`) only
+/// update at clock-tick granularity (commonly ~15ms). A bare passthrough
+/// transform does negligible real work, so its true CPU usage can round down
+/// to exactly zero over the whole test. Burning 1ms of real CPU per event,
+/// across `EVENT_COUNT` events, guarantees the cumulative usage comfortably
+/// exceeds that granularity on every supported platform.
+const CPU_BURN_MS: u64 = 1;
+
 fn has_transform_tags(metric: &Metric, transform_id: &str) -> bool {
     metric.tags().is_some_and(|tags| {
         tags.get("component_id") == Some(transform_id)
@@ -132,7 +142,7 @@ async fn run_cpu_topology(
 #[tokio::test]
 async fn component_cpu_usage_emitted_function_transform() {
     let id = "cpu_transform_fn";
-    let metrics = run_cpu_topology(id, true, |c| c).await;
+    let metrics = run_cpu_topology(id, true, |c| c.with_cpu_burn_ms(CPU_BURN_MS)).await;
     assert_cpu_counter_positive(&metrics, id);
 }
 
@@ -142,8 +152,10 @@ async fn component_cpu_usage_emitted_function_transform() {
 #[tokio::test]
 async fn component_cpu_usage_emitted_task_transform() {
     let id = "cpu_transform_task";
-    let metrics =
-        run_cpu_topology(id, true, |_| NoopTransformConfig::from(TransformType::Task)).await;
+    let metrics = run_cpu_topology(id, true, |_| {
+        NoopTransformConfig::from(TransformType::Task).with_cpu_burn_ms(CPU_BURN_MS)
+    })
+    .await;
     assert_cpu_counter_positive(&metrics, id);
 }
 
@@ -153,7 +165,10 @@ async fn component_cpu_usage_emitted_task_transform() {
 #[tokio::test]
 async fn component_cpu_usage_emitted_concurrent_transform() {
     let id = "cpu_transform_concurrent";
-    let metrics = run_cpu_topology(id, true, |c| c.with_concurrency()).await;
+    let metrics = run_cpu_topology(id, true, |c| {
+        c.with_concurrency().with_cpu_burn_ms(CPU_BURN_MS)
+    })
+    .await;
     assert_cpu_counter_positive(&metrics, id);
 }
 


### PR DESCRIPTION
## Summary
The `component_cpu_usage_emitted_function_transform` and `..._task_transform` regression tests (added in #25672) were failing consistently on Windows CI (https://github.com/vectordotdev/vector/actions/runs/28814782944/job/85451367379).

Root cause: `GetThreadTimes` on Windows only updates at OS clock-tick granularity (commonly ~15ms). The `test_noop` mock transform used by these tests does negligible real work (100 trivial passthrough events), so its true CPU usage never crossed a tick boundary and the counter stayed at exactly 0.

Fix: added a `cpu_burn_ms` option to the test-only `NoopTransformConfig` that actively busy-spins (unlike the existing `delay_ms`, which sleeps and burns no CPU), and wired the affected CPU-usage tests to use it. This guarantees measurable CPU usage on every platform regardless of clock-tick resolution.

## Vector configuration
NA

## How did you test this PR?
Ran `cargo test --lib topology::test::cpu_metrics` locally; all 4 tests pass. Also ran `cargo clippy` and `cargo fmt --check` on the changed files.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: https://dd.slack.com/archives/C06LZ45V63V/p1783342553149029