### PR TITLE
chore(vrl playground): UX overhaul

### DIFF
--- a/changelog.d/vrl_playground_ux.enhancement.md
+++ b/changelog.d/vrl_playground_ux.enhancement.md
@@ -1,3 +1,10 @@
-Improve the VRL playground UX: resizable panels, dark/light/system theme toggle, run history with clear button, Shift+Enter to run, share URL copies to clipboard, and various visual polish.
+Improved the VRL playground UX:
+
+  - Added resizable panels via draggable gutters.
+  - Added a dark/light/system theme toggle that syncs with the OS preference.
+  - Added run history persisted in localStorage, with a clear button.
+  - Added a Shift+Enter shortcut to run the program.
+  - The Share button now copies the shareable URL to the clipboard.
+  - Various visual polish (unified header, purple accents, tightened spacing).
 
 authors: pront

--- a/changelog.d/vrl_playground_ux.enhancement.md
+++ b/changelog.d/vrl_playground_ux.enhancement.md
@@ -1,0 +1,3 @@
+Improve the VRL playground UX: resizable panels, dark/light/system theme toggle, run history with clear button, Shift+Enter to run, share URL copies to clipboard, and various visual polish.
+
+authors: pront

--- a/changelog.d/vrl_playground_ux.enhancement.md
+++ b/changelog.d/vrl_playground_ux.enhancement.md
@@ -1,10 +1,10 @@
 Improved the VRL playground UX:
 
-  - Added resizable panels via draggable gutters.
-  - Added a dark/light/system theme toggle that syncs with the OS preference.
-  - Added run history persisted in localStorage, with a clear button.
-  - Added a Shift+Enter shortcut to run the program.
-  - The Share button now copies the shareable URL to the clipboard.
-  - Various visual polish (unified header, purple accents, tightened spacing).
+- Added resizable panels via draggable gutters.
+- Added a dark/light/system theme toggle that syncs with the OS preference.
+- Added run history persisted in localStorage, with a clear button.
+- Added a Shift+Enter shortcut to run the program.
+- The Share button now copies the shareable URL to the clipboard.
+- Various visual polish (unified header, purple accents, tightened spacing).
 
 authors: pront

--- a/lib/vector-vrl/web-playground/public/index.css
+++ b/lib/vector-vrl/web-playground/public/index.css
@@ -43,7 +43,7 @@ body {
 }
 
 .top-bar-wrapper {
-  padding: 10px 15px;
+  padding: 15px 15px 4px;
 }
 
 .theme-section {
@@ -152,6 +152,7 @@ a:hover {
   display: flex;
   justify-content: space-between;
   align-items: baseline;
+  gap: 12px;
 }
 
 .version-info td {
@@ -175,14 +176,14 @@ div#App {
   flex-direction: column;
   width: calc(100% - 40px);
   max-width: 1600px;
-  height: calc(100vh - 240px);
-  gap: 1rem;
-  padding: 20px 20px;
+  height: calc(100vh - 210px);
+  gap: 0.5rem;
+  padding: 4px 20px 20px;
   margin: 0 auto;
 }
 
 div#toolbar-section {
-  padding: 10px 0;
+  padding: 0;
   display: flex;
   flex-wrap: wrap;
   gap: 1rem;

--- a/lib/vector-vrl/web-playground/public/index.css
+++ b/lib/vector-vrl/web-playground/public/index.css
@@ -457,6 +457,31 @@ div#output-section {
     width: 100%;
     margin-bottom: 8px;
   }
+
+  #toolbar-controls {
+    margin-left: 0;
+    width: 100%;
+    flex-wrap: wrap;
+  }
+
+  #toolbar-controls .toolbar-group {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  #toolbar-controls .toolbar-group + .toolbar-group {
+    margin-left: 0;
+    padding-left: 0;
+    border-left: none;
+    margin-top: 8px;
+  }
+
+  #toolbar-controls select,
+  #toolbar-controls input[type="text"] {
+    flex: 1 1 auto;
+    width: auto;
+    min-width: 0;
+  }
 }
 
 @media only screen and (max-width: 320px) {

--- a/lib/vector-vrl/web-playground/public/index.css
+++ b/lib/vector-vrl/web-playground/public/index.css
@@ -21,28 +21,30 @@ body {
 }
 
 .top-bar-wrapper {
-  border-bottom: 1px solid var(--datadog-purple-light);
-  padding: 10px 0;
+  padding: 10px 15px;
 }
 
 .headers-grid {
   display: grid;
   grid-template-columns: auto 1fr auto;
-  gap: 20px;
-  padding: 0 15px;
   max-width: 1600px;
   margin: 0 auto;
   align-items: stretch;
+  background-color: var(--datadog-purple-lightest);
+  border: 1px solid var(--datadog-purple-light);
+  border-radius: 12px;
+  overflow: hidden;
 }
 
 .headers-grid-item {
-  background-color: var(--datadog-purple-lightest);
-  padding: 16px;
-  border-radius: 12px;
-  border: 1px solid var(--datadog-purple-light);
+  padding: 16px 20px;
   display: flex;
   flex-direction: column;
   justify-content: center;
+}
+
+.headers-grid-item + .headers-grid-item {
+  border-left: 1px solid var(--datadog-purple-light);
 }
 
 .title-section {
@@ -148,7 +150,6 @@ div#toolbar-section {
 div#input-section,
 div#output-section {
   border: 1px solid var(--datadog-gray-lighter);
-  border-radius: 4px;
   overflow: hidden;
   height: 100%;
   min-height: 0;

--- a/lib/vector-vrl/web-playground/public/index.css
+++ b/lib/vector-vrl/web-playground/public/index.css
@@ -384,6 +384,18 @@ div#output-section {
     flex-direction: column;
   }
 
+  #main-split > #input-section,
+  #main-split > #output-section {
+    width: 100% !important;
+    flex-basis: auto !important;
+    height: auto !important;
+    min-height: 40vh;
+  }
+
+  #main-split > .gutter.gutter-horizontal {
+    display: none;
+  }
+
   #output-section #event-cell,
   #output-section #output-cell {
     min-height: 30vh;

--- a/lib/vector-vrl/web-playground/public/index.css
+++ b/lib/vector-vrl/web-playground/public/index.css
@@ -9,6 +9,27 @@
   --datadog-gray-lighter: #eaeaea;
   --datadog-background: #fafbfc;
   --light-grey: #f5f5f5;
