### PR TITLE
fix(sources): restore zero-copy fast path for HTTP body collection

### DIFF
--- a/src/sources/util/http/encoding.rs
+++ b/src/sources/util/http/encoding.rs
@@ -187,10 +187,10 @@ fn decompress_snappy(
 const ADDITIONAL_CAPACITY_FOR_CHUNKS_BEYOND_FIRST_TWO: usize = 16 * 1024;
 
 /// Collects the body into [`Bytes`] under `max_body_size`, mirroring the fast
-/// paths of hyper `to_bytes`. Collecting into a fresh `BytesMut` regressed
-/// throughput, since that always pays one allocation plus a full copy; instead
-/// we return a one- or two-chunk body directly and only grow a buffer once a
-/// third chunk arrives.
+/// paths of hyper `to_bytes`. Single-chunk bodies avoid the `BytesMut`
+/// allocation: a buffer sized for both chunks plus an arbitrary 16 KiB (to try
+/// to avoid having to reallocate multiple times once other chunks arrive) is
+/// only allocated once a second chunk arrives.
 /// (<https://github.com/hyperium/hyper/blob/v0.14.32/src/body/to_bytes.rs>).
 #[cfg(any(
     feature = "sources-utils-http-prelude",
@@ -213,7 +213,7 @@ where
             )
         })?;
 
-        total_body_size += chunk.remaining();
+        total_body_size = total_body_size.saturating_add(chunk.remaining());
         if total_body_size > max_body_size {
             return Err(request_body_too_large_error(max_body_size));
         }

--- a/src/sources/util/http/encoding.rs
+++ b/src/sources/util/http/encoding.rs
@@ -183,7 +183,8 @@ fn decompress_snappy(
     feature = "sources-opentelemetry",
     test
 ))]
-const ADDITIONAL_CAPACITY_FOR_CHUNKS_BEYOND_FIRST_TWO: usize = 8 * 1024;
+/// Spare capacity added to the initial buffer so a third or later chunk can be appended without reallocating right away.
+const ADDITIONAL_CAPACITY_FOR_CHUNKS_BEYOND_FIRST_TWO: usize = 16 * 1024;
 
 /// Collects the body into [`Bytes`] under `max_body_size`, mirroring the fast
 /// paths of hyper `to_bytes`. Collecting into a fresh `BytesMut` regressed
@@ -203,33 +204,31 @@ where
 {
     futures_util::pin_mut!(body);
 
-    let mut remaining_byte_allowance = max_body_size;
-    let mut admit_chunk_within_allowance =
-        |chunk: Result<B, warp::Error>| -> Result<B, ErrorMessage> {
-            let chunk = chunk.map_err(|error| {
-                ErrorMessage::new(
-                    StatusCode::BAD_REQUEST,
-                    format!("Failed reading request body: {error}"),
-                )
-            })?;
+    let mut total_body_size = 0;
+    let mut admit_chunk_within_limit = |chunk: Result<B, warp::Error>| -> Result<B, ErrorMessage> {
+        let chunk = chunk.map_err(|error| {
+            ErrorMessage::new(
+                StatusCode::BAD_REQUEST,
+                format!("Failed reading request body: {error}"),
+            )
+        })?;
 
-            let chunk_len = chunk.remaining();
-            if chunk_len > remaining_byte_allowance {
-                return Err(request_body_too_large_error(max_body_size));
-            }
+        total_body_size += chunk.remaining();
+        if total_body_size > max_body_size {
+            return Err(request_body_too_large_error(max_body_size));
+        }
 
-            remaining_byte_allowance -= chunk_len;
-            Ok(chunk)
-        };
+        Ok(chunk)
+    };
 
     let mut first = if let Some(chunk) = body.next().await {
-        admit_chunk_within_allowance(chunk)?
+        admit_chunk_within_limit(chunk)?
     } else {
         return Ok(Bytes::new());
     };
 
     let second = if let Some(chunk) = body.next().await {
-        admit_chunk_within_allowance(chunk)?
+        admit_chunk_within_limit(chunk)?
     } else {
         return Ok(first.copy_to_bytes(first.remaining()));
     };
@@ -241,7 +240,7 @@ where
     bytes.put(second);
 
     while let Some(chunk) = body.next().await {
-        bytes.put(admit_chunk_within_allowance(chunk)?);
+        bytes.put(admit_chunk_within_limit(chunk)?);
     }
 
     Ok(bytes.freeze())

--- a/src/sources/util/http/encoding.rs
+++ b/src/sources/util/http/encoding.rs
@@ -221,17 +221,15 @@ where
         Ok(chunk)
     };
 
