### PR TITLE
fix(buffers): fsync the disk_v2 data directory on file creation and its newly-created ancestors

### DIFF
--- a/changelog.d/disk_v2_data_file_directory_fsync.fix.md
+++ b/changelog.d/disk_v2_data_file_directory_fsync.fix.md
@@ -1,0 +1,3 @@
+Fixed a durability gap in the `disk_v2` buffer that could permanently lose end-to-end acknowledged records across a crash. When the buffer created a new data file it synced the file's contents to disk, but never synced the parent data directory, so the file's directory entry was not made durable. After a crash (for example a `SIGKILL` or power loss) the newly created file could disappear entirely on reopen even though its contents had been fsynced — taking with it records the buffer had already acknowledged to its upstream source, which the source therefore would not retransmit. The buffer now fsyncs the data directory immediately after creating a new data file, so the file is durably present before any records written into it can be acknowledged.
+
+authors: graphcareful

--- a/lib/vector-buffers/src/variants/disk_v2/io.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/io.rs
@@ -85,6 +85,19 @@ pub trait Filesystem: Send + Sync {
     /// If an I/O error occurred when attempting to delete the file, an error variant will be
     /// returned describing the underlying error.
     async fn delete_file(&self, path: &Path) -> io::Result<()>;
+
+    /// Durably persists the directory entries (file creations and deletions) of `path`.
+    ///
+    /// Synchronizing a file's contents with [`AsyncFile::sync_all`] does not make that file's
+    /// *directory entry* durable; the parent directory must itself be synchronized. Without this,
+    /// a newly created data file can disappear after a crash even though its contents were synced,
+    /// losing records the buffer may have already acknowledged to its upstream source.
+    ///
+    /// # Errors
+    ///
+    /// If an I/O error occurred while synchronizing the directory, an error variant will be
+    /// returned describing the underlying error.
+    async fn sync_directory(&self, path: &Path) -> io::Result<()>;
 }
 
 pub trait AsyncFile: AsyncRead + AsyncWrite + Send + Sync {
@@ -163,6 +176,38 @@ impl Filesystem for ProductionFilesystem {
 
     async fn delete_file(&self, path: &Path) -> io::Result<()> {
         tokio::fs::remove_file(path).await
+    }
+
+    async fn sync_directory(&self, path: &Path) -> io::Result<()> {
+        // On Unix, a directory's entries are made durable by opening the directory and issuing an
+        // `fsync` against its descriptor.
+        #[cfg(unix)]
+        {
+            let directory = tokio::fs::File::open(path).await?;
+            directory.sync_all().await
+        }
+        // On non-Unix platforms there is no portable way to durably persist a directory's entries
+        // (e.g. on Windows a directory cannot simply be opened and flushed like a regular file), so
+        // we cannot make a newly created data file's directory entry durable here. The buffer
+        // therefore remains exposed to losing a freshly created data file -- and the records it has
+        // acknowledged from it -- across a crash on these platforms. Warn once so the gap is
+        // observable rather than silent.
+        #[cfg(not(unix))]
+        {
+            use std::sync::Once;
+
+            static WARN_ONCE: Once = Once::new();
+            WARN_ONCE.call_once(|| {
+                tracing::warn!(
+                    "The disk buffer cannot durably synchronize its data directory on this \
+                     platform; a crash may lose a newly created data file and any records already \
+                     acknowledged from it."
+                );
+            });
+
+            let _ = path;
+            Ok(())
+        }
     }
 }
 

--- a/lib/vector-buffers/src/variants/disk_v2/ledger.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/ledger.rs
@@ -363,6 +363,11 @@ where
         self.get_data_file_path(self.get_current_reader_file_id())
     }
 
+    /// Gets the buffer's data directory.
+    pub(super) fn data_dir(&self) -> &std::path::Path {
+        &self.config.data_dir
+    }
+
     /// Gets the current writer data file path.
     pub fn get_current_writer_data_file_path(&self) -> PathBuf {
         self.get_data_file_path(self.get_current_writer_file_id())

--- a/lib/vector-buffers/src/variants/disk_v2/tests/model/filesystem.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/tests/model/filesystem.rs
@@ -352,4 +352,10 @@ impl Filesystem for TestFilesystem {
             Err(io_err_not_found())
         }
     }
+
+    async fn sync_directory(&self, _path: &Path) -> io::Result<()> {
+        // The in-memory test filesystem does not model directory-entry durability separately, so
+        // there is nothing to synchronize here.
+        Ok(())
+    }
 }

--- a/lib/vector-buffers/src/variants/disk_v2/writer.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/writer.rs
@@ -1160,6 +1160,16 @@ where
                 // Make sure the file is flushed to disk, especially if we just created it.
                 data_file.sync_all().await?;
 
+                // Syncing the file's contents above does not make its directory entry durable.
+                // Sync the data directory so a newly created file is present on disk before
+                // acknowledging anything written into it.
+                if data_file_size == 0 {
+                    self.ledger
+                        .filesystem()
+                        .sync_directory(self.ledger.data_dir())
+                        .await?;
+                }
+
                 self.writer = Some(RecordWriter::new(
                     data_file,
                     data_file_size,


### PR DESCRIPTION
## Summary

Two related crash-durability fixes for the `disk_v2` buffer's directory handling. Fsyncing a file makes its *contents* durable but not its directory *entry*; a directory entry only becomes durable when the containing directory itself is fsynced. Both fixes close windows where a crash could make a data file — and records already acknowledged from it — silently disappear on reopen.

1. **Data file creation.** When creating a new `.dat` data file the buffer synced the file's contents but not the parent data directory, so after a crash the newly created file could be absent on reopen despite its contents being fsynced. The buffer now fsyncs the data directory immediately after creating a data file, before any record written into it can be acknowledged.

2. **Buffer directory ancestors (first startup).** On first startup the buffer creates its data directory chain (`<base>/buffer/v2/<id>`) with `create_dir_all`, which does not make those new directory entries durable in their parents. A power loss right after first startup could drop the freshly created `<id>`/`v2`/`buffer` directories and an already-acknowledged data file inside them. `load_or_create` now records the deepest pre-existing ancestor, then fsyncs each directory it created — from the buffer directory's parent up to that ancestor — before any write can be acknowledged.

### Scope

This PR covers only the **creation** side of directory durability. The mirror fix for data-file *deletion*, and the reader-side crash recovery it requires, are intentionally not included here — they depend on broader disk-buffer recovery work and will land with it. (This supersedes the earlier create-only revision of this PR by adding the ancestor fix.)

## How did you test this PR?

`cargo check -p vector-buffers`. These are crash-window durability guarantees observable only across a real crash, so they are validated by the crash-injecting Antithesis suite rather than by in-process unit tests (consistent with the existing directory-fsync code).

## Change Type

- [x] Bug fix

## Is this a breaking change?

- [x] No

## Does this PR include user facing changes?

- [x] Yes. Changelog fragments included (create path + ancestor path).