+
+  --input-bg: #f8f9fa;
+  --input-border: #ccc;
+  --input-text: #212529;
+}
+
+[data-theme="dark"] {
+  --datadog-purple-lightest: #1e1a29;
+  --datadog-purple-light: #3a2f52;
+  --datadog-purple: #b092d9;
+  --datadog-purple-vibrant: #c9b3e8;
+  --datadog-purple-dark: #d5c2ee;
+  --datadog-gray: #e5e5ea;
+  --datadog-gray-light: #5a5a63;
+  --datadog-gray-lighter: #2a2a30;
+  --datadog-background: #14161a;
+  --light-grey: #1a1a1e;
+
+  --input-bg: #24222c;
+  --input-border: #3d3d44;
+  --input-text: #e5e5ea;
 }
 
 body {
@@ -18,15 +39,52 @@ body {
     Cantarell, "Helvetica Neue", sans-serif;
   background-color: var(--datadog-background);
   color: var(--datadog-gray);
+  transition: background-color 0.2s ease, color 0.2s ease;
 }
 
 .top-bar-wrapper {
   padding: 10px 15px;
 }
 
+.theme-section {
+  align-items: center;
+}
+
+#theme-toggle-btn {
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border: 1px solid var(--datadog-purple-light);
+  border-radius: 50%;
+  background-color: transparent;
+  color: var(--datadog-purple);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color 0.2s ease, border-color 0.2s ease;
+}
+
+#theme-toggle-btn:hover {
+  background-color: var(--datadog-purple-light);
+}
+
+#theme-toggle-btn svg {
+  width: 16px;
+  height: 16px;
+}
+
+a {
+  color: var(--datadog-purple);
+}
+
+a:hover {
+  color: var(--datadog-purple-dark);
+}
+
 .headers-grid {
   display: grid;
-  grid-template-columns: auto 1fr auto;
+  grid-template-columns: auto 1fr auto auto;
   max-width: 1600px;
   margin: 0 auto;
   align-items: stretch;
@@ -421,13 +479,13 @@ div#output-section {
   width: 180px;
   height: 36px;
   padding: 0 30px 0 10px;
-  border: 1px solid #ccc;
+  border: 1px solid var(--input-border);
   border-radius: 4px;
-  background-color: #f8f9fa;
+  background-color: var(--input-bg);
   font-size: 14px;
   font-family: "Open Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu,
     Cantarell, "Helvetica Neue", sans-serif;
-  color: #212529;
+  color: var(--input-text);
   box-sizing: border-box;
   cursor: pointer;
   appearance: none;
@@ -436,6 +494,11 @@ div#output-section {
   background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'><path d='M1 1l4 4 4-4' stroke='%23555' stroke-width='1.5' fill='none' stroke-linecap='round' stroke-linejoin='round'/></svg>");
   background-repeat: no-repeat;
   background-position: right 10px center;
+}
+
+[data-theme="dark"] #toolbar-controls select,
+[data-theme="dark"] #toolbar-controls input[type="text"] {
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'><path d='M1 1l4 4 4-4' stroke='%23aaa' stroke-width='1.5' fill='none' stroke-linecap='round' stroke-linejoin='round'/></svg>");
 }
 
 #toolbar-controls select:hover,
@@ -453,10 +516,10 @@ div#output-section {
   width: 36px;
   height: 36px;
   padding: 0;
-  border: 1px solid #ccc;
+  border: 1px solid var(--input-border);
   border-radius: 4px;
-  background-color: #f8f9fa;
-  color: #555;
+  background-color: var(--input-bg);
+  color: var(--input-text);
   cursor: pointer;
   box-sizing: border-box;
   display: inline-flex;

--- a/lib/vector-vrl/web-playground/public/index.css
+++ b/lib/vector-vrl/web-playground/public/index.css
@@ -374,49 +374,67 @@ div#output-section {
   }
 }
 
-#toolbar-section {
+#toolbar-controls {
+  margin-left: auto;
   display: flex;
   align-items: center;
   gap: 8px;
 }
 
-.timezone-container {
-  margin-left: auto;
-  display: flex;
-  align-items: center;
-}
-
-#timezone-label {
-  margin-right: 8px;
-  font-weight: bold;
-  font-family: "Open Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu,
-  Cantarell, "Helvetica Neue", sans-serif;
-  font-size: 14px;
-}
-
-#timezone-input {
-  padding: 0px 10px;
+#toolbar-controls select,
+#toolbar-controls input[type="text"] {
+  width: 180px;
+  height: 36px;
+  padding: 0 30px 0 10px;
   border: 1px solid #ccc;
   border-radius: 4px;
   background-color: #f8f9fa;
-  border-width: 1px;
-  border-style: solid;
   font-size: 14px;
   font-family: "Open Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu,
-  Cantarell, "Helvetica Neue", sans-serif;
-  line-height: 1.5;
+    Cantarell, "Helvetica Neue", sans-serif;
   color: #212529;
-  height: 36px;
   box-sizing: border-box;
   cursor: pointer;
-  min-width: 200px;
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'><path d='M1 1l4 4 4-4' stroke='%23555' stroke-width='1.5' fill='none' stroke-linecap='round' stroke-linejoin='round'/></svg>");
+  background-repeat: no-repeat;
+  background-position: right 10px center;
 }
 
-#timezone-input:hover {
+#toolbar-controls select:hover,
+#toolbar-controls input[type="text"]:hover {
   border-color: var(--datadog-gray-light);
 }
 
-#timezone-input:focus {
+#toolbar-controls select:focus,
+#toolbar-controls input[type="text"]:focus {
+  outline: 2px solid var(--datadog-purple-light);
+  border-color: var(--datadog-purple);
+}
+
+#clear-history-btn {
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  background-color: #f8f9fa;
+  color: #555;
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+  box-sizing: border-box;
+}
+
+#clear-history-btn:hover {
+  background-color: var(--datadog-gray-lighter);
+  border-color: var(--datadog-gray-light);
+  color: var(--datadog-gray);
+}
+
+#clear-history-btn:focus {
   outline: 2px solid var(--datadog-purple-light);
   border-color: var(--datadog-purple);
 }

--- a/lib/vector-vrl/web-playground/public/index.css
+++ b/lib/vector-vrl/web-playground/public/index.css
@@ -216,12 +216,19 @@ div#output-section {
   flex-direction: column;
 }
 
-#input-section #cell,
+#input-section #cell {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 0;
+  min-height: 0;
+  overflow: hidden;
+}
+
+/* Split.js writes inline flex-basis for vertical sizing — don't collapse to 0 */
 #output-section #event-cell,
 #output-section #output-cell {
   display: flex;
   flex-direction: column;
-  flex: 1 1 0;
   min-height: 0;
   overflow: hidden;
 }