-    let mut first = if let Some(chunk) = body.next().await {
-        admit_chunk_within_limit(chunk)?
-    } else {
+    let Some(chunk) = body.next().await else {
         return Ok(Bytes::new());
     };
+    let mut first = admit_chunk_within_limit(chunk)?;
 
-    let second = if let Some(chunk) = body.next().await {
-        admit_chunk_within_limit(chunk)?
-    } else {
+    let Some(chunk) = body.next().await else {
         return Ok(first.copy_to_bytes(first.remaining()));
     };
+    let second = admit_chunk_within_limit(chunk)?;
 
     let mut bytes = BytesMut::with_capacity(
         first.remaining() + second.remaining() + ADDITIONAL_CAPACITY_FOR_CHUNKS_BEYOND_FIRST_TWO,

--- a/src/sources/util/http/encoding.rs
+++ b/src/sources/util/http/encoding.rs
@@ -204,7 +204,7 @@ where
 {
     futures_util::pin_mut!(body);
 
-    let mut total_body_size = 0;
+    let mut total_body_size: usize = 0;
     let mut admit_chunk_within_limit = |chunk: Result<B, warp::Error>| -> Result<B, ErrorMessage> {
         let chunk = chunk.map_err(|error| {
             ErrorMessage::new(

--- a/src/sources/util/http/encoding.rs
+++ b/src/sources/util/http/encoding.rs
@@ -183,6 +183,19 @@ fn decompress_snappy(
     feature = "sources-opentelemetry",
     test
 ))]
+const ADDITIONAL_CAPACITY_FOR_CHUNKS_BEYOND_FIRST_TWO: usize = 8 * 1024;
+
+/// Collects the body into [`Bytes`] under `max_body_size`, mirroring the fast
+/// paths of hyper `to_bytes`. Collecting into a fresh `BytesMut` regressed
+/// throughput, since that always pays one allocation plus a full copy; instead
+/// we return a one- or two-chunk body directly and only grow a buffer once a
+/// third chunk arrives.
+/// (<https://github.com/hyperium/hyper/blob/v0.14.32/src/body/to_bytes.rs>).
+#[cfg(any(
+    feature = "sources-utils-http-prelude",
+    feature = "sources-opentelemetry",
+    test
+))]
 async fn collect_body_with_limit<S, B>(body: S, max_body_size: usize) -> Result<Bytes, ErrorMessage>
 where
     S: futures_util::Stream<Item = Result<B, warp::Error>>,
@@ -190,18 +203,45 @@ where
 {
     futures_util::pin_mut!(body);
 
-    let mut bytes = BytesMut::new();
+    let mut remaining_byte_allowance = max_body_size;
+    let mut admit_chunk_within_allowance =
+        |chunk: Result<B, warp::Error>| -> Result<B, ErrorMessage> {
+            let chunk = chunk.map_err(|error| {
+                ErrorMessage::new(
+                    StatusCode::BAD_REQUEST,
+                    format!("Failed reading request body: {error}"),
+                )
+            })?;
+
+            let chunk_len = chunk.remaining();
+            if chunk_len > remaining_byte_allowance {
+                return Err(request_body_too_large_error(max_body_size));
+            }
+
+            remaining_byte_allowance -= chunk_len;
+            Ok(chunk)
+        };
+
+    let mut first = if let Some(chunk) = body.next().await {
+        admit_chunk_within_allowance(chunk)?
+    } else {
+        return Ok(Bytes::new());
+    };
+
+    let second = if let Some(chunk) = body.next().await {
+        admit_chunk_within_allowance(chunk)?
+    } else {
+        return Ok(first.copy_to_bytes(first.remaining()));
+    };
+
+    let mut bytes = BytesMut::with_capacity(
+        first.remaining() + second.remaining() + ADDITIONAL_CAPACITY_FOR_CHUNKS_BEYOND_FIRST_TWO,
+    );
+    bytes.put(first);
+    bytes.put(second);
+
     while let Some(chunk) = body.next().await {
-        let chunk = chunk.map_err(|error| {
-            ErrorMessage::new(
-                StatusCode::BAD_REQUEST,
-                format!("Failed reading request body: {error}"),
-            )
-        })?;
-        if chunk.remaining() > max_body_size.saturating_sub(bytes.len()) {
-            return Err(request_body_too_large_error(max_body_size));
-        }
-        bytes.put(chunk);
+        bytes.put(admit_chunk_within_allowance(chunk)?);
     }
 
     Ok(bytes.freeze())


### PR DESCRIPTION

## Summary
Follow-up to #25488.

We detected some performance regression that seems to come from #25488. The issue seems to be that we collect the body into a `BytesMut` created empty, with no pre-defined capacity. As the body streams in, the buffer grows (up to the 100 MiB cap), and each time it needs more room we have to allocate again (and possibly copy all the already-buffered data), as the capacity grows by `max(previous_capacity * 2, requested_size)`.

This restores the short-circuit that `warp::body::bytes()` (hyper [`to_bytes`](https://github.com/hyperium/hyper/blob/v0.14.32/src/body/to_bytes.rs)) used before we replaced it: a one- or two-chunk body is returned directly with no allocation or copy, and only a third chunk falls back to a single growing `BytesMut`.

## Change

- `collect_body_with_limit` returns one/two-chunk bodies directly (zero-copy); only a third-or-later chunk allocates a growing `BytesMut`.
- No behavior change.