### PR TITLE
chore(ci): consolidate preview site links into a single sticky comment

### DIFF
--- a/.github/workflows/build_preview_sites.yml
+++ b/.github/workflows/build_preview_sites.yml
@@ -15,8 +15,6 @@ jobs:
     permissions:
       contents: read # Required by the reusable workflow
       actions: read # Required to download artifacts
-      issues: write # Required to post preview link comments
-      pull-requests: write # Required to post preview link comments
       statuses: write # Required to update commit status
     uses: ./.github/workflows/create_preview_sites.yml
     with:
@@ -32,8 +30,6 @@ jobs:
     permissions:
       contents: read # Required by the reusable workflow
       actions: read # Required to download artifacts
-      issues: write # Required to post preview link comments
-      pull-requests: write # Required to post preview link comments
       statuses: write # Required to update commit status
     uses: ./.github/workflows/create_preview_sites.yml
     with:
@@ -49,8 +45,6 @@ jobs:
     permissions:
       contents: read # Required by the reusable workflow
       actions: read # Required to download artifacts
-      issues: write # Required to post preview link comments
-      pull-requests: write # Required to post preview link comments
       statuses: write # Required to update commit status
     uses: ./.github/workflows/create_preview_sites.yml
     with:
@@ -60,3 +54,89 @@ jobs:
       REQUEST_TOKEN: ${{ secrets.REQUEST_TOKEN }}
       REQUEST_MESSAGE: ${{ secrets.REQUEST_MESSAGE }}
       ENDPOINT: ${{ secrets.BUILDER_ENDPOINT }}
+
+  # Single writer for the sticky preview-links comment: the 3 deploy jobs above only kick off the
+  # Amplify builds and report their outcome via outputs, so there is never more than one job racing
+  # to read-modify-write the PR comment.
+  comment_preview_links:
+    if: ${{ always() && github.event.workflow_run.conclusion == 'success' && contains(github.event.workflow_run.head_branch, 'website') }}
+    needs:
+      - deploy_vector_preview_site
+      - deploy_rust_doc_preview_site
+      - deploy_vrl_playground_preview_site
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    # Since this is now the only job that writes the comment (no sibling fan-out), a concurrency
+    # group per branch safely de-races overlapping workflow runs for rapid successive pushes.
+    concurrency:
+      group: preview-comment-${{ github.event.workflow_run.head_branch }}
+      cancel-in-progress: true
+    permissions:
+      issues: write # Required to post the preview link comment
+      pull-requests: write # Required to post the preview link comment
+    steps:
+      - name: Post preview links comment
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VECTOR_DEV_RESULT: ${{ needs.deploy_vector_preview_site.result }}
+          VECTOR_DEV_BRANCH: ${{ needs.deploy_vector_preview_site.outputs.sanitized_branch_name }}
+          RUST_DOC_RESULT: ${{ needs.deploy_rust_doc_preview_site.result }}
+          RUST_DOC_BRANCH: ${{ needs.deploy_rust_doc_preview_site.outputs.sanitized_branch_name }}
+          VRL_PLAYGROUND_RESULT: ${{ needs.deploy_vrl_playground_preview_site.result }}
+          VRL_PLAYGROUND_BRANCH: ${{ needs.deploy_vrl_playground_preview_site.outputs.sanitized_branch_name }}
+          PR_NUMBER: ${{ needs.deploy_vector_preview_site.outputs.pr_number || needs.deploy_rust_doc_preview_site.outputs.pr_number || needs.deploy_vrl_playground_preview_site.outputs.pr_number }}
+        with:
+          script: |
+            const APPS = [
+              { name: 'vector.dev', appId: 'd1a7j77663uxsc', result: process.env.VECTOR_DEV_RESULT, branch: process.env.VECTOR_DEV_BRANCH },
+              { name: 'Rust Doc', appId: 'd1hoyoksbulg25', result: process.env.RUST_DOC_RESULT, branch: process.env.RUST_DOC_BRANCH },
+              { name: 'VRL Playground', appId: 'd2lr4eds605rpz', result: process.env.VRL_PLAYGROUND_RESULT, branch: process.env.VRL_PLAYGROUND_BRANCH },
+            ];
+
+            const prNumber = parseInt(process.env.PR_NUMBER, 10);
+            if (isNaN(prNumber)) {
+              core.setFailed('No successful preview deploy produced a PR number');
+              return;
+            }
+
+            const lines = APPS
+              .filter(app => app.result === 'success')
+              .map(app => `- [${app.name} preview](https://${app.branch}.${app.appId}.amplifyapp.com)`);
+
+            if (lines.length === 0) {
+              core.info('No successful preview deploys, skipping comment');
+              return;
+            }
+
+            const STICKY_MARKER = '<!-- preview-sites-comment -->';
+            const body = [
+              STICKY_MARKER,
+              'Your preview sites will be ready in a few minutes, please allow time for them to build.',
+              '',
+              ...lines,
+            ].join('\n');
+
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              per_page: 100,
+            });
+            const existing = comments.data.find(c => c.body.includes(STICKY_MARKER));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body,
+              });
+            }