--- a/lib/vector-vrl/web-playground/public/index.css
+++ b/lib/vector-vrl/web-playground/public/index.css
@@ -204,7 +204,10 @@ div#output-section {
 
 /* BUTTONS */
 .btn {
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
   outline: 0;
   border: none;
   cursor: pointer;
@@ -214,6 +217,12 @@ div#output-section {
   padding: 0 16px;
   font-weight: 500;
   transition: all 0.2s ease;
+}
+
+.btn-icon {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
 }
 
 .btn:active {
@@ -448,10 +457,16 @@ div#output-section {
   border-radius: 4px;
   background-color: #f8f9fa;
   color: #555;
-  font-size: 18px;
-  line-height: 1;
   cursor: pointer;
   box-sizing: border-box;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+#clear-history-btn svg {
+  width: 16px;
+  height: 16px;
 }
 
 #clear-history-btn:hover {

--- a/lib/vector-vrl/web-playground/public/index.css
+++ b/lib/vector-vrl/web-playground/public/index.css
@@ -378,7 +378,18 @@ div#output-section {
   margin-left: auto;
   display: flex;
   align-items: center;
+}
+
+.toolbar-group {
+  display: flex;
+  align-items: center;
   gap: 8px;
+}
+
+#toolbar-controls .toolbar-group + .toolbar-group {
+  margin-left: 16px;
+  padding-left: 16px;
+  border-left: 1px solid var(--datadog-purple-light);
 }
 
 #toolbar-controls select,

--- a/lib/vector-vrl/web-playground/public/index.css
+++ b/lib/vector-vrl/web-playground/public/index.css
@@ -195,11 +195,11 @@ div#output-section {
 .cell-title {
   font-weight: 600;
   font-size: 14px;
-  color: var(--datadog-gray);
+  color: var(--datadog-purple);
   margin: 0;
   padding: 8px 12px;
-  background-color: var(--datadog-gray-lighter);
-  border-bottom: 1px solid var(--datadog-gray-light);
+  background-color: var(--datadog-purple-lightest);
+  border-bottom: 1px solid var(--datadog-purple-light);
 }
 
 /* BUTTONS */

--- a/lib/vector-vrl/web-playground/public/index.css
+++ b/lib/vector-vrl/web-playground/public/index.css
@@ -111,13 +111,12 @@ body {
 }
 
 div#App {
-  display: grid;
+  display: flex;
+  flex-direction: column;
   width: calc(100% - 40px);
   max-width: 1600px;
   height: calc(100vh - 240px);
-  grid-template-columns: minmax(45%, 1fr) minmax(0, 1fr);
-  grid-template-rows: auto 1fr;
-  grid-gap: 1rem;
+  gap: 1rem;
   padding: 20px 20px;
   margin: 0 auto;
 }
@@ -126,10 +125,9 @@ div#toolbar-section {
   padding: 10px 0;
   display: flex;
   flex-wrap: wrap;
-  grid-row: 1;
-  grid-column: 1 / -1;
   gap: 1rem;
   align-items: center;
+  flex: 0 0 auto;
 }
 
 #toolbar-section #run-code-btn,
@@ -139,31 +137,58 @@ div#toolbar-section {
   min-width: 120px;
 }
 
+#main-split {
+  display: flex;
+  flex-direction: row;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: hidden;
+}
+
 div#input-section,
 div#output-section {
   border: 1px solid var(--datadog-gray-lighter);
   border-radius: 4px;
-}
-
-div#input-section {
-  display: grid;
-  grid-column: 1;
-  grid-row: 2;
-}
-
-div#output-section {
-  display: grid;
-  grid-column: 2;
-  grid-row: 2;
-  grid-template-rows: 1fr 1fr;
-  gap: 1rem;
+  overflow: hidden;
+  height: 100%;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
 }
 
 #input-section #cell,
 #output-section #event-cell,
 #output-section #output-cell {
-  display: grid;
-  grid-template-rows: auto 1fr;
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 0;
+  min-height: 0;
+  overflow: hidden;
+}
+
+#container-program,
+#container-event,
+#container-output {
+  flex: 1 1 0;
+  min-height: 0;
+  width: 100%;
+}
+
+.gutter {
+  background-color: var(--datadog-purple-light);
+  transition: background-color 0.2s ease;
+}
+
+.gutter:hover {
+  background-color: var(--datadog-purple);
+}
+
+.gutter.gutter-horizontal {
+  cursor: col-resize;
+}
+
+.gutter.gutter-vertical {
+  cursor: row-resize;
 }
 
 .cell-title {
@@ -282,28 +307,17 @@ div#output-section {
   }
 
   div#App {
-    grid-template-columns: 1fr;
     height: auto;
     min-height: calc(100vh - 180px);
   }
 
-  div#input-section {
-    grid-column: 1;
-    grid-row: 2;
-    height: 40vh;
-  }
-
-  div#output-section {
-    grid-column: 1;
-    grid-row: 3;
-    grid-template-rows: auto auto;
-    grid-template-columns: 1fr;
-    height: auto;
+  #main-split {
+    flex-direction: column;
   }
 
   #output-section #event-cell,
   #output-section #output-cell {
-    height: 30vh;
+    min-height: 30vh;
   }
 }
 

--- a/lib/vector-vrl/web-playground/public/index.html
+++ b/lib/vector-vrl/web-playground/public/index.html
@@ -52,14 +52,14 @@
       <div id="toolbar-section">
         <button id="run-code-btn" class="btn btn-primary" onClick="vrlPlayground.handleRunCode()" title="Run program (Shift+Enter)">Run program</button>
         <button id="share-code-btn" class="btn btn-secondary" onClick="vrlPlayground.handleShareCode()">Share program</button>
-        <div class="timezone-container">
-          <label for="timezone-input" id="timezone-label">Select Timezone</label>
+        <div id="toolbar-controls">
           <input
             type="text"
             id="timezone-input"
             name="timezone"
             list="timezone-list"
-            placeholder="Default"
+            placeholder="Timezone"
+            title="Select Timezone"
           >
           <datalist id="timezone-list">
             <option value="Default"></option>
@@ -74,6 +74,10 @@
             <option value="Asia/Dubai"></option>
             <option value="Australia/Sydney"></option>
           </datalist>
+          <select id="history-select" title="Run history (stored locally in your browser)">
+            <option value="" disabled selected>History</option>
+          </select>
+          <button id="clear-history-btn" type="button" title="Clear run history" onClick="vrlPlayground.handleClearHistory()">&times;</button>
         </div>
         </div>
       <div id="input-section">

--- a/lib/vector-vrl/web-playground/public/index.html
+++ b/lib/vector-vrl/web-playground/public/index.html
@@ -86,35 +86,38 @@
           </div>
         </div>
         </div>
-      <div id="input-section">
-        <div id="cell">
-          <div id="input-cell-title">
-            <p class="cell-title">Program</p>
+      <div id="main-split">
+        <div id="input-section">
+          <div id="cell">
+            <div id="input-cell-title">
+              <p class="cell-title">Program</p>
+            </div>
+            <div id="container-program"></div>
           </div>
-          <div id="container-program"></div>
-        </div>
-      </div>
-
-      <div id="output-section">
-        <div id="event-cell">
-          <div id="event-cell-title">
-              <p class="cell-title">Input</p>
-          </div>
-          <div id="container-event"></div>
         </div>
 
-        <div id="output-cell">
-          <div id="output-cell-title">
-            <p class="cell-title">
-              <span>Output</span>
-              <code id="elapsed-time"></code>
-            </p>
+        <div id="output-section">
+          <div id="event-cell">
+            <div id="event-cell-title">
+                <p class="cell-title">Input</p>
+            </div>
+            <div id="container-event"></div>
           </div>
-          <div id="container-output"></div>
+
+          <div id="output-cell">
+            <div id="output-cell-title">
+              <p class="cell-title">
+                <span>Output</span>
+                <code id="elapsed-time"></code>
+              </p>
+            </div>
+            <div id="container-output"></div>
+          </div>
         </div>
       </div>
     </div>
 
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/split.js/1.6.5/split.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.26.1/min/vs/loader.min.js"></script>
 
     <script src="index.js" type="module"></script>

--- a/lib/vector-vrl/web-playground/public/index.html
+++ b/lib/vector-vrl/web-playground/public/index.html
@@ -46,6 +46,9 @@
             </tr>
           </table>
         </div>
+        <div class="headers-grid-item theme-section">
+          <button id="theme-toggle-btn" type="button" title="Theme" aria-label="Toggle theme"></button>
+        </div>
       </div>
     </div>
     <div id="App">

--- a/lib/vector-vrl/web-playground/public/index.html
+++ b/lib/vector-vrl/web-playground/public/index.html
@@ -128,7 +128,7 @@
       </div>
     </div>
 
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/split.js/1.6.5/split.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/split.js/1.6.5/split.min.js" integrity="sha384-q2ksSc8z6Q4ZUnxlfZj9AXZLpSdWmD3q/YrId1twTeNHh56fNh98YbJSpppzGUvL" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.26.1/min/vs/loader.min.js"></script>
 
     <script src="index.js" type="module"></script>

--- a/lib/vector-vrl/web-playground/public/index.html
+++ b/lib/vector-vrl/web-playground/public/index.html
@@ -50,7 +50,7 @@
     </div>
     <div id="App">
       <div id="toolbar-section">
-        <button id="run-code-btn" class="btn btn-primary" onClick="vrlPlayground.handleRunCode()">Run program</button>
+        <button id="run-code-btn" class="btn btn-primary" onClick="vrlPlayground.handleRunCode()" title="Run program (Shift+Enter)">Run program</button>
         <button id="share-code-btn" class="btn btn-secondary" onClick="vrlPlayground.handleShareCode()">Share program</button>
         <div class="timezone-container">
           <label for="timezone-input" id="timezone-label">Select Timezone</label>

--- a/lib/vector-vrl/web-playground/public/index.html
+++ b/lib/vector-vrl/web-playground/public/index.html
@@ -51,8 +51,14 @@
     <div id="App">
       <div id="toolbar-section">
         <div class="toolbar-group">
-          <button id="run-code-btn" class="btn btn-primary" onClick="vrlPlayground.handleRunCode()" title="Run program (Shift+Enter)">Run program</button>
-          <button id="share-code-btn" class="btn btn-secondary" onClick="vrlPlayground.handleShareCode()">Share program</button>
+          <button id="run-code-btn" class="btn btn-primary" onClick="vrlPlayground.handleRunCode()" title="Run program (Shift+Enter)">
+            <svg class="btn-icon" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path d="M6.3 4.3a1 1 0 011.55-.832l8 5.7a1 1 0 010 1.664l-8 5.7A1 1 0 016.3 15.7V4.3z"/></svg>
+            <span>Run program</span>
+          </button>
+          <button id="share-code-btn" class="btn btn-secondary" onClick="vrlPlayground.handleShareCode()">
+            <svg class="btn-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M13.19 8.688a4.5 4.5 0 0 1 1.242 7.244l-4.5 4.5a4.5 4.5 0 0 1-6.364-6.364l1.757-1.757m13.35-.622 1.757-1.757a4.5 4.5 0 0 0-6.364-6.364l-4.5 4.5a4.5 4.5 0 0 0 1.242 7.244"/></svg>
+            <span>Share program</span>
+          </button>
         </div>
         <div id="toolbar-controls">
           <div class="toolbar-group">
@@ -82,7 +88,9 @@
             <select id="history-select" title="Run history (stored locally in your browser)">
               <option value="" disabled selected>History</option>
             </select>
-            <button id="clear-history-btn" type="button" title="Clear run history" onClick="vrlPlayground.handleClearHistory()">&times;</button>
+            <button id="clear-history-btn" type="button" title="Clear run history" onClick="vrlPlayground.handleClearHistory()" aria-label="Clear run history">
+              <svg viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M14.7 6l-.5 9.4a2 2 0 01-2 1.9H7.8a2 2 0 01-2-1.9L5.3 6m10.7 0h-2.7m-6 0H5.3m2.7 0V4.5A1.5 1.5 0 019.5 3h1a1.5 1.5 0 011.5 1.5V6m-4 0h4"/></svg>
+            </button>
           </div>
         </div>
         </div>

--- a/lib/vector-vrl/web-playground/public/index.html
+++ b/lib/vector-vrl/web-playground/public/index.html
@@ -50,34 +50,40 @@
     </div>
     <div id="App">
       <div id="toolbar-section">
-        <button id="run-code-btn" class="btn btn-primary" onClick="vrlPlayground.handleRunCode()" title="Run program (Shift+Enter)">Run program</button>
-        <button id="share-code-btn" class="btn btn-secondary" onClick="vrlPlayground.handleShareCode()">Share program</button>
+        <div class="toolbar-group">
+          <button id="run-code-btn" class="btn btn-primary" onClick="vrlPlayground.handleRunCode()" title="Run program (Shift+Enter)">Run program</button>
+          <button id="share-code-btn" class="btn btn-secondary" onClick="vrlPlayground.handleShareCode()">Share program</button>
+        </div>
         <div id="toolbar-controls">