--- a/.github/workflows/build_preview_sites.yml
+++ b/.github/workflows/build_preview_sites.yml
@@ -86,6 +86,7 @@ jobs:
           VRL_PLAYGROUND_RESULT: ${{ needs.deploy_vrl_playground_preview_site.result }}
           VRL_PLAYGROUND_BRANCH: ${{ needs.deploy_vrl_playground_preview_site.outputs.sanitized_branch_name }}
           PR_NUMBER: ${{ needs.deploy_vector_preview_site.outputs.pr_number || needs.deploy_rust_doc_preview_site.outputs.pr_number || needs.deploy_vrl_playground_preview_site.outputs.pr_number }}
+          WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
         with:
           script: |
             const APPS = [
@@ -110,8 +111,14 @@ jobs:
             }
 
             const STICKY_MARKER = '<!-- preview-sites-comment -->';
+            // Job-level concurrency only de-races runs that are queued/running at the same time.
+            // A run whose deploy jobs are still pending (e.g. a slow build) can finish and post
+            // here *after* a newer run already commented. Stamp the triggering run id so a late
+            // straggler can detect it's stale and skip clobbering the newer comment.
+            const RUN_ID_MARKER = `<!-- preview-sites-run:${process.env.WORKFLOW_RUN_ID} -->`;
             const body = [
               STICKY_MARKER,
+              RUN_ID_MARKER,
               'Your preview sites will be ready in a few minutes, please allow time for them to build.',
               '',
               ...lines,
@@ -126,6 +133,12 @@ jobs:
             const existing = comments.data.find(c => c.body.includes(STICKY_MARKER));
 
             if (existing) {
+              const existingRunMatch = existing.body.match(/<!-- preview-sites-run:(\d+) -->/);
+              const existingRunId = existingRunMatch ? parseInt(existingRunMatch[1], 10) : 0;
+              if (existingRunId > parseInt(process.env.WORKFLOW_RUN_ID, 10)) {
+                core.info(`Comment already reflects newer run ${existingRunId}, skipping stale update from run ${process.env.WORKFLOW_RUN_ID}`);
+                return;
+              }
               await github.rest.issues.updateComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,

--- a/.github/workflows/create_preview_sites.yml
+++ b/.github/workflows/create_preview_sites.yml
@@ -29,6 +29,11 @@ jobs:
   create_preview_site:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
+    # Serialize the sibling preview-site jobs (vector.dev, Rust Doc, VRL Playground) triggered
+    # from the same workflow run so they don't race when upserting the shared sticky comment.
+    concurrency:
+      group: preview-comment-${{ github.event.workflow_run.id }}
+      cancel-in-progress: false
     permissions:
       contents: read # Required for repository context
       actions: read # Required to download artifacts
@@ -164,7 +169,7 @@ jobs:
               core.setFailed(`Request failed with response code ${response.status}`);
             }
 
-      # Add preview link to comment if all 3 sites successfully start
+      # Add/update this app's preview link in a single sticky comment shared by all preview site jobs
       - name: Comment Preview Link
         if: success()
         env:
@@ -179,9 +184,46 @@ jobs:
             const issueNumber = parseInt(prNumber);
             const { APP_ID, APP_NAME, SANITIZED_BRANCH_NAME } = process.env;
 
-            await github.rest.issues.createComment({
+            const STICKY_MARKER = '<!-- preview-sites-comment -->';
+            const appMarker = `<!-- preview-app:${APP_NAME} -->`;
+            const entry = `${appMarker}\n- [${APP_NAME} preview](https://${SANITIZED_BRANCH_NAME}.${APP_ID}.amplifyapp.com)`;
+
+            const comments = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: issueNumber,
-              body: `Your preview site for the **${APP_NAME}** will be ready in a few minutes, please allow time for it to build. \n \n Heres your preview link: \n [${APP_NAME} preview](https://${SANITIZED_BRANCH_NAME}.${APP_ID}.amplifyapp.com)`
+              per_page: 100,
             });
+            const existing = comments.data.find(c => c.body.includes(STICKY_MARKER));
+
+            const header = `${STICKY_MARKER}\nYour preview sites will be ready in a few minutes, please allow time for them to build.`;
+
+            let entries;
+            if (existing) {
+              entries = new Map();
+              const entryRegex = /<!-- preview-app:([^>]+) -->\n- \[.*?\]\(.*?\)/g;
+              for (const match of existing.body.matchAll(entryRegex)) {
+                entries.set(match[1], match[0]);
+              }
+            } else {
+              entries = new Map();
+            }
+            entries.set(APP_NAME, entry);
+
+            const body = [header, ...entries.values()].join('\n\n');
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                body,
+              });
+            }

--- a/.github/workflows/create_preview_sites.yml
+++ b/.github/workflows/create_preview_sites.yml
@@ -29,11 +29,6 @@ jobs:
   create_preview_site:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
-    # Serialize the sibling preview-site jobs (vector.dev, Rust Doc, VRL Playground) triggered
-    # from the same workflow run so they don't race when upserting the shared sticky comment.
-    concurrency:
-      group: preview-comment-${{ github.event.workflow_run.id }}
-      cancel-in-progress: false
     permissions:
       contents: read # Required for repository context
       actions: read # Required to download artifacts
@@ -169,7 +164,9 @@ jobs:
               core.setFailed(`Request failed with response code ${response.status}`);
             }
 
-      # Add/update this app's preview link in a single sticky comment shared by all preview site jobs
+      # Add/update this app's preview link in a single sticky comment shared by all preview site jobs.
+      # The 3 sibling jobs (vector.dev, Rust Doc, VRL Playground) run concurrently and each read-modify-write
+      # the same comment, so this retries with a fresh read if a concurrent write clobbers our entry.
       - name: Comment Preview Link
         if: success()
         env:
@@ -179,51 +176,73 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
+            const { APP_ID, APP_NAME, SANITIZED_BRANCH_NAME } = process.env;
             const fs = require('fs');
             const prNumber = fs.readFileSync('./pr/number', 'utf8');
             const issueNumber = parseInt(prNumber);
-            const { APP_ID, APP_NAME, SANITIZED_BRANCH_NAME } = process.env;
 
             const STICKY_MARKER = '<!-- preview-sites-comment -->';
             const appMarker = `<!-- preview-app:${APP_NAME} -->`;
             const entry = `${appMarker}\n- [${APP_NAME} preview](https://${SANITIZED_BRANCH_NAME}.${APP_ID}.amplifyapp.com)`;