-          <input
-            type="text"
-            id="timezone-input"
-            name="timezone"
-            list="timezone-list"
-            placeholder="Timezone"
-            title="Select Timezone"
-          >
-          <datalist id="timezone-list">
-            <option value="Default"></option>
-            <option value="Etc/UTC"></option>
-            <option value="America/New_York"></option>
-            <option value="America/Chicago"></option>
-            <option value="America/Denver"></option>
-            <option value="America/Los_Angeles"></option>
-            <option value="Europe/London"></option>
-            <option value="Europe/Paris"></option>
-            <option value="Asia/Tokyo"></option>
-            <option value="Asia/Dubai"></option>
-            <option value="Australia/Sydney"></option>
-          </datalist>
-          <select id="history-select" title="Run history (stored locally in your browser)">
-            <option value="" disabled selected>History</option>
-          </select>
-          <button id="clear-history-btn" type="button" title="Clear run history" onClick="vrlPlayground.handleClearHistory()">&times;</button>
+          <div class="toolbar-group">
+            <input
+              type="text"
+              id="timezone-input"
+              name="timezone"
+              list="timezone-list"
+              placeholder="Timezone"
+              title="Select Timezone"
+            >
+            <datalist id="timezone-list">
+              <option value="Default"></option>
+              <option value="Etc/UTC"></option>
+              <option value="America/New_York"></option>
+              <option value="America/Chicago"></option>
+              <option value="America/Denver"></option>
+              <option value="America/Los_Angeles"></option>
+              <option value="Europe/London"></option>
+              <option value="Europe/Paris"></option>
+              <option value="Asia/Tokyo"></option>
+              <option value="Asia/Dubai"></option>
+              <option value="Australia/Sydney"></option>
+            </datalist>
+          </div>
+          <div class="toolbar-group">
+            <select id="history-select" title="Run history (stored locally in your browser)">
+              <option value="" disabled selected>History</option>
+            </select>
+            <button id="clear-history-btn" type="button" title="Clear run history" onClick="vrlPlayground.handleClearHistory()">&times;</button>
+          </div>
         </div>
         </div>
       <div id="input-section">

--- a/lib/vector-vrl/web-playground/public/index.js
+++ b/lib/vector-vrl/web-playground/public/index.js
@@ -97,6 +97,14 @@ export class VrlWebPlayground {
     // Versions
     this.addVersions();
 
+    // Keyboard shortcut: Shift+Enter runs the program
+    window.addEventListener("keydown", (e) => {
+      if (e.shiftKey && e.key === "Enter") {
+        e.preventDefault();
+        this.handleRunCode();
+      }
+    });
+
     // Handle shared state from URL (if present)
     this._maybeLoadFromUrl();
   }