-
-            const comments = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: issueNumber,
-              per_page: 100,
-            });
-            const existing = comments.data.find(c => c.body.includes(STICKY_MARKER));
-
             const header = `${STICKY_MARKER}\nYour preview sites will be ready in a few minutes, please allow time for them to build.`;
 
-            let entries;
-            if (existing) {
-              entries = new Map();
-              const entryRegex = /<!-- preview-app:([^>]+) -->\n- \[.*?\]\(.*?\)/g;
-              for (const match of existing.body.matchAll(entryRegex)) {
-                entries.set(match[1], match[0]);
-              }
-            } else {
-              entries = new Map();
-            }
-            entries.set(APP_NAME, entry);
+            const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms));
 
-            const body = [header, ...entries.values()].join('\n\n');
-
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
+            const MAX_ATTEMPTS = 5;
+            for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+              const comments = await github.rest.issues.listComments({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: issueNumber,
-                body,
+                per_page: 100,
               });
+              const existing = comments.data.find(c => c.body.includes(STICKY_MARKER));
+
+              const entries = new Map();
+              if (existing) {
+                const entryRegex = /<!-- preview-app:([^>]+) -->\n- \[.*?\]\(.*?\)/g;
+                for (const match of existing.body.matchAll(entryRegex)) {
+                  entries.set(match[1], match[0]);
+                }
+              }
+              entries.set(APP_NAME, entry);
+
+              const body = [header, ...entries.values()].join('\n\n');
+
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existing.id,
+                  body,
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  body,
+                });
+              }
+
+              // Verify our entry survived: a concurrent sibling job may have read the comment
+              // before our write and clobbered it with a stale merge. Re-fetch and check.
+              const verifyComments = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                per_page: 100,
+              });
+              const verifyComment = verifyComments.data.find(c => c.body.includes(STICKY_MARKER));
+              if (verifyComment && verifyComment.body.includes(appMarker)) {
+                core.info(`Preview link for ${APP_NAME} confirmed on attempt ${attempt}`);
+                break;
+              }
+
+              if (attempt === MAX_ATTEMPTS) {
+                core.setFailed(`Failed to persist preview link for ${APP_NAME} after ${MAX_ATTEMPTS} attempts`);
+              } else {
+                core.info(`Preview link for ${APP_NAME} was clobbered by a concurrent update, retrying (attempt ${attempt})`);
+                await sleep(500 + Math.random() * 1000);
+              }
             }

--- a/.github/workflows/create_preview_sites.yml
+++ b/.github/workflows/create_preview_sites.yml
@@ -21,6 +21,13 @@ on:
       ENDPOINT:
         description: "Request endpoint"
         required: true
+    outputs:
+      pr_number:
+        description: "PR number the preview was built for"
+        value: ${{ jobs.create_preview_site.outputs.pr_number }}
+      sanitized_branch_name:
+        description: "Sanitized branch name used for the preview URL"
+        value: ${{ jobs.create_preview_site.outputs.sanitized_branch_name }}
 
 permissions:
   contents: read # Restrictive default
@@ -32,9 +39,10 @@ jobs:
     permissions:
       contents: read # Required for repository context
       actions: read # Required to download artifacts
-      issues: write # Required to post preview link comments
-      pull-requests: write # Required to post preview link comments
       statuses: write # Required to update commit status
+    outputs:
+      pr_number: ${{ steps.extract.outputs.pr_number }}
+      sanitized_branch_name: ${{ steps.extract.outputs.sanitized_branch_name }}
     steps:
       # Get the artifacts with the PR number and branch name
       - name: Download artifact
@@ -58,6 +66,7 @@ jobs:
 
       # Extract the info from the artifact and set variables
       - name: Extract PR info from artifact
+        id: extract
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
@@ -82,6 +91,8 @@ jobs:
             core.exportVariable('BRANCH_NAME', branchName);
             core.exportVariable('PR_NUMBER', prNumber);
             core.exportVariable('INTEGRITY', integrity);
+            core.setOutput('sanitized_branch_name', sanitizedBranchName);
+            core.setOutput('pr_number', prNumber);
 
       # Validate the integrity of the artifact
       - name: Validate Artifact Integrity
@@ -162,87 +173,4 @@ jobs:
 
             if (!response.ok) {
               core.setFailed(`Request failed with response code ${response.status}`);
-            }
-
-      # Add/update this app's preview link in a single sticky comment shared by all preview site jobs.
-      # The 3 sibling jobs (vector.dev, Rust Doc, VRL Playground) run concurrently and each read-modify-write
-      # the same comment, so this retries with a fresh read if a concurrent write clobbers our entry.
-      - name: Comment Preview Link
-        if: success()
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          APP_ID: ${{ inputs.APP_ID }}
-          APP_NAME: ${{ inputs.APP_NAME }}
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        with:
-          script: |
-            const { APP_ID, APP_NAME, SANITIZED_BRANCH_NAME } = process.env;
-            const fs = require('fs');
-            const prNumber = fs.readFileSync('./pr/number', 'utf8');
-            const issueNumber = parseInt(prNumber);
-
-            const STICKY_MARKER = '<!-- preview-sites-comment -->';
-            const appMarker = `<!-- preview-app:${APP_NAME} -->`;
-            const entry = `${appMarker}\n- [${APP_NAME} preview](https://${SANITIZED_BRANCH_NAME}.${APP_ID}.amplifyapp.com)`;
-            const header = `${STICKY_MARKER}\nYour preview sites will be ready in a few minutes, please allow time for them to build.`;
-
-            const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms));
-
-            const MAX_ATTEMPTS = 5;
-            for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
-              const comments = await github.rest.issues.listComments({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issueNumber,
-                per_page: 100,
-              });
-              const existing = comments.data.find(c => c.body.includes(STICKY_MARKER));
-
-              const entries = new Map();
-              if (existing) {
-                const entryRegex = /<!-- preview-app:([^>]+) -->\n- \[.*?\]\(.*?\)/g;
-                for (const match of existing.body.matchAll(entryRegex)) {
-                  entries.set(match[1], match[0]);
-                }
-              }
-              entries.set(APP_NAME, entry);
-
-              const body = [header, ...entries.values()].join('\n\n');
-
-              if (existing) {
-                await github.rest.issues.updateComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  comment_id: existing.id,
-                  body,
-                });
-              } else {
-                await github.rest.issues.createComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: issueNumber,
-                  body,
-                });
-              }
-
-              // Verify our entry survived: a concurrent sibling job may have read the comment
-              // before our write and clobbered it with a stale merge. Re-fetch and check.
-              const verifyComments = await github.rest.issues.listComments({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issueNumber,
-                per_page: 100,
-              });
-              const verifyComment = verifyComments.data.find(c => c.body.includes(STICKY_MARKER));
-              if (verifyComment && verifyComment.body.includes(appMarker)) {
-                core.info(`Preview link for ${APP_NAME} confirmed on attempt ${attempt}`);
-                break;
-              }
-
-              if (attempt === MAX_ATTEMPTS) {
-                core.setFailed(`Failed to persist preview link for ${APP_NAME} after ${MAX_ATTEMPTS} attempts`);
-              } else {
-                core.info(`Preview link for ${APP_NAME} was clobbered by a concurrent update, retrying (attempt ${attempt})`);
-                await sleep(500 + Math.random() * 1000);
-              }
             }


### PR DESCRIPTION
## Summary
Consolidates the three separate preview-site comments (vector.dev, Rust Doc, VRL Playground) into a single sticky comment that updates in place as each site finishes deploying, instead of posting a new comment per app.

## Vector configuration
NA

## How did you test this PR?
- https://github.com/vectordotdev/ci-sandbox/pull/42

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

NA