--- a/lib/vector-vrl/web-playground/public/index.js
+++ b/lib/vector-vrl/web-playground/public/index.js
@@ -569,6 +569,8 @@ export class VrlWebPlayground {
           .writeText(shareUrl)
           .then(() => this._flashShareButton("Copied!"))
           .catch(() => this._flashShareButton("Copy failed"));
+      } else {
+        this._flashShareButton("Copy unavailable");
       }
       return true;
     } catch (e) {

--- a/lib/vector-vrl/web-playground/public/index.js
+++ b/lib/vector-vrl/web-playground/public/index.js
@@ -28,6 +28,7 @@ const OUTPUT_EDITOR_DEFAULT_VALUE = `{}`;
 
 const HISTORY_STORAGE_KEY = "vrl_playground_history";
 const HISTORY_MAX_ENTRIES = 50;
+const THEME_STORAGE_KEY = "vrl_playground_theme";
 
 const ERROR_INVALID_JSONL_EVENT_MSG = `Error attempting to parse the following string into valid JSON
 
@@ -85,6 +86,17 @@ export class VrlWebPlayground {
     // VRL lang + theme
     this.monaco.languages.register({ id: "vrl" });
     this.monaco.editor.defineTheme("vrl-theme", vrlThemeDefinition);
+    this.monaco.editor.defineTheme("vrl-theme-dark", {
+      ...vrlThemeDefinition,
+      base: "vs-dark",
+      colors: {
+        ...vrlThemeDefinition.colors,
+        "editor.background": "#0d1117",
+        "editor.foreground": "#c9d1d9",
+        "editor.lineHighlightBackground": "#161b22",
+        "editorCursor.foreground": "#c9d1d9",
+      },
+    });
     this.monaco.languages.setMonarchTokensProvider("vrl", vrlLanguageDefinition);
 
     // Editors
@@ -99,6 +111,9 @@ export class VrlWebPlayground {
 
     // Resizable panels
     this._initSplitPanels();
+
+    // Theme
+    this._initTheme();
 
     // Versions
     this.addVersions();
@@ -155,6 +170,54 @@ export class VrlWebPlayground {
       this.disableJsonLinting();
       this.outputEditor.setValue(`Error reading the shared URL\n${e}`);
     }
+  }
+
+  _initTheme() {
+    const stored = localStorage.getItem(THEME_STORAGE_KEY);
+    this._themePreference = stored === "light" || stored === "dark" ? stored : "system";
+
+    const btn = document.getElementById("theme-toggle-btn");
+    if (btn) {
+      btn.addEventListener("click", () => {
+        const cycle = { system: "light", light: "dark", dark: "system" };
+        this._themePreference = cycle[this._themePreference] || "system";
+        if (this._themePreference === "system") localStorage.removeItem(THEME_STORAGE_KEY);
+        else localStorage.setItem(THEME_STORAGE_KEY, this._themePreference);
+        this._applyTheme();
+      });
+    }
+
+    // Follow system changes when in "system" mode
+    const mql = window.matchMedia("(prefers-color-scheme: dark)");
+    mql.addEventListener?.("change", () => {
+      if (this._themePreference === "system") this._applyTheme();
+    });
+
+    this._applyTheme();
+  }
+
+  _applyTheme() {
+    const preference = this._themePreference || "system";
+    const isDark = preference === "dark" ||
+      (preference === "system" && window.matchMedia("(prefers-color-scheme: dark)").matches);
+
+    document.documentElement.setAttribute("data-theme", isDark ? "dark" : "light");
+    // Monaco's theme is global — all editors switch together
+    this.monaco?.editor?.setTheme(isDark ? "vrl-theme-dark" : "vrl-theme");
+
+    this._renderThemeButton(preference);
+  }
+
+  _renderThemeButton(preference) {
+    const btn = document.getElementById("theme-toggle-btn");
+    if (!btn) return;
+    const icons = {
+      system: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M9 17.25v1.007a3 3 0 01-.879 2.122L7.5 21h9l-.621-.621A3 3 0 0115 18.257V17.25m6-12v11.25a2.25 2.25 0 01-2.25 2.25H5.25a2.25 2.25 0 01-2.25-2.25V5.25A2.25 2.25 0 015.25 3h13.5A2.25 2.25 0 0121 5.25z"/></svg>',
+      light: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M12 3v2.25m6.364.386l-1.591 1.591M21 12h-2.25m-.386 6.364l-1.591-1.591M12 18.75V21m-4.773-4.227l-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0z"/></svg>',
+      dark: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M21.752 15.002A9.72 9.72 0 0118 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 003 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 009.002-5.998z"/></svg>',
+    };
+    btn.innerHTML = icons[preference] || icons.system;
+    btn.title = `Theme: ${preference.charAt(0).toUpperCase()}${preference.slice(1)} (click to cycle)`;
   }
 
   _initSplitPanels() {

--- a/lib/vector-vrl/web-playground/public/index.js
+++ b/lib/vector-vrl/web-playground/public/index.js
@@ -97,6 +97,9 @@ export class VrlWebPlayground {
       "vrl-theme"
     );
 
+    // Resizable panels
+    this._initSplitPanels();
+
     // Versions
     this.addVersions();
 
@@ -152,6 +155,25 @@ export class VrlWebPlayground {
       this.disableJsonLinting();
       this.outputEditor.setValue(`Error reading the shared URL\n${e}`);
     }
+  }
+
+  _initSplitPanels() {
+    if (typeof window.Split !== "function") return;
+
+    window.Split(["#input-section", "#output-section"], {
+      sizes: [50, 50],
+      minSize: 200,
+      gutterSize: 6,
+      cursor: "col-resize",
+    });
+
+    window.Split(["#event-cell", "#output-cell"], {
+      direction: "vertical",
+      sizes: [50, 50],
+      minSize: 100,
+      gutterSize: 6,
+      cursor: "row-resize",
+    });
   }
 
   addVersions() {

--- a/lib/vector-vrl/web-playground/public/index.js
+++ b/lib/vector-vrl/web-playground/public/index.js
@@ -87,10 +87,12 @@ export class VrlWebPlayground {
     this.monaco.languages.register({ id: "vrl" });
     this.monaco.editor.defineTheme("vrl-theme", vrlThemeDefinition);
     this.monaco.editor.defineTheme("vrl-theme-dark", {
-      ...vrlThemeDefinition,
       base: "vs-dark",
+      inherit: true,
+      // Rely on vs-dark's default token colors — light-theme colors in vrlThemeDefinition
+      // are too dark for a dark background.
+      rules: [],
       colors: {
-        ...vrlThemeDefinition.colors,
         "editor.background": "#0d1117",
         "editor.foreground": "#c9d1d9",
         "editor.lineHighlightBackground": "#161b22",
@@ -563,7 +565,10 @@ export class VrlWebPlayground {
       window.history.pushState(state, "", `?state=${encoded}`);
       const shareUrl = `${window.location.origin}${window.location.pathname}?state=${encoded}`;
       if (navigator.clipboard?.writeText) {
-        navigator.clipboard.writeText(shareUrl).then(() => this._flashShareButton("Copied!"));
+        navigator.clipboard
+          .writeText(shareUrl)
+          .then(() => this._flashShareButton("Copied!"))
+          .catch(() => this._flashShareButton("Copy failed"));
       }
       return true;
     } catch (e) {

--- a/lib/vector-vrl/web-playground/public/index.js
+++ b/lib/vector-vrl/web-playground/public/index.js
@@ -173,7 +173,12 @@ export class VrlWebPlayground {
   }
 
   _initTheme() {
-    const stored = localStorage.getItem(THEME_STORAGE_KEY);
+    let stored = null;
+    try {
+      stored = localStorage.getItem(THEME_STORAGE_KEY);
+    } catch (_e) {
+      /* storage blocked (private mode, quotas) — fall back to system */
+    }
     this._themePreference = stored === "light" || stored === "dark" ? stored : "system";
 
     const btn = document.getElementById("theme-toggle-btn");
@@ -181,8 +186,12 @@ export class VrlWebPlayground {
       btn.addEventListener("click", () => {
         const cycle = { system: "light", light: "dark", dark: "system" };
         this._themePreference = cycle[this._themePreference] || "system";
-        if (this._themePreference === "system") localStorage.removeItem(THEME_STORAGE_KEY);
-        else localStorage.setItem(THEME_STORAGE_KEY, this._themePreference);
+        try {
+          if (this._themePreference === "system") localStorage.removeItem(THEME_STORAGE_KEY);
+          else localStorage.setItem(THEME_STORAGE_KEY, this._themePreference);
+        } catch (_e) {
+          /* ignore storage errors — in-memory preference still applies */
+        }
         this._applyTheme();
       });
     }
@@ -567,11 +576,13 @@ export class VrlWebPlayground {
   _flashShareButton(text) {
     const btn = document.getElementById("share-code-btn");
     if (!btn) return;
-    const original = btn.textContent;
-    btn.textContent = text;
+    const label = btn.querySelector("span");
+    if (!label) return;
+    const original = label.textContent;
+    label.textContent = text;
     btn.disabled = true;
     setTimeout(() => {
-      btn.textContent = original;
+      label.textContent = original;
       btn.disabled = false;
     }, 1200);
   }

--- a/lib/vector-vrl/web-playground/public/index.js
+++ b/lib/vector-vrl/web-playground/public/index.js
@@ -480,12 +480,28 @@ export class VrlWebPlayground {
     try {
       const encoded = encodeURIComponent(btoa(JSON.stringify(state)));
       window.history.pushState(state, "", `?state=${encoded}`);
+      const shareUrl = `${window.location.origin}${window.location.pathname}?state=${encoded}`;
+      if (navigator.clipboard?.writeText) {
+        navigator.clipboard.writeText(shareUrl).then(() => this._flashShareButton("Copied!"));
+      }
       return true;
     } catch (e) {
       this.disableJsonLinting();
       this.outputEditor.setValue(`Error encoding state for URL\n${e}`);
       return false;
     }
+  }
+
+  _flashShareButton(text) {
+    const btn = document.getElementById("share-code-btn");
+    if (!btn) return;
+    const original = btn.textContent;
+    btn.textContent = text;
+    btn.disabled = true;
+    setTimeout(() => {
+      btn.textContent = original;
+      btn.disabled = false;
+    }, 1200);
   }
 }
 

--- a/lib/vector-vrl/web-playground/public/index.js
+++ b/lib/vector-vrl/web-playground/public/index.js
@@ -94,8 +94,8 @@ export class VrlWebPlayground {
         "editor.background": "#0d1117",
         "editor.foreground": "#c9d1d9",
         "editor.lineHighlightBackground": "#161b22",
-        "editorCursor.foreground": "#c9d1d9",
-      },
+        "editorCursor.foreground": "#c9d1d9"
+      }
     });
     this.monaco.languages.setMonarchTokensProvider("vrl", vrlLanguageDefinition);
 
@@ -198,8 +198,8 @@ export class VrlWebPlayground {
 
   _applyTheme() {
     const preference = this._themePreference || "system";
-    const isDark = preference === "dark" ||
-      (preference === "system" && window.matchMedia("(prefers-color-scheme: dark)").matches);
+    const isDark =
+      preference === "dark" || (preference === "system" && window.matchMedia("(prefers-color-scheme: dark)").matches);
 
     document.documentElement.setAttribute("data-theme", isDark ? "dark" : "light");
     // Monaco's theme is global — all editors switch together
@@ -212,9 +212,11 @@ export class VrlWebPlayground {
     const btn = document.getElementById("theme-toggle-btn");
     if (!btn) return;
     const icons = {
-      system: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M9 17.25v1.007a3 3 0 01-.879 2.122L7.5 21h9l-.621-.621A3 3 0 0115 18.257V17.25m6-12v11.25a2.25 2.25 0 01-2.25 2.25H5.25a2.25 2.25 0 01-2.25-2.25V5.25A2.25 2.25 0 015.25 3h13.5A2.25 2.25 0 0121 5.25z"/></svg>',
-      light: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M12 3v2.25m6.364.386l-1.591 1.591M21 12h-2.25m-.386 6.364l-1.591-1.591M12 18.75V21m-4.773-4.227l-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0z"/></svg>',
-      dark: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M21.752 15.002A9.72 9.72 0 0118 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 003 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 009.002-5.998z"/></svg>',
+      system:
+        '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M9 17.25v1.007a3 3 0 01-.879 2.122L7.5 21h9l-.621-.621A3 3 0 0115 18.257V17.25m6-12v11.25a2.25 2.25 0 01-2.25 2.25H5.25a2.25 2.25 0 01-2.25-2.25V5.25A2.25 2.25 0 015.25 3h13.5A2.25 2.25 0 0121 5.25z"/></svg>',
+      light:
+        '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M12 3v2.25m6.364.386l-1.591 1.591M21 12h-2.25m-.386 6.364l-1.591-1.591M12 18.75V21m-4.773-4.227l-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0z"/></svg>',
+      dark: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M21.752 15.002A9.72 9.72 0 0118 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 003 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 009.002-5.998z"/></svg>'
     };
     btn.innerHTML = icons[preference] || icons.system;
     btn.title = `Theme: ${preference.charAt(0).toUpperCase()}${preference.slice(1)} (click to cycle)`;
@@ -227,7 +229,7 @@ export class VrlWebPlayground {
       sizes: [50, 50],
       minSize: 200,
       gutterSize: 6,
-      cursor: "col-resize",
+      cursor: "col-resize"
     });
 
     window.Split(["#event-cell", "#output-cell"], {
@@ -235,7 +237,7 @@ export class VrlWebPlayground {
       sizes: [50, 50],
       minSize: 100,
       gutterSize: 6,
-      cursor: "row-resize",
+      cursor: "row-resize"
     });
   }
 
@@ -270,8 +272,8 @@ export class VrlWebPlayground {
       scrollbar: {
         vertical: "auto",
         horizontal: "auto",
-        useShadows: false,
-      },
+        useShadows: false
+      }
     });
   }
 
@@ -380,7 +382,10 @@ export class VrlWebPlayground {
 
   _historyLabel(entry) {
     const program = typeof entry.program === "string" ? entry.program : "";
-    const firstLine = program.split("\n").map((l) => l.trim()).find((l) => l.length > 0 && !l.startsWith("#"));
+    const firstLine = program
+      .split("\n")
+      .map((l) => l.trim())
+      .find((l) => l.length > 0 && !l.startsWith("#"));
     const snippet = (firstLine || program.trim()).substring(0, 40);
     const when = typeof entry.timestamp === "number" ? new Date(entry.timestamp) : new Date();
     const ts = when.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit" });
@@ -406,7 +411,9 @@ export class VrlWebPlayground {
 
     try {
       localStorage.setItem(HISTORY_STORAGE_KEY, JSON.stringify(history));
-    } catch (_e) { /* ignore quota errors */ }
+    } catch (_e) {
+      /* ignore quota errors */
+    }
 
     this._populateHistoryDropdown();
   }
@@ -483,7 +490,7 @@ export class VrlWebPlayground {
       output: text,
       outputIsJson: isJson,
       elapsedTime: runResult?.elapsed_time,
-      timezone,
+      timezone
     });
     return runResult;
   }
@@ -524,7 +531,7 @@ export class VrlWebPlayground {
       output: outputText,
       outputIsJson: false,
       elapsedTime: total,
-      timezone,
+      timezone
     });
 
     return results;
@@ -534,7 +541,9 @@ export class VrlWebPlayground {
     if (!window.confirm("Clear all run history stored in this browser?")) return;
     try {
       localStorage.removeItem(HISTORY_STORAGE_KEY);
-    } catch (_e) { /* ignore */ }
+    } catch (_e) {
+      /* ignore */
+    }
     this._populateHistoryDropdown();
   }
 

--- a/lib/vector-vrl/web-playground/public/index.js
+++ b/lib/vector-vrl/web-playground/public/index.js
@@ -26,6 +26,9 @@ const EVENT_EDITOR_DEFAULT_VALUE = `{
 
 const OUTPUT_EDITOR_DEFAULT_VALUE = `{}`;
 
+const HISTORY_STORAGE_KEY = "vrl_playground_history";
+const HISTORY_MAX_ENTRIES = 50;
+
 const ERROR_INVALID_JSONL_EVENT_MSG = `Error attempting to parse the following string into valid JSON
 
 String: {{str}}
@@ -104,6 +107,18 @@ export class VrlWebPlayground {
         this.handleRunCode();
       }
     });
+
+    // Populate history dropdown from localStorage
+    this._populateHistoryDropdown();
+
+    const historySelect = document.getElementById("history-select");
+    if (historySelect) {
+      historySelect.addEventListener("change", (e) => {
+        const idx = parseInt(e.target.value, 10);
+        this._restoreFromHistory(idx);
+        e.target.value = "";
+      });
+    }
 
     // Handle shared state from URL (if present)
     this._maybeLoadFromUrl();
@@ -272,6 +287,75 @@ export class VrlWebPlayground {
     return tzEl?.value && tzEl.value.trim().length > 0 ? tzEl.value.trim() : "Default";
   }
 
+  _historyLabel(entry) {
+    const program = typeof entry.program === "string" ? entry.program : "";
+    const firstLine = program.split("\n").map((l) => l.trim()).find((l) => l.length > 0 && !l.startsWith("#"));
+    const snippet = (firstLine || program.trim()).substring(0, 40);
+    const when = typeof entry.timestamp === "number" ? new Date(entry.timestamp) : new Date();
+    const ts = when.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit" });
+    return `${ts} — ${snippet}`;
+  }
+
+  _readHistory() {
+    let raw;
+    try {
+      raw = JSON.parse(localStorage.getItem(HISTORY_STORAGE_KEY) || "[]");
+    } catch (_e) {
+      return [];
+    }
+    if (!Array.isArray(raw)) return [];
+    return raw.filter((e) => e && typeof e === "object" && typeof e.program === "string");
+  }
+
+  _saveToHistory(entry) {
+    const history = this._readHistory();
+
+    history.unshift({ ...entry, timestamp: Date.now() });
+    if (history.length > HISTORY_MAX_ENTRIES) history.length = HISTORY_MAX_ENTRIES;
+
+    try {
+      localStorage.setItem(HISTORY_STORAGE_KEY, JSON.stringify(history));
+    } catch (_e) { /* ignore quota errors */ }
+
+    this._populateHistoryDropdown();
+  }
+
+  _populateHistoryDropdown() {
+    const select = document.getElementById("history-select");
+    if (!select) return;
+
+    const history = this._readHistory();
+
+    // Remove all options except the placeholder
+    while (select.options.length > 1) select.remove(1);
+
+    history.forEach((entry, idx) => {
+      const opt = document.createElement("option");
+      opt.value = idx;
+      opt.textContent = this._historyLabel(entry);
+      select.appendChild(opt);
+    });
+  }
+
+  _restoreFromHistory(idx) {
+    const history = this._readHistory();
+    const entry = history[idx];
+    if (!entry) return;
+
+    this.programEditor?.setValue(entry.program);
+    this.eventEditor?.setValue(entry.event ?? "");
+
+    const tzEl = document.getElementById("timezone-input");
+    if (tzEl && typeof entry.timezone === "string") {
+      tzEl.value = entry.timezone === "Default" ? "" : entry.timezone;
+    }
+
+    if (entry.outputIsJson) this.enableJsonLinting();
+    else this.disableJsonLinting();
+    this.outputEditor?.setValue(entry.output ?? "");
+    this._setElapsed(entry.elapsedTime);
+  }
+
   handleRunCode(input) {
     this._clearOutput();
 
@@ -302,6 +386,14 @@ export class VrlWebPlayground {
     this.outputEditor.setValue(text);
 
     this._setElapsed(runResult?.elapsed_time);
+    this._saveToHistory({
+      program: this._safeGet(this.programEditor),
+      event: this._safeGet(this.eventEditor),
+      output: text,
+      outputIsJson: isJson,
+      elapsedTime: runResult?.elapsed_time,
+      timezone,
+    });
     return runResult;
   }
 
@@ -326,16 +418,33 @@ export class VrlWebPlayground {
     const results = inputs.map((input) => this.run_vrl(input, timezone));
 
     const outputs = results.map((r) => this._formatRunResult(r).text);
+    const outputText = outputs.join("\n");
 
     // Output is not pure JSON (multiple objects / possible errors)
     this.disableJsonLinting();
-    this.outputEditor.setValue(outputs.join("\n"));
+    this.outputEditor.setValue(outputText);
 
     // Aggregate elapsed time, rounded
     const total = results.reduce((sum, r) => sum + (typeof r?.elapsed_time === "number" ? r.elapsed_time : 0), 0);
     this._setElapsed(total);
+    this._saveToHistory({
+      program,
+      event: this._safeGet(this.eventEditor),
+      output: outputText,
+      outputIsJson: false,
+      elapsedTime: total,
+      timezone,
+    });
 
     return results;
+  }
+
+  handleClearHistory() {
+    if (!window.confirm("Clear all run history stored in this browser?")) return;
+    try {
+      localStorage.removeItem(HISTORY_STORAGE_KEY);
+    } catch (_e) { /* ignore */ }
+    this._populateHistoryDropdown();
   }
 
   handleShareCode() {

--- a/lib/vector-vrl/web-playground/public/index.js
+++ b/lib/vector-vrl/web-playground/public/index.js
@@ -202,7 +202,13 @@ export class VrlWebPlayground {
       theme,
       minimap: { enabled: false },
       automaticLayout: true,
-      wordWrap: "on"
+      wordWrap: "on",
+      scrollBeyondLastLine: false,
+      scrollbar: {
+        vertical: "auto",
+        horizontal: "auto",
+        useShadows: false,
+      },
     });
   }
 


### PR DESCRIPTION
## Summary

### Motivation

`playground.vrl.dev` is a public, hands-on surface — often a developer's first exposure to VRL. It sits alongside peer tools like OTLP's playground (`ottl.run`), and a side-by-side comparison surfaced several UX gaps: no resizable panes, no run history, no dark mode, no keyboard shortcut to run, silent share action, and various visual noise.

This PR closes those gaps in a focused pass so the playground is competitive as an evaluation surface for prospective Vector/VRL users. It is intentionally scoped to UX — no changes to VRL semantics or the WASM interface — and does not touch shipped Vector runtime code.

### Changes

- **Shift+Enter** keyboard shortcut to run the program.
- **Run history** persisted in `localStorage` (last 50 runs) with restore + clear button.
- **Resizable panels** via Split.js (horizontal split between Program and Input/Output, vertical split between Input and Output).
- **Auto-hide editor scrollbars** — no phantom empty scroll region past the last line.
- **Copy share URL to clipboard** on Share click (with success / failure / unavailable feedback).
- **Theme selector** — cycling icon toggle (System / Light / Dark) in the top-right, syncing Monaco editor themes and following the OS `prefers-color-scheme` when in System mode.
- **Icons** on Run, Share, and Clear buttons (Heroicons, MIT).
- **Visual polish**: unified top-panel bubble with internal dividers, purple accent on cell titles, toolbar grouped into logical sections, tightened vertical spacing.
- **Responsive fix**: keep the Program panel visible when the viewport narrows enough to stack panels, toolbar controls wrap cleanly on mobile.

## Vector configuration

Not applicable — playground UI/UX only.

## How did you test this PR?

- Built the playground locally with `wasm-pack build --target web --out-dir public/pkg` and served `public/` with `python3 -m http.server`.
- Exercised: Shift+Enter shortcut, history save/restore/clear, gutter drag, dark/light/system theme cycling, clipboard copy, mobile viewport at ~375px width.
- Ran `node --check`, `prettier --check` on `index.js`, and `make check-markdown`.
- Three rounds of `codex` review; findings addressed in follow-up commits (storage guards, Split.js sizing, dark-theme token contrast, mobile toolbar wrap, clipboard failure feedback, Split.js SRI pin).

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

None.