### PR TITLE
chore(tests): replace bare string paths with explicit path macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,14 +19,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "aead"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1973cfbc1a2daf9cf550e74e1f088c28e7f7d8c1e1418fb6c9dc5184b7e84c99"
+dependencies = [
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
+]
+
+[[package]]
 name = "aes"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac1f845298e95f983ff1944b728ae08b8cebab80d684f0a832ed0fc74dfa27e2"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.4.4",
  "cpufeatures 0.2.11",
+]
+
+[[package]]
+name = "aes"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
+dependencies = [
+ "cipher 0.5.2",
+ "cpubits",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -35,11 +56,11 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e08d0cdb774acd1e4dac11478b1a0c0d203134b2aab0ba25eb430de9b18f8b9"
 dependencies = [
- "aead",
- "aes",
- "cipher",
+ "aead 0.5.2",
+ "aes 0.8.3",
+ "cipher 0.4.4",
  "cmac",
- "ctr",
+ "ctr 0.9.2",
  "dbl",
  "digest 0.10.7",
  "zeroize",
@@ -1396,7 +1417,7 @@ dependencies = [
  "http-body-util",
  "md-5 0.10.6",
  "pin-project-lite",
- "sha1",
+ "sha1 0.10.6",
  "sha2 0.10.9",
  "tracing 0.1.44",
 ]
@@ -1888,7 +1909,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "proc-macro2 1.0.106",
  "quote 1.0.45",
  "regex",
@@ -1969,11 +1990,11 @@ dependencies = [
 
 [[package]]
 name = "block-padding"
-version = "0.3.3"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+checksum = "710f1dd022ef4e93f8a438b4ba958de7f64308434fa6a87104481645cc30068b"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -2277,11 +2298,11 @@ dependencies = [
 
 [[package]]
 name = "cbc"
-version = "0.1.2"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+checksum = "ce2dc9ee5f88d11e0beb842c88b33c8a5cf0d1329c4b19494af42b07dbfe8896"
 dependencies = [
- "cipher",
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -2313,11 +2334,11 @@ dependencies = [
 
 [[package]]
 name = "cfb-mode"
-version = "0.8.2"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "738b8d467867f80a71351933f70461f5b56f24d5c93e0cf216e59229c968d330"
+checksum = "ac64b0984be8510caae81455ea2c8c23e5af6be61c36129df62f3380d5d64e1f"
 dependencies = [
- "cipher",
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -2334,37 +2355,26 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
-dependencies = [
- "cfg-if",
- "cipher",
- "cpufeatures 0.2.11",
-]
-
-[[package]]
-name = "chacha20"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
+ "cipher 0.5.2",
  "cpufeatures 0.3.0",
  "rand_core 0.10.0",
 ]
 
 [[package]]
 name = "chacha20poly1305"
-version = "0.10.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+checksum = "9b89e1c441e926b9c82a8d023f6e1b7ae0adcfaa7d621814e4d60789bac751cb"
 dependencies = [
- "aead",
- "chacha20 0.9.1",
- "cipher",
- "poly1305",
- "zeroize",
+ "aead 0.6.1",
+ "chacha20",
+ "cipher 0.5.2",
+ "poly1305 0.9.1",
 ]
 
 [[package]]
@@ -2442,8 +2452,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common 0.1.6",
- "inout",
+ "inout 0.1.3",
  "zeroize",
+]
+
+[[package]]
+name = "cipher"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+dependencies = [
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
 ]
 
 [[package]]
@@ -2532,7 +2553,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8543454e3c3f5126effff9cd44d562af4e31fb8ce1cc0d3dcd8f084515dbc1aa"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
  "dbl",
  "digest 0.10.7",
 ]
@@ -2668,7 +2689,7 @@ dependencies = [
  "hex",
  "lazy_static",
  "num_enum 0.6.1",
- "sha1",
+ "sha1 0.10.6",
 ]
 
 [[package]]
@@ -2905,6 +2926,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3108,7 +3135,9 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
+ "getrandom 0.4.2",
  "hybrid-array",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -3117,10 +3146,10 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d6cf87adf719ddf43a805e92c6870a531aedda35ff640442cbaf8674e141e1"
 dependencies = [
- "aead",
- "cipher",
+ "aead 0.5.2",
+ "cipher 0.4.4",
  "generic-array",
- "poly1305",
+ "poly1305 0.8.0",
  "salsa20",
  "subtle",
  "zeroize",
@@ -3153,7 +3182,16 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
+]
+
+[[package]]
+name = "ctr"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaca1c4b237092596f64d571e9db6ce4109c4ef9742e27590f1709594461f21"
+dependencies = [
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -4125,6 +4163,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fancy-regex"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
+dependencies = [
+ "bit-set",
+ "regex-automata 0.4.14",
+ "regex-syntax",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4840,7 +4889,7 @@ dependencies = [
  "http 0.2.12",
  "httpdate",
  "mime",
- "sha1",
+ "sha1 0.10.6",
 ]
 
 [[package]]
@@ -4855,7 +4904,7 @@ dependencies = [
  "http 1.3.1",
  "httpdate",
  "mime",
- "sha1",
+ "sha1 0.10.6",
 ]
 
 [[package]]
@@ -5782,8 +5831,17 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
 dependencies = [
- "block-padding",
  "generic-array",
+]
+
+[[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "block-padding",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -5829,7 +5887,7 @@ version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96e4f67dbfc0f75d7b65953ecf0be3fd84ee0cb1ae72a00a4aa9a2f5518a2c80"
 dependencies = [
- "aes",
+ "aes 0.8.3",
 ]
 
 [[package]]
@@ -6086,7 +6144,7 @@ dependencies = [
  "bytecount",
  "data-encoding",
  "email_address",
- "fancy-regex",
+ "fancy-regex 0.17.0",
  "fraction",
  "getrandom 0.3.4",
  "idna",
@@ -6161,6 +6219,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
  "cpufeatures 0.2.11",
+]
+
+[[package]]
+name = "keccak"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -6298,7 +6366,7 @@ dependencies = [
  "petgraph 0.6.4",
  "regex",
  "regex-syntax",
- "sha3",
+ "sha3 0.10.8",
  "string_cache",
  "term 1.0.1",
  "unicode-xid 0.2.4",
@@ -7064,7 +7132,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_with",
- "sha1",
+ "sha1 0.10.6",
  "sha2 0.10.9",
  "socket2 0.6.3",
  "stringprep",
@@ -7598,11 +7666,11 @@ dependencies = [
 
 [[package]]
 name = "ofb"
-version = "0.6.1"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cc40678e045ff4eb1666ea6c0f994b133c31f673c09aed292261b6d5b6963a0"
+checksum = "5f9e502b30c14fb1fecc196f9543975522c4380e4b0e8dcf4bf42e1d76375173"
 dependencies = [
- "cipher",
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -8225,7 +8293,17 @@ checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
  "cpufeatures 0.2.11",
  "opaque-debug",
- "universal-hash",
+ "universal-hash 0.5.1",
+]
+
+[[package]]
+name = "poly1305"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2d0073b297041425c7c3df6eb4792d598a15323fe63346852b092eca02904c"
+dependencies = [
+ "cpufeatures 0.3.0",
+ "universal-hash 0.6.1",
 ]
 
 [[package]]
@@ -8567,7 +8645,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.12.1",
  "log",
  "multimap",
@@ -8587,8 +8665,8 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
- "heck 0.4.1",
- "itertools 0.14.0",
+ "heck 0.5.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "once_cell",
@@ -8607,8 +8685,8 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
- "itertools 0.14.0",
+ "heck 0.5.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -8642,7 +8720,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2 1.0.106",
  "quote 1.0.45",
  "syn 2.0.117",
@@ -8655,7 +8733,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2 1.0.106",
  "quote 1.0.45",
  "syn 2.0.117",
@@ -9104,7 +9182,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
- "chacha20 0.10.0",
+ "chacha20",
  "getrandom 0.4.2",
  "rand_core 0.10.0",
 ]
@@ -10123,7 +10201,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -10551,6 +10629,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10579,7 +10668,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
  "digest 0.10.7",
- "keccak",
+ "keccak 0.1.6",
+]
+
+[[package]]
+name = "sha3"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc9bad02c26382724b2d2692c6f179285e4b54eeecd7968f52a50059c3c11759"
+dependencies = [
+ "digest 0.11.3",
+ "keccak 0.2.0",
+ "sponge-cursor",
 ]
 
 [[package]]
@@ -10824,7 +10924,7 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2 1.0.106",
  "quote 1.0.45",
  "syn 2.0.117",
@@ -10836,7 +10936,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54254b8531cafa275c5e096f62d48c81435d1015405a91198ddb11e967301d40"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2 1.0.106",
  "quote 1.0.45",
  "syn 2.0.117",
@@ -10907,6 +11007,12 @@ dependencies = [
  "base64ct",
  "der",
 ]
+
+[[package]]
+name = "sponge-cursor"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a0219bd7d979d58245a4f41f695e1ac9f8befdffadd7f61f1bae9e39abc6620"
 
 [[package]]
 name = "sqlx"
@@ -11029,7 +11135,7 @@ dependencies = [
  "rand 0.8.6",
  "rsa",
  "serde",
- "sha1",
+ "sha1 0.10.6",
  "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
@@ -11456,7 +11562,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.0",
@@ -12451,7 +12557,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.8.6",
- "sha1",
+ "sha1 0.10.6",
  "thiserror 1.0.68",
  "url",
  "utf-8",
@@ -12678,6 +12784,16 @@ checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
  "crypto-common 0.1.6",
  "subtle",
+]
+
+[[package]]
+name = "universal-hash"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
+dependencies = [
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -13473,9 +13589,9 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 [[package]]
 name = "vrl"
 version = "0.33.1"
-source = "git+https://github.com/vectordotdev/vrl.git?branch=main#74e3e74582aa6b4445c1a94004bb3f14276d07df"
+source = "git+https://github.com/vectordotdev/vrl.git?branch=main#33fec9bddb7e75db90187f686ac3a69063882ced"
 dependencies = [
- "aes",
+ "aes 0.9.1",
  "aes-siv",
  "arbitrary",
  "base16",
@@ -13498,19 +13614,21 @@ dependencies = [
  "crc",
  "crypto_secretbox",
  "csv",
- "ctr",
- "digest 0.10.7",
+ "ctr 0.10.1",
+ "digest 0.11.3",
  "dns-lookup",
  "domain",
  "dyn-clone",
  "encoding_rs",
  "exitcode",
- "fancy-regex",
+ "fancy-regex 0.18.0",
  "flate2",
+ "getrandom 0.2.15",
  "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "grok",
  "hex",
- "hmac 0.12.1",
+ "hmac 0.13.0",
  "hostname 0.4.2",
  "iana-time-zone",
  "idna",
@@ -13523,7 +13641,7 @@ dependencies = [
  "lalrpop",
  "lalrpop-util",
  "lz4_flex",
- "md-5 0.10.6",
+ "md-5 0.11.0",
  "mlua",
  "nom 8.0.0",
  "nom-language",
@@ -13560,9 +13678,9 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml_ng",
- "sha1",
- "sha2 0.10.9",
- "sha3",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
+ "sha3 0.12.0",
  "simdutf8",
  "snafu 0.8.9",
  "snap",

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -146,9 +146,8 @@ cbc,https://github.com/RustCrypto/block-modes,MIT OR Apache-2.0,RustCrypto Devel
 cesu8,https://github.com/emk/cesu8-rs,Apache-2.0 OR MIT,Eric Kidd <git@randomhacks.net>
 cfb-mode,https://github.com/RustCrypto/block-modes,MIT OR Apache-2.0,RustCrypto Developers
 cfg-if,https://github.com/rust-lang/cfg-if,MIT OR Apache-2.0,Alex Crichton <alex@alexcrichton.com>
-chacha20,https://github.com/RustCrypto/stream-ciphers,Apache-2.0 OR MIT,RustCrypto Developers
 chacha20,https://github.com/RustCrypto/stream-ciphers,MIT OR Apache-2.0,RustCrypto Developers
-chacha20poly1305,https://github.com/RustCrypto/AEADs/tree/master/chacha20poly1305,Apache-2.0 OR MIT,RustCrypto Developers
+chacha20poly1305,https://github.com/RustCrypto/AEADs,Apache-2.0 OR MIT,RustCrypto Developers
 charset,https://github.com/hsivonen/charset,MIT OR Apache-2.0,Henri Sivonen <hsivonen@hsivonen.fi>
 chrono,https://github.com/chronotope/chrono,MIT OR Apache-2.0,The chrono Authors
 chrono-tz,https://github.com/chronotope/chrono-tz,MIT OR Apache-2.0,The chrono-tz Authors
@@ -189,6 +188,7 @@ cookie_store,https://github.com/pfernie/cookie_store,MIT OR Apache-2.0,Patrick F
 core-foundation,https://github.com/servo/core-foundation-rs,MIT  OR  Apache-2.0,The Servo Project Developers
 core-foundation,https://github.com/servo/core-foundation-rs,MIT OR Apache-2.0,The Servo Project Developers
 core-foundation-sys,https://github.com/servo/core-foundation-rs,MIT OR Apache-2.0,The Servo Project Developers
+cpubits,https://github.com/RustCrypto/utils,MIT OR Apache-2.0,RustCrypto Developers
 cpufeatures,https://github.com/RustCrypto/utils,MIT OR Apache-2.0,RustCrypto Developers
 crc,https://github.com/mrhooray/crc-rs,MIT OR Apache-2.0,"Rui Hu <code@mrhooray.com>, Akhil Velagapudi <4@4khil.com>"
 crc-catalog,https://github.com/akhilles/crc-catalog,MIT OR Apache-2.0,Akhil Velagapudi <akhilvelagapudi@gmail.com>
@@ -415,7 +415,7 @@ jsonptr,https://github.com/chanced/jsonptr,MIT OR Apache-2.0,"chance dinkins, An
 jsonschema,https://github.com/Stranger6667/jsonschema,MIT,Dmitry Dygalo <dmitry@dygalo.dev>
 k8s-openapi,https://github.com/Arnavion/k8s-openapi,Apache-2.0,Arnav Singh <me@arnavion.dev>
 kasuari,https://github.com/ratatui/kasuari,MIT OR Apache-2.0,"Dylan Ede <dylanede@googlemail.com>, The Ratatui Developers"
-keccak,https://github.com/RustCrypto/sponges/tree/master/keccak,Apache-2.0 OR MIT,RustCrypto Developers
+keccak,https://github.com/RustCrypto/sponges,Apache-2.0 OR MIT,RustCrypto Developers
 kqueue,https://gitlab.com/rust-kqueue/rust-kqueue,MIT,William Orr <will@worrbase.com>
 kqueue-sys,https://gitlab.com/rust-kqueue/rust-kqueue-sys,MIT,"William Orr <will@worrbase.com>, Daniel (dmilith) Dettlaff <dmilith@me.com>"
 krb5-src,https://github.com/MaterializeInc/rust-krb5-src,Apache-2.0,"Materialize, Inc."
@@ -738,6 +738,7 @@ spin,https://github.com/mvdnes/spin-rs,MIT,"Mathijs van de Nes <git@mathijs.vd-n
 spin,https://github.com/mvdnes/spin-rs,MIT,"Mathijs van de Nes <git@mathijs.vd-nes.nl>, John Ericson <git@JohnEricson.me>, Joshua Barretto <joshua.s.barretto@gmail.com>"
 spinning_top,https://github.com/rust-osdev/spinning_top,MIT OR Apache-2.0,Philipp Oppermann <dev@phil-opp.com>
 spki,https://github.com/RustCrypto/formats/tree/master/spki,Apache-2.0 OR MIT,RustCrypto Developers
+sponge-cursor,https://github.com/RustCrypto/utils,MIT OR Apache-2.0,RustCrypto Developers
 sqlx,https://github.com/launchbadge/sqlx,MIT OR Apache-2.0,"Ryan Leckey <leckey.ryan@gmail.com>, Austin Bonander <austin.bonander@gmail.com>, Chloe Ross <orangesnowfox@gmail.com>, Daniel Akhterov <akhterovd@gmail.com>"
 sqlx-core,https://github.com/launchbadge/sqlx,MIT OR Apache-2.0,"Ryan Leckey <leckey.ryan@gmail.com>, Austin Bonander <austin.bonander@gmail.com>, Chloe Ross <orangesnowfox@gmail.com>, Daniel Akhterov <akhterovd@gmail.com>"
 sqlx-macros,https://github.com/launchbadge/sqlx,MIT OR Apache-2.0,"Ryan Leckey <leckey.ryan@gmail.com>, Austin Bonander <austin.bonander@gmail.com>, Chloe Ross <orangesnowfox@gmail.com>, Daniel Akhterov <akhterovd@gmail.com>"

--- a/benches/remap.rs
+++ b/benches/remap.rs
@@ -129,7 +129,7 @@ fn benchmark_remap(c: &mut Criterion) {
             let mut event = Event::Log(LogEvent::from("parse me"));
             event
                 .as_mut_log()
-                .insert("foo", r#"{"key": "value"}"#.to_owned());
+                .insert(vrl::event_path!("foo"), r#"{"key": "value"}"#.to_owned());
             event
         };
 

--- a/changelog.d/25778_reduce_quoted_timestamp_path_panic.fix.md
+++ b/changelog.d/25778_reduce_quoted_timestamp_path_panic.fix.md
@@ -1,0 +1,3 @@
+Fixed a `reduce` transform bug where a timestamp field with a name that requires quoting in a VRL path (e.g. `"created.at"` or `"event-time"`) would have its `_end` companion silently dropped from the reduced event. The companion path is now built structurally and correctly lands next to the base field.
+
+authors: pront

--- a/lib/codecs/src/decoding/decoder.rs
+++ b/lib/codecs/src/decoding/decoder.rs
@@ -116,6 +116,7 @@ mod tests {
     use bytes::Bytes;
     use futures::{StreamExt, stream};
     use tokio_util::io::StreamReader;
+    use vrl::event_path;
     use vrl::value::Value;
 
     use super::Decoder;
@@ -141,7 +142,7 @@ mod tests {
 
         let next = stream.next().await.unwrap();
         let event = next.unwrap().0.pop().unwrap().into_log();
-        assert_eq!(event.get("foo").unwrap(), &Value::from(1));
+        assert_eq!(event.get(event_path!("foo")).unwrap(), &Value::from(1));
 
         let next = stream.next().await.unwrap();
         let error = next.unwrap_err();
@@ -149,6 +150,6 @@ mod tests {
 
         let next = stream.next().await.unwrap();
         let event = next.unwrap().0.pop().unwrap().into_log();
-        assert_eq!(event.get("bar").unwrap(), &Value::from(2));
+        assert_eq!(event.get(event_path!("bar")).unwrap(), &Value::from(2));
     }
 }

--- a/lib/codecs/src/decoding/format/avro.rs
+++ b/lib/codecs/src/decoding/format/avro.rs
@@ -290,7 +290,7 @@ mod tests {
         assert_eq!(events.len(), 1);
 
         assert_eq!(
-            events[0].as_log().get("message").unwrap(),
+            events[0].as_log().get(event_path!("message")).unwrap(),
             &VrlValue::from("hello from avro")
         );
     }
@@ -316,7 +316,7 @@ mod tests {
         assert_eq!(events.len(), 1);
 
         assert_eq!(
-            events[0].as_log().get("message").unwrap(),
+            events[0].as_log().get(event_path!("message")).unwrap(),
             &VrlValue::from("hello from avro")
         );
     }
@@ -343,7 +343,7 @@ mod tests {
             .unwrap();
         assert_eq!(events.len(), 1);
         assert_eq!(
-            events[0].as_log().get("message").unwrap(),
+            events[0].as_log().get(event_path!("message")).unwrap(),
             &VrlValue::from(uuid)
         );
     }

--- a/lib/codecs/src/decoding/format/bytes.rs
+++ b/lib/codecs/src/decoding/format/bytes.rs
@@ -88,6 +88,7 @@ impl Deserializer for BytesDeserializer {
 
 #[cfg(test)]
 mod tests {
+    use vrl::event_path;
     use vrl::value::Value;
 
     use super::*;
@@ -117,6 +118,9 @@ mod tests {
         let events = deserializer.parse(input, LogNamespace::Vector).unwrap();
         assert_eq!(events.len(), 1);
 
-        assert_eq!(events[0].as_log().get(".").unwrap(), &Value::from("foo"));
+        assert_eq!(
+            events[0].as_log().get(event_path!()).unwrap(),
+            &Value::from("foo")
+        );
     }
 }

--- a/lib/codecs/src/decoding/format/gelf.rs
+++ b/lib/codecs/src/decoding/format/gelf.rs
@@ -302,11 +302,11 @@ mod tests {
         let log = events[0].as_log();
 
         assert_eq!(
-            log.get(VERSION),
+            log.get(event_path!(VERSION)),
             Some(&Value::Bytes(Bytes::from_static(b"1.1")))
         );
         assert_eq!(
-            log.get(HOST),
+            log.get(event_path!(HOST)),
             Some(&Value::Bytes(Bytes::from_static(b"example.org")))
         );
         assert_eq!(
@@ -316,24 +316,24 @@ mod tests {
             )))
         );
         assert_eq!(
-            log.get(FULL_MESSAGE),
+            log.get(event_path!(FULL_MESSAGE)),
             Some(&Value::Bytes(Bytes::from_static(
                 b"Backtrace here\n\nmore stuff"
             )))
         );
         let dt = DateTime::from_timestamp(1385053862, 307_200_000).expect("invalid timestamp");
-        assert_eq!(log.get(TIMESTAMP), Some(&Value::Timestamp(dt)));
-        assert_eq!(log.get(LEVEL), Some(&Value::Integer(1)));
+        assert_eq!(log.get(event_path!(TIMESTAMP)), Some(&Value::Timestamp(dt)));
+        assert_eq!(log.get(event_path!(LEVEL)), Some(&Value::Integer(1)));
         assert_eq!(
-            log.get(FACILITY),
+            log.get(event_path!(FACILITY)),
             Some(&Value::Bytes(Bytes::from_static(b"foo")))
         );
         assert_eq!(
-            log.get(LINE),
+            log.get(event_path!(LINE)),
             Some(&Value::Float(ordered_float::NotNan::new(42.0).unwrap()))
         );
         assert_eq!(
-            log.get(FILE),
+            log.get(event_path!(FILE)),
             Some(&Value::Bytes(Bytes::from_static(b"/tmp/bar")))
         );
         assert_eq!(
@@ -472,7 +472,7 @@ mod tests {
         let log = events[0].as_log();
 
         assert_eq!(
-            log.get(VERSION),
+            log.get(event_path!(VERSION)),
             Some(&Value::Bytes(Bytes::from_static(b"1.0")))
         );
 

--- a/lib/codecs/src/decoding/format/otlp.rs
+++ b/lib/codecs/src/decoding/format/otlp.rs
@@ -11,7 +11,7 @@ use vector_core::{
     event::Event,
     schema,
 };
-use vrl::{protobuf::parse::Options, value::Kind};
+use vrl::{event_path, protobuf::parse::Options, value::Kind};
 
 use super::{Deserializer, ProtobufDeserializer};
 
@@ -165,7 +165,7 @@ impl Deserializer for OtlpDeserializer {
                 OtlpSignalType::Logs => {
                     if let Ok(events) = self.logs_deserializer.parse(bytes.clone(), log_namespace)
                         && let Some(Event::Log(log)) = events.first()
-                        && log.get(RESOURCE_LOGS_JSON_FIELD).is_some()
+                        && log.get(event_path!(RESOURCE_LOGS_JSON_FIELD)).is_some()
                     {
                         return Ok(events);
                     }
@@ -175,7 +175,7 @@ impl Deserializer for OtlpDeserializer {
                         .metrics_deserializer
                         .parse(bytes.clone(), log_namespace)
                         && let Some(Event::Log(log)) = events.first()
-                        && log.get(RESOURCE_METRICS_JSON_FIELD).is_some()
+                        && log.get(event_path!(RESOURCE_METRICS_JSON_FIELD)).is_some()
                     {
                         return Ok(events);
                     }
@@ -185,7 +185,7 @@ impl Deserializer for OtlpDeserializer {
                     if let Ok(mut events) =
                         self.traces_deserializer.parse(bytes.clone(), log_namespace)
                         && let Some(Event::Log(log)) = events.first()
-                        && log.get(RESOURCE_SPANS_JSON_FIELD).is_some()
+                        && log.get(event_path!(RESOURCE_SPANS_JSON_FIELD)).is_some()
                     {
                         // Convert the log event to a trace event by taking ownership
                         if let Some(Event::Log(log)) = events.pop() {
@@ -214,6 +214,7 @@ mod tests {
         trace::v1::{ResourceSpans, ScopeSpans, Span},
     };
     use prost::Message;
+    use vrl::path;
 
     use super::*;
 
@@ -317,7 +318,7 @@ mod tests {
     fn validate_trace_ids(trace: &vrl::value::Value) {
         // Navigate to the span and check traceId and spanId
         let resource_spans = trace
-            .get("resourceSpans")
+            .get(path!("resourceSpans"))
             .and_then(|v| v.as_array())
             .expect("resourceSpans should be an array");
 
@@ -326,7 +327,7 @@ mod tests {
             .expect("should have at least one resource span");
 
         let scope_spans = first_rs
-            .get("scopeSpans")
+            .get(path!("scopeSpans"))
             .and_then(|v| v.as_array())
             .expect("scopeSpans should be an array");
 
@@ -335,7 +336,7 @@ mod tests {
             .expect("should have at least one scope span");
 
         let spans = first_ss
-            .get("spans")
+            .get(path!("spans"))
             .and_then(|v| v.as_array())
             .expect("spans should be an array");
 
@@ -343,7 +344,7 @@ mod tests {
 
         // Verify traceId - should be raw bytes (16 bytes for trace_id)
         let trace_id = span
-            .get("traceId")
+            .get(path!("traceId"))
             .and_then(|v| v.as_bytes())
             .expect("traceId should exist and be bytes");
 
@@ -355,7 +356,7 @@ mod tests {
 
         // Verify spanId - should be raw bytes (8 bytes for span_id)
         let span_id = span
-            .get("spanId")
+            .get(path!("spanId"))
             .and_then(|v| v.as_bytes())
             .expect("spanId should exist and be bytes");
 
@@ -374,10 +375,10 @@ mod tests {
         if is_trace {
             assert!(matches!(events[0], Event::Trace(_)));
             let trace = events[0].as_trace();
-            assert!(trace.get(field).is_some());
+            assert!(trace.get(event_path!(field)).is_some());
             validate_trace_ids(trace.value());
         } else {
-            assert!(events[0].as_log().get(field).is_some());
+            assert!(events[0].as_log().get(event_path!(field)).is_some());
         }
     }
 

--- a/lib/codecs/src/decoding/format/protobuf.rs
+++ b/lib/codecs/src/decoding/format/protobuf.rs
@@ -186,6 +186,7 @@ mod tests {
     use std::{env, fs, path::PathBuf};
 
     use vector_core::config::log_schema;
+    use vrl::event_path;
 
     use super::*;
 
@@ -279,10 +280,10 @@ mod tests {
         let message_type = "test_protobuf.Person";
         let validate_log = |log: &LogEvent| {
             // No field will be set.
-            assert!(!log.contains("name"));
-            assert!(!log.contains("id"));
-            assert!(!log.contains("email"));
-            assert!(!log.contains("phones"));
+            assert!(!log.contains(event_path!("name")));
+            assert!(!log.contains(event_path!("id")));
+            assert!(!log.contains(event_path!("email")));
+            assert!(!log.contains(event_path!("phones")));
         };
 
         parse_and_validate(

--- a/lib/codecs/src/decoding/format/vrl.rs
+++ b/lib/codecs/src/decoding/format/vrl.rs
@@ -164,7 +164,7 @@ impl VrlDeserializer {
 mod tests {
     use chrono::{DateTime, Utc};
     use indoc::indoc;
-    use vrl::{btreemap, path::OwnedTargetPath, value::Value};
+    use vrl::{btreemap, event_path, path::OwnedTargetPath, value::Value};
 
     use super::*;
 
@@ -369,7 +369,7 @@ mod tests {
 
         assert_eq!(events.len(), 1);
         assert_eq!(
-            *events[0].as_log().get("secret_value").unwrap(),
+            *events[0].as_log().get(event_path!("secret_value")).unwrap(),
             Value::from("super-secret")
         );
     }

--- a/lib/codecs/src/encoding/format/arrow.rs
+++ b/lib/codecs/src/encoding/format/arrow.rs
@@ -384,6 +384,7 @@ mod tests {
     use chrono::Utc;
     use std::io::Cursor;
     use vector_core::event::{LogEvent, Value};
+    use vrl::event_path;
 
     /// Helper to encode events and return the decoded RecordBatch
     fn encode_and_decode(
@@ -403,7 +404,7 @@ mod tests {
     {
         let mut log = LogEvent::default();
         for (key, value) in fields {
-            log.insert(key, value.into());
+            log.insert(&vrl::path::parse_target_path(key).unwrap(), value.into());
         }
         Event::Log(log)
     }
@@ -445,25 +446,28 @@ mod tests {
 
             let mut log = LogEvent::default();
             // Primitive types
-            log.insert("string_field", "test");
-            log.insert("int8_field", 127);
-            log.insert("int16_field", 32000);
-            log.insert("int32_field", 1000000);
-            log.insert("int64_field", 42);
-            log.insert("uint8_field", 255);
-            log.insert("uint16_field", 65535);
-            log.insert("uint32_field", 4000000);
-            log.insert("uint64_field", 9000000000_i64);
-            log.insert("float32_field", 3.15);
-            log.insert("float64_field", 3.15);
-            log.insert("bool_field", true);
-            log.insert("timestamp_field", now);
-            log.insert("decimal_field", 99.99);
+            log.insert(event_path!("string_field"), "test");
+            log.insert(event_path!("int8_field"), 127);
+            log.insert(event_path!("int16_field"), 32000);
+            log.insert(event_path!("int32_field"), 1000000);
+            log.insert(event_path!("int64_field"), 42);
+            log.insert(event_path!("uint8_field"), 255);
+            log.insert(event_path!("uint16_field"), 65535);
+            log.insert(event_path!("uint32_field"), 4000000);
+            log.insert(event_path!("uint64_field"), 9000000000_i64);
+            log.insert(event_path!("float32_field"), 3.15);
+            log.insert(event_path!("float64_field"), 3.15);
+            log.insert(event_path!("bool_field"), true);
+            log.insert(event_path!("timestamp_field"), now);
+            log.insert(event_path!("decimal_field"), 99.99);
             // Complex types
-            log.insert("list_field", list_value);
-            log.insert("struct_field", Value::Object(tuple_value));
-            log.insert("named_struct_field", Value::Object(named_tuple_value));
-            log.insert("map_field", Value::Object(map_value));
+            log.insert(event_path!("list_field"), list_value);
+            log.insert(event_path!("struct_field"), Value::Object(tuple_value));
+            log.insert(
+                event_path!("named_struct_field"),
+                Value::Object(named_tuple_value),
+            );
+            log.insert(event_path!("map_field"), Value::Object(map_value));
 
             let events = vec![Event::Log(log)];
 
@@ -639,10 +643,10 @@ mod tests {
         fn test_encode_timestamp_precisions() {
             let now = Utc::now();
             let mut log = LogEvent::default();
-            log.insert("ts_second", now);
-            log.insert("ts_milli", now);
-            log.insert("ts_micro", now);
-            log.insert("ts_nano", now);
+            log.insert(event_path!("ts_second"), now);
+            log.insert(event_path!("ts_milli"), now);
+            log.insert(event_path!("ts_micro"), now);
+            log.insert(event_path!("ts_nano"), now);
 
             let events = vec![Event::Log(log)];
 
@@ -697,13 +701,13 @@ mod tests {
             let now = Utc::now();
 
             let mut log1 = LogEvent::default();
-            log1.insert("ts", "2025-10-22T10:18:44.256Z"); // RFC3339 String
+            log1.insert(event_path!("ts"), "2025-10-22T10:18:44.256Z"); // RFC3339 String
 
             let mut log2 = LogEvent::default();
-            log2.insert("ts", now); // Native Timestamp
+            log2.insert(event_path!("ts"), now); // Native Timestamp
 
             let mut log3 = LogEvent::default();
-            log3.insert("ts", 1729594724256000000_i64); // Integer (nanoseconds)
+            log3.insert(event_path!("ts"), 1729594724256000000_i64); // Integer (nanoseconds)
 
             let events = vec![Event::Log(log1), Event::Log(log2), Event::Log(log3)];
 
@@ -747,7 +751,7 @@ mod tests {
         #[test]
         fn test_config_allow_nullable_fields_overrides_schema() {
             let mut log1 = LogEvent::default();
-            log1.insert("strict_field", 42);
+            log1.insert(event_path!("strict_field"), 42);
             let log2 = LogEvent::default();
             let events = vec![Event::Log(log1), Event::Log(log2)];
 

--- a/lib/codecs/src/encoding/format/otlp.rs
+++ b/lib/codecs/src/encoding/format/otlp.rs
@@ -8,7 +8,7 @@ use opentelemetry_proto::proto::{
 use tokio_util::codec::Encoder;
 use vector_config_macros::configurable_component;
 use vector_core::{config::DataType, event::Event, schema};
-use vrl::protobuf::encode::Options;
+use vrl::{event_path, protobuf::encode::Options};
 
 /// Config used to build an `OtlpSerializer`.
 #[configurable_component]
@@ -103,9 +103,9 @@ impl Encoder<Event> for OtlpSerializer {
         // The deserializer uses use_json_names: true, so fields are in camelCase
         match &event {
             Event::Log(log) => {
-                if log.contains(RESOURCE_LOGS_JSON_FIELD) {
+                if log.contains(event_path!(RESOURCE_LOGS_JSON_FIELD)) {
                     self.logs_descriptor.encode(event, buffer)
-                } else if log.contains(RESOURCE_METRICS_JSON_FIELD) {
+                } else if log.contains(event_path!(RESOURCE_METRICS_JSON_FIELD)) {
                     // Currently the OTLP metrics are Vector logs (not metrics).
                     self.metrics_descriptor.encode(event, buffer)
                 } else {
@@ -116,7 +116,7 @@ impl Encoder<Event> for OtlpSerializer {
                 }
             }
             Event::Trace(trace) => {
-                if trace.contains(RESOURCE_SPANS_JSON_FIELD) {
+                if trace.contains(event_path!(RESOURCE_SPANS_JSON_FIELD)) {
                     self.traces_descriptor.encode(event, buffer)
                 } else {
                     Err(format!(

--- a/lib/codecs/src/encoding/format/parquet.rs
+++ b/lib/codecs/src/encoding/format/parquet.rs
@@ -441,6 +441,7 @@ mod tests {
     use parquet::record::reader::RowIter;
     use tokio_util::codec::Encoder;
     use vector_core::event::LogEvent;
+    use vrl::event_path;
 
     fn create_event<V>(fields: Vec<(&str, V)>) -> Event
     where
@@ -448,7 +449,7 @@ mod tests {
     {
         let mut log = LogEvent::default();
         for (key, value) in fields {
-            log.insert(key, value.into());
+            log.insert(&vrl::path::parse_target_path(key).unwrap(), value.into());
         }
         Event::Log(log)
     }
@@ -490,14 +491,14 @@ mod tests {
     ) -> Event {
         use vector_core::event::Value;
         let mut log = LogEvent::default();
-        log.insert("host", "localhost");
-        log.insert("message", message);
-        log.insert("service", "vector");
-        log.insert("source_type", "demo_logs");
-        log.insert("timestamp", Value::Timestamp(timestamp));
-        log.insert("random_time", Value::Timestamp(timestamp));
-        log.insert("status_code", Value::Integer(status_code));
-        log.insert("response_time_secs", response_time_secs);
+        log.insert(event_path!("host"), "localhost");
+        log.insert(event_path!("message"), message);
+        log.insert(event_path!("service"), "vector");
+        log.insert(event_path!("source_type"), "demo_logs");
+        log.insert(event_path!("timestamp"), Value::Timestamp(timestamp));
+        log.insert(event_path!("random_time"), Value::Timestamp(timestamp));
+        log.insert(event_path!("status_code"), Value::Integer(status_code));
+        log.insert(event_path!("response_time_secs"), response_time_secs);
         Event::Log(log)
     }
 
@@ -764,7 +765,7 @@ mod tests {
             ParquetSerializer::new(config).expect("Should create serializer from schema file");
 
         let mut log = LogEvent::default();
-        log.insert("name", "alice");
+        log.insert(event_path!("name"), "alice");
 
         let mut buffer = BytesMut::new();
         serializer
@@ -865,8 +866,8 @@ mod tests {
         .expect("Failed to create strict serializer");
 
         let mut log = LogEvent::default();
-        log.insert("name", "test");
-        log.insert("level", "info");
+        log.insert(event_path!("name"), "test");
+        log.insert(event_path!("level"), "info");
 
         let mut buffer = BytesMut::new();
         assert!(

--- a/lib/codecs/src/encoding/format/syslog.rs
+++ b/lib/codecs/src/encoding/format/syslog.rs
@@ -14,6 +14,7 @@ use vector_core::{
     event::{Event, LogEvent, Value},
     schema,
 };
+use vrl::event_path;
 use vrl::value::ObjectMap;
 
 /// Config used to build a `SyslogSerializer`.
@@ -161,7 +162,7 @@ impl<'a> ConfigDecanter<'a> {
 
     fn get_structured_data(&self) -> Option<StructuredData> {
         self.log
-            .get("structured_data")
+            .get(event_path!("structured_data"))
             .and_then(|v| v.clone().into_object())
             .map(StructuredData::from)
     }
@@ -993,7 +994,7 @@ mod tests {
         .unwrap();
 
         let mut log = LogEvent::default();
-        log.insert("syslog.service", "meaning-app");
+        log.insert(event_path!("syslog", "service"), "meaning-app");
 
         let schema = schema::Definition::new_with_default_metadata(
             Kind::object(btreemap! {

--- a/lib/codecs/src/encoding/transformer.rs
+++ b/lib/codecs/src/encoding/transformer.rs
@@ -3,7 +3,7 @@
 use std::collections::BTreeMap;
 
 use chrono::{DateTime, Utc};
-use lookup::{PathPrefix, event_path, lookup_v2::ConfigValuePath};
+use lookup::{PathPrefix, lookup_v2::ConfigValuePath};
 use ordered_float::NotNan;
 use serde::{Deserialize, Deserializer};
 use vector_config::configurable_component;
@@ -197,7 +197,7 @@ impl Transformer {
                 None
             };
             if let Some(ts) = timestamp {
-                log.insert(event_path!(), ts.into());
+                log.insert(&vrl::path::OwnedTargetPath::event_root(), ts.into());
             }
         }
     }
@@ -265,7 +265,7 @@ mod tests {
     use std::{collections::BTreeMap, sync::Arc};
 
     use indoc::indoc;
-    use lookup::path::parse_target_path;
+    use lookup::{event_path, path::parse_target_path};
     use vector_core::{
         config::{LogNamespace, log_schema},
         schema,

--- a/lib/codecs/src/encoding/transformer.rs
+++ b/lib/codecs/src/encoding/transformer.rs
@@ -303,29 +303,29 @@ mod tests {
             toml::from_str(r#"except_fields = ["a.b.c", "b", "c[0].y", "d.z", "e"]"#).unwrap();
         let mut log = LogEvent::default();
         {
-            log.insert("a", 1);
-            log.insert("a.b", 1);
-            log.insert("a.b.c", 1);
-            log.insert("a.b.d", 1);
-            log.insert("b[0]", 1);
-            log.insert("b[1].x", 1);
-            log.insert("c[0].x", 1);
-            log.insert("c[0].y", 1);
-            log.insert("d.z", 1);
-            log.insert("e.a", 1);
-            log.insert("e.b", 1);
+            log.insert(event_path!("a"), 1);
+            log.insert(event_path!("a", "b"), 1);
+            log.insert(event_path!("a", "b", "c"), 1);
+            log.insert(event_path!("a", "b", "d"), 1);
+            log.insert(event_path!("b", 0isize), 1);
+            log.insert(event_path!("b", 1isize, "x"), 1);
+            log.insert(event_path!("c", 0isize, "x"), 1);
+            log.insert(event_path!("c", 0isize, "y"), 1);
+            log.insert(event_path!("d", "z"), 1);
+            log.insert(event_path!("e", "a"), 1);
+            log.insert(event_path!("e", "b"), 1);
         }
         let mut event = Event::from(log);
         transformer.transform(&mut event);
-        assert!(!event.as_mut_log().contains("a.b.c"));
-        assert!(!event.as_mut_log().contains("b"));
-        assert!(!event.as_mut_log().contains("b[1].x"));
-        assert!(!event.as_mut_log().contains("c[0].y"));
-        assert!(!event.as_mut_log().contains("d.z"));
-        assert!(!event.as_mut_log().contains("e.a"));
+        assert!(!event.as_mut_log().contains(event_path!("a", "b", "c")));
+        assert!(!event.as_mut_log().contains(event_path!("b")));
+        assert!(!event.as_mut_log().contains(event_path!("b", 1isize, "x")));
+        assert!(!event.as_mut_log().contains(event_path!("c", 0isize, "y")));
+        assert!(!event.as_mut_log().contains(event_path!("d", "z")));
+        assert!(!event.as_mut_log().contains(event_path!("e", "a")));
 
-        assert!(event.as_mut_log().contains("a.b.d"));
-        assert!(event.as_mut_log().contains("c[0].x"));
+        assert!(event.as_mut_log().contains(event_path!("a", "b", "d")));
+        assert!(event.as_mut_log().contains(event_path!("c", 0isize, "x")));
     }
 
     #[test]
@@ -334,38 +334,38 @@ mod tests {
             toml::from_str(r#"only_fields = ["a.b.c", "b", "c[0].y", "\"g.z\""]"#).unwrap();
         let mut log = LogEvent::default();
         {
-            log.insert("a", 1);
-            log.insert("a.b", 1);
-            log.insert("a.b.c", 1);
-            log.insert("a.b.d", 1);
-            log.insert("b[0]", 1);
-            log.insert("b[1].x", 1);
-            log.insert("c[0].x", 1);
-            log.insert("c[0].y", 1);
-            log.insert("d.y", 1);
-            log.insert("d.z", 1);
-            log.insert("e[0]", 1);
-            log.insert("e[1]", 1);
-            log.insert("\"f.z\"", 1);
-            log.insert("\"g.z\"", 1);
-            log.insert("h", BTreeMap::new());
-            log.insert("i", Vec::<Value>::new());
+            log.insert(event_path!("a"), 1);
+            log.insert(event_path!("a", "b"), 1);
+            log.insert(event_path!("a", "b", "c"), 1);
+            log.insert(event_path!("a", "b", "d"), 1);
+            log.insert(event_path!("b", 0isize), 1);
+            log.insert(event_path!("b", 1isize, "x"), 1);
+            log.insert(event_path!("c", 0isize, "x"), 1);
+            log.insert(event_path!("c", 0isize, "y"), 1);
+            log.insert(event_path!("d", "y"), 1);
+            log.insert(event_path!("d", "z"), 1);
+            log.insert(event_path!("e", 0isize), 1);
+            log.insert(event_path!("e", 1isize), 1);
+            log.insert(event_path!("f.z"), 1);
+            log.insert(event_path!("g.z"), 1);
+            log.insert(event_path!("h"), BTreeMap::new());
+            log.insert(event_path!("i"), Vec::<Value>::new());
         }
         let mut event = Event::from(log);
         transformer.transform(&mut event);
-        assert!(event.as_mut_log().contains("a.b.c"));
-        assert!(event.as_mut_log().contains("b"));
-        assert!(event.as_mut_log().contains("b[1].x"));
-        assert!(event.as_mut_log().contains("c[0].y"));
-        assert!(event.as_mut_log().contains("\"g.z\""));
+        assert!(event.as_mut_log().contains(event_path!("a", "b", "c")));
+        assert!(event.as_mut_log().contains(event_path!("b")));
+        assert!(event.as_mut_log().contains(event_path!("b", 1isize, "x")));
+        assert!(event.as_mut_log().contains(event_path!("c", 0isize, "y")));
+        assert!(event.as_mut_log().contains(event_path!("g.z")));
 
-        assert!(!event.as_mut_log().contains("a.b.d"));
-        assert!(!event.as_mut_log().contains("c[0].x"));
-        assert!(!event.as_mut_log().contains("d"));
-        assert!(!event.as_mut_log().contains("e"));
-        assert!(!event.as_mut_log().contains("f"));
-        assert!(!event.as_mut_log().contains("h"));
-        assert!(!event.as_mut_log().contains("i"));
+        assert!(!event.as_mut_log().contains(event_path!("a", "b", "d")));
+        assert!(!event.as_mut_log().contains(event_path!("c", 0isize, "x")));
+        assert!(!event.as_mut_log().contains(event_path!("d")));
+        assert!(!event.as_mut_log().contains(event_path!("e")));
+        assert!(!event.as_mut_log().contains(event_path!("f")));
+        assert!(!event.as_mut_log().contains(event_path!("h")));
+        assert!(!event.as_mut_log().contains(event_path!("i")));
     }
 
     #[test]
@@ -378,7 +378,7 @@ mod tests {
             .clone();
         let timestamp = timestamp.as_timestamp().unwrap();
         base.as_mut_log()
-            .insert("another", Value::Timestamp(*timestamp));
+            .insert(event_path!("another"), Value::Timestamp(*timestamp));
 
         let cases = [
             ("unix", Value::from(timestamp.timestamp())),
@@ -405,7 +405,7 @@ mod tests {
                 log.get((PathPrefix::Event, log_schema().timestamp_key().unwrap()))
                     .unwrap(),
                 // second key
-                log.get("another").unwrap(),
+                log.get(event_path!("another")).unwrap(),
             ] {
                 // type matches
                 assert_eq!(expected.kind_str(), actual.kind_str());
@@ -441,8 +441,8 @@ mod tests {
         let transformer: Transformer = toml::from_str(r#"only_fields = ["message"]"#).unwrap();
         let mut log = LogEvent::default();
         {
-            log.insert("message", 1);
-            log.insert("thing.service", "carrot");
+            log.insert(event_path!("message"), 1);
+            log.insert(event_path!("thing", "service"), "carrot");
         }
 
         let schema = schema::Definition::new_with_default_metadata(
@@ -463,10 +463,10 @@ mod tests {
             .set_schema_definition(&Arc::new(schema));
 
         transformer.transform(&mut event);
-        assert!(event.as_mut_log().contains("message"));
+        assert!(event.as_mut_log().contains(event_path!("message")));
 
         // Event no longer contains the service field.
-        assert!(!event.as_mut_log().contains("thing.service"));
+        assert!(!event.as_mut_log().contains(event_path!("thing", "service")));
 
         // But we can still get the service by meaning.
         assert_eq!(
@@ -481,8 +481,8 @@ mod tests {
             toml::from_str(r#"except_fields = ["thing.service"]"#).unwrap();
         let mut log = LogEvent::default();
         {
-            log.insert("message", 1);
-            log.insert("thing.service", "carrot");
+            log.insert(event_path!("message"), 1);
+            log.insert(event_path!("thing", "service"), "carrot");
         }
 
         let schema = schema::Definition::new_with_default_metadata(
@@ -503,10 +503,10 @@ mod tests {
             .set_schema_definition(&Arc::new(schema));
 
         transformer.transform(&mut event);
-        assert!(event.as_mut_log().contains("message"));
+        assert!(event.as_mut_log().contains(event_path!("message")));
 
         // Event no longer contains the service field.
-        assert!(!event.as_mut_log().contains("thing.service"));
+        assert!(!event.as_mut_log().contains(event_path!("thing", "service")));
 
         // But we can still get the service by meaning.
         assert_eq!(

--- a/lib/codecs/tests/protobuf.rs
+++ b/lib/codecs/tests/protobuf.rs
@@ -14,6 +14,7 @@ use codecs::{
 };
 use tokio_util::codec::Encoder;
 use vector_core::config::LogNamespace;
+use vrl::event_path;
 
 fn test_data_dir() -> PathBuf {
     PathBuf::from(std::env::var_os("CARGO_MANIFEST_DIR").unwrap()).join("tests/data/protobuf")
@@ -93,15 +94,18 @@ fn roundtrip_coding_with_json_names() {
     // Verify that protobuf field names are being used (snake_case)
     let event = events_snake_case[0].as_log();
     assert!(
-        event.contains("job_description"),
+        event.contains(event_path!("job_description")),
         "Event should contain 'job_description' (protobuf field name) when use_json_names is disabled"
     );
     assert_eq!(
-        event.get("job_description").unwrap().to_string_lossy(),
+        event
+            .get(event_path!("job_description"))
+            .unwrap()
+            .to_string_lossy(),
         "Software Engineer"
     );
     assert!(
-        !event.contains("jobDescription"),
+        !event.contains(event_path!("jobDescription")),
         "Event should not contain 'jobDescription' (JSON name) when use_json_names is disabled"
     );
 
@@ -127,15 +131,18 @@ fn roundtrip_coding_with_json_names() {
     // Verify that JSON names are being used (camelCase)
     let event = events_camel_case[0].as_log();
     assert!(
-        event.contains("jobDescription"),
+        event.contains(event_path!("jobDescription")),
         "Event should contain 'jobDescription' (JSON name) when use_json_names is enabled"
     );
     assert_eq!(
-        event.get("jobDescription").unwrap().to_string_lossy(),
+        event
+            .get(event_path!("jobDescription"))
+            .unwrap()
+            .to_string_lossy(),
         "Software Engineer"
     );
     assert!(
-        !event.contains("job_description"),
+        !event.contains(event_path!("job_description")),
         "Event should not contain 'job_description' (protobuf name) when use_json_names is enabled"
     );
 

--- a/lib/vector-core/src/config/mod.rs
+++ b/lib/vector-core/src/config/mod.rs
@@ -652,7 +652,7 @@ mod test {
         valid_event
             .metadata_mut()
             .value_mut()
-            .insert(path!("vector").concat("zork"), 32);
+            .insert(path!("vector").concat(path!("zork")), 32);
 
         let valid_event = valid_event.into();
 
@@ -663,7 +663,7 @@ mod test {
         invalid_event
             .metadata_mut()
             .value_mut()
-            .insert(path!("vector").concat("zork"), "noog");
+            .insert(path!("vector").concat(path!("zork")), "noog");
 
         let invalid_event = invalid_event.into();
 

--- a/lib/vector-core/src/event/discriminant.rs
+++ b/lib/vector-core/src/event/discriminant.rs
@@ -183,6 +183,7 @@ mod tests {
 
     use super::*;
     use crate::event::LogEvent;
+    use vrl::event_path;
 
     fn hash<H: Hash>(hash: H) -> u64 {
         let mut hasher = DefaultHasher::new();
@@ -193,10 +194,13 @@ mod tests {
     #[test]
     fn equal() {
         let mut event_1 = LogEvent::default();
-        event_1.insert("hostname", "localhost");
-        event_1.insert("irrelevant", "not even used");
+        event_1.insert(event_path!("hostname"), "localhost");
+        event_1.insert(event_path!("irrelevant"), "not even used");
         let mut event_2 = event_1.clone();
-        event_2.insert("irrelevant", "does not matter if it's different");
+        event_2.insert(
+            event_path!("irrelevant"),
+            "does not matter if it's different",
+        );
 
         let discriminant_fields = vec!["hostname".to_string(), "container_id".to_string()];
 
@@ -210,10 +214,10 @@ mod tests {
     #[test]
     fn not_equal() {
         let mut event_1 = LogEvent::default();
-        event_1.insert("hostname", "localhost");
-        event_1.insert("container_id", "abc");
+        event_1.insert(event_path!("hostname"), "localhost");
+        event_1.insert(event_path!("container_id"), "abc");
         let mut event_2 = event_1.clone();
-        event_2.insert("container_id", "def");
+        event_2.insert(event_path!("container_id"), "def");
 
         let discriminant_fields = vec!["hostname".to_string(), "container_id".to_string()];
 
@@ -227,11 +231,11 @@ mod tests {
     #[test]
     fn field_order() {
         let mut event_1 = LogEvent::default();
-        event_1.insert("a", "a");
-        event_1.insert("b", "b");
+        event_1.insert(event_path!("a"), "a");
+        event_1.insert(event_path!("b"), "b");
         let mut event_2 = LogEvent::default();
-        event_2.insert("b", "b");
-        event_2.insert("a", "a");
+        event_2.insert(event_path!("b"), "b");
+        event_2.insert(event_path!("a"), "a");
 
         let discriminant_fields = vec!["a".to_string(), "b".to_string()];
 
@@ -245,11 +249,11 @@ mod tests {
     #[test]
     fn map_values_key_order() {
         let mut event_1 = LogEvent::default();
-        event_1.insert("nested.a", "a");
-        event_1.insert("nested.b", "b");
+        event_1.insert(event_path!("nested", "a"), "a");
+        event_1.insert(event_path!("nested", "b"), "b");
         let mut event_2 = LogEvent::default();
-        event_2.insert("nested.b", "b");
-        event_2.insert("nested.a", "a");
+        event_2.insert(event_path!("nested", "b"), "b");
+        event_2.insert(event_path!("nested", "a"), "a");
 
         let discriminant_fields = vec!["nested".to_string()];
 
@@ -263,11 +267,11 @@ mod tests {
     #[test]
     fn array_values_insertion_order() {
         let mut event_1 = LogEvent::default();
-        event_1.insert("array[0]", "a");
-        event_1.insert("array[1]", "b");
+        event_1.insert(event_path!("array", 0isize), "a");
+        event_1.insert(event_path!("array", 1isize), "b");
         let mut event_2 = LogEvent::default();
-        event_2.insert("array[1]", "b");
-        event_2.insert("array[0]", "a");
+        event_2.insert(event_path!("array", 1isize), "b");
+        event_2.insert(event_path!("array", 0isize), "a");
 
         let discriminant_fields = vec!["array".to_string()];
 
@@ -281,7 +285,7 @@ mod tests {
     #[test]
     fn map_values_matter_1() {
         let mut event_1 = LogEvent::default();
-        event_1.insert("nested.a", "a"); // `nested` is a `Value::Map`
+        event_1.insert(event_path!("nested", "a"), "a"); // `nested` is a `Value::Map`
         let event_2 = LogEvent::default(); // empty event
 
         let discriminant_fields = vec!["nested".to_string()];
@@ -296,9 +300,9 @@ mod tests {
     #[test]
     fn map_values_matter_2() {
         let mut event_1 = LogEvent::default();
-        event_1.insert("nested.a", "a"); // `nested` is a `Value::Map`
+        event_1.insert(event_path!("nested", "a"), "a"); // `nested` is a `Value::Map`
         let mut event_2 = LogEvent::default();
-        event_2.insert("nested", "x"); // `nested` is a `Value::String`
+        event_2.insert(event_path!("nested"), "x"); // `nested` is a `Value::String`
 
         let discriminant_fields = vec!["nested".to_string()];
 
@@ -316,15 +320,15 @@ mod tests {
 
         let event_stream_1 = {
             let mut event = LogEvent::default();
-            event.insert("hostname", "a.test");
-            event.insert("container_id", "abc");
+            event.insert(event_path!("hostname"), "a.test");
+            event.insert(event_path!("container_id"), "abc");
             event
         };
 
         let event_stream_2 = {
             let mut event = LogEvent::default();
-            event.insert("hostname", "b.test");
-            event.insert("container_id", "def");
+            event.insert(event_path!("hostname"), "b.test");
+            event.insert(event_path!("container_id"), "def");
             event
         };
 
@@ -342,40 +346,40 @@ mod tests {
 
         {
             let mut event = event_stream_1.clone();
-            event.insert("message", "a");
+            event.insert(event_path!("message"), "a");
             assert_eq!(process_event(event), 0);
         }
 
         {
             let mut event = event_stream_1.clone();
-            event.insert("message", "b");
-            event.insert("irrelevant", "c");
+            event.insert(event_path!("message"), "b");
+            event.insert(event_path!("irrelevant"), "c");
             assert_eq!(process_event(event), 1);
         }
 
         {
             let mut event = event_stream_2.clone();
-            event.insert("message", "d");
+            event.insert(event_path!("message"), "d");
             assert_eq!(process_event(event), 0);
         }
 
         {
             let mut event = event_stream_2.clone();
-            event.insert("message", "e");
-            event.insert("irrelevant", "d");
+            event.insert(event_path!("message"), "e");
+            event.insert(event_path!("irrelevant"), "d");
             assert_eq!(process_event(event), 1);
         }
 
         {
             let mut event = event_stream_3.clone();
-            event.insert("message", "f");
+            event.insert(event_path!("message"), "f");
             assert_eq!(process_event(event), 0);
         }
 
         {
             let mut event = event_stream_3.clone();
-            event.insert("message", "g");
-            event.insert("irrelevant", "d");
+            event.insert(event_path!("message"), "g");
+            event.insert(event_path!("irrelevant"), "d");
             assert_eq!(process_event(event), 1);
         }
 
@@ -388,8 +392,8 @@ mod tests {
     #[test]
     fn test_display() {
         let mut event = LogEvent::default();
-        event.insert("hostname", "localhost");
-        event.insert("container_id", 1);
+        event.insert(event_path!("hostname"), "localhost");
+        event.insert(event_path!("container_id"), 1);
 
         let discriminant = Discriminant::from_log_event(
             &event,

--- a/lib/vector-core/src/event/log_event.rs
+++ b/lib/vector-core/src/event/log_event.rs
@@ -894,8 +894,8 @@ mod test {
         });
 
         let mut expected_value = value.clone();
-        let one = expected_value.remove("one", true).unwrap();
-        expected_value.insert("three", one);
+        let one = expected_value.remove(path!("one"), true).unwrap();
+        expected_value.insert(path!("three"), one);
 
         let mut base = LogEvent::from_parts(value, EventMetadata::default());
         base.rename_key(event_path!("one"), event_path!("three"));
@@ -914,8 +914,8 @@ mod test {
         });
 
         let mut expected_value = value.clone();
-        let val = expected_value.remove("one", true).unwrap();
-        expected_value.insert("two", val);
+        let val = expected_value.remove(path!("one"), true).unwrap();
+        expected_value.insert(path!("two"), val);
 
         let mut base = LogEvent::from_parts(value, EventMetadata::default());
         base.rename_key(event_path!("one"), event_path!("two"));
@@ -928,20 +928,20 @@ mod test {
     fn insert() {
         let mut log = LogEvent::default();
 
-        let old = log.insert("foo", "foo");
+        let old = log.insert(event_path!("foo"), "foo");
 
-        assert_eq!(log.get("foo"), Some(&"foo".into()));
+        assert_eq!(log.get(event_path!("foo")), Some(&"foo".into()));
         assert_eq!(old, None);
     }
 
     #[test]
     fn insert_existing() {
         let mut log = LogEvent::default();
-        log.insert("foo", "foo");
+        log.insert(event_path!("foo"), "foo");
 
-        let old = log.insert("foo", "bar");
+        let old = log.insert(event_path!("foo"), "bar");
 
-        assert_eq!(log.get("foo"), Some(&"bar".into()));
+        assert_eq!(log.get(event_path!("foo")), Some(&"bar".into()));
         assert_eq!(old, Some("foo".into()));
     }
 
@@ -949,39 +949,39 @@ mod test {
     fn try_insert() {
         let mut log = LogEvent::default();
 
-        log.try_insert("foo", "foo");
+        log.try_insert(event_path!("foo"), "foo");
 
-        assert_eq!(log.get("foo"), Some(&"foo".into()));
+        assert_eq!(log.get(event_path!("foo")), Some(&"foo".into()));
     }
 
     #[test]
     fn try_insert_existing() {
         let mut log = LogEvent::default();
-        log.insert("foo", "foo");
+        log.insert(event_path!("foo"), "foo");
 
-        log.try_insert("foo", "bar");
+        log.try_insert(event_path!("foo"), "bar");
 
-        assert_eq!(log.get("foo"), Some(&"foo".into()));
+        assert_eq!(log.get(event_path!("foo")), Some(&"foo".into()));
     }
 
     #[test]
-    fn try_insert_dotted() {
+    fn try_insert_nested() {
         let mut log = LogEvent::default();
 
-        log.try_insert("foo.bar", "foo");
+        log.try_insert(event_path!("foo", "bar"), "foo");
 
-        assert_eq!(log.get("foo.bar"), Some(&"foo".into()));
+        assert_eq!(log.get(event_path!("foo", "bar")), Some(&"foo".into()));
         assert_eq!(log.get(event_path!("foo.bar")), None);
     }
 
     #[test]
-    fn try_insert_existing_dotted() {
+    fn try_insert_existing_nested() {
         let mut log = LogEvent::default();
-        log.insert("foo.bar", "foo");
+        log.insert(event_path!("foo", "bar"), "foo");
 
-        log.try_insert("foo.bar", "bar");
+        log.try_insert(event_path!("foo", "bar"), "bar");
 
-        assert_eq!(log.get("foo.bar"), Some(&"foo".into()));
+        assert_eq!(log.get(event_path!("foo", "bar")), Some(&"foo".into()));
         assert_eq!(log.get(event_path!("foo.bar")), None);
     }
 
@@ -1011,7 +1011,6 @@ mod test {
         log.try_insert(event_path!("foo.bar"), "foo");
 
         assert_eq!(log.get(event_path!("foo.bar")), Some(&"foo".into()));
-        assert_eq!(log.get("foo.bar"), None);
     }
 
     #[test]
@@ -1022,7 +1021,6 @@ mod test {
         log.try_insert(event_path!("foo.bar"), "bar");
 
         assert_eq!(log.get(event_path!("foo.bar")), Some(&"foo".into()));
-        assert_eq!(log.get("foo.bar"), None);
     }
 
     // This test iterates over the `tests/data/fixtures/log_event` folder and:
@@ -1092,14 +1090,14 @@ mod test {
         let current = {
             let mut log = LogEvent::default();
 
-            log.insert("merge", "hello "); // will be concatenated with the `merged` from `incoming`.
-            log.insert("do_not_merge", "my_first_value"); // will remain as is, since it's not selected for merging.
+            log.insert(event_path!("merge"), "hello "); // will be concatenated with the `merged` from `incoming`.
+            log.insert(event_path!("do_not_merge"), "my_first_value"); // will remain as is, since it's not selected for merging.
 
-            log.insert("merge_a", true); // will be overwritten with the `merge_a` from `incoming` (since it's a non-bytes kind).
-            log.insert("merge_b", 123i64); // will be overwritten with the `merge_b` from `incoming` (since it's a non-bytes kind).
+            log.insert(event_path!("merge_a"), true); // will be overwritten with the `merge_a` from `incoming` (since it's a non-bytes kind).
+            log.insert(event_path!("merge_b"), 123i64); // will be overwritten with the `merge_b` from `incoming` (since it's a non-bytes kind).
 
-            log.insert("a", true); // will remain as is since it's not selected for merge.
-            log.insert("b", 123i64); // will remain as is since it's not selected for merge.
+            log.insert(event_path!("a"), true); // will remain as is since it's not selected for merge.
+            log.insert(event_path!("b"), 123i64); // will remain as is since it's not selected for merge.
 
             // `c` is not present in the `current`, and not selected for merge,
             // so it won't be included in the final event.
@@ -1110,16 +1108,16 @@ mod test {
         let incoming = {
             let mut log = LogEvent::default();
 
-            log.insert("merge", "world"); // will be concatenated to the `merge` from `current`.
-            log.insert("do_not_merge", "my_second_value"); // will be ignored, since it's not selected for merge.
+            log.insert(event_path!("merge"), "world"); // will be concatenated to the `merge` from `current`.
+            log.insert(event_path!("do_not_merge"), "my_second_value"); // will be ignored, since it's not selected for merge.
 
-            log.insert("merge_b", 456i64); // will be merged in as `456`.
-            log.insert("merge_c", false); // will be merged in as `false`.
+            log.insert(event_path!("merge_b"), 456i64); // will be merged in as `456`.
+            log.insert(event_path!("merge_c"), false); // will be merged in as `false`.
 
             // `a` will remain as-is, since it's not marked for merge and
             // neither is it specified in the `incoming` event.
-            log.insert("b", 456i64); // `b` not marked for merge, will not change.
-            log.insert("c", true); // `c` not marked for merge, will be ignored.
+            log.insert(event_path!("b"), 456i64); // `b` not marked for merge, will not change.
+            log.insert(event_path!("c"), true); // `c` not marked for merge, will be ignored.
 
             log
         };
@@ -1129,13 +1127,13 @@ mod test {
 
         let expected = {
             let mut log = LogEvent::default();
-            log.insert("merge", "hello world");
-            log.insert("do_not_merge", "my_first_value");
-            log.insert("a", true);
-            log.insert("b", 123i64);
-            log.insert("merge_a", true);
-            log.insert("merge_b", 456i64);
-            log.insert("merge_c", false);
+            log.insert(event_path!("merge"), "hello world");
+            log.insert(event_path!("do_not_merge"), "my_first_value");
+            log.insert(event_path!("a"), true);
+            log.insert(event_path!("b"), 123i64);
+            log.insert(event_path!("merge_a"), true);
+            log.insert(event_path!("merge_b"), 456i64);
+            log.insert(event_path!("merge_c"), false);
             log
         };
 
@@ -1145,9 +1143,9 @@ mod test {
     #[test]
     fn event_fields_iter() {
         let mut log = LogEvent::default();
-        log.insert("a", 0);
-        log.insert("a.b", 1);
-        log.insert("c", 2);
+        log.insert(event_path!("a"), 0);
+        log.insert(event_path!("a", "b"), 1);
+        log.insert(event_path!("c"), 2);
         let actual: Vec<(KeyString, Value)> = log
             .all_event_fields()
             .unwrap()
@@ -1162,9 +1160,9 @@ mod test {
     #[test]
     fn metadata_fields_iter() {
         let mut log = LogEvent::default();
-        log.insert("%a", 0);
-        log.insert("%a.b", 1);
-        log.insert("%c", 2);
+        log.insert(metadata_path!("a"), 0);
+        log.insert(metadata_path!("a", "b"), 1);
+        log.insert(metadata_path!("c"), 2);
         let actual: Vec<(KeyString, Value)> = log
             .all_metadata_fields()
             .unwrap()

--- a/lib/vector-core/src/event/lua/event.rs
+++ b/lib/vector-core/src/event/lua/event.rs
@@ -95,8 +95,9 @@ mod test {
 
     #[test]
     fn into_lua_log() {
+        use vrl::event_path;
         let mut event = LogEvent::default();
-        event.insert("field", "value");
+        event.insert(event_path!("field"), "value");
 
         let assertions = vec![
             "type(event) == 'table'",

--- a/lib/vector-core/src/event/lua/log.rs
+++ b/lib/vector-core/src/event/lua/log.rs
@@ -20,14 +20,15 @@ impl FromLua for LogEvent {
 #[cfg(test)]
 mod test {
     use super::*;
+    use vrl::event_path;
 
     #[test]
     fn into_lua() {
         let mut log = LogEvent::default();
-        log.insert("a", 1);
-        log.insert("nested.field", "2");
-        log.insert("nested.array[0]", "example value");
-        log.insert("nested.array[2]", "another value");
+        log.insert(event_path!("a"), 1);
+        log.insert(event_path!("nested", "field"), "2");
+        log.insert(event_path!("nested", "array", 0isize), "example value");
+        log.insert(event_path!("nested", "array", 2isize), "another value");
 
         let assertions = vec![
             "type(log) == 'table'",

--- a/lib/vector-core/src/event/merge_state.rs
+++ b/lib/vector-core/src/event/merge_state.rs
@@ -54,7 +54,7 @@ mod test {
 
         assert_eq!(
             merged_event
-                .get("message")
+                .get(vrl::event_path!("message"))
                 .unwrap()
                 .coerce_to_bytes()
                 .as_ref(),

--- a/lib/vector-core/src/event/test/mod.rs
+++ b/lib/vector-core/src/event/test/mod.rs
@@ -4,13 +4,17 @@ mod size_of;
 use std::collections::HashSet;
 
 use super::*;
+use vrl::event_path;
 
 #[test]
 fn event_iteration() {
     let mut log = LogEvent::default();
 
-    log.insert("\"Ke$ha\"", "It's going down, I'm yelling timber");
-    log.insert("Pitbull", "The bigger they are, the harder they fall");
+    log.insert(event_path!("Ke$ha"), "It's going down, I'm yelling timber");
+    log.insert(
+        event_path!("Pitbull"),
+        "The bigger they are, the harder they fall",
+    );
 
     let all = log
         .all_event_fields()
@@ -37,9 +41,9 @@ fn event_iteration() {
 #[test]
 fn event_iteration_order() {
     let mut log = LogEvent::default();
-    log.insert("lZDfzKIL", Value::from("tOVrjveM"));
-    log.insert("o9amkaRY", Value::from("pGsfG7Nr"));
-    log.insert("YRjhxXcg", Value::from("nw8iM5Jr"));
+    log.insert(event_path!("lZDfzKIL"), Value::from("tOVrjveM"));
+    log.insert(event_path!("o9amkaRY"), Value::from("pGsfG7Nr"));
+    log.insert(event_path!("YRjhxXcg"), Value::from("nw8iM5Jr"));
 
     let collected: Vec<_> = log.all_event_fields().unwrap().collect();
     assert_eq!(

--- a/lib/vector-core/src/event/test/serialization.rs
+++ b/lib/vector-core/src/event/test/serialization.rs
@@ -5,6 +5,7 @@ use quickcheck::{QuickCheck, TestResult};
 use regex::Regex;
 use similar_asserts::assert_eq;
 use vector_buffers::encoding::Encodable;
+use vrl::event_path;
 
 fn encode_value<T: Encodable, B: BufMut>(value: T, buffer: &mut B) {
     value.encode(buffer).expect("encoding should not fail");
@@ -62,14 +63,14 @@ fn back_and_forth_through_bytes() {
 #[test]
 fn serialization() {
     let mut event = LogEvent::from("raw log line");
-    event.insert("foo", "bar");
-    event.insert("bar", "baz");
+    event.insert(event_path!("foo"), "bar");
+    event.insert(event_path!("bar"), "baz");
 
     let expected_all = serde_json::json!({
         "message": "raw log line",
         "foo": "bar",
         "bar": "baz",
-        "timestamp": event.get(log_schema().timestamp_key().unwrap().to_string().as_str()),
+        "timestamp": event.get(log_schema().timestamp_key_target_path().unwrap()),
     });
 
     let actual_all = serde_json::to_value(event.all_event_fields().unwrap()).unwrap();
@@ -84,10 +85,10 @@ fn type_serialization() {
     use serde_json::json;
 
     let mut event = LogEvent::from("hello world");
-    event.insert("int", 4);
-    event.insert("float", 5.5);
-    event.insert("bool", true);
-    event.insert("string", "thisisastring");
+    event.insert(event_path!("int"), 4);
+    event.insert(event_path!("float"), 5.5);
+    event.insert(event_path!("bool"), true);
+    event.insert(event_path!("string"), "thisisastring");
 
     let map = serde_json::to_value(event.all_event_fields().unwrap()).unwrap();
     assert_eq!(map["float"], json!(5.5));

--- a/lib/vector-core/src/event/test/size_of.rs
+++ b/lib/vector-core/src/event/test/size_of.rs
@@ -118,7 +118,7 @@ fn log_operation_maintains_size() {
                     let new_value_sz = value.size_of();
                     let target_path = (PathPrefix::Event, path!(key.as_str()));
                     let old_value_sz = log_event.get(target_path).map_or(0, ByteSizeOf::size_of);
-                    if !log_event.contains(key.as_str()) {
+                    if !log_event.contains((PathPrefix::Event, path!(key.as_str()))) {
                         current_size += key.size_of();
                     }
                     log_event.insert(target_path, value);
@@ -129,10 +129,12 @@ fn log_operation_maintains_size() {
                     assert_eq!(current_size, log_event.size_of());
                 }
                 Action::Contains { key } => {
-                    log_event.contains(key.as_str());
+                    log_event.contains((PathPrefix::Event, path!(key.as_str())));
                 }
                 Action::Remove { key } => {
-                    let value_sz = log_event.remove(key.as_str()).size_of();
+                    let value_sz = log_event
+                        .remove((PathPrefix::Event, path!(key.as_str())))
+                        .size_of();
                     current_size -= value_sz;
                     current_size -= key.size_of();
                 }

--- a/lib/vector-core/src/fanout.rs
+++ b/lib/vector-core/src/fanout.rs
@@ -517,7 +517,7 @@ mod tests {
             channel::{BufferReceiver, BufferSender},
         },
     };
-    use vrl::value::Value;
+    use vrl::{event_path, value::Value};
 
     use super::{ControlMessage, Fanout};
     use crate::{
@@ -653,7 +653,7 @@ mod tests {
             .expect("must have at least one event");
         let event = event.into_log();
         event
-            .get("message")
+            .get(event_path!("message"))
             .and_then(Value::as_bytes)
             .and_then(|b| String::from_utf8(b.to_vec()).ok())
             .expect("must be valid log event with `message` field")

--- a/lib/vector-core/src/source_sender/tests.rs
+++ b/lib/vector-core/src/source_sender/tests.rs
@@ -19,7 +19,7 @@ use crate::{
 async fn emits_lag_time_for_log() {
     emit_and_test(|timestamp| {
         let mut log = LogEvent::from("Log message");
-        log.insert("timestamp", timestamp);
+        log.insert(event_path!("timestamp"), timestamp);
         Event::Log(log)
     })
     .await;

--- a/lib/vector-vrl/dnstap-parser/src/parser.rs
+++ b/lib/vector-vrl/dnstap-parser/src/parser.rs
@@ -1148,7 +1148,9 @@ mod tests {
 
         // The maps need to contain identical keys and values.
         for (exp_key, exp_value) in expected_map {
-            let value = log_event.get(exp_key).unwrap();
+            let value = log_event
+                .get(&vrl::path::parse_target_path(exp_key).unwrap())
+                .unwrap();
             assert_eq!(*value, exp_value);
         }
     }
@@ -1203,11 +1205,15 @@ mod tests {
 
         // The maps need to contain identical keys and values.
         for (exp_key, exp_value) in no_lowercase_expected {
-            let value = log_event.get(exp_key).unwrap();
+            let value = log_event
+                .get(&vrl::path::parse_target_path(exp_key).unwrap())
+                .unwrap();
             assert_eq!(*value, exp_value);
         }
         for (exp_key, exp_value) in expected_map {
-            let value = lowercase_log_event.get(exp_key).unwrap();
+            let value = lowercase_log_event
+                .get(&vrl::path::parse_target_path(exp_key).unwrap())
+                .unwrap();
             assert_eq!(*value, exp_value);
         }
     }
@@ -1242,7 +1248,9 @@ mod tests {
 
         // The maps need to contain identical keys and values.
         for (exp_key, exp_value) in expected_map {
-            let value = log_event.get(exp_key).unwrap();
+            let value = log_event
+                .get(&vrl::path::parse_target_path(exp_key).unwrap())
+                .unwrap();
             assert_eq!(*value, exp_value);
         }
     }
@@ -1337,7 +1345,9 @@ mod tests {
 
         // The maps need to contain identical keys and values.
         for (exp_key, exp_value) in expected_map {
-            let value = log_event.get(exp_key).unwrap();
+            let value = log_event
+                .get(&vrl::path::parse_target_path(exp_key).unwrap())
+                .unwrap();
             assert_eq!(*value, exp_value);
         }
     }

--- a/src/enrichment_tables/mmdb.rs
+++ b/src/enrichment_tables/mmdb.rs
@@ -76,8 +76,11 @@ impl Mmdb {
             let mut filtered = Value::from(ObjectMap::new());
             let mut data_value = Value::from(data);
             for field in fields {
-                let field_path = vrl::path::parse_value_path(field).ok();
-                let Some(field_path) = field_path else {
+                // Unparseable field names in the caller's `select` list are
+                // skipped: this matches the pre-migration behavior where the
+                // JIT `&str` path parser failed to iterate and the field was
+                // omitted from the output entirely.
+                let Ok(field_path) = vrl::path::parse_value_path(field) else {
                     continue;
                 };
                 filtered.insert(
@@ -201,6 +204,29 @@ mod tests {
                 ("longitude".into(), Value::from(-1.25)),
             ])
             .into(),
+        );
+
+        assert_eq!(values, expected);
+    }
+
+    #[test]
+    fn city_partial_lookup_skips_unparseable_selects() {
+        // An unparseable path in the select list is silently dropped from the
+        // output rather than surfacing as a null-valued literal field.
+        let values = find_select(
+            "2.125.160.216",
+            "tests/data/GeoIP2-City-Test.mmdb",
+            Some(&[
+                "location.latitude".to_string(),
+                "not a valid path".to_string(),
+            ]),
+        )
+        .unwrap();
+
+        let mut expected = ObjectMap::new();
+        expected.insert(
+            "location".into(),
+            ObjectMap::from([("latitude".into(), Value::from(51.75))]).into(),
         );
 
         assert_eq!(values, expected);

--- a/src/enrichment_tables/mmdb.rs
+++ b/src/enrichment_tables/mmdb.rs
@@ -76,11 +76,13 @@ impl Mmdb {
             let mut filtered = Value::from(ObjectMap::new());
             let mut data_value = Value::from(data);
             for field in fields {
+                let field_path = vrl::path::parse_value_path(field).ok();
+                let Some(field_path) = field_path else {
+                    continue;
+                };
                 filtered.insert(
-                    field.as_str(),
-                    data_value
-                        .remove(field.as_str(), false)
-                        .unwrap_or(Value::Null),
+                    &field_path,
+                    data_value.remove(&field_path, false).unwrap_or(Value::Null),
                 );
             }
             filtered.into_object()

--- a/src/sinks/amqp/config.rs
+++ b/src/sinks/amqp/config.rs
@@ -164,6 +164,7 @@ pub(super) async fn healthcheck(channels: AmqpSinkChannels) -> crate::Result<()>
 mod tests {
     use super::*;
     use crate::config::format::{Format, deserialize};
+    use vrl::event_path;
 
     #[test]
     pub fn generate_config() {
@@ -276,7 +277,7 @@ mod tests {
             let config: AmqpSinkConfig = deserialize(config, format).unwrap();
             let event = {
                 let mut event = LogEvent::from_str_legacy("message");
-                event.insert("priority", 2);
+                event.insert(event_path!("priority"), 2);
                 event
             };
             assert_config_priority_eq(config, &event, 2);

--- a/src/sinks/amqp/integration_tests.rs
+++ b/src/sinks/amqp/integration_tests.rs
@@ -4,6 +4,7 @@ use config::AmqpPropertiesConfig;
 use futures::StreamExt;
 use lapin::types::ShortString;
 use vector_lib::{config::LogNamespace, event::LogEvent};
+use vrl::event_path;
 
 use super::*;
 use crate::{
@@ -319,7 +320,7 @@ async fn amqp_priority_with_template(
     let event = {
         let mut event = LogEvent::from_str_legacy(&input);
         if let Some(priority) = event_field_priority {
-            event.insert("priority", priority);
+            event.insert(event_path!("priority"), priority);
         }
         event
     };

--- a/src/sinks/aws_cloudwatch_logs/integration_tests.rs
+++ b/src/sinks/aws_cloudwatch_logs/integration_tests.rs
@@ -7,6 +7,7 @@ use chrono::Duration;
 use futures::{StreamExt, stream};
 use similar_asserts::assert_eq;
 use vector_lib::{codecs::TextSerializerConfig, lookup};
+use vrl::event_path;
 
 use super::*;
 use crate::{
@@ -485,7 +486,7 @@ async fn cloudwatch_insert_log_event_partitioned() {
         .map(|(i, e)| {
             let mut event = LogEvent::from(e);
             let stream = (i % 2).to_string();
-            event.insert("key", stream);
+            event.insert(event_path!("key"), stream);
             Event::Log(event)
         })
         .collect::<Vec<_>>();

--- a/src/sinks/aws_kinesis/firehose/integration_tests.rs
+++ b/src/sinks/aws_kinesis/firehose/integration_tests.rs
@@ -4,6 +4,7 @@ use futures::{StreamExt, TryFutureExt};
 use serde_json::{Value, json};
 use tokio::time::{Duration, sleep};
 use vector_lib::{codecs::JsonSerializerConfig, lookup::lookup_v2::ConfigValuePath};
+use vrl::event_path;
 
 use super::{config::KinesisFirehoseClientBuilder, *};
 use crate::{
@@ -174,13 +175,14 @@ async fn firehose_put_records_with_partition_key() {
 
     let events = events.map(move |mut events| {
         events.iter_logs_mut().for_each(move |log| {
-            log.insert("partition_key", partition_value);
+            log.insert(event_path!("partition_key"), partition_value);
         });
         events
     });
 
     input.iter_mut().for_each(move |log| {
-        log.as_mut_log().insert("partition_key", partition_value);
+        log.as_mut_log()
+            .insert(event_path!("partition_key"), partition_value);
     });
 
     run_and_assert_sink_compliance(sink, events, &AWS_SINK_TAGS).await;

--- a/src/sinks/aws_kinesis/streams/integration_tests.rs
+++ b/src/sinks/aws_kinesis/streams/integration_tests.rs
@@ -6,6 +6,7 @@ use aws_smithy_types::DateTime;
 use futures::StreamExt;
 use tokio::time::{Duration, sleep};
 use vector_lib::{codecs::TextSerializerConfig, lookup::lookup_v2::ConfigValuePath};
+use vrl::event_path;
 
 use super::{config::KinesisClientBuilder, *};
 use crate::{
@@ -60,7 +61,7 @@ async fn kinesis_put_records_with_partition_key() {
 
     let events = events.map(move |mut events| {
         events.iter_logs_mut().for_each(move |log| {
-            log.insert("partition_key", partition_value);
+            log.insert(event_path!("partition_key"), partition_value);
         });
         events
     });
@@ -252,7 +253,7 @@ async fn kinesis_retry_failed_records_on_partial_failure() {
         events.iter_logs_mut().enumerate().for_each(|(i, log)| {
             // Use a limited set of partition keys to force collisions
             let partition_key = format!("key-{}", i % 3); // Only 3 different keys
-            log.insert("partition_key", partition_key);
+            log.insert(event_path!("partition_key"), partition_key);
         });
         events
     });

--- a/src/sinks/aws_s3/integration_tests.rs
+++ b/src/sinks/aws_s3/integration_tests.rs
@@ -7,8 +7,28 @@ use std::{
     time::Duration,
 };
 
+use super::S3SinkConfig;
 #[cfg(feature = "codecs-parquet")]
 use super::config::S3BatchEncoding;
+use crate::{
+    aws::{AwsAuthentication, RegionOrEndpoint, create_client},
+    common::s3::S3ClientBuilder,
+    config::{Config, SinkContext},
+    sinks::{
+        aws_s3::config::default_filename_time_format,
+        s3_common::config::{S3Options, S3ServerSideEncryption},
+        util::{BatchConfig, Compression, TowerRequestConfig},
+    },
+    test_util::{
+        self,
+        components::{
+            AWS_SINK_TAGS, COMPONENT_ERROR_TAGS, run_and_assert_sink_compliance,
+            run_and_assert_sink_error,
+        },
+        mock::basic_source,
+        random_lines_with_stream, random_string, start_topology,
+    },
+};
 use aws_sdk_s3::{
     Client as S3Client,
     operation::{create_bucket::CreateBucketError, get_object::GetObjectOutput},
@@ -29,27 +49,6 @@ use vector_lib::{
     codecs::{TextSerializerConfig, encoding::FramingConfig},
     config::{ComponentKey, proxy::ProxyConfig},
     event::{BatchNotifier, BatchStatus, BatchStatusReceiver, Event, EventArray, LogEvent},
-};
-
-use super::S3SinkConfig;
-use crate::{
-    aws::{AwsAuthentication, RegionOrEndpoint, create_client},
-    common::s3::S3ClientBuilder,
-    config::{Config, SinkContext},
-    sinks::{
-        aws_s3::config::default_filename_time_format,
-        s3_common::config::{S3Options, S3ServerSideEncryption},
-        util::{BatchConfig, Compression, TowerRequestConfig},
-    },
-    test_util::{
-        self,
-        components::{
-            AWS_SINK_TAGS, COMPONENT_ERROR_TAGS, run_and_assert_sink_compliance,
-            run_and_assert_sink_error,
-        },
-        mock::basic_source,
-        random_lines_with_stream, random_string, start_topology,
-    },
 };
 
 fn s3_address() -> String {
@@ -199,7 +198,7 @@ async fn s3_rotate_files_after_the_buffer_size_is_reached() {
         } else {
             3
         };
-        e.insert("i", i.to_string());
+        e.insert(vrl::event_path!("i"), i.to_string());
         Event::from(e)
     });
 
@@ -453,7 +452,7 @@ async fn s3_flush_on_exhaustion() {
         } else {
             3
         };
-        e.insert("i", i.to_string());
+        e.insert(vrl::event_path!("i"), i.to_string());
         Event::from(e)
     });
 
@@ -490,6 +489,7 @@ async fn s3_parquet_insert_message() {
     use vector_lib::codecs::encoding::format::{
         ParquetCompression, ParquetSchemaMode, ParquetSerializerConfig,
     };
+    use vrl::event_path;
 
     let cx = SinkContext::default();
     let bucket = uuid::Uuid::new_v4().to_string();
@@ -514,7 +514,7 @@ async fn s3_parquet_insert_message() {
     let events: Vec<Event> = (0..10)
         .map(|i| {
             let mut log = LogEvent::from(format!("message_{}", i));
-            log.insert("host", format!("host_{}", i % 3));
+            log.insert(event_path!("host"), format!("host_{}", i % 3));
             Event::from(log).with_batch_notifier(&batch_notifier)
         })
         .collect();

--- a/src/sinks/axiom/integration_tests.rs
+++ b/src/sinks/axiom/integration_tests.rs
@@ -42,14 +42,14 @@ async fn axiom_logs_put_data() {
     let (batch, mut receiver) = BatchNotifier::new_with_receiver();
 
     let mut event1 = LogEvent::from("message_1").with_batch_notifier(&batch);
-    event1.insert("host", "aws.cloud.eur");
-    event1.insert("source_type", "file");
-    event1.insert("test_id", test_id.clone());
+    event1.insert(vrl::event_path!("host"), "aws.cloud.eur");
+    event1.insert(vrl::event_path!("source_type"), "file");
+    event1.insert(vrl::event_path!("test_id"), test_id.clone());
 
     let mut event2 = LogEvent::from("message_2").with_batch_notifier(&batch);
-    event2.insert("host", "aws.cloud.eur");
-    event2.insert("source_type", "file");
-    event2.insert("test_id", test_id.clone());
+    event2.insert(vrl::event_path!("host"), "aws.cloud.eur");
+    event2.insert(vrl::event_path!("source_type"), "file");
+    event2.insert(vrl::event_path!("test_id"), test_id.clone());
 
     drop(batch);
 

--- a/src/sinks/azure_blob/integration_tests.rs
+++ b/src/sinks/azure_blob/integration_tests.rs
@@ -1,6 +1,8 @@
 use std::io::{BufRead, BufReader};
 use std::sync::Arc;
 
+use vrl::event_path;
+
 use azure_core::http::StatusCode;
 use azure_storage_blob::BlobContainerClient;
 
@@ -431,7 +433,7 @@ fn random_lines_with_stream_with_group_key(
         .map(move |(i, line)| {
             let mut log = LogEvent::from(line);
             let i = ((i / key) + 1) as i32;
-            log.insert("key", i);
+            log.insert(event_path!("key"), i);
             Event::from(log)
         })
         .fold((0, Vec::new()), |(mut size, mut events), event| {

--- a/src/sinks/azure_logs_ingestion/sink.rs
+++ b/src/sinks/azure_logs_ingestion/sink.rs
@@ -117,6 +117,12 @@ impl crate::sinks::util::encoding::Encoder<Vec<Event>> for JsonEncoding {
                 chrono::Utc::now()
             };
 
+            // `timestamp_field` is a plain `String` on the config. Parse per-insert
+            // rather than at config load to keep this change scoped to the
+            // `string_path` removal. Silently skipping on parse error matches the
+            // pre-migration behavior, where the JIT parser tolerated unparseable
+            // inputs without panicking. A follow-up should validate this at config
+            // load time (see `ConfigValuePath`/`OptionalValuePath`).
             if let Ok(ts_path) = vrl::path::parse_value_path(&self.timestamp_field) {
                 log.insert(
                     (PathPrefix::Event, &ts_path),

--- a/src/sinks/azure_logs_ingestion/sink.rs
+++ b/src/sinks/azure_logs_ingestion/sink.rs
@@ -117,12 +117,14 @@ impl crate::sinks::util::encoding::Encoder<Vec<Event>> for JsonEncoding {
                 chrono::Utc::now()
             };
 
-            log.insert(
-                (PathPrefix::Event, self.timestamp_field.as_str()),
-                serde_json::Value::String(
-                    timestamp.to_rfc3339_opts(chrono::SecondsFormat::Micros, true),
-                ),
-            );
+            if let Ok(ts_path) = vrl::path::parse_value_path(&self.timestamp_field) {
+                log.insert(
+                    (PathPrefix::Event, &ts_path),
+                    serde_json::Value::String(
+                        timestamp.to_rfc3339_opts(chrono::SecondsFormat::Micros, true),
+                    ),
+                );
+            }
         }
 
         self.encoder.encode_input(input, writer)

--- a/src/sinks/clickhouse/integration_tests.rs
+++ b/src/sinks/clickhouse/integration_tests.rs
@@ -22,6 +22,7 @@ use vector_lib::{
     event::{BatchNotifier, BatchStatus, BatchStatusReceiver, Event, LogEvent},
     lookup::PathPrefix,
 };
+use vrl::event_path;
 use warp::Filter;
 
 use crate::{
@@ -77,7 +78,7 @@ async fn insert_events() {
     let (mut input_event, mut receiver) = make_event();
     input_event
         .as_mut_log()
-        .insert("items", vec!["item1", "item2"]);
+        .insert(event_path!("items"), vec!["item1", "item2"]);
 
     run_and_assert_sink_compliance(sink, stream::once(ready(input_event.clone())), &SINK_TAGS)
         .await;
@@ -122,7 +123,9 @@ async fn skip_unknown_fields() {
     let (sink, _hc) = config.build(SinkContext::default()).await.unwrap();
 
     let (mut input_event, mut receiver) = make_event();
-    input_event.as_mut_log().insert("unknown", "mysteries");
+    input_event
+        .as_mut_log()
+        .insert(event_path!("unknown"), "mysteries");
 
     run_and_assert_sink_compliance(sink, stream::once(ready(input_event.clone())), &SINK_TAGS)
         .await;
@@ -130,7 +133,7 @@ async fn skip_unknown_fields() {
     let output = client.select_all(&table).await;
     assert_eq!(1, output.rows);
 
-    input_event.as_mut_log().remove("unknown");
+    input_event.as_mut_log().remove(event_path!("unknown"));
     let expected = serde_json::to_value(input_event.into_log()).unwrap();
     assert_eq!(expected, output.data[0]);
 
@@ -346,7 +349,9 @@ async fn templated_table() {
         .map(|_| {
             let table = random_table_name();
             let (mut event, receiver) = make_event();
-            event.as_mut_log().insert("table", table.as_str());
+            event
+                .as_mut_log()
+                .insert(event_path!("table"), table.as_str());
             (table, event, receiver)
         })
         .collect();
@@ -402,7 +407,7 @@ async fn templated_table() {
 fn make_event() -> (Event, BatchStatusReceiver) {
     let (batch, receiver) = BatchNotifier::new_with_receiver();
     let mut event = LogEvent::from("raw log line").with_batch_notifier(&batch);
-    event.insert("host", "example.com");
+    event.insert(event_path!("host"), "example.com");
     (event.into(), receiver)
 }
 
@@ -528,8 +533,8 @@ async fn insert_events_arrow_format() {
     let mut events: Vec<Event> = Vec::new();
     for i in 0..5 {
         let mut event = LogEvent::from(format!("log message {}", i));
-        event.insert("host", format!("host{}.example.com", i));
-        event.insert("count", i as i64);
+        event.insert(event_path!("host"), format!("host{}.example.com", i));
+        event.insert(event_path!("count"), i as i64);
         events.push(event.into());
     }
 
@@ -593,13 +598,13 @@ async fn insert_events_arrow_with_schema_fetching() {
     let mut events: Vec<Event> = Vec::new();
     for i in 0..3 {
         let mut event = LogEvent::from(format!("Test message {}", i));
-        event.insert("host", format!("host{}.example.com", i));
-        event.insert("id", i as i64);
-        event.insert("name", format!("user_{}", i));
-        event.insert("score", 95.5 + i as f64);
-        event.insert("active", i % 2 == 0);
+        event.insert(event_path!("host"), format!("host{}.example.com", i));
+        event.insert(event_path!("id"), i as i64);
+        event.insert(event_path!("name"), format!("user_{}", i));
+        event.insert(event_path!("score"), 95.5 + i as f64);
+        event.insert(event_path!("active"), i % 2 == 0);
         event.insert(
-            "request_id",
+            event_path!("request_id"),
             format!("550e8400-e29b-41d4-a716-44665544000{}", i),
         );
         events.push(event.into());
@@ -701,11 +706,11 @@ async fn test_complex_types() {
 
     // Event 1: Comprehensive test with all complex types
     let mut event1 = LogEvent::from("Comprehensive complex types test");
-    event1.insert("host", "host1.example.com");
+    event1.insert(event_path!("host"), "host1.example.com");
 
     // Nested arrays
     event1.insert(
-        "nested_int_array",
+        event_path!("nested_int_array"),
         vector_lib::event::Value::Array(vec![
             vector_lib::event::Value::Array(vec![
                 vector_lib::event::Value::Integer(1),
@@ -718,7 +723,7 @@ async fn test_complex_types() {
         ]),
     );
     event1.insert(
-        "nested_string_array",
+        event_path!("nested_string_array"),
         vector_lib::event::Value::Array(vec![vector_lib::event::Value::Array(vec![
             vector_lib::event::Value::Bytes("a".into()),
             vector_lib::event::Value::Bytes("b".into()),
@@ -734,7 +739,10 @@ async fn test_complex_types() {
             vector_lib::event::Value::Bytes("banana".into()),
         ]),
     );
-    event1.insert("array_map", vector_lib::event::Value::Object(array_map));
+    event1.insert(
+        event_path!("array_map"),
+        vector_lib::event::Value::Object(array_map),
+    );
 
     let mut int_array_map = vector_lib::event::ObjectMap::new();
     int_array_map.insert(
@@ -745,7 +753,7 @@ async fn test_complex_types() {
         ]),
     );
     event1.insert(
-        "int_array_map",
+        event_path!("int_array_map"),
         vector_lib::event::Value::Object(int_array_map),
     );
 
@@ -763,7 +771,7 @@ async fn test_complex_types() {
         ]),
     );
     event1.insert(
-        "tuple_with_array",
+        event_path!("tuple_with_array"),
         vector_lib::event::Value::Object(tuple_with_array),
     );
 
@@ -779,7 +787,7 @@ async fn test_complex_types() {
     );
     tuple_with_map.insert("f1".into(), vector_lib::event::Value::Object(inner_map));
     event1.insert(
-        "tuple_with_map",
+        event_path!("tuple_with_map"),
         vector_lib::event::Value::Object(tuple_with_map),
     );
 
@@ -799,7 +807,7 @@ async fn test_complex_types() {
     );
     tuple_complex.insert("f2".into(), vector_lib::event::Value::Object(inner_map2));
     event1.insert(
-        "tuple_with_nested",
+        event_path!("tuple_with_nested"),
         vector_lib::event::Value::Object(tuple_complex),
     );
 
@@ -818,7 +826,7 @@ async fn test_complex_types() {
         vector_lib::event::Value::Float(NotNan::new(-122.4194).unwrap()),
     );
     event1.insert(
-        "locations",
+        event_path!("locations"),
         vector_lib::event::Value::Array(vec![vector_lib::event::Value::Object(loc1)]),
     );
 
@@ -826,14 +834,14 @@ async fn test_complex_types() {
     let mut tags1 = vector_lib::event::ObjectMap::new();
     tags1.insert("env".into(), vector_lib::event::Value::Bytes("prod".into()));
     event1.insert(
-        "tags_history",
+        event_path!("tags_history"),
         vector_lib::event::Value::Array(vec![vector_lib::event::Value::Object(tags1)]),
     );
 
     let mut metrics1 = vector_lib::event::ObjectMap::new();
     metrics1.insert("cpu".into(), vector_lib::event::Value::Integer(45));
     event1.insert(
-        "metrics_history",
+        event_path!("metrics_history"),
         vector_lib::event::Value::Array(vec![vector_lib::event::Value::Object(metrics1)]),
     );
 
@@ -843,7 +851,10 @@ async fn test_complex_types() {
         "user-agent".into(),
         vector_lib::event::Value::Bytes("Mozilla/5.0".into()),
     );
-    event1.insert("request_headers", vector_lib::event::Value::Object(headers));
+    event1.insert(
+        event_path!("request_headers"),
+        vector_lib::event::Value::Object(headers),
+    );
 
     let mut metrics = vector_lib::event::ObjectMap::new();
     metrics.insert("f0".into(), vector_lib::event::Value::Integer(200));
@@ -853,12 +864,12 @@ async fn test_complex_types() {
         vector_lib::event::Value::Float(NotNan::new(0.145).unwrap()),
     );
     event1.insert(
-        "response_metrics",
+        event_path!("response_metrics"),
         vector_lib::event::Value::Object(metrics),
     );
 
     event1.insert(
-        "tags",
+        event_path!("tags"),
         vector_lib::event::Value::Array(vec![
             vector_lib::event::Value::Bytes("api".into()),
             vector_lib::event::Value::Bytes("v2".into()),
@@ -871,13 +882,13 @@ async fn test_complex_types() {
         vector_lib::event::Value::Array(vec![vector_lib::event::Value::Bytes("admin".into())]),
     );
     event1.insert(
-        "user_properties",
+        event_path!("user_properties"),
         vector_lib::event::Value::Object(user_props),
     );
 
     // Nullable array
     event1.insert(
-        "array_with_nulls",
+        event_path!("array_with_nulls"),
         vector_lib::event::Value::Array(vec![
             vector_lib::event::Value::Integer(100),
             vector_lib::event::Value::Integer(200),
@@ -903,7 +914,7 @@ async fn test_complex_types() {
     );
 
     event1.insert(
-        "array_with_named_tuple",
+        event_path!("array_with_named_tuple"),
         vector_lib::event::Value::Array(vec![
             vector_lib::event::Value::Object(named_tuple1),
             vector_lib::event::Value::Object(named_tuple2),
@@ -914,20 +925,23 @@ async fn test_complex_types() {
 
     // Event 2: Empty and edge cases
     let mut event2 = LogEvent::from("Test empty collections");
-    event2.insert("host", "host2.example.com");
-    event2.insert("nested_int_array", vector_lib::event::Value::Array(vec![]));
+    event2.insert(event_path!("host"), "host2.example.com");
     event2.insert(
-        "nested_string_array",
+        event_path!("nested_int_array"),
+        vector_lib::event::Value::Array(vec![]),
+    );
+    event2.insert(
+        event_path!("nested_string_array"),
         vector_lib::event::Value::Array(vec![]),
     );
 
     let empty_map = vector_lib::event::ObjectMap::new();
     event2.insert(
-        "array_map",
+        event_path!("array_map"),
         vector_lib::event::Value::Object(empty_map.clone()),
     );
     event2.insert(
-        "int_array_map",
+        event_path!("int_array_map"),
         vector_lib::event::Value::Object(empty_map.clone()),
     );
 
@@ -935,7 +949,7 @@ async fn test_complex_types() {
     empty_tuple.insert("f0".into(), vector_lib::event::Value::Bytes("empty".into()));
     empty_tuple.insert("f1".into(), vector_lib::event::Value::Array(vec![]));
     event2.insert(
-        "tuple_with_array",
+        event_path!("tuple_with_array"),
         vector_lib::event::Value::Object(empty_tuple),
     );
 
@@ -946,7 +960,7 @@ async fn test_complex_types() {
         vector_lib::event::Value::Object(empty_map.clone()),
     );
     event2.insert(
-        "tuple_with_map",
+        event_path!("tuple_with_map"),
         vector_lib::event::Value::Object(empty_tuple_map),
     );
 
@@ -958,15 +972,24 @@ async fn test_complex_types() {
         vector_lib::event::Value::Object(empty_map.clone()),
     );
     event2.insert(
-        "tuple_with_nested",
+        event_path!("tuple_with_nested"),
         vector_lib::event::Value::Object(empty_tuple_complex),
     );
 
-    event2.insert("locations", vector_lib::event::Value::Array(vec![]));
-    event2.insert("tags_history", vector_lib::event::Value::Array(vec![]));
-    event2.insert("metrics_history", vector_lib::event::Value::Array(vec![]));
     event2.insert(
-        "request_headers",
+        event_path!("locations"),
+        vector_lib::event::Value::Array(vec![]),
+    );
+    event2.insert(
+        event_path!("tags_history"),
+        vector_lib::event::Value::Array(vec![]),
+    );
+    event2.insert(
+        event_path!("metrics_history"),
+        vector_lib::event::Value::Array(vec![]),
+    );
+    event2.insert(
+        event_path!("request_headers"),
         vector_lib::event::Value::Object(empty_map.clone()),
     );
 
@@ -978,18 +1001,21 @@ async fn test_complex_types() {
         vector_lib::event::Value::Float(NotNan::new(0.0).unwrap()),
     );
     event2.insert(
-        "response_metrics",
+        event_path!("response_metrics"),
         vector_lib::event::Value::Object(empty_metrics),
     );
 
-    event2.insert("tags", vector_lib::event::Value::Array(vec![]));
+    event2.insert(event_path!("tags"), vector_lib::event::Value::Array(vec![]));
     event2.insert(
-        "user_properties",
+        event_path!("user_properties"),
         vector_lib::event::Value::Object(empty_map),
     );
-    event2.insert("array_with_nulls", vector_lib::event::Value::Array(vec![]));
     event2.insert(
-        "array_with_named_tuple",
+        event_path!("array_with_nulls"),
+        vector_lib::event::Value::Array(vec![]),
+    );
+    event2.insert(
+        event_path!("array_with_named_tuple"),
         vector_lib::event::Value::Array(vec![]),
     );
 
@@ -997,17 +1023,17 @@ async fn test_complex_types() {
 
     // Event 3: More varied data
     let mut event3 = LogEvent::from("Test varied data");
-    event3.insert("host", "host3.example.com");
+    event3.insert(event_path!("host"), "host3.example.com");
 
     event3.insert(
-        "nested_int_array",
+        event_path!("nested_int_array"),
         vector_lib::event::Value::Array(vec![
             vector_lib::event::Value::Array(vec![]),
             vector_lib::event::Value::Array(vec![vector_lib::event::Value::Integer(99)]),
         ]),
     );
     event3.insert(
-        "nested_string_array",
+        event_path!("nested_string_array"),
         vector_lib::event::Value::Array(vec![vector_lib::event::Value::Array(vec![
             vector_lib::event::Value::Bytes("test".into()),
         ])]),
@@ -1018,14 +1044,20 @@ async fn test_complex_types() {
         "colors".into(),
         vector_lib::event::Value::Array(vec![vector_lib::event::Value::Bytes("red".into())]),
     );
-    event3.insert("array_map", vector_lib::event::Value::Object(map3));
+    event3.insert(
+        event_path!("array_map"),
+        vector_lib::event::Value::Object(map3),
+    );
 
     let mut int_map3 = vector_lib::event::ObjectMap::new();
     int_map3.insert(
         "values".into(),
         vector_lib::event::Value::Array(vec![vector_lib::event::Value::Integer(42)]),
     );
-    event3.insert("int_array_map", vector_lib::event::Value::Object(int_map3));
+    event3.insert(
+        event_path!("int_array_map"),
+        vector_lib::event::Value::Object(int_map3),
+    );
 
     let mut tuple3 = vector_lib::event::ObjectMap::new();
     tuple3.insert("f0".into(), vector_lib::event::Value::Bytes("data".into()));
@@ -1033,7 +1065,10 @@ async fn test_complex_types() {
         "f1".into(),
         vector_lib::event::Value::Array(vec![vector_lib::event::Value::Integer(5)]),
     );
-    event3.insert("tuple_with_array", vector_lib::event::Value::Object(tuple3));
+    event3.insert(
+        event_path!("tuple_with_array"),
+        vector_lib::event::Value::Object(tuple3),
+    );
 
     let mut map_inner = vector_lib::event::ObjectMap::new();
     map_inner.insert(
@@ -1044,7 +1079,7 @@ async fn test_complex_types() {
     tuple_map3.insert("f0".into(), vector_lib::event::Value::Bytes("test".into()));
     tuple_map3.insert("f1".into(), vector_lib::event::Value::Object(map_inner));
     event3.insert(
-        "tuple_with_map",
+        event_path!("tuple_with_map"),
         vector_lib::event::Value::Object(tuple_map3),
     );
 
@@ -1061,7 +1096,7 @@ async fn test_complex_types() {
     );
     tuple_nested3.insert("f2".into(), vector_lib::event::Value::Object(map_inner2));
     event3.insert(
-        "tuple_with_nested",
+        event_path!("tuple_with_nested"),
         vector_lib::event::Value::Object(tuple_nested3),
     );
 
@@ -1076,21 +1111,21 @@ async fn test_complex_types() {
         vector_lib::event::Value::Float(NotNan::new(-74.0060).unwrap()),
     );
     event3.insert(
-        "locations",
+        event_path!("locations"),
         vector_lib::event::Value::Array(vec![vector_lib::event::Value::Object(loc3)]),
     );
 
     let mut tags3 = vector_lib::event::ObjectMap::new();
     tags3.insert("env".into(), vector_lib::event::Value::Bytes("dev".into()));
     event3.insert(
-        "tags_history",
+        event_path!("tags_history"),
         vector_lib::event::Value::Array(vec![vector_lib::event::Value::Object(tags3)]),
     );
 
     let mut metrics3 = vector_lib::event::ObjectMap::new();
     metrics3.insert("cpu".into(), vector_lib::event::Value::Integer(60));
     event3.insert(
-        "metrics_history",
+        event_path!("metrics_history"),
         vector_lib::event::Value::Array(vec![vector_lib::event::Value::Object(metrics3)]),
     );
 
@@ -1100,7 +1135,7 @@ async fn test_complex_types() {
         vector_lib::event::Value::Bytes("application/json".into()),
     );
     event3.insert(
-        "request_headers",
+        event_path!("request_headers"),
         vector_lib::event::Value::Object(headers3),
     );
 
@@ -1112,12 +1147,12 @@ async fn test_complex_types() {
         vector_lib::event::Value::Float(NotNan::new(0.001).unwrap()),
     );
     event3.insert(
-        "response_metrics",
+        event_path!("response_metrics"),
         vector_lib::event::Value::Object(metrics3_resp),
     );
 
     event3.insert(
-        "tags",
+        event_path!("tags"),
         vector_lib::event::Value::Array(vec![vector_lib::event::Value::Bytes("test".into())]),
     );
 
@@ -1127,12 +1162,12 @@ async fn test_complex_types() {
         vector_lib::event::Value::Array(vec![vector_lib::event::Value::Bytes("read".into())]),
     );
     event3.insert(
-        "user_properties",
+        event_path!("user_properties"),
         vector_lib::event::Value::Object(user_props3),
     );
 
     event3.insert(
-        "array_with_nulls",
+        event_path!("array_with_nulls"),
         vector_lib::event::Value::Array(vec![vector_lib::event::Value::Integer(42)]),
     );
 
@@ -1147,7 +1182,7 @@ async fn test_complex_types() {
         vector_lib::event::Value::Bytes("active".into()),
     );
     event3.insert(
-        "array_with_named_tuple",
+        event_path!("array_with_named_tuple"),
         vector_lib::event::Value::Array(vec![vector_lib::event::Value::Object(named_tuple3)]),
     );
 
@@ -1248,7 +1283,7 @@ async fn test_missing_required_field_emits_null_constraint_error() {
 
     // Create an event WITHOUT the required_field
     let mut event = LogEvent::from("test message");
-    event.insert("host", "example.com");
+    event.insert(event_path!("host"), "example.com");
     // Deliberately NOT inserting "required_field"
 
     // Run the sink - should fail due to missing required field
@@ -1347,11 +1382,11 @@ async fn arrow_schema_excludes_non_insertable_columns() {
     let mut events: Vec<Event> = Vec::new();
     for i in 0..2 {
         let mut event = LogEvent::from(format!("log message {i}"));
-        event.insert("host", format!("host-{i}.example.com"));
+        event.insert(event_path!("host"), format!("host-{i}.example.com"));
 
         if i == 1 {
             event.insert(
-                "timestamp_date",
+                event_path!("timestamp_date"),
                 vector_lib::event::Value::Timestamp(
                     Utc.with_ymd_and_hms(2025, 6, 15, 12, 0, 0).unwrap(),
                 ),
@@ -1364,7 +1399,7 @@ async fn arrow_schema_excludes_non_insertable_columns() {
             vector_lib::event::Value::Bytes(format!("cluster-{i}").into()),
         );
         event.insert(
-            "resource_attributes",
+            event_path!("resource_attributes"),
             vector_lib::event::Value::Object(attrs),
         );
 

--- a/src/sinks/databend/integration_tests.rs
+++ b/src/sinks/databend/integration_tests.rs
@@ -3,6 +3,7 @@ use std::{collections::BTreeMap, sync::Arc};
 use databend_client::{APIClient as DatabendAPIClient, Page};
 use futures::{future::ready, stream};
 use vector_lib::event::{BatchNotifier, BatchStatus, BatchStatusReceiver, Event, LogEvent};
+use vrl::event_path;
 
 use super::config::DatabendConfig;
 use crate::{
@@ -22,7 +23,7 @@ fn databend_endpoint() -> String {
 fn make_event() -> (Event, BatchStatusReceiver) {
     let (batch, receiver) = BatchNotifier::new_with_receiver();
     let mut event = LogEvent::from("raw log line").with_batch_notifier(&batch);
-    event.insert("host", "example.com");
+    event.insert(event_path!("host"), "example.com");
     (event.into(), receiver)
 }
 

--- a/src/sinks/databricks_zerobus/service.rs
+++ b/src/sinks/databricks_zerobus/service.rs
@@ -1043,12 +1043,12 @@ mod tests {
         let resolved = ResolvedSchema::for_test(schema);
 
         let mut e1 = LogEvent::default();
-        e1.insert("id", 1i64);
-        e1.insert("body", "hello");
-        e1.insert("ts", Utc::now());
+        e1.insert(vrl::event_path!("id"), 1i64);
+        e1.insert(vrl::event_path!("body"), "hello");
+        e1.insert(vrl::event_path!("ts"), Utc::now());
 
         let mut e2 = LogEvent::default();
-        e2.insert("id", 2i64);
+        e2.insert(vrl::event_path!("id"), 2i64);
         // `body` and `ts` omitted — both nullable, so they encode as null.
 
         let batch =
@@ -1086,7 +1086,7 @@ mod tests {
         let resolved = ResolvedSchema::for_test(schema);
 
         let mut e = LogEvent::default();
-        e.insert("body", "no id here"); // `id` omitted
+        e.insert(vrl::event_path!("body"), "no id here"); // `id` omitted
 
         let err = ZerobusService::encode_batch(&resolved, &[Event::Log(e)]).unwrap_err();
         assert!(matches!(err, ZerobusSinkError::EncodingError { .. }));

--- a/src/sinks/datadog/events/tests.rs
+++ b/src/sinks/datadog/events/tests.rs
@@ -6,6 +6,7 @@ use hyper::StatusCode;
 use indoc::indoc;
 use similar_asserts::assert_eq;
 use vector_lib::event::{BatchNotifier, BatchStatus};
+use vrl::event_path;
 
 use super::*;
 use crate::{
@@ -29,8 +30,8 @@ fn random_events_with_stream(
         lines,
         stream.map(|mut events| {
             events.iter_logs_mut().for_each(|log| {
-                log.insert("title", "All!");
-                log.insert("invalid", "Tik");
+                log.insert(event_path!("title"), "All!");
+                log.insert(event_path!("invalid"), "Tik");
             });
             events
         }),

--- a/src/sinks/datadog/logs/sink.rs
+++ b/src/sinks/datadog/logs/sink.rs
@@ -110,7 +110,7 @@ pub fn normalize_event(event: &mut Event) {
 
     // Will cast the internal value to an object if it already isn't
     if !log.value().is_object() {
-        log.insert(MESSAGE, log.value().clone());
+        log.insert(event_path!(MESSAGE), log.value().clone());
     }
 
     // Upstream Sources may have semantically defined Datadog reserved attributes outside of their
@@ -176,7 +176,7 @@ pub fn normalize_as_agent_event(event: &mut Event) {
         }
     }
     // .. nest this object at the root under the reserved key named 'message'
-    log.insert(MESSAGE, local_root);
+    log.insert(event_path!(MESSAGE), local_root);
 }
 
 // If an expected reserved attribute is not located in the event root, rename it and handle
@@ -590,7 +590,7 @@ mod tests {
         assert_normalized_log_has_expected_attrs(event.as_log());
         assert_only_reserved_fields_at_root(event.as_log());
         assert_eq!(
-            event.as_log().get("message"),
+            event.as_log().get(event_path!("message")),
             Some(&value!({"message": "the_message"}))
         );
     }

--- a/src/sinks/doris/integration_test.rs
+++ b/src/sinks/doris/integration_test.rs
@@ -9,6 +9,7 @@ use vector_lib::{
     codecs::{JsonSerializerConfig, MetricTagValues, encoding::FramingConfig},
     event::{BatchNotifier, BatchStatusReceiver, Event, LogEvent, Value},
 };
+use vrl::event_path;
 // use vector_common::finalization::BatchStatus;
 use vector_common::sensitive_string::SensitiveString;
 
@@ -37,7 +38,7 @@ fn doris_address() -> String {
 fn make_event() -> (Event, BatchStatusReceiver) {
     let (batch, receiver) = BatchNotifier::new_with_receiver();
     let mut event = LogEvent::from("raw log line").with_batch_notifier(&batch);
-    event.insert("host", "example.com");
+    event.insert(event_path!("host"), "example.com");
     (event.into(), receiver)
 }
 
@@ -50,7 +51,10 @@ fn assert_fields_match(
 ) {
     for field in fields {
         // Get field value from event
-        let event_value = event_log.get(*field).cloned().unwrap_or(Value::Null);
+        let event_value = event_log
+            .get(&vrl::path::parse_target_path(field).unwrap())
+            .cloned()
+            .unwrap_or(Value::Null);
 
         // Get field value from database row
         let db_value = db_row.get(*field).cloned().unwrap_or(DbValue::Null);

--- a/src/sinks/elasticsearch/integration_tests.rs
+++ b/src/sinks/elasticsearch/integration_tests.rs
@@ -10,6 +10,7 @@ use vector_lib::{
     config::{Tags, Telemetry, init_telemetry, log_schema},
     event::{BatchNotifier, BatchStatus, Event, LogEvent},
 };
+use vrl::event_path;
 
 use super::{config::DATA_STREAM_TIMESTAMP_KEY, *};
 use crate::{
@@ -186,8 +187,8 @@ async fn structures_events_correctly() {
 
     let (batch, mut receiver) = BatchNotifier::new_with_receiver();
     let mut input_event = LogEvent::from("raw log line").with_batch_notifier(&batch);
-    input_event.insert("my_id", "42");
-    input_event.insert("foo", "bar");
+    input_event.insert(event_path!("my_id"), "42");
+    input_event.insert(event_path!("foo"), "bar");
     drop(batch);
 
     let timestamp = input_event[crate::config::log_schema()
@@ -654,7 +655,7 @@ async fn run_insert_tests_with_config(
             let events = events.map(move |mut events| {
                 if doit {
                     events.iter_logs_mut().for_each(|log| {
-                        log.insert("_type", 1);
+                        log.insert(event_path!("_type"), 1);
                     });
                 }
                 doit = true;

--- a/src/sinks/elasticsearch/tests.rs
+++ b/src/sinks/elasticsearch/tests.rs
@@ -2,6 +2,7 @@ use std::{convert::TryFrom, iter::zip};
 
 use vector_common::sensitive_string::SensitiveString;
 use vector_lib::lookup::PathPrefix;
+use vrl::event_path;
 
 use crate::{
     codecs::Transformer,
@@ -50,7 +51,7 @@ async fn sets_create_action_when_configured() {
             .single()
             .expect("invalid timestamp"),
     );
-    log.insert("action", "crea");
+    log.insert(event_path!("action"), "crea");
 
     let mut encoded = vec![];
     let (encoded_size, _json_size) = es
@@ -118,8 +119,8 @@ async fn encoding_with_external_versioning_with_version_set_includes_version() {
             .single()
             .expect("invalid timestamp"),
     );
-    log.insert("my_field", "1337");
-    log.insert("my_id", "42");
+    log.insert(event_path!("my_field"), "1337");
+    log.insert(event_path!("my_id"), "42");
 
     let mut encoded = vec![];
     let (encoded_size, _json_size) = es
@@ -168,8 +169,8 @@ async fn encoding_with_external_gte_versioning_with_version_set_includes_version
             .single()
             .expect("invalid timestamp"),
     );
-    log.insert("my_field", "1337");
-    log.insert("my_id", "42");
+    log.insert(event_path!("my_field"), "1337");
+    log.insert(event_path!("my_id"), "42");
 
     let mut encoded = vec![];
     let (encoded_size, _json_size) = es
@@ -251,7 +252,7 @@ async fn encode_datastream_mode() {
             .expect("invalid timestamp"),
     );
     log.insert(
-        "data_stream",
+        event_path!("data_stream"),
         data_stream_body(
             Some("synthetics".to_string()),
             Some("testing".to_string()),
@@ -301,7 +302,7 @@ async fn encode_datastream_mode_no_routing() {
 
     let mut log = LogEvent::from("hello there");
     log.insert(
-        "data_stream",
+        event_path!("data_stream"),
         data_stream_body(
             Some("synthetics".to_string()),
             Some("testing".to_string()),
@@ -391,8 +392,8 @@ async fn decode_bulk_action_error() {
     let es = ElasticsearchCommon::parse_single(&config).await.unwrap();
 
     let mut log = LogEvent::from("hello world");
-    log.insert("foo", "bar");
-    log.insert("idx", "purple");
+    log.insert(event_path!("foo"), "bar");
+    log.insert(event_path!("idx"), "purple");
     let action = es.mode.bulk_action(&log);
     assert!(action.is_none());
 }
@@ -454,7 +455,7 @@ async fn encode_datastream_mode_no_sync() {
 
     let mut log = LogEvent::from("hello there");
     log.insert(
-        "data_stream",
+        event_path!("data_stream"),
         data_stream_body(
             Some("synthetics".to_string()),
             Some("testing".to_string()),
@@ -501,8 +502,8 @@ async fn allows_using_except_fields() {
     let es = ElasticsearchCommon::parse_single(&config).await.unwrap();
 
     let mut log = LogEvent::from("hello there");
-    log.insert("foo", "bar");
-    log.insert("idx", "purple");
+    log.insert(event_path!("foo"), "bar");
+    log.insert(event_path!("idx"), "purple");
 
     let mut encoded = vec![];
     let (encoded_size, _json_size) = es
@@ -536,8 +537,8 @@ async fn allows_using_only_fields() {
     let es = ElasticsearchCommon::parse_single(&config).await.unwrap();
 
     let mut log = LogEvent::from("hello there");
-    log.insert("foo", "bar");
-    log.insert("idx", "purple");
+    log.insert(event_path!("foo"), "bar");
+    log.insert(event_path!("idx"), "purple");
 
     let mut encoded = vec![];
     let (encoded_size, _json_size) = es
@@ -662,7 +663,7 @@ async fn datastream_index_name() {
     for test_case in test_cases {
         let mut log = LogEvent::from("hello there");
         log.insert(
-            "data_stream",
+            event_path!("data_stream"),
             data_stream_body(
                 test_case.dtype.clone(),
                 test_case.dataset.clone(),

--- a/src/sinks/file/mod.rs
+++ b/src/sinks/file/mod.rs
@@ -537,6 +537,7 @@ mod tests {
         event::{LogEvent, TraceEvent},
         sink::VectorSink,
     };
+    use vrl::event_path;
 
     use super::*;
     use crate::{
@@ -658,22 +659,48 @@ mod tests {
         };
 
         let (mut input, _events) = random_events_with_stream(32, 8, None);
-        input[0].as_mut_log().insert("date", "2019-26-07");
-        input[0].as_mut_log().insert("level", "warning");
-        input[1].as_mut_log().insert("date", "2019-26-07");
-        input[1].as_mut_log().insert("level", "error");
-        input[2].as_mut_log().insert("date", "2019-26-07");
-        input[2].as_mut_log().insert("level", "warning");
-        input[3].as_mut_log().insert("date", "2019-27-07");
-        input[3].as_mut_log().insert("level", "error");
-        input[4].as_mut_log().insert("date", "2019-27-07");
-        input[4].as_mut_log().insert("level", "warning");
-        input[5].as_mut_log().insert("date", "2019-27-07");
-        input[5].as_mut_log().insert("level", "warning");
-        input[6].as_mut_log().insert("date", "2019-28-07");
-        input[6].as_mut_log().insert("level", "warning");
-        input[7].as_mut_log().insert("date", "2019-29-07");
-        input[7].as_mut_log().insert("level", "error");
+        input[0]
+            .as_mut_log()
+            .insert(event_path!("date"), "2019-26-07");
+        input[0]
+            .as_mut_log()
+            .insert(event_path!("level"), "warning");
+        input[1]
+            .as_mut_log()
+            .insert(event_path!("date"), "2019-26-07");
+        input[1].as_mut_log().insert(event_path!("level"), "error");
+        input[2]
+            .as_mut_log()
+            .insert(event_path!("date"), "2019-26-07");
+        input[2]
+            .as_mut_log()
+            .insert(event_path!("level"), "warning");
+        input[3]
+            .as_mut_log()
+            .insert(event_path!("date"), "2019-27-07");
+        input[3].as_mut_log().insert(event_path!("level"), "error");
+        input[4]
+            .as_mut_log()
+            .insert(event_path!("date"), "2019-27-07");
+        input[4]
+            .as_mut_log()
+            .insert(event_path!("level"), "warning");
+        input[5]
+            .as_mut_log()
+            .insert(event_path!("date"), "2019-27-07");
+        input[5]
+            .as_mut_log()
+            .insert(event_path!("level"), "warning");
+        input[6]
+            .as_mut_log()
+            .insert(event_path!("date"), "2019-28-07");
+        input[6]
+            .as_mut_log()
+            .insert(event_path!("level"), "warning");
+        input[7]
+            .as_mut_log()
+            .insert(event_path!("date"), "2019-29-07");
+        input[7].as_mut_log().insert(event_path!("level"), "error");
 
         run_assert_sink(&config, input.clone().into_iter()).await;
 

--- a/src/sinks/gcp/cloud_storage.rs
+++ b/src/sinks/gcp/cloud_storage.rs
@@ -501,6 +501,7 @@ mod tests {
         partition::Partitioner,
         request_metadata::GroupedCountByteSize,
     };
+    use vrl::event_path;
 
     use super::*;
     use crate::{
@@ -547,7 +548,7 @@ mod tests {
 
         let message = "hello world".to_string();
         let mut event = LogEvent::from(message);
-        event.insert("key", "value");
+        event.insert(event_path!("key"), "value");
 
         let sink_config = GcsSinkConfig {
             key_prefix: Some("key: {{ key }}".into()),

--- a/src/sinks/gcp/stackdriver/logs/tests.rs
+++ b/src/sinks/gcp/stackdriver/logs/tests.rs
@@ -162,10 +162,10 @@ fn encode_inserts_timestamp() {
     );
 
     let mut log = LogEvent::default();
-    log.insert("message", Value::Bytes("hello world".into()));
-    log.insert("anumber", Value::Bytes("100".into()));
+    log.insert(event_path!("message"), Value::Bytes("hello world".into()));
+    log.insert(event_path!("anumber"), Value::Bytes("100".into()));
     log.insert(
-        "timestamp",
+        event_path!("timestamp"),
         Value::Timestamp(
             Utc.with_ymd_and_hms(2020, 1, 1, 12, 30, 0)
                 .single()

--- a/src/sinks/greptimedb/logs/integration_tests.rs
+++ b/src/sinks/greptimedb/logs/integration_tests.rs
@@ -1,6 +1,7 @@
 use chrono::{DateTime, Utc};
 use futures::stream;
 use vector_lib::event::{Event, LogEvent};
+use vrl::event_path;
 
 use crate::{
     config::{SinkConfig, SinkContext},
@@ -137,10 +138,10 @@ impl GreptimeClient {
 
 fn create_event(i: i32, base_time: DateTime<Utc>) -> Event {
     let mut event = LogEvent::default();
-    event.insert("message", format!("test message {i}"));
-    event.insert("timestamp", base_time);
-    event.insert("name", "test");
-    event.insert("namespace", "default");
-    event.insert("kind", "test");
+    event.insert(event_path!("message"), format!("test message {i}"));
+    event.insert(event_path!("timestamp"), base_time);
+    event.insert(event_path!("name"), "test");
+    event.insert(event_path!("namespace"), "default");
+    event.insert(event_path!("kind"), "test");
     Event::Log(event)
 }

--- a/src/sinks/http/tests.rs
+++ b/src/sinks/http/tests.rs
@@ -20,6 +20,8 @@ use vector_lib::{
     finalization::AddBatchNotifier,
 };
 
+use vrl::event_path;
+
 use super::{
     config::{HttpSinkConfig, validate_headers, validate_payload_wrapper},
     encoder::HttpEncoder,
@@ -295,8 +297,10 @@ async fn http_passes_template_headers() {
         "#},
         || {
             let mut event = Event::Log(LogEvent::from("test message"));
-            event.as_mut_log().insert("level", "info");
-            event.as_mut_log().insert("message", "templated message");
+            event.as_mut_log().insert(event_path!("level"), "info");
+            event
+                .as_mut_log()
+                .insert(event_path!("message"), "templated message");
             event
         },
         10,
@@ -352,7 +356,9 @@ async fn http_template_headers_missing_fields() {
         "#},
         || {
             let mut event = Event::Log(LogEvent::from("good event"));
-            event.as_mut_log().insert("required_field", "present");
+            event
+                .as_mut_log()
+                .insert(event_path!("required_field"), "present");
             event
         },
         10,

--- a/src/sinks/humio/logs.rs
+++ b/src/sinks/humio/logs.rs
@@ -237,6 +237,8 @@ mod integration_tests {
     use serde_json::{Value as JsonValue, json};
     use tokio::time::Duration;
 
+    use vrl::event_path;
+
     use super::*;
     use crate::{
         config::{SinkConfig, SinkContext, log_schema},
@@ -342,7 +344,7 @@ mod integration_tests {
             let mut event = LogEvent::from(message.clone());
             // Humio expects to find an @timestamp field for JSON lines
             // https://docs.humio.com/ingesting-data/parsers/built-in-parsers/#json
-            event.insert("@timestamp", Utc::now().to_rfc3339());
+            event.insert(event_path!("@timestamp"), Utc::now().to_rfc3339());
 
             run_and_assert_sink_compliance(sink, stream::once(ready(event)), &HTTP_SINK_TAGS).await;
 

--- a/src/sinks/influxdb/logs.rs
+++ b/src/sinks/influxdb/logs.rs
@@ -447,8 +447,10 @@ mod tests {
     #[test]
     fn test_encode_event_apply_rules() {
         let mut event = Event::Log(LogEvent::from("hello"));
-        event.as_mut_log().insert("host", "aws.cloud.eur");
-        event.as_mut_log().insert("timestamp", ts());
+        event
+            .as_mut_log()
+            .insert(event_path!("host"), "aws.cloud.eur");
+        event.as_mut_log().insert(event_path!("timestamp"), ts());
 
         let mut sink = create_sink(
             "http://localhost:9999",
@@ -488,14 +490,20 @@ mod tests {
     #[test]
     fn test_encode_event_v1() {
         let mut event = Event::Log(LogEvent::from("hello"));
-        event.as_mut_log().insert("host", "aws.cloud.eur");
-        event.as_mut_log().insert("source_type", "file");
+        event
+            .as_mut_log()
+            .insert(event_path!("host"), "aws.cloud.eur");
+        event
+            .as_mut_log()
+            .insert(event_path!("source_type"), "file");
 
-        event.as_mut_log().insert("int", 4i32);
-        event.as_mut_log().insert("float", 5.5);
-        event.as_mut_log().insert("bool", true);
-        event.as_mut_log().insert("string", "thisisastring");
-        event.as_mut_log().insert("timestamp", ts());
+        event.as_mut_log().insert(event_path!("int"), 4i32);
+        event.as_mut_log().insert(event_path!("float"), 5.5);
+        event.as_mut_log().insert(event_path!("bool"), true);
+        event
+            .as_mut_log()
+            .insert(event_path!("string"), "thisisastring");
+        event.as_mut_log().insert(event_path!("timestamp"), ts());
 
         let sink = create_sink(
             "http://localhost:9999",
@@ -533,14 +541,20 @@ mod tests {
     #[test]
     fn test_encode_event() {
         let mut event = Event::Log(LogEvent::from("hello"));
-        event.as_mut_log().insert("host", "aws.cloud.eur");
-        event.as_mut_log().insert("source_type", "file");
+        event
+            .as_mut_log()
+            .insert(event_path!("host"), "aws.cloud.eur");
+        event
+            .as_mut_log()
+            .insert(event_path!("source_type"), "file");
 
-        event.as_mut_log().insert("int", 4i32);
-        event.as_mut_log().insert("float", 5.5);
-        event.as_mut_log().insert("bool", true);
-        event.as_mut_log().insert("string", "thisisastring");
-        event.as_mut_log().insert("timestamp", ts());
+        event.as_mut_log().insert(event_path!("int"), 4i32);
+        event.as_mut_log().insert(event_path!("float"), 5.5);
+        event.as_mut_log().insert(event_path!("bool"), true);
+        event
+            .as_mut_log()
+            .insert(event_path!("string"), "thisisastring");
+        event.as_mut_log().insert(event_path!("timestamp"), ts());
 
         let sink = create_sink(
             "http://localhost:9999",
@@ -579,8 +593,8 @@ mod tests {
     fn test_encode_event_without_tags() {
         let mut event = Event::Log(LogEvent::from("hello"));
 
-        event.as_mut_log().insert("value", 100);
-        event.as_mut_log().insert("timestamp", ts());
+        event.as_mut_log().insert(event_path!("value"), 100);
+        event.as_mut_log().insert(event_path!("timestamp"), ts());
 
         let mut sink = create_sink(
             "http://localhost:9999",
@@ -617,12 +631,12 @@ mod tests {
     fn test_encode_nested_fields() {
         let mut event = LogEvent::default();
 
-        event.insert("a", 1);
-        event.insert("nested.field", "2");
-        event.insert("nested.bool", true);
-        event.insert("nested.array[0]", "example-value");
-        event.insert("nested.array[2]", "another-value");
-        event.insert("nested.array[3]", 15);
+        event.insert(event_path!("a"), 1);
+        event.insert(event_path!("nested", "field"), "2");
+        event.insert(event_path!("nested", "bool"), true);
+        event.insert(event_path!("nested", "array", 0isize), "example-value");
+        event.insert(event_path!("nested", "array", 2isize), "another-value");
+        event.insert(event_path!("nested", "array", 3isize), 15);
 
         let sink = create_sink(
             "http://localhost:9999",
@@ -657,10 +671,12 @@ mod tests {
     #[test]
     fn test_add_tag() {
         let mut event = Event::Log(LogEvent::from("hello"));
-        event.as_mut_log().insert("source_type", "file");
+        event
+            .as_mut_log()
+            .insert(event_path!("source_type"), "file");
 
-        event.as_mut_log().insert("as_a_tag", 10);
-        event.as_mut_log().insert("timestamp", ts());
+        event.as_mut_log().insert(event_path!("as_a_tag"), 10);
+        event.as_mut_log().insert(event_path!("timestamp"), ts());
 
         let sink = create_sink(
             "http://localhost:9999",
@@ -782,14 +798,14 @@ mod tests {
         // Create 5 events with custom field
         for (i, line) in lines.iter().enumerate() {
             let mut event = LogEvent::from(line.to_string()).with_batch_notifier(&batch);
-            event.insert(format!("key{i}").as_str(), format!("value{i}"));
+            event.insert(event_path!(format!("key{i}").as_str()), format!("value{i}"));
 
             let timestamp = Utc
                 .with_ymd_and_hms(1970, 1, 1, 0, 0, (i as u32) + 1)
                 .single()
                 .expect("invalid timestamp");
-            event.insert("timestamp", timestamp);
-            event.insert("source_type", "file");
+            event.insert(event_path!("timestamp"), timestamp);
+            event.insert(event_path!("source_type"), "file");
 
             events.push(Event::Log(event));
         }
@@ -928,12 +944,12 @@ mod integration_tests {
         let (batch, mut receiver) = BatchNotifier::new_with_receiver();
 
         let mut event1 = LogEvent::from("message_1").with_batch_notifier(&batch);
-        event1.insert("host", "aws.cloud.eur");
-        event1.insert("source_type", "file");
+        event1.insert(event_path!("host"), "aws.cloud.eur");
+        event1.insert(event_path!("source_type"), "file");
 
         let mut event2 = LogEvent::from("message_2").with_batch_notifier(&batch);
-        event2.insert("host", "aws.cloud.eur");
-        event2.insert("source_type", "file");
+        event2.insert(event_path!("host"), "aws.cloud.eur");
+        event2.insert(event_path!("source_type"), "file");
 
         let mut namespaced_log =
             LogEvent::from(value!("namespaced message")).with_batch_notifier(&batch);

--- a/src/sinks/kafka/tests.rs
+++ b/src/sinks/kafka/tests.rs
@@ -18,6 +18,7 @@ mod integration_test {
         event::{BatchNotifier, BatchStatus},
         lookup::lookup_v2::ConfigTargetPath,
     };
+    use vrl::event_path;
 
     use super::super::{config::KafkaSinkConfig, sink::KafkaSink, *};
     use crate::{
@@ -352,9 +353,9 @@ mod integration_test {
                 expected_messages.push(message.clone());
 
                 let mut trace = TraceEvent::default();
-                trace.insert("message", message);
-                trace.insert("trace_key", trace_key);
-                trace.insert("timestamp", chrono::Utc::now());
+                trace.insert(event_path!("message"), message);
+                trace.insert(event_path!("trace_key"), trace_key);
+                trace.insert(event_path!("timestamp"), chrono::Utc::now());
 
                 let mut trace_headers = ObjectMap::new();
                 trace_headers.insert(header_key.into(), Value::Bytes(Bytes::from(header_value)));

--- a/src/sinks/loki/integration_tests.rs
+++ b/src/sinks/loki/integration_tests.rs
@@ -1,5 +1,7 @@
 use std::{convert::TryFrom, sync::Arc};
 
+use vrl::event_path;
+
 use bytes::Bytes;
 use chrono::{DateTime, Duration, Utc};
 use futures::stream;
@@ -109,8 +111,11 @@ fn namespaced_timestamp_generator(
 ) -> impl Fn(usize) -> Event {
     move |index: usize| {
         let mut log = LogEvent::default();
-        log.insert("message", line_generator(index));
-        log.insert(timestamp_field.as_str(), Value::from(timestamp));
+        log.insert(event_path!("message"), line_generator(index));
+        log.insert(
+            &vrl::path::parse_target_path(&timestamp_field).unwrap(),
+            Value::from(timestamp),
+        );
 
         // We need vector metadata for it to pick up that it is in the Vector namespace.
         LogNamespace::Vector.insert_standard_vector_source_metadata(&mut log, "loki", Utc::now());
@@ -282,7 +287,7 @@ async fn json_nested_fields() {
     let generator = |idx| {
         let mut event = event_generator(idx);
         let log = event.as_mut_log();
-        log.insert("foo.bar", "baz");
+        log.insert(event_path!("foo", "bar"), "baz");
         event
     };
     let (lines, events) = generate_events_with_stream(generator, 10, Some(batch));
@@ -339,9 +344,9 @@ async fn many_streams() {
         if idx < 10 {
             let log = event.as_mut_log();
             if idx % 2 == 0 {
-                log.insert("stream_id", stream1.to_string());
+                log.insert(event_path!("stream_id"), stream1.to_string());
             } else {
-                log.insert("stream_id", stream2.to_string());
+                log.insert(event_path!("stream_id"), stream2.to_string());
             }
         }
         event
@@ -401,7 +406,9 @@ async fn interpolate_stream_key() {
     let generator = |idx| {
         let mut event = event_generator(idx);
         if idx < 10 {
-            event.as_mut_log().insert("stream_key", "test_name");
+            event
+                .as_mut_log()
+                .insert(event_path!("stream_key"), "test_name");
         }
         event
     };
@@ -459,7 +466,10 @@ async fn many_tenants() {
     for (i, event) in events.iter_mut().enumerate() {
         let log = event.as_mut_log();
 
-        log.insert("tenant_id", if i % 2 == 0 { "tenant1" } else { "tenant2" });
+        log.insert(
+            event_path!("tenant_id"),
+            if i % 2 == 0 { "tenant1" } else { "tenant2" },
+        );
     }
 
     run_and_assert_sink_compliance(sink, stream::iter(events), &SINK_TAGS).await;

--- a/src/sinks/loki/sink.rs
+++ b/src/sinks/loki/sink.rs
@@ -573,6 +573,8 @@ mod tests {
         lookup::PathPrefix,
     };
 
+    use vrl::event_path;
+
     use super::{EventEncoder, KeyPartitioner, RecordFilter};
     use crate::{
         codecs::Encoder, config::log_schema, sinks::loki::config::OutOfOrderAction,
@@ -644,13 +646,13 @@ mod tests {
             (PathPrefix::Event, log_schema().timestamp_key().unwrap()),
             chrono::Utc::now(),
         );
-        log.insert("name", "foo");
-        log.insert("value", "bar");
+        log.insert(event_path!("name"), "foo");
+        log.insert(event_path!("value"), "bar");
 
         let mut test_dict = ObjectMap::default();
         test_dict.insert("one".into(), Value::from("foo"));
         test_dict.insert("two".into(), Value::from("baz"));
-        log.insert("dict", Value::from(test_dict));
+        log.insert(event_path!("dict"), Value::from(test_dict));
 
         let record = encoder.encode_event(event).unwrap();
         assert!(
@@ -847,8 +849,8 @@ mod tests {
             (PathPrefix::Event, log_schema().timestamp_key().unwrap()),
             chrono::Utc::now(),
         );
-        log.insert("name", "foo");
-        log.insert("value", "bar");
+        log.insert(event_path!("name"), "foo");
+        log.insert(event_path!("value"), "bar");
         let record = encoder.encode_event(event).unwrap();
         assert!(!String::from_utf8_lossy(&record.event.event).contains("value"));
     }

--- a/src/sinks/loki/tests.rs
+++ b/src/sinks/loki/tests.rs
@@ -1,4 +1,5 @@
 use vector_lib::config::{log_schema, proxy::ProxyConfig};
+use vrl::event_path;
 
 use super::{config::LokiConfig, healthcheck::healthcheck, sink::LokiSink};
 use crate::{
@@ -31,7 +32,7 @@ async fn interpolate_labels() {
 
     let mut e1 = Event::Log(LogEvent::from("hello world"));
 
-    e1.as_mut_log().insert("foo", "bar");
+    e1.as_mut_log().insert(event_path!("foo"), "bar");
 
     let mut record = sink.encoder.encode_event(e1).unwrap();
 
@@ -72,7 +73,7 @@ async fn use_label_from_dropped_fields() {
 
     let mut e1 = Event::Log(LogEvent::from("hello world"));
 
-    e1.as_mut_log().insert("foo", "bar");
+    e1.as_mut_log().insert(event_path!("foo"), "bar");
 
     let record = sink.encoder.encode_event(e1).unwrap();
 
@@ -195,7 +196,7 @@ async fn structured_metadata_as_json() {
     let mut sink = LokiSink::new(config, client).unwrap();
 
     let mut e1 = Event::Log(LogEvent::from("hello world"));
-    e1.as_mut_log().insert("foo", "bar");
+    e1.as_mut_log().insert(event_path!("foo"), "bar");
 
     let event = sink.encoder.encode_event(e1).unwrap();
     let body = serde_json::json!(event.event);

--- a/src/sinks/mezmo.rs
+++ b/src/sinks/mezmo.rs
@@ -431,16 +431,16 @@ mod tests {
         let mut encoder = config.build_encoder();
 
         let mut event1 = Event::Log(LogEvent::from("hello world"));
-        event1.as_mut_log().insert("app", "notvector");
-        event1.as_mut_log().insert("magic", "vector");
+        event1.as_mut_log().insert(event_path!("app"), "notvector");
+        event1.as_mut_log().insert(event_path!("magic"), "vector");
 
         let mut event2 = Event::Log(LogEvent::from("hello world"));
-        event2.as_mut_log().insert("file", "log.txt");
+        event2.as_mut_log().insert(event_path!("file"), "log.txt");
 
         let event3 = Event::Log(LogEvent::from("hello world"));
 
         let mut event4 = Event::Log(LogEvent::from("hello world"));
-        event4.as_mut_log().insert("env", "staging");
+        event4.as_mut_log().insert(event_path!("env"), "staging");
 
         let event1_out = encoder.encode_event(event1).unwrap().into_parts().0;
         let event1_out = event1_out.as_object().unwrap();
@@ -505,7 +505,7 @@ mod tests {
         for (i, line) in lines.iter().enumerate() {
             let mut event = LogEvent::from(line.as_str()).with_batch_notifier(&batch);
             let p = i % 2;
-            event.insert("hostname", hosts[p]);
+            event.insert(event_path!("hostname"), hosts[p]);
 
             partitions[p].push(line.into());
             events.push(Event::Log(event));

--- a/src/sinks/papertrail.rs
+++ b/src/sinks/papertrail.rs
@@ -192,6 +192,7 @@ mod tests {
         codecs::JsonSerializerConfig,
         event::{Event, LogEvent},
     };
+    use vrl::event_path;
 
     use super::*;
     use crate::test_util::{
@@ -226,8 +227,8 @@ mod tests {
     #[test]
     fn encode_event_apply_rules() {
         let mut evt = Event::Log(LogEvent::from("vector"));
-        evt.as_mut_log().insert("magic", "key");
-        evt.as_mut_log().insert("process", "foo");
+        evt.as_mut_log().insert(event_path!("magic"), "key");
+        evt.as_mut_log().insert(event_path!("process"), "foo");
 
         let mut encoder = PapertrailEncoder {
             pid: 0,

--- a/src/sinks/postgres/integration_tests.rs
+++ b/src/sinks/postgres/integration_tests.rs
@@ -36,11 +36,11 @@ fn timestamp() -> DateTime<Utc> {
 
 fn create_event(id: i64) -> Event {
     let mut event = LogEvent::from("raw log line");
-    event.insert("id", id);
-    event.insert("host", "example.com");
+    event.insert(event_path!("id"), id);
+    event.insert(event_path!("host"), "example.com");
     let event_payload = event.clone().into_parts().0;
-    event.insert("payload", event_payload);
-    event.insert("timestamp", timestamp());
+    event.insert(event_path!("payload"), event_payload);
+    event.insert(event_path!("timestamp"), timestamp());
     event.into()
 }
 

--- a/src/sinks/redis/integration_tests.rs
+++ b/src/sinks/redis/integration_tests.rs
@@ -327,7 +327,7 @@ async fn redis_sink_sorted_set_zadd() {
     for i in 0..num_events {
         let s: String = i.to_string();
         let mut e = LogEvent::from(s);
-        e.insert("num", i);
+        e.insert(vrl::event_path!("num"), i);
         events.push(e.into());
     }
     let input = stream::iter(events.clone().into_iter().map(Into::into));
@@ -651,8 +651,8 @@ async fn redis_sink_traces() {
 
         // Create a  trace event
         let mut trace = TraceEvent::default();
-        trace.insert("name", "test_trace");
-        trace.insert("service", "redis_test");
+        trace.insert(vrl::event_path!("name"), "test_trace");
+        trace.insert(vrl::event_path!("service"), "redis_test");
 
         // Set up batch notification for checking delivery status
         let (batch, receiver) = BatchNotifier::new_with_receiver();

--- a/src/sinks/redis/tests.rs
+++ b/src/sinks/redis/tests.rs
@@ -22,7 +22,7 @@ fn redis_log_event_json() {
     let msg = "hello_world".to_owned();
     let mut byte_size = GroupedCountByteSize::new_untagged();
     let mut evt = LogEvent::from(msg.clone());
-    evt.insert("key", "value");
+    evt.insert(vrl::event_path!("key"), "value");
     let result = encode_event(
         evt.into(),
         "key".to_string(),
@@ -60,7 +60,7 @@ fn redis_log_encode_event() {
     let msg = "hello_world";
     let mut evt = LogEvent::from(msg);
     let mut byte_size = GroupedCountByteSize::new_untagged();
-    evt.insert("key", "value");
+    evt.insert(vrl::event_path!("key"), "value");
 
     let result = encode_event(
         evt.into(),
@@ -109,7 +109,7 @@ fn redis_log_scoring() {
     let msg = "hello_world";
     let mut evt = LogEvent::from(msg);
     let mut byte_size = GroupedCountByteSize::new_untagged();
-    evt.insert("key", "value");
+    evt.insert(vrl::event_path!("key"), "value");
 
     let result = encode_event(
         evt.into(),

--- a/src/sinks/splunk_hec/logs/integration_tests.rs
+++ b/src/sinks/splunk_hec/logs/integration_tests.rs
@@ -11,7 +11,7 @@ use vector_lib::{
     lookup,
     lookup::lookup_v2::{ConfigValuePath, OptionalTargetPath},
 };
-use vrl::path::OwnedTargetPath;
+use vrl::{event_path, path::OwnedTargetPath};
 
 use crate::{
     codecs::EncodingConfig,
@@ -315,7 +315,7 @@ async fn splunk_index_is_interpolated() {
 
     let message = random_string(100);
     let mut event = LogEvent::from(message.clone());
-    event.insert("index_name", "custom_index");
+    event.insert(event_path!("index_name"), "custom_index");
     run_and_assert_sink_compliance(sink, stream::once(ready(event)), &HTTP_SINK_TAGS).await;
 
     let entry = find_entry(message.as_str()).await;
@@ -347,7 +347,7 @@ async fn splunk_custom_fields() {
 
     let message = random_string(100);
     let mut event = LogEvent::from(message.clone());
-    event.insert("asdf", "hello");
+    event.insert(event_path!("asdf"), "hello");
     run_and_assert_sink_compliance(sink, stream::once(ready(event)), &HTTP_SINK_TAGS).await;
 
     let entry = find_entry(message.as_str()).await;
@@ -367,8 +367,8 @@ async fn splunk_hostname() {
 
     let message = random_string(100);
     let mut event = LogEvent::from(message.clone());
-    event.insert("asdf", "hello");
-    event.insert("host", "example.com:1234");
+    event.insert(event_path!("asdf"), "hello");
+    event.insert(event_path!("host"), "example.com:1234");
     run_and_assert_sink_compliance(sink, stream::once(ready(event)), &HTTP_SINK_TAGS).await;
 
     let entry = find_entry(message.as_str()).await;
@@ -392,7 +392,7 @@ async fn splunk_sourcetype() {
 
     let message = random_string(100);
     let mut event = LogEvent::from(message.clone());
-    event.insert("asdf", "hello");
+    event.insert(event_path!("asdf"), "hello");
     run_and_assert_sink_compliance(sink, stream::once(ready(event)), &HTTP_SINK_TAGS).await;
 
     let entry = find_entry(message.as_str()).await;
@@ -417,9 +417,9 @@ async fn splunk_configure_hostname() {
 
     let message = random_string(100);
     let mut event = LogEvent::from(message.clone());
-    event.insert("asdf", "hello");
-    event.insert("host", "example.com:1234");
-    event.insert("roast", "beef.example.com:1234");
+    event.insert(event_path!("asdf"), "hello");
+    event.insert(event_path!("host"), "example.com:1234");
+    event.insert(event_path!("roast"), "beef.example.com:1234");
     run_and_assert_sink_compliance(sink, stream::once(ready(event)), &HTTP_SINK_TAGS).await;
 
     let entry = find_entry(message.as_str()).await;
@@ -507,7 +507,7 @@ async fn splunk_auto_extracted_timestamp() {
         let mut event = LogEvent::from(message.as_str());
 
         event.insert(
-            "timestamp",
+            vrl::event_path!("timestamp"),
             Value::from(
                 Utc.with_ymd_and_hms(2020, 3, 5, 0, 0, 0)
                     .single()
@@ -563,7 +563,7 @@ async fn splunk_non_auto_extracted_timestamp() {
 
         // With auto_extract_timestamp switched off the timestamp comes from the event timestamp.
         event.insert(
-            "timestamp",
+            vrl::event_path!("timestamp"),
             Value::from(
                 Utc.with_ymd_and_hms(2020, 3, 5, 0, 0, 0)
                     .single()

--- a/src/sinks/splunk_hec/logs/tests.rs
+++ b/src/sinks/splunk_hec/logs/tests.rs
@@ -72,14 +72,24 @@ fn get_processed_event_timestamp(
     let mut event = Event::Log(LogEvent::from("hello world"));
     event
         .as_mut_log()
-        .insert("event_sourcetype", "test_sourcetype");
-    event.as_mut_log().insert("event_source", "test_source");
-    event.as_mut_log().insert("event_index", "test_index");
-    event.as_mut_log().insert("host_key", "test_host");
-    event.as_mut_log().insert("event_field1", "test_value1");
-    event.as_mut_log().insert("event_field2", "test_value2");
-    event.as_mut_log().insert("key", "value");
-    event.as_mut_log().insert("int_val", 123);
+        .insert(event_path!("event_sourcetype"), "test_sourcetype");
+    event
+        .as_mut_log()
+        .insert(event_path!("event_source"), "test_source");
+    event
+        .as_mut_log()
+        .insert(event_path!("event_index"), "test_index");
+    event
+        .as_mut_log()
+        .insert(event_path!("host_key"), "test_host");
+    event
+        .as_mut_log()
+        .insert(event_path!("event_field1"), "test_value1");
+    event
+        .as_mut_log()
+        .insert(event_path!("event_field2"), "test_value2");
+    event.as_mut_log().insert(event_path!("key"), "value");
+    event.as_mut_log().insert(event_path!("int_val"), 123);
 
     if let Some(OptionalTargetPath {
         path: Some(ts_path),
@@ -150,8 +160,8 @@ fn splunk_process_log_event() {
     assert_eq!(metadata.source, Some("test_source".to_string()));
     assert_eq!(metadata.index, Some("test_index".to_string()));
     assert_eq!(metadata.host, Some(Value::from("test_host")));
-    assert!(metadata.fields.contains("event_field1"));
-    assert!(metadata.fields.contains("event_field2"));
+    assert!(metadata.fields.contains(vrl::event_path!("event_field1")));
+    assert!(metadata.fields.contains(vrl::event_path!("event_field2")));
 }
 
 fn hec_encoder(encoding: EncodingConfig) -> HecLogsEncoder {

--- a/src/sinks/vector/mod.rs
+++ b/src/sinks/vector/mod.rs
@@ -951,7 +951,7 @@ mod tests {
                 let event: Event = event.into();
                 let string = event
                     .as_log()
-                    .get("message")
+                    .get(vrl::event_path!("message"))
                     .unwrap()
                     .to_string_lossy()
                     .into_owned();

--- a/src/sinks/vector/mod.rs
+++ b/src/sinks/vector/mod.rs
@@ -951,7 +951,7 @@ mod tests {
                 let event: Event = event.into();
                 let string = event
                     .as_log()
-                    .get(vrl::event_path!("message"))
+                    .get_message()
                     .unwrap()
                     .to_string_lossy()
                     .into_owned();

--- a/src/sinks/webhdfs/integration_tests.rs
+++ b/src/sinks/webhdfs/integration_tests.rs
@@ -67,7 +67,7 @@ async fn hdfs_rotate_files_after_the_buffer_size_is_reached() {
         } else {
             3
         };
-        e.insert("i", i.to_string());
+        e.insert(vrl::event_path!("i"), i.to_string());
         Event::from(e)
     });
 

--- a/src/sinks/websocket_server/sink.rs
+++ b/src/sinks/websocket_server/sink.rs
@@ -876,7 +876,7 @@ mod tests {
                 )
                 .unwrap();
                 // Removing message_id from message, since it is not part of the event
-                base_msg.remove("message_id", true);
+                base_msg.remove(vrl::path!("message_id"), true);
                 let msg_text = serde_json::to_string(&base_msg).unwrap();
                 let expected = serde_json::to_string(expected.clone().into_log().value()).unwrap();
                 assert_eq!(expected, msg_text);

--- a/src/sources/aws_sqs/source.rs
+++ b/src/sources/aws_sqs/source.rs
@@ -259,7 +259,7 @@ mod tests {
             events[0]
                 .clone()
                 .as_log()
-                .get(".")
+                .get(vrl::event_path!())
                 .unwrap()
                 .to_string_lossy(),
             message

--- a/src/sources/datadog_agent/integration_tests.rs
+++ b/src/sources/datadog_agent/integration_tests.rs
@@ -15,6 +15,7 @@ use crate::{
     schema,
     test_util::{spawn_collect_n, wait_for_tcp},
 };
+use vrl::event_path;
 
 fn agent_address() -> String {
     std::env::var("AGENT_ADDRESS").unwrap_or_else(|_| "0.0.0.0:8181".to_owned())
@@ -100,10 +101,10 @@ async fn wait_for_message() {
     .await;
     assert_eq!(events.len(), 2);
     let event = events.first().unwrap().as_log();
-    let msg = event.get("message").unwrap().coerce_to_bytes();
+    let msg = event.get(event_path!("message")).unwrap().coerce_to_bytes();
     assert_eq!(msg, "hello world");
     let event = events.get(1).unwrap().as_log();
-    let msg = event.get("message").unwrap().coerce_to_bytes();
+    let msg = event.get(event_path!("message")).unwrap().coerce_to_bytes();
     assert_eq!(msg, "it's vector speaking");
 }
 
@@ -149,16 +150,29 @@ async fn wait_for_traces() {
 
     assert_eq!(events.len(), 1);
     let trace = events.first().unwrap().as_trace();
-    let spans = trace.get("spans").unwrap().as_array().unwrap();
+    let spans = trace
+        .get(vrl::event_path!("spans"))
+        .unwrap()
+        .as_array()
+        .unwrap();
     assert_eq!(spans.len(), 1);
     let span = spans.first().unwrap();
-    assert_eq!(span.get("name"), Some(&Value::from("a_name")));
-    assert_eq!(span.get("service"), Some(&Value::from("a_service")));
-    assert_eq!(span.get("resource"), Some(&Value::from("a_resource")));
-    assert_eq!(span.get("name"), Some(&Value::from("a_name")));
-    assert_eq!(span.get("trace_id"), Some(&Value::Integer(123)));
-    assert_eq!(span.get("span_id"), Some(&Value::Integer(456)));
-    assert_eq!(span.get("parent_id"), Some(&Value::Integer(789)));
+    assert_eq!(span.get(vrl::path!("name")), Some(&Value::from("a_name")));
+    assert_eq!(
+        span.get(vrl::path!("service")),
+        Some(&Value::from("a_service"))
+    );
+    assert_eq!(
+        span.get(vrl::path!("resource")),
+        Some(&Value::from("a_resource"))
+    );
+    assert_eq!(span.get(vrl::path!("name")), Some(&Value::from("a_name")));
+    assert_eq!(span.get(vrl::path!("trace_id")), Some(&Value::Integer(123)));
+    assert_eq!(span.get(vrl::path!("span_id")), Some(&Value::Integer(456)));
+    assert_eq!(
+        span.get(vrl::path!("parent_id")),
+        Some(&Value::Integer(789))
+    );
 }
 
 fn get_simple_trace() -> String {

--- a/src/sources/datadog_agent/tests.rs
+++ b/src/sources/datadog_agent/tests.rs
@@ -31,7 +31,7 @@ use vector_lib::{
 };
 use vrl::{
     compiler::value::Collection,
-    value,
+    event_path, value,
     value::{Kind, ObjectMap},
 };
 
@@ -1312,7 +1312,7 @@ async fn decode_traces() {
             assert_eq!(trace_v1.as_map()["host"], "a_hostname".into());
             assert_eq!(trace_v1.as_map()["env"], "an_environment".into());
             assert_eq!(trace_v1.as_map()["language_name"], "ada".into());
-            assert!(trace_v1.contains("spans"));
+            assert!(trace_v1.contains(vrl::event_path!("spans")));
             assert_eq!(trace_v1.as_map()["spans"].as_array().unwrap().len(), 1);
             let span_from_trace_v1 = trace_v1.as_map()["spans"].as_array().unwrap()[0]
                 .as_object()
@@ -1348,7 +1348,7 @@ async fn decode_traces() {
             );
 
             let apm_event = events[1].as_trace();
-            assert!(apm_event.contains("spans"));
+            assert!(apm_event.contains(event_path!("spans")));
             assert_eq!(apm_event.as_map()["host"], "a_hostname".into());
             assert_eq!(apm_event.as_map()["env"], "an_environment".into());
             assert_eq!(apm_event.as_map()["language_name"], "ada".into());
@@ -1392,7 +1392,7 @@ async fn decode_traces() {
                 trace_v2.as_map()["error_tps"],
                 Value::Float(NotNan::new(10.0f64).unwrap())
             );
-            assert!(trace_v2.contains("spans"));
+            assert!(trace_v2.contains(vrl::event_path!("spans")));
             assert_eq!(trace_v2.as_map()["spans"].as_array().unwrap().len(), 1);
             let span_from_trace_v2 = trace_v2.as_map()["spans"].as_array().unwrap()[0]
                 .as_object()

--- a/src/sources/dnstap/mod.rs
+++ b/src/sources/dnstap/mod.rs
@@ -349,6 +349,7 @@ impl FrameHandler for CommonFrameHandler {
 #[cfg(test)]
 mod tests {
     use vector_lib::event::{Event, LogEvent};
+    use vrl::event_path;
 
     use super::*;
 
@@ -400,7 +401,9 @@ mod tests {
 
         let json: serde_json::Value = serde_json::from_str(record).unwrap();
         let mut event = Event::from(LogEvent::from(vrl::value::Value::from(json)));
-        event.as_mut_log().insert("timestamp", chrono::Utc::now());
+        event
+            .as_mut_log()
+            .insert(event_path!("timestamp"), chrono::Utc::now());
 
         let definition = DnstapEventSchema;
         let schema = vector_lib::schema::Definition::empty_legacy_namespace()
@@ -424,6 +427,7 @@ mod integration_tests {
     use serde_json::json;
     use tokio::time;
     use vector_lib::{event::Event, lookup::lookup_v2::OptionalValuePath};
+    use vrl::event_path;
 
     use self::unix::UnixConfig;
     use super::*;
@@ -523,7 +527,9 @@ mod integration_tests {
         if raw_data {
             assert_eq!(events.len(), 2);
             assert!(
-                events.iter().all(|v| v.as_log().get("rawData").is_some()),
+                events
+                    .iter()
+                    .all(|v| v.as_log().get(event_path!("rawData")).is_some()),
                 "No rawData field!"
             );
         } else if query_event == "query" {
@@ -531,13 +537,15 @@ mod integration_tests {
             assert!(
                 events
                     .iter()
-                    .any(|v| v.as_log().get("messageType")
+                    .any(|v| v.as_log().get(event_path!("messageType"))
                         == Some(&Value::Bytes("ClientQuery".into()))),
                 "No ClientQuery event!"
             );
             assert!(
-                events.iter().any(|v| v.as_log().get("messageType")
-                    == Some(&Value::Bytes("ClientResponse".into()))),
+                events
+                    .iter()
+                    .any(|v| v.as_log().get(event_path!("messageType"))
+                        == Some(&Value::Bytes("ClientResponse".into()))),
                 "No ClientResponse event!"
             );
         } else if query_event == "update" {
@@ -545,26 +553,28 @@ mod integration_tests {
             assert!(
                 events
                     .iter()
-                    .any(|v| v.as_log().get("messageType")
+                    .any(|v| v.as_log().get(event_path!("messageType"))
                         == Some(&Value::Bytes("UpdateQuery".into()))),
                 "No UpdateQuery event!"
             );
             assert!(
-                events.iter().any(|v| v.as_log().get("messageType")
-                    == Some(&Value::Bytes("UpdateResponse".into()))),
+                events
+                    .iter()
+                    .any(|v| v.as_log().get(event_path!("messageType"))
+                        == Some(&Value::Bytes("UpdateResponse".into()))),
                 "No UpdateResponse event!"
             );
             assert!(
                 events
                     .iter()
-                    .any(|v| v.as_log().get("messageType")
+                    .any(|v| v.as_log().get(event_path!("messageType"))
                         == Some(&Value::Bytes("AuthQuery".into()))),
                 "No UpdateQuery event!"
             );
             assert!(
                 events
                     .iter()
-                    .any(|v| v.as_log().get("messageType")
+                    .any(|v| v.as_log().get(event_path!("messageType"))
                         == Some(&Value::Bytes("AuthResponse".into()))),
                 "No UpdateResponse event!"
             );

--- a/src/sources/docker_logs/mod.rs
+++ b/src/sources/docker_logs/mod.rs
@@ -1337,7 +1337,7 @@ fn line_agg_adapter(
     let line_agg_in = inner.map(move |mut log| {
         let message_value = match log_namespace {
             LogNamespace::Vector => log
-                .remove(event_path!())
+                .remove(&vrl::path::OwnedTargetPath::event_root())
                 .expect("`.` must exist in the event"),
             LogNamespace::Legacy => log
                 .remove(
@@ -1363,7 +1363,7 @@ fn line_agg_adapter(
     let line_agg_out = LineAgg::<_, Bytes, LogEvent>::new(line_agg_in, logic);
     line_agg_out.map(move |(_, message, mut log, _)| {
         match log_namespace {
-            LogNamespace::Vector => log.insert(event_path!(), message),
+            LogNamespace::Vector => log.insert(&vrl::path::OwnedTargetPath::event_root(), message),
             LogNamespace::Legacy => log.insert(
                 log_schema()
                     .message_key_target_path()

--- a/src/sources/docker_logs/tests.rs
+++ b/src/sources/docker_logs/tests.rs
@@ -40,7 +40,8 @@ mod integration_tests {
     use futures::{FutureExt, stream::TryStreamExt};
     use itertools::Itertools as _;
     use similar_asserts::assert_eq;
-    use vrl::value;
+    use vrl::path::parse_target_path;
+    use vrl::{event_path, value};
 
     use crate::{
         SourceSender,
@@ -321,7 +322,10 @@ mod integration_tests {
             schema_definitions
                 .unwrap()
                 .assert_valid_for_event(&events[0]);
-            assert_eq!(events[0].as_log().get(".").unwrap(), &value!(message));
+            assert_eq!(
+                events[0].as_log().get(event_path!()).unwrap(),
+                &value!(message)
+            );
         })
         .await;
     }
@@ -388,7 +392,7 @@ mod integration_tests {
 
             let log = events[0].as_log();
             let meta = log.metadata().value();
-            assert_eq!(log.get(".").unwrap(), &value!(message));
+            assert_eq!(log.get(event_path!()).unwrap(), &value!(message));
             assert_eq!(
                 meta.get(path!(DockerLogsConfig::NAME, CONTAINER)).unwrap(),
                 &value!(id)
@@ -451,9 +455,12 @@ mod integration_tests {
             let log = events[0].as_log();
             assert_eq!(*log.get_message().unwrap(), message.into());
             assert_eq!(log[CONTAINER], id.into());
-            assert!(log.get(CREATED_AT).is_some());
+            assert!(log.get(vrl::event_path!(CREATED_AT)).is_some());
             assert_eq!(log[IMAGE], "busybox".into());
-            assert!(log.get(format!("label.{label}").as_str()).is_some());
+            assert!(
+                log.get(&parse_target_path(&format!("label.{label}")).unwrap())
+                    .is_some()
+            );
             assert_eq!(events[0].as_log()[&NAME], name.into());
             assert_eq!(
                 events[0].as_log()[log_schema().source_type_key().unwrap().to_string()],
@@ -648,9 +655,12 @@ mod integration_tests {
             let log = events[0].as_log();
             assert_eq!(*log.get_message().unwrap(), message.into());
             assert_eq!(log[CONTAINER], id.into());
-            assert!(log.get(CREATED_AT).is_some());
+            assert!(log.get(vrl::event_path!(CREATED_AT)).is_some());
             assert_eq!(log[IMAGE], "busybox".into());
-            assert!(log.get(format!("label.{label}").as_str()).is_some());
+            assert!(
+                log.get(&parse_target_path(&format!("label.{label}")).unwrap())
+                    .is_some()
+            );
             assert_eq!(events[0].as_log()[&NAME], name.into());
             assert_eq!(
                 events[0].as_log()[log_schema().source_type_key().unwrap().to_string()],
@@ -783,10 +793,10 @@ mod integration_tests {
             let log = events[0].as_log();
             assert_eq!(*log.get_message().unwrap(), message.into());
             assert_eq!(log[CONTAINER], id.into());
-            assert!(log.get(CREATED_AT).is_some());
+            assert!(log.get(vrl::event_path!(CREATED_AT)).is_some());
             assert_eq!(log[IMAGE], "busybox".into());
             assert!(
-                log.get("label")
+                log.get(event_path!("label"))
                     .unwrap()
                     .as_object()
                     .unwrap()
@@ -896,7 +906,7 @@ mod integration_tests {
 
                     event
                         .into_log()
-                        .remove(".")
+                        .remove(vrl::event_path!())
                         .unwrap()
                         .to_string_lossy()
                         .into_owned()

--- a/src/sources/exec/tests.rs
+++ b/src/sources/exec/tests.rs
@@ -372,7 +372,7 @@ async fn test_run_command_linux() {
         assert_eq!(*log.get_source_type().unwrap(), "exec".into());
         assert_eq!(*log.get_message().unwrap(), "Hello World!".into());
         assert_eq!(*log.get_host().unwrap(), "Some.Machine".into());
-        assert!(log.get(PID_KEY).is_some());
+        assert!(log.get(vrl::event_path!(PID_KEY)).is_some());
         assert!(log.get_timestamp().is_some());
 
         assert_eq!(8, log.all_event_fields().unwrap().count());

--- a/src/sources/fluent/mod.rs
+++ b/src/sources/fluent/mod.rs
@@ -837,6 +837,7 @@ mod tests {
     };
     use tokio_util::codec::Decoder;
     use vector_lib::{assert_event_data_eq, lookup::OwnedTargetPath, schema::Definition};
+    use vrl::event_path;
     use vrl::value::{ObjectMap, Value, kind::Collection};
 
     use super::{message::FluentMessageOptions, *};
@@ -1125,10 +1126,16 @@ mod tests {
 
         assert_eq!(events.len(), 1);
         let log = events[0].as_log();
-        assert_eq!(log.get("field").unwrap(), &msg.into());
-        assert!(matches!(log.get("host").unwrap(), Value::Bytes(_)));
-        assert!(matches!(log.get("timestamp").unwrap(), Value::Timestamp(_)));
-        assert_eq!(log.get("tag").unwrap(), &tag.into());
+        assert_eq!(log.get(event_path!("field")).unwrap(), &msg.into());
+        assert!(matches!(
+            log.get(event_path!("host")).unwrap(),
+            Value::Bytes(_)
+        ));
+        assert!(matches!(
+            log.get(event_path!("timestamp")).unwrap(),
+            Value::Timestamp(_)
+        ));
+        assert_eq!(log.get(event_path!("tag")).unwrap(), &tag.into());
 
         (result, output.into())
     }
@@ -1257,6 +1264,7 @@ mod integration_tests {
     use futures::Stream;
     use tokio::time::sleep;
     use vector_lib::event::{Event, EventStatus};
+    use vrl::event_path;
 
     use crate::{
         SourceSender,
@@ -1349,8 +1357,8 @@ mod integration_tests {
             let log = events[0].as_log();
             assert_eq!(log["tag"], "http.0".into());
             assert_eq!(log["message"], msg.into());
-            assert!(log.get("timestamp").is_some());
-            assert!(log.get("host").is_some());
+            assert!(log.get(event_path!("timestamp")).is_some());
+            assert!(log.get(event_path!("host")).is_some());
         })
         .await;
     }
@@ -1428,8 +1436,8 @@ mod integration_tests {
             assert_eq!(events.len(), 1);
             assert_eq!(events[0].as_log()["tag"], "".into());
             assert_eq!(events[0].as_log()["message"], msg.into());
-            assert!(events[0].as_log().get("timestamp").is_some());
-            assert!(events[0].as_log().get("host").is_some());
+            assert!(events[0].as_log().get(event_path!("timestamp")).is_some());
+            assert!(events[0].as_log().get(event_path!("host")).is_some());
         })
         .await;
     }

--- a/src/sources/gcp_pubsub.rs
+++ b/src/sources/gcp_pubsub.rs
@@ -855,7 +855,7 @@ mod integration_tests {
     use hyper::{Request, StatusCode};
     use serde_json::{Value, json};
     use tokio::time::{Duration, Instant};
-    use vrl::btreemap;
+    use vrl::{btreemap, event_path};
 
     use super::*;
     use crate::{
@@ -1179,16 +1179,36 @@ mod integration_tests {
         assert_eq!(events.len(), lines.len());
         for (message, event) in lines.into_iter().zip(events) {
             let log = event.into_log();
-            assert_eq!(log.get("message"), Some(&message.into()));
-            assert_eq!(log.get("source_type"), Some(&"gcp_pubsub".into()));
-            assert!(log.get("timestamp").unwrap().as_timestamp().unwrap() >= &start);
-            assert!(log.get("timestamp").unwrap().as_timestamp().unwrap() <= &end);
+            assert_eq!(log.get(event_path!("message")), Some(&message.into()));
+            assert_eq!(
+                log.get(event_path!("source_type")),
+                Some(&"gcp_pubsub".into())
+            );
             assert!(
-                message_ids.insert(log.get("message_id").unwrap().clone().to_string()),
+                log.get(event_path!("timestamp"))
+                    .unwrap()
+                    .as_timestamp()
+                    .unwrap()
+                    >= &start
+            );
+            assert!(
+                log.get(event_path!("timestamp"))
+                    .unwrap()
+                    .as_timestamp()
+                    .unwrap()
+                    <= &end
+            );
+            assert!(
+                message_ids.insert(
+                    log.get(event_path!("message_id"))
+                        .unwrap()
+                        .clone()
+                        .to_string()
+                ),
                 "Message contained duplicate message_id"
             );
             let logattr = log
-                .get("attributes")
+                .get(event_path!("attributes"))
                 .expect("missing attributes")
                 .as_object()
                 .unwrap()

--- a/src/sources/http_client/tests.rs
+++ b/src/sources/http_client/tests.rs
@@ -10,6 +10,7 @@ use vector_lib::{
     config::LogNamespace,
     event::Event,
 };
+use vrl::event_path;
 use warp::{Filter, http::HeaderMap};
 
 use super::HttpClientConfig;
@@ -226,7 +227,9 @@ async fn request_query_applied() {
     ]);
 
     for log in logs {
-        let query = log.get("data").expect("data must be available");
+        let query = log
+            .get(event_path!("data"))
+            .expect("data must be available");
         let mut got: HashMap<String, Vec<String>> = HashMap::new();
         for (k, v) in
             url::form_urlencoded::parse(query.as_bytes().expect("byte conversion should succeed"))
@@ -356,7 +359,9 @@ async fn request_query_vrl_applied() {
     }
 
     for log in logs {
-        let query = log.get("data").expect("data must be available");
+        let query = log
+            .get(event_path!("data"))
+            .expect("data must be available");
         let mut got: HashMap<String, Vec<String>> = HashMap::new();
         for (k, v) in
             url::form_urlencoded::parse(query.as_bytes().expect("byte conversion should succeed"))
@@ -417,7 +422,9 @@ async fn request_query_vrl_dynamic_updates() {
 
     let mut timestamps = Vec::new();
     for log in logs {
-        let query = log.get("data").expect("data must be available");
+        let query = log
+            .get(event_path!("data"))
+            .expect("data must be available");
         let query_bytes = query.as_bytes().expect("byte conversion should succeed");
 
         // Parse the timestamp value
@@ -545,8 +552,11 @@ async fn post_with_body() {
 
     // Verify the body was echoed back correctly
     for log in logs {
-        assert_eq!(log.get("key").unwrap().as_str().unwrap(), "value");
-        let number = log.get("number").unwrap();
+        assert_eq!(
+            log.get(event_path!("key")).unwrap().as_str().unwrap(),
+            "value"
+        );
+        let number = log.get(event_path!("number")).unwrap();
         match number {
             vector_lib::event::Value::Integer(n) => assert_eq!(*n, 42),
             _ => panic!("Expected integer value"),
@@ -653,8 +663,11 @@ async fn post_with_vrl_body() {
 
     // Verify VRL was evaluated correctly
     for log in logs {
-        assert_eq!(log.get("message").unwrap().as_str().unwrap(), "HELLO");
-        let value = log.get("value").unwrap();
+        assert_eq!(
+            log.get(event_path!("message")).unwrap().as_str().unwrap(),
+            "HELLO"
+        );
+        let value = log.get(event_path!("value")).unwrap();
         match value {
             vector_lib::event::Value::Integer(n) => assert_eq!(*n, 42),
             _ => panic!("Expected integer value"),

--- a/src/sources/internal_logs.rs
+++ b/src/sources/internal_logs.rs
@@ -214,6 +214,7 @@ mod tests {
     use vrl::value::kind::Collection;
 
     use serial_test::serial;
+    use vrl::event_path;
 
     use super::*;
     use crate::{
@@ -289,7 +290,7 @@ mod tests {
         sleep(Duration::from_millis(1)).await;
         let mut events = collect_ready(rx).await;
         let test_id = Value::from(test_id.to_string());
-        events.retain(|event| event.as_log().get("test_id") == Some(&test_id));
+        events.retain(|event| event.as_log().get(event_path!("test_id")) == Some(&test_id));
 
         let end = chrono::Utc::now();
 
@@ -320,9 +321,9 @@ mod tests {
             assert_eq!(log["metadata.level"], "ERROR".into());
             // The first log event occurs outside our custom span
             if i == 0 {
-                assert!(log.get("vector.component_id").is_none());
-                assert!(log.get("vector.component_kind").is_none());
-                assert!(log.get("vector.component_type").is_none());
+                assert!(log.get(event_path!("vector", "component_id")).is_none());
+                assert!(log.get(event_path!("vector", "component_kind")).is_none());
+                assert!(log.get(event_path!("vector", "component_type")).is_none());
             } else if i < 3 {
                 assert_eq!(log["vector.component_id"], "foo".into());
                 assert_eq!(log["vector.component_kind"], "source".into());
@@ -336,7 +337,7 @@ mod tests {
                 assert_eq!(log["vector.component_type"], "internal_logs".into());
                 assert_eq!(log["vector.component_new_field"], "baz".into());
                 assert_eq!(log["vector.component_numerical_field"], 1.into());
-                assert!(log.get("vector.ignored_field").is_none());
+                assert!(log.get(event_path!("vector", "ignored_field")).is_none());
             }
         }
     }
@@ -383,7 +384,7 @@ mod tests {
         sleep(Duration::from_millis(1)).await;
         let mut events = collect_ready(rx).await;
         let test_id_value = Value::from(test_id.to_string());
-        events.retain(|event| event.as_log().get("test_id") == Some(&test_id_value));
+        events.retain(|event| event.as_log().get(event_path!("test_id")) == Some(&test_id_value));
 
         assert_eq!(events.len(), 1);
         let log = events[0].as_log();
@@ -392,7 +393,7 @@ mod tests {
             "captured".into()
         );
         // The unregistered span field is still filtered out.
-        assert!(log.get("vector.some_other_field").is_none());
+        assert!(log.get(event_path!("vector", "some_other_field")).is_none());
     }
 
     // NOTE: This test requires #[serial] because it directly interacts with global tracing state.
@@ -418,7 +419,7 @@ mod tests {
             .iter()
             .filter(|e| {
                 e.as_log()
-                    .get("message")
+                    .get(event_path!("message"))
                     .map(|m| m.to_string_lossy() == "Repeated test message.")
                     .unwrap_or(false)
             })

--- a/src/sources/journald.rs
+++ b/src/sources/journald.rs
@@ -842,7 +842,7 @@ fn enrich_log_event(log: &mut LogEvent, log_namespace: LogNamespace) {
         LogNamespace::Vector => {
             if let Some(host) = log
                 .get(metadata_path!(JournaldConfig::NAME, "metadata"))
-                .and_then(|meta| meta.get(HOSTNAME))
+                .and_then(|meta| meta.get(path!(HOSTNAME)))
             {
                 log.insert(metadata_path!(JournaldConfig::NAME, "host"), host.clone());
             }
@@ -865,8 +865,8 @@ fn enrich_log_event(log: &mut LogEvent, log_namespace: LogNamespace) {
         LogNamespace::Vector => log
             .get(metadata_path!(JournaldConfig::NAME, "metadata"))
             .and_then(|meta| {
-                meta.get(SOURCE_TIMESTAMP)
-                    .or_else(|| meta.get(RECEIVED_TIMESTAMP))
+                meta.get(path!(SOURCE_TIMESTAMP))
+                    .or_else(|| meta.get(path!(RECEIVED_TIMESTAMP)))
             }),
         LogNamespace::Legacy => log
             .get(event_path!(SOURCE_TIMESTAMP))
@@ -1806,7 +1806,9 @@ mod tests {
         let json: serde_json::Value = serde_json::from_str(record).unwrap();
         let mut event = Event::from(LogEvent::from(vrl::value::Value::from(json)));
 
-        event.as_mut_log().insert("timestamp", chrono::Utc::now());
+        event
+            .as_mut_log()
+            .insert(event_path!("timestamp"), chrono::Utc::now());
 
         let definitions = config.outputs(namespace).remove(0).schema_definition(true);
 

--- a/src/sources/kafka.rs
+++ b/src/sources/kafka.rs
@@ -1721,8 +1721,8 @@ mod integration_test {
                     now.trunc_subsecs(3).into()
                 );
                 assert_eq!(event.as_log()["topic"], topic.clone().into());
-                assert!(event.as_log().contains("partition"));
-                assert!(event.as_log().contains("offset"));
+                assert!(event.as_log().contains(event_path!("partition")));
+                assert!(event.as_log().contains(event_path!("offset")));
                 let mut expected_headers = ObjectMap::new();
                 expected_headers.insert(HEADER_KEY.into(), Value::from(HEADER_VALUE));
                 assert_eq!(event.as_log()["headers"], Value::from(expected_headers));

--- a/src/sources/kubernetes_logs/partial_events_merger.rs
+++ b/src/sources/kubernetes_logs/partial_events_merger.rs
@@ -215,14 +215,14 @@ fn merge_partial_events_with_custom_expiration(
 #[cfg(test)]
 mod test {
     use vector_lib::event::LogEvent;
-    use vrl::value;
+    use vrl::{event_path, metadata_path, value};
 
     use super::*;
 
     #[tokio::test]
     async fn merge_single_event_legacy() {
         let mut e_1 = LogEvent::from("test message 1");
-        e_1.insert("foo", 1);
+        e_1.insert(event_path!("foo"), 1);
 
         let input_stream = futures::stream::iter([e_1.into()]);
         let output_stream = merge_partial_events(input_stream, LogNamespace::Legacy, None);
@@ -230,7 +230,7 @@ mod test {
         let output: Vec<Event> = output_stream.collect().await;
         assert_eq!(output.len(), 1);
         assert_eq!(
-            output[0].as_log().get(".message"),
+            output[0].as_log().get(event_path!("message")),
             Some(&value!("test message 1"))
         );
     }
@@ -238,7 +238,7 @@ mod test {
     #[tokio::test]
     async fn merge_single_event_legacy_exceeds_max_merged_line_limit() {
         let mut e_1 = LogEvent::from("test message 1");
-        e_1.insert("foo", 1);
+        e_1.insert(event_path!("foo"), 1);
 
         let input_stream = futures::stream::iter([e_1.into()]);
         let output_stream = merge_partial_events(input_stream, LogNamespace::Legacy, Some(1));
@@ -250,11 +250,11 @@ mod test {
     #[tokio::test]
     async fn merge_multiple_events_legacy() {
         let mut e_1 = LogEvent::from("test message 1");
-        e_1.insert("foo", 1);
-        e_1.insert("_partial", true);
+        e_1.insert(event_path!("foo"), 1);
+        e_1.insert(event_path!("_partial"), true);
 
         let mut e_2 = LogEvent::from("test message 2");
-        e_2.insert("foo2", 1);
+        e_2.insert(event_path!("foo2"), 1);
 
         let input_stream = futures::stream::iter([e_1.into(), e_2.into()]);
         let output_stream = merge_partial_events(input_stream, LogNamespace::Legacy, None);
@@ -262,7 +262,7 @@ mod test {
         let output: Vec<Event> = output_stream.collect().await;
         assert_eq!(output.len(), 1);
         assert_eq!(
-            output[0].as_log().get(".message"),
+            output[0].as_log().get(event_path!("message")),
             Some(&value!("test message 1test message 2"))
         );
     }
@@ -270,11 +270,11 @@ mod test {
     #[tokio::test]
     async fn merge_multiple_events_legacy_exceeds_max_merged_line_limit() {
         let mut e_1 = LogEvent::from("test message 1");
-        e_1.insert("foo", 1);
-        e_1.insert("_partial", true);
+        e_1.insert(event_path!("foo"), 1);
+        e_1.insert(event_path!("_partial"), true);
 
         let mut e_2 = LogEvent::from("test message 2");
-        e_2.insert("foo2", 1);
+        e_2.insert(event_path!("foo2"), 1);
 
         let input_stream = futures::stream::iter([e_1.into(), e_2.into()]);
         // 24 > length of first message but less than the two combined
@@ -287,12 +287,12 @@ mod test {
     #[tokio::test]
     async fn multiple_events_flush_legacy() {
         let mut e_1 = LogEvent::from("test message 1");
-        e_1.insert("foo", 1);
-        e_1.insert("_partial", true);
+        e_1.insert(event_path!("foo"), 1);
+        e_1.insert(event_path!("_partial"), true);
 
         let mut e_2 = LogEvent::from("test message 2");
-        e_2.insert("foo2", 1);
-        e_1.insert("_partial", true);
+        e_2.insert(event_path!("foo2"), 1);
+        e_1.insert(event_path!("_partial"), true);
 
         let input_stream = futures::stream::iter([e_1.into(), e_2.into()]);
         let output_stream = merge_partial_events(input_stream, LogNamespace::Legacy, None);
@@ -300,7 +300,7 @@ mod test {
         let output: Vec<Event> = output_stream.collect().await;
         assert_eq!(output.len(), 1);
         assert_eq!(
-            output[0].as_log().get(".message"),
+            output[0].as_log().get(event_path!("message")),
             Some(&value!("test message 1test message 2"))
         );
     }
@@ -308,12 +308,12 @@ mod test {
     #[tokio::test]
     async fn multiple_events_flush_legacy_exceeds_max_merged_line_limit() {
         let mut e_1 = LogEvent::from("test message 1");
-        e_1.insert("foo", 1);
-        e_1.insert("_partial", true);
+        e_1.insert(event_path!("foo"), 1);
+        e_1.insert(event_path!("_partial"), true);
 
         let mut e_2 = LogEvent::from("test message 2");
-        e_2.insert("foo2", 1);
-        e_1.insert("_partial", true);
+        e_2.insert(event_path!("foo2"), 1);
+        e_1.insert(event_path!("_partial"), true);
 
         let input_stream = futures::stream::iter([e_1.into(), e_2.into()]);
         // 24 > length of first message but less than the two combined
@@ -326,12 +326,12 @@ mod test {
     #[tokio::test]
     async fn multiple_events_expire_legacy() {
         let mut e_1 = LogEvent::from("test message");
-        e_1.insert(FILE_KEY, "foo1");
-        e_1.insert("_partial", true);
+        e_1.insert(event_path!(FILE_KEY), "foo1");
+        e_1.insert(event_path!("_partial"), true);
 
         let mut e_2 = LogEvent::from("test message");
-        e_2.insert(FILE_KEY, "foo2");
-        e_1.insert("_partial", true);
+        e_2.insert(event_path!(FILE_KEY), "foo2");
+        e_1.insert(event_path!("_partial"), true);
 
         // and input stream that never ends
         let input_stream =
@@ -347,11 +347,11 @@ mod test {
         let output: Vec<Event> = output_stream.take(2).collect().await;
         assert_eq!(output.len(), 2);
         assert_eq!(
-            output[0].as_log().get(".message"),
+            output[0].as_log().get(event_path!("message")),
             Some(&value!("test message"))
         );
         assert_eq!(
-            output[1].as_log().get(".message"),
+            output[1].as_log().get(event_path!("message")),
             Some(&value!("test message"))
         );
     }
@@ -369,9 +369,14 @@ mod test {
 
         let output: Vec<Event> = output_stream.collect().await;
         assert_eq!(output.len(), 1);
-        assert_eq!(output[0].as_log().get("."), Some(&value!("test message 1")));
         assert_eq!(
-            output[0].as_log().get("%kubernetes_logs.file"),
+            output[0].as_log().get(event_path!()),
+            Some(&value!("test message 1"))
+        );
+        assert_eq!(
+            output[0]
+                .as_log()
+                .get(metadata_path!("kubernetes_logs", "file")),
             Some(&value!("foo1"))
         );
     }
@@ -400,11 +405,13 @@ mod test {
         let output: Vec<Event> = output_stream.collect().await;
         assert_eq!(output.len(), 1);
         assert_eq!(
-            output[0].as_log().get("."),
+            output[0].as_log().get(event_path!()),
             Some(&value!("test message 1test message 2"))
         );
         assert_eq!(
-            output[0].as_log().get("%kubernetes_logs.file"),
+            output[0]
+                .as_log()
+                .get(metadata_path!("kubernetes_logs", "file")),
             Some(&value!("foo1"))
         );
     }

--- a/src/sources/logstash.rs
+++ b/src/sources/logstash.rs
@@ -793,6 +793,7 @@ mod test {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use vector_lib::codecs::ReadyFrames;
     use vector_lib::lookup::OwnedTargetPath;
+    use vrl::event_path;
     use vrl::value::kind::Collection;
 
     use super::*;
@@ -859,15 +860,17 @@ mod test {
         assert_eq!(events.len(), 1);
         let log = events[0].as_log();
         assert_eq!(
-            log.get("message").unwrap().to_string_lossy(),
+            log.get(event_path!("message")).unwrap().to_string_lossy(),
             "Hello, world!".to_string()
         );
         assert_eq!(
-            log.get("source_type").unwrap().to_string_lossy(),
+            log.get(event_path!("source_type"))
+                .unwrap()
+                .to_string_lossy(),
             "logstash".to_string()
         );
-        assert!(log.get("host").is_some());
-        assert!(log.get("timestamp").is_some());
+        assert!(log.get(event_path!("host")).is_some());
+        assert!(log.get(event_path!("timestamp")).is_some());
     }
 
     fn push_req(req: &mut BytesMut, seq: u32, pairs: &[(&str, &str)]) {
@@ -1278,6 +1281,7 @@ mod integration_tests {
 
     use futures::Stream;
     use tokio::time::timeout;
+    use vrl::event_path;
 
     use super::*;
     use crate::{
@@ -1312,12 +1316,15 @@ mod integration_tests {
 
         let log = events[0].as_log();
         assert_eq!(
-            log.get("@metadata.beat"),
+            log.get(event_path!("@metadata", "beat")),
             Some(String::from("heartbeat").into()).as_ref()
         );
-        assert_eq!(log.get("summary.up"), Some(1.into()).as_ref());
-        assert!(log.get("timestamp").is_some());
-        assert!(log.get("host").is_some());
+        assert_eq!(
+            log.get(event_path!("summary", "up")),
+            Some(1.into()).as_ref()
+        );
+        assert!(log.get(event_path!("timestamp")).is_some());
+        assert!(log.get(event_path!("host")).is_some());
     }
 
     fn logstash_address() -> String {
@@ -1355,12 +1362,12 @@ mod integration_tests {
 
         let log = events[0].as_log();
         assert!(
-            log.get("line")
+            log.get(event_path!("line"))
                 .unwrap()
                 .to_string_lossy()
                 .contains("Hello World")
         );
-        assert!(log.get("host").is_some());
+        assert!(log.get(event_path!("host")).is_some());
     }
 
     async fn source(

--- a/src/sources/okta/tests.rs
+++ b/src/sources/okta/tests.rs
@@ -110,7 +110,7 @@ async fn okta_compliance() {
     let log_event = events[0].as_log();
     assert_eq!(
         log_event
-            .get("data")
+            .get(vrl::event_path!("data"))
             .expect("data must be available")
             .as_str()
             .unwrap(),

--- a/src/sources/opentelemetry/mod.rs
+++ b/src/sources/opentelemetry/mod.rs
@@ -25,13 +25,13 @@ fn count_items_inner(resource: &Value, array_id: &str, inner_id: &str) -> usize 
     resource_array
         .iter()
         .map(|r| {
-            r.get(array_id)
+            r.get(vrl::path!(array_id))
                 .and_then(|s| s.as_array())
                 .map(|scope_array| {
                     scope_array
                         .iter()
                         .map(|sl| {
-                            sl.get(inner_id)
+                            sl.get(vrl::path!(inner_id))
                                 .and_then(|lr| lr.as_array())
                                 .map(|arr| arr.len())
                                 .unwrap_or(0)
@@ -53,9 +53,11 @@ pub(crate) fn count_otlp_items(events: &[Event]) -> usize {
         .iter()
         .map(|event| match event {
             Event::Log(log) => {
-                if let Some(resource_logs) = log.get(RESOURCE_LOGS_JSON_FIELD) {
+                if let Some(resource_logs) = log.get(vrl::event_path!(RESOURCE_LOGS_JSON_FIELD)) {
                     count_items_inner(resource_logs, "scopeLogs", "logRecords")
-                } else if let Some(resource_metrics) = log.get(RESOURCE_METRICS_JSON_FIELD) {
+                } else if let Some(resource_metrics) =
+                    log.get(vrl::event_path!(RESOURCE_METRICS_JSON_FIELD))
+                {
                     count_items_inner(resource_metrics, "scopeMetrics", "metrics")
                 } else {
                     0
@@ -63,7 +65,8 @@ pub(crate) fn count_otlp_items(events: &[Event]) -> usize {
             }
             Event::Trace(trace) => {
                 // Count spans in resourceSpans
-                if let Some(resource_spans) = trace.get(RESOURCE_SPANS_JSON_FIELD) {
+                if let Some(resource_spans) = trace.get(vrl::event_path!(RESOURCE_SPANS_JSON_FIELD))
+                {
                     count_items_inner(resource_spans, "scopeSpans", "spans")
                 } else {
                     0

--- a/src/sources/opentelemetry/tests.rs
+++ b/src/sources/opentelemetry/tests.rs
@@ -50,7 +50,7 @@ use vector_lib::{
         resource::v1::{Resource, Resource as OtelResource},
     },
 };
-use vrl::value;
+use vrl::{event_path, value};
 
 fn create_test_logs_request() -> Request<ExportLogsServiceRequest> {
     Request::new(ExportLogsServiceRequest {
@@ -252,7 +252,10 @@ async fn receive_grpc_logs_vector_namespace() {
         let event = output.pop().unwrap();
         schema_definitions.unwrap().assert_valid_for_event(&event);
 
-        assert_eq!(event.as_log().get(".").unwrap(), &value!("log body"));
+        assert_eq!(
+            event.as_log().get(event_path!()).unwrap(),
+            &value!("log body")
+        );
 
         let meta = event.as_log().metadata().value();
         assert_eq!(
@@ -1413,7 +1416,7 @@ async fn http_headers_metrics_use_otlp_decoding_false() {
                 .value()
                 .get(path!("opentelemetry", "headers"))
                 .unwrap()
-                .get("AbsentHeader")
+                .get(path!("AbsentHeader"))
                 .unwrap(),
             &Value::Null
         );
@@ -1423,7 +1426,7 @@ async fn http_headers_metrics_use_otlp_decoding_false() {
                 .value()
                 .get(path!("opentelemetry", "headers"))
                 .unwrap()
-                .get("User-Agent")
+                .get(path!("User-Agent"))
                 .unwrap(),
             &value!("Test")
         );
@@ -1465,7 +1468,7 @@ async fn http_headers_traces_use_otlp_decoding_false() {
                 .value()
                 .get(path!("opentelemetry", "headers"))
                 .unwrap()
-                .get("AbsentHeader")
+                .get(path!("AbsentHeader"))
                 .unwrap(),
             &Value::Null
         );
@@ -1475,7 +1478,7 @@ async fn http_headers_traces_use_otlp_decoding_false() {
                 .value()
                 .get(path!("opentelemetry", "headers"))
                 .unwrap()
-                .get("User-Agent")
+                .get(path!("User-Agent"))
                 .unwrap(),
             &value!("Test")
         );
@@ -1500,7 +1503,7 @@ async fn http_headers_traces_use_otlp_decoding_true() {
                 .value()
                 .get(path!("opentelemetry", "headers"))
                 .unwrap()
-                .get("AbsentHeader")
+                .get(path!("AbsentHeader"))
                 .unwrap(),
             &Value::Null
         );
@@ -1510,7 +1513,7 @@ async fn http_headers_traces_use_otlp_decoding_true() {
                 .value()
                 .get(path!("opentelemetry", "headers"))
                 .unwrap()
-                .get("User-Agent")
+                .get(path!("User-Agent"))
                 .unwrap(),
             &value!("Test")
         );

--- a/src/sources/splunk_hec/mod.rs
+++ b/src/sources/splunk_hec/mod.rs
@@ -1159,9 +1159,11 @@ impl<'de, R: JsonRead<'de>> EventIterator<'de, R> {
                         .and_then(|e| e.value.clone())
                 });
             if let Some(v) = val {
-                metadata
-                    .value_mut()
-                    .insert(&vrl::path::parse_value_path(meta_path).unwrap(), v);
+                metadata.value_mut().insert(
+                    &vrl::path::parse_value_path(meta_path)
+                        .expect("hardcoded splunk_hec metadata path is a valid VRL path"),
+                    v,
+                );
             }
         }
 
@@ -1173,7 +1175,8 @@ impl<'de, R: JsonRead<'de>> EventIterator<'de, R> {
             .or_else(|| self.channel.clone());
         if let Some(ch) = channel {
             metadata.value_mut().insert(
-                &vrl::path::parse_value_path("splunk_hec.channel").unwrap(),
+                &vrl::path::parse_value_path("splunk_hec.channel")
+                    .expect("splunk_hec.channel is a valid VRL path"),
                 ch,
             );
         }
@@ -1751,12 +1754,14 @@ fn raw_event(
             }
             if let Some(ref h) = host {
                 meta.value_mut().insert(
-                    &vrl::path::parse_value_path("splunk_hec.host").unwrap(),
+                    &vrl::path::parse_value_path("splunk_hec.host")
+                        .expect("splunk_hec.host is a valid VRL path"),
                     h.clone(),
                 );
             }
             meta.value_mut().insert(
-                &vrl::path::parse_value_path("splunk_hec.channel").unwrap(),
+                &vrl::path::parse_value_path("splunk_hec.channel")
+                    .expect("splunk_hec.channel is a valid VRL path"),
                 channel.clone(),
             );
             decoder.with_metadata_template(meta)

--- a/src/sources/splunk_hec/mod.rs
+++ b/src/sources/splunk_hec/mod.rs
@@ -1159,7 +1159,9 @@ impl<'de, R: JsonRead<'de>> EventIterator<'de, R> {
                         .and_then(|e| e.value.clone())
                 });
             if let Some(v) = val {
-                metadata.value_mut().insert(*meta_path, v);
+                metadata
+                    .value_mut()
+                    .insert(&vrl::path::parse_value_path(meta_path).unwrap(), v);
             }
         }
 
@@ -1170,7 +1172,10 @@ impl<'de, R: JsonRead<'de>> EventIterator<'de, R> {
             .map(|s| Value::from(s.to_string()))
             .or_else(|| self.channel.clone());
         if let Some(ch) = channel {
-            metadata.value_mut().insert("splunk_hec.channel", ch);
+            metadata.value_mut().insert(
+                &vrl::path::parse_value_path("splunk_hec.channel").unwrap(),
+                ch,
+            );
         }
 
         metadata
@@ -1745,10 +1750,15 @@ fn raw_event(
                 meta.set_splunk_hec_token(Arc::clone(token));
             }
             if let Some(ref h) = host {
-                meta.value_mut().insert("splunk_hec.host", h.clone());
+                meta.value_mut().insert(
+                    &vrl::path::parse_value_path("splunk_hec.host").unwrap(),
+                    h.clone(),
+                );
             }
-            meta.value_mut()
-                .insert("splunk_hec.channel", channel.clone());
+            meta.value_mut().insert(
+                &vrl::path::parse_value_path("splunk_hec.channel").unwrap(),
+                channel.clone(),
+            );
             decoder.with_metadata_template(meta)
         };
 
@@ -2390,8 +2400,8 @@ mod tests {
         .await;
 
         let mut log = LogEvent::default();
-        log.insert("greeting", "hello");
-        log.insert("name", "bob");
+        log.insert(event_path!("greeting"), "hello");
+        log.insert(event_path!("name"), "bob");
         sink.run_events(vec![log.into()]).await.unwrap();
 
         let event = collect_n(source, 1).await.remove(0).into_log();
@@ -2437,7 +2447,7 @@ mod tests {
         .await;
 
         let mut event = LogEvent::default();
-        event.insert("line", "hello");
+        event.insert(event_path!("line"), "hello");
         sink.run_events(vec![event.into()]).await.unwrap();
 
         let event = collect_n(source, 1).await.remove(0);
@@ -3447,7 +3457,7 @@ mod tests {
             let event = collect_n(source, 1).await.remove(0);
             let log = event.as_log();
             assert_eq!(log["foo"], "bar".into());
-            assert_eq!(*log.get("nested.k").unwrap(), 1.into());
+            assert_eq!(*log.get(event_path!("nested", "k")).unwrap(), 1.into());
             assert_eq!(
                 log[log_schema().host_key().unwrap().to_string().as_str()],
                 "h".into()
@@ -3634,14 +3644,14 @@ mod tests {
             // The /event request produces one log with `foo=bar`.
             let event_log = events
                 .iter()
-                .find(|e| e.as_log().contains("foo"))
+                .find(|e| e.as_log().contains(event_path!("foo")))
                 .expect("expected /event request to produce a log with `foo` set");
             assert_eq!(event_log.as_log()["foo"], "bar".into());
 
             // The /raw request produces three logs whose messages are the lines.
             let raw_messages: Vec<String> = events
                 .iter()
-                .filter(|e| !e.as_log().contains("foo"))
+                .filter(|e| !e.as_log().contains(event_path!("foo")))
                 .map(|e| {
                     e.as_log()[log_schema().message_key().unwrap().to_string()]
                         .to_string_lossy()

--- a/src/sources/syslog.rs
+++ b/src/sources/syslog.rs
@@ -839,21 +839,21 @@ mod test {
                 log_schema().source_type_key_target_path().unwrap(),
                 "syslog",
             );
-            expected.insert("host", "74794bfb6795");
-            expected.insert("hostname", "74794bfb6795");
+            expected.insert(event_path!("host"), "74794bfb6795");
+            expected.insert(event_path!("hostname"), "74794bfb6795");
 
-            expected.insert("meta.sequenceId", "1");
-            expected.insert("meta.sysUpTime", "37");
-            expected.insert("meta.language", "EN");
-            expected.insert("origin.software", "test");
-            expected.insert("origin.ip", "192.168.0.1");
+            expected.insert(event_path!("meta", "sequenceId"), "1");
+            expected.insert(event_path!("meta", "sysUpTime"), "37");
+            expected.insert(event_path!("meta", "language"), "EN");
+            expected.insert(event_path!("origin", "software"), "test");
+            expected.insert(event_path!("origin", "ip"), "192.168.0.1");
 
-            expected.insert("severity", "notice");
-            expected.insert("facility", "user");
-            expected.insert("version", 1);
-            expected.insert("appname", "root");
-            expected.insert("procid", 8449);
-            expected.insert("source_ip", "192.168.0.254");
+            expected.insert(event_path!("severity"), "notice");
+            expected.insert(event_path!("facility"), "user");
+            expected.insert(event_path!("version"), 1);
+            expected.insert(event_path!("appname"), "root");
+            expected.insert(event_path!("procid"), 8449);
+            expected.insert(event_path!("source_ip"), "192.168.0.254");
         }
 
         assert_event_data_eq!(
@@ -886,20 +886,20 @@ mod test {
                     .expect("invalid timestamp"),
             );
             expected.insert(
-                log_schema().host_key().unwrap().to_string().as_str(),
+                (PathPrefix::Event, log_schema().host_key().unwrap()),
                 "74794bfb6795",
             );
-            expected.insert("hostname", "74794bfb6795");
+            expected.insert(event_path!("hostname"), "74794bfb6795");
             expected.insert(
                 log_schema().source_type_key_target_path().unwrap(),
                 "syslog",
             );
-            expected.insert("severity", "notice");
-            expected.insert("facility", "user");
-            expected.insert("version", 1);
-            expected.insert("appname", "root");
-            expected.insert("procid", 8449);
-            expected.insert("source_ip", "192.168.0.254");
+            expected.insert(event_path!("severity"), "notice");
+            expected.insert(event_path!("facility"), "user");
+            expected.insert(event_path!("version"), 1);
+            expected.insert(event_path!("appname"), "root");
+            expected.insert(event_path!("procid"), 8449);
+            expected.insert(event_path!("source_ip"), "192.168.0.254");
         }
 
         let event = event_from_bytes(
@@ -931,7 +931,7 @@ mod test {
         fn there_is_map_called_empty(event: Event) -> bool {
             event
                 .as_log()
-                .get("empty")
+                .get(event_path!("empty"))
                 .expect("empty exists")
                 .is_object()
         }
@@ -996,7 +996,7 @@ mod test {
         let event =
             event_from_bytes("host", None, raw.to_owned().into(), LogNamespace::Legacy).unwrap();
         assert_eq!(
-            event.as_log().get(r#"origin."foo.bar""#),
+            event.as_log().get(event_path!("origin", "foo.bar")),
             Some(&Value::from("baz"))
         );
     }
@@ -1015,7 +1015,7 @@ mod test {
 
         let mut expected = Event::Log(LogEvent::from(msg));
         {
-            let value = event.as_log().get("timestamp").unwrap();
+            let value = event.as_log().get(event_path!("timestamp")).unwrap();
             let year = value.as_timestamp().unwrap().naive_local().year();
 
             let expected = expected.as_mut_log();
@@ -1030,19 +1030,19 @@ mod test {
                 expected_date,
             );
             expected.insert(
-                log_schema().host_key().unwrap().to_string().as_str(),
+                (PathPrefix::Event, log_schema().host_key().unwrap()),
                 "74794bfb6795",
             );
             expected.insert(
                 log_schema().source_type_key_target_path().unwrap(),
                 "syslog",
             );
-            expected.insert("hostname", "74794bfb6795");
-            expected.insert("severity", "notice");
-            expected.insert("facility", "user");
-            expected.insert("appname", "root");
-            expected.insert("procid", 8539);
-            expected.insert("source_ip", "192.168.0.254");
+            expected.insert(event_path!("hostname"), "74794bfb6795");
+            expected.insert(event_path!("severity"), "notice");
+            expected.insert(event_path!("facility"), "user");
+            expected.insert(event_path!("appname"), "root");
+            expected.insert(event_path!("procid"), 8539);
+            expected.insert(event_path!("source_ip"), "192.168.0.254");
         }
 
         assert_event_data_eq!(event, expected);
@@ -1064,7 +1064,7 @@ mod test {
 
         let mut expected = Event::Log(LogEvent::from(msg));
         {
-            let value = event.as_log().get("timestamp").unwrap();
+            let value = event.as_log().get(event_path!("timestamp")).unwrap();
             let year = value.as_timestamp().unwrap().naive_local().year();
 
             let expected = expected.as_mut_log();
@@ -1081,14 +1081,14 @@ mod test {
                 log_schema().source_type_key_target_path().unwrap(),
                 "syslog",
             );
-            expected.insert("host", "74794bfb6795");
-            expected.insert("hostname", "74794bfb6795");
-            expected.insert("severity", "info");
-            expected.insert("facility", "local7");
-            expected.insert("appname", "liblogging-stdlog");
-            expected.insert("origin.software", "rsyslogd");
-            expected.insert("origin.swVersion", "8.24.0");
-            expected.insert("source_ip", "192.168.0.254");
+            expected.insert(event_path!("host"), "74794bfb6795");
+            expected.insert(event_path!("hostname"), "74794bfb6795");
+            expected.insert(event_path!("severity"), "info");
+            expected.insert(event_path!("facility"), "local7");
+            expected.insert(event_path!("appname"), "liblogging-stdlog");
+            expected.insert(event_path!("origin", "software"), "rsyslogd");
+            expected.insert(event_path!("origin", "swVersion"), "8.24.0");
+            expected.insert(event_path!("source_ip"), "192.168.0.254");
             expected.insert(event_path!("origin", "x-pid"), "8979");
             expected.insert(event_path!("origin", "x-info"), "http://www.rsyslog.com");
         }
@@ -1117,13 +1117,13 @@ mod test {
                 log_schema().source_type_key_target_path().unwrap(),
                 "syslog",
             );
-            expected.insert("host", "74794bfb6795");
-            expected.insert("hostname", "74794bfb6795");
-            expected.insert("severity", "info");
-            expected.insert("facility", "local7");
-            expected.insert("appname", "liblogging-stdlog");
-            expected.insert("origin.software", "rsyslogd");
-            expected.insert("origin.swVersion", "8.24.0");
+            expected.insert(event_path!("host"), "74794bfb6795");
+            expected.insert(event_path!("hostname"), "74794bfb6795");
+            expected.insert(event_path!("severity"), "info");
+            expected.insert(event_path!("facility"), "local7");
+            expected.insert(event_path!("appname"), "liblogging-stdlog");
+            expected.insert(event_path!("origin", "software"), "rsyslogd");
+            expected.insert(event_path!("origin", "swVersion"), "8.24.0");
             expected.insert(event_path!("origin", "x-pid"), "9043");
             expected.insert(event_path!("origin", "x-info"), "http://www.rsyslog.com");
         }
@@ -1191,8 +1191,8 @@ mod test {
             let output_messages: Vec<SyslogMessageRfc5424> = output_events
                 .into_iter()
                 .map(|mut e| {
-                    e.as_mut_log().remove("hostname"); // Vector adds this field which will cause a parse error.
-                    e.as_mut_log().remove("source_ip"); // Vector adds this field which will cause a parse error.
+                    e.as_mut_log().remove(event_path!("hostname")); // Vector adds this field which will cause a parse error.
+                    e.as_mut_log().remove(event_path!("source_ip")); // Vector adds this field which will cause a parse error.
                     e.into()
                 })
                 .collect();
@@ -1257,8 +1257,8 @@ mod test {
             let output_messages: Vec<SyslogMessageRfc5424> = output_events
                 .into_iter()
                 .map(|mut e| {
-                    e.as_mut_log().remove("hostname"); // Vector adds this field which will cause a parse error.
-                    e.as_mut_log().remove("source_ip"); // Vector adds this field which will cause a parse error.
+                    e.as_mut_log().remove(event_path!("hostname")); // Vector adds this field which will cause a parse error.
+                    e.as_mut_log().remove(event_path!("source_ip")); // Vector adds this field which will cause a parse error.
                     e.into()
                 })
                 .collect();
@@ -1335,8 +1335,8 @@ mod test {
             let output_messages: Vec<SyslogMessageRfc5424> = output_events
                 .into_iter()
                 .map(|mut e| {
-                    e.as_mut_log().remove("hostname"); // Vector adds this field which will cause a parse error.
-                    e.as_mut_log().remove("source_ip"); // Vector adds this field which will cause a parse error.
+                    e.as_mut_log().remove(event_path!("hostname")); // Vector adds this field which will cause a parse error.
+                    e.as_mut_log().remove(event_path!("source_ip")); // Vector adds this field which will cause a parse error.
                     e.into()
                 })
                 .collect();
@@ -1413,8 +1413,8 @@ mod test {
             let output_messages: Vec<SyslogMessageRfc5424> = output_events
                 .into_iter()
                 .map(|mut e| {
-                    e.as_mut_log().remove("hostname"); // Vector adds this field which will cause a parse error.
-                    e.as_mut_log().remove("source_ip"); // Vector adds this field which will cause a parse error.
+                    e.as_mut_log().remove(event_path!("hostname")); // Vector adds this field which will cause a parse error.
+                    e.as_mut_log().remove(event_path!("source_ip")); // Vector adds this field which will cause a parse error.
                     e.into()
                 })
                 .collect();

--- a/src/sources/util/http/headers.rs
+++ b/src/sources/util/http/headers.rs
@@ -220,7 +220,7 @@ mod tests {
             "Checking log contains Content-Type header"
         );
         assert!(
-            !log.contains("user-agent"),
+            !log.contains(vrl::event_path!("user-agent")),
             "Checking log does not contain User-Agent header"
         );
         assert_eq!(
@@ -254,16 +254,16 @@ mod tests {
             .unwrap();
 
         assert_eq!(
-            metric_headers.get("content-type").unwrap(),
+            metric_headers.get(path!("content-type")).unwrap(),
             &value!("application/x-protobuf"),
             "Checking metric contains Content-Type header"
         );
         assert!(
-            !metric_headers.contains("user-agent"),
+            !metric_headers.contains(path!("user-agent")),
             "Checking metric does not contain User-Agent header"
         );
         assert_eq!(
-            metric_headers.get("content-encoding").unwrap(),
+            metric_headers.get(path!("content-encoding")).unwrap(),
             &value!("gzip"),
             "Checking metric contains Content-Encoding header"
         );
@@ -291,16 +291,16 @@ mod tests {
             .unwrap();
 
         assert_eq!(
-            trace_headers.get("content-type").unwrap(),
+            trace_headers.get(path!("content-type")).unwrap(),
             &value!("application/x-protobuf"),
             "Checking trace contains Content-Type header"
         );
         assert!(
-            !trace_headers.contains("user-agent"),
+            !trace_headers.contains(path!("user-agent")),
             "Checking trace does not contain User-Agent header"
         );
         assert_eq!(
-            trace_headers.get("content-encoding").unwrap(),
+            trace_headers.get(path!("content-encoding")).unwrap(),
             &value!("gzip"),
             "Checking trace contains Content-Encoding header"
         );

--- a/src/sources/windows_event_log/integration_tests.rs
+++ b/src/sources/windows_event_log/integration_tests.rs
@@ -8,6 +8,8 @@ use std::time::Duration;
 use futures::StreamExt;
 use tokio::fs;
 
+use vrl::event_path;
+
 use super::*;
 use crate::config::{SourceAcknowledgementsConfig, SourceConfig, SourceContext};
 use crate::test_util::components::run_and_assert_source_compliance;
@@ -168,7 +170,7 @@ async fn test_backlog_drain_no_duplicates() {
     let mut record_ids = HashSet::new();
     let mut duplicate_count = 0;
     for event in &events {
-        if let Some(rid) = event.as_log().get("record_id") {
+        if let Some(rid) = event.as_log().get(event_path!("record_id")) {
             if !record_ids.insert(rid.to_string_lossy()) {
                 duplicate_count += 1;
             }
@@ -212,7 +214,7 @@ async fn test_checkpoint_resume_no_redelivery() {
     // Phase 1 event should NOT be redelivered (checkpoint should have advanced past it)
     let has_phase1 = second_run.iter().any(|e| {
         e.as_log()
-            .get("message")
+            .get(event_path!("message"))
             .map(|m| m.to_string_lossy().contains("checkpoint-test-phase1"))
             .unwrap_or(false)
     });
@@ -226,7 +228,7 @@ async fn test_checkpoint_resume_no_redelivery() {
     // The new phase 2 event should be present
     let has_phase2 = second_run.iter().any(|e| {
         e.as_log()
-            .get("message")
+            .get(event_path!("message"))
             .map(|m| m.to_string_lossy().contains("checkpoint-test-phase2"))
             .unwrap_or(false)
     });
@@ -259,7 +261,7 @@ async fn test_channel_isolation() {
     let events = run_and_assert_source_compliance(config, Duration::from_secs(3), &[]).await;
 
     for event in &events {
-        if let Some(channel) = event.as_log().get("channel") {
+        if let Some(channel) = event.as_log().get(event_path!("channel")) {
             let ch = channel.to_string_lossy();
             assert_eq!(
                 ch, "System",
@@ -294,7 +296,7 @@ async fn test_only_event_ids_filter() {
     let events = run_and_assert_source_compliance(config, Duration::from_secs(5), &[]).await;
 
     for event in &events {
-        if let Some(eid) = event.as_log().get("event_id") {
+        if let Some(eid) = event.as_log().get(event_path!("event_id")) {
             let id: i64 = match eid {
                 vrl::value::Value::Integer(i) => *i,
                 other => other.to_string_lossy().parse().unwrap_or(-1),
@@ -326,7 +328,7 @@ async fn test_ignore_event_ids_filter() {
     let events = run_and_assert_source_compliance(config, Duration::from_secs(3), &[]).await;
 
     for event in &events {
-        if let Some(eid) = event.as_log().get("event_id") {
+        if let Some(eid) = event.as_log().get(event_path!("event_id")) {
             let id: i64 = match eid {
                 vrl::value::Value::Integer(i) => *i,
                 other => other.to_string_lossy().parse().unwrap_or(-1),
@@ -378,7 +380,7 @@ async fn test_only_event_ids_generates_xpath_filter() {
 
     // Every event must have event_id == 1000.
     for event in &events {
-        if let Some(eid) = event.as_log().get("event_id") {
+        if let Some(eid) = event.as_log().get(event_path!("event_id")) {
             let id: i64 = match eid {
                 vrl::value::Value::Integer(i) => *i,
                 other => other.to_string_lossy().parse().unwrap_or(-1),
@@ -410,7 +412,7 @@ async fn test_multiple_event_levels() {
 
     let mut levels_seen: HashSet<String> = HashSet::new();
     for event in &events {
-        if let Some(level) = event.as_log().get("level") {
+        if let Some(level) = event.as_log().get(event_path!("level")) {
             levels_seen.insert(level.to_string_lossy().to_string());
         }
     }
@@ -443,7 +445,7 @@ async fn test_rendered_message_content() {
 
     let found = events.iter().any(|e| {
         e.as_log()
-            .get("message")
+            .get(event_path!("message"))
             .map(|m| m.to_string_lossy().contains(marker))
             .unwrap_or(false)
     });
@@ -456,7 +458,7 @@ async fn test_rendered_message_content() {
         events.len(),
         events
             .first()
-            .and_then(|e| e.as_log().get("message"))
+            .and_then(|e| e.as_log().get(event_path!("message")))
             .map(|m| m.to_string_lossy())
     );
 }
@@ -476,7 +478,7 @@ async fn test_render_message_disabled_fallback() {
     if !events.is_empty() {
         let log = events[0].as_log();
         assert!(
-            log.contains("message"),
+            log.contains(event_path!("message")),
             "render_message=false should still produce a message field (generic fallback). \
              Event keys: {:?}",
             log.keys().into_iter().flatten().collect::<Vec<_>>()
@@ -503,7 +505,7 @@ async fn test_include_xml_well_formed() {
     );
 
     let log = events[0].as_log();
-    let xml = log.get("xml").expect(
+    let xml = log.get(event_path!("xml")).expect(
         "include_xml=true but 'xml' field missing. \
          Check raw_xml population in parse_event_xml.",
     );
@@ -528,7 +530,7 @@ async fn test_exclude_xml_by_default() {
 
     for event in &events {
         assert!(
-            !event.as_log().contains("xml"),
+            !event.as_log().contains(event_path!("xml")),
             "include_xml=false but 'xml' field is present."
         );
     }
@@ -560,11 +562,11 @@ async fn test_field_filter_exclude_event_data() {
     for event in events.iter().take(10) {
         let log = event.as_log();
         assert!(
-            !log.contains("event_data"),
+            !log.contains(event_path!("event_data")),
             "include_event_data=false but 'event_data' field is present."
         );
         assert!(
-            !log.contains("user_data"),
+            !log.contains(event_path!("user_data")),
             "include_user_data=false but 'user_data' field is present."
         );
     }
@@ -650,7 +652,7 @@ async fn test_event_field_completeness() {
 
     let mut missing = Vec::new();
     for field in &required {
-        if !log.contains(*field) {
+        if !log.contains(event_path!(*field)) {
             missing.push(*field);
         }
     }
@@ -664,7 +666,7 @@ async fn test_event_field_completeness() {
     );
 
     // Verify event_id is a positive integer
-    if let Some(eid) = log.get("event_id") {
+    if let Some(eid) = log.get(event_path!("event_id")) {
         match eid {
             vrl::value::Value::Integer(i) => {
                 assert!(*i > 0, "event_id should be a positive integer, got {i}")
@@ -677,7 +679,7 @@ async fn test_event_field_completeness() {
     }
 
     // Verify record_id is a positive integer
-    if let Some(rid) = log.get("record_id") {
+    if let Some(rid) = log.get(event_path!("record_id")) {
         match rid {
             vrl::value::Value::Integer(i) => {
                 assert!(*i > 0, "record_id should be a positive integer, got {i}")
@@ -687,7 +689,7 @@ async fn test_event_field_completeness() {
     }
 
     // Verify level is a human-readable string
-    if let Some(level) = log.get("level") {
+    if let Some(level) = log.get(event_path!("level")) {
         let level_str = level.to_string_lossy();
         assert!(
             ["Information", "Warning", "Error", "Critical", "Verbose"]
@@ -801,7 +803,7 @@ async fn test_max_event_age_filtering() {
 
     // If we got events, verify none of them are our old test event
     for event in &events {
-        if let Some(msg) = event.as_log().get("message") {
+        if let Some(msg) = event.as_log().get(event_path!("message")) {
             assert!(
                 !msg.to_string_lossy().contains("age-filter-test"),
                 "max_event_age_secs=3 but old event was not filtered out. \
@@ -840,7 +842,7 @@ async fn test_event_data_format_coercion() {
 
     // event_id should be converted to string by the custom formatter
     let log = events[0].as_log();
-    if let Some(eid) = log.get("event_id") {
+    if let Some(eid) = log.get(event_path!("event_id")) {
         assert!(
             matches!(eid, vrl::value::Value::Bytes(_)),
             "event_data_format set event_id to String but got {:?}. \
@@ -874,7 +876,7 @@ async fn test_multi_channel_ingestion() {
 
     let mut channels_seen: HashSet<String> = HashSet::new();
     for event in &events {
-        if let Some(channel) = event.as_log().get("channel") {
+        if let Some(channel) = event.as_log().get(event_path!("channel")) {
             channels_seen.insert(channel.to_string_lossy().to_string());
         }
     }
@@ -1144,7 +1146,7 @@ async fn test_acknowledgements_checkpoint_after_delivery() {
     // Should NOT see phase1 event again (checkpoint advanced)
     let has_phase1 = events.iter().any(|e| {
         e.as_log()
-            .get("message")
+            .get(event_path!("message"))
             .map(|m| m.to_string_lossy().contains("ack-test-phase1"))
             .unwrap_or(false)
     });
@@ -1276,13 +1278,13 @@ async fn test_rejected_ack_does_not_advance_checkpoint() {
         let log = e.as_log();
         // Check message field (rendered message or string_inserts fallback)
         let in_message = log
-            .get("message")
+            .get(event_path!("message"))
             .map(|m| m.to_string_lossy().contains("rejected-ack-test-marker"))
             .unwrap_or(false);
         // Also check string_inserts directly in case EvtFormatMessage is unavailable
         // on this CI runner and the fallback doesn't surface the description.
         let in_inserts = log
-            .get("string_inserts")
+            .get(event_path!("string_inserts"))
             .and_then(|v| v.as_array())
             .map(|arr| {
                 arr.iter()
@@ -1344,7 +1346,7 @@ async fn test_stress_burst_ingestion() {
     let mut record_ids = HashSet::new();
     let mut dups = 0;
     for event in &events {
-        if let Some(rid) = event.as_log().get("record_id") {
+        if let Some(rid) = event.as_log().get(event_path!("record_id")) {
             if !record_ids.insert(rid.to_string_lossy()) {
                 dups += 1;
             }
@@ -1360,7 +1362,7 @@ async fn test_stress_burst_ingestion() {
         let log = event.as_log();
         for field in ["event_id", "record_id", "channel", "provider_name"] {
             assert!(
-                log.contains(field),
+                log.contains(event_path!(field)),
                 "Stress test event missing field '{field}' — possible render corruption."
             );
         }
@@ -1493,7 +1495,7 @@ async fn test_resubscribe_after_log_clear() {
                 tokio::select! {
                     event = rx.next() => {
                         if let Some(event) = event {
-                            if let Some(msg) = event.as_log().get("message") {
+                            if let Some(msg) = event.as_log().get(event_path!("message")) {
                                 if msg.to_string_lossy().contains("post-clear-event") {
                                     found_post_clear = true;
                                     break;
@@ -1620,7 +1622,7 @@ async fn test_checkpoint_resume_no_duplicate_record_ids() {
         .iter()
         .filter_map(|e| {
             e.as_log()
-                .get("record_id")
+                .get(event_path!("record_id"))
                 .map(|v| v.to_string_lossy().into_owned())
         })
         .collect();
@@ -1649,7 +1651,7 @@ async fn test_checkpoint_resume_no_duplicate_record_ids() {
         .iter()
         .filter_map(|e| {
             e.as_log()
-                .get("record_id")
+                .get(event_path!("record_id"))
                 .map(|v| v.to_string_lossy().into_owned())
         })
         .collect();

--- a/src/sources/windows_event_log/parser.rs
+++ b/src/sources/windows_event_log/parser.rs
@@ -1,5 +1,8 @@
 use vector_lib::config::{LogNamespace, log_schema};
-use vrl::value::{ObjectMap, Value};
+use vrl::{
+    event_path,
+    value::{ObjectMap, Value},
+};
 
 use vector_lib::event::LogEvent;
 
@@ -138,58 +141,94 @@ impl EventLogParser {
         event: &WindowsEvent,
     ) -> Result<(), WindowsEventLogError> {
         // Core Windows Event Log fields
-        log_event.insert("event_id", Value::Integer(event.event_id as i64));
-
-        log_event.insert("record_id", Value::Integer(event.record_id as i64));
-
-        log_event.insert("level", Value::Bytes(event.level_name().into()));
-
-        log_event.insert("level_value", Value::Integer(event.level as i64));
-
-        log_event.insert("channel", Value::Bytes(event.channel.clone().into()));
+        log_event.insert(
+            event_path!("event_id"),
+            Value::Integer(event.event_id as i64),
+        );
 
         log_event.insert(
-            "provider_name",
+            event_path!("record_id"),
+            Value::Integer(event.record_id as i64),
+        );
+
+        log_event.insert(
+            event_path!("level"),
+            Value::Bytes(event.level_name().into()),
+        );
+
+        log_event.insert(
+            event_path!("level_value"),
+            Value::Integer(event.level as i64),
+        );
+
+        log_event.insert(
+            event_path!("channel"),
+            Value::Bytes(event.channel.clone().into()),
+        );
+
+        log_event.insert(
+            event_path!("provider_name"),
             Value::Bytes(event.provider_name.clone().into()),
         );
 
         if let Some(ref provider_guid) = event.provider_guid {
-            log_event.insert("provider_guid", Value::Bytes(provider_guid.clone().into()));
+            log_event.insert(
+                event_path!("provider_guid"),
+                Value::Bytes(provider_guid.clone().into()),
+            );
         }
 
-        log_event.insert("computer", Value::Bytes(event.computer.clone().into()));
+        log_event.insert(
+            event_path!("computer"),
+            Value::Bytes(event.computer.clone().into()),
+        );
 
         if let Some(ref user_id) = event.user_id {
-            log_event.insert("user_id", Value::Bytes(user_id.clone().into()));
+            log_event.insert(event_path!("user_id"), Value::Bytes(user_id.clone().into()));
         }
 
         if let Some(ref user_name) = event.user_name {
-            log_event.insert("user_name", Value::Bytes(user_name.clone().into()));
+            log_event.insert(
+                event_path!("user_name"),
+                Value::Bytes(user_name.clone().into()),
+            );
         }
 
-        log_event.insert("process_id", Value::Integer(event.process_id as i64));
+        log_event.insert(
+            event_path!("process_id"),
+            Value::Integer(event.process_id as i64),
+        );
 
-        log_event.insert("thread_id", Value::Integer(event.thread_id as i64));
+        log_event.insert(
+            event_path!("thread_id"),
+            Value::Integer(event.thread_id as i64),
+        );
 
         if event.task != 0 {
-            log_event.insert("task", Value::Integer(event.task as i64));
+            log_event.insert(event_path!("task"), Value::Integer(event.task as i64));
 
             if let Some(ref task_name) = event.task_name {
-                log_event.insert("task_name", Value::Bytes(task_name.clone().into()));
+                log_event.insert(
+                    event_path!("task_name"),
+                    Value::Bytes(task_name.clone().into()),
+                );
             }
         }
 
         if event.opcode != 0 {
-            log_event.insert("opcode", Value::Integer(event.opcode as i64));
+            log_event.insert(event_path!("opcode"), Value::Integer(event.opcode as i64));
 
             if let Some(ref opcode_name) = event.opcode_name {
-                log_event.insert("opcode_name", Value::Bytes(opcode_name.clone().into()));
+                log_event.insert(
+                    event_path!("opcode_name"),
+                    Value::Bytes(opcode_name.clone().into()),
+                );
             }
         }
 
         if event.keywords != 0 {
             log_event.insert(
-                "keywords",
+                event_path!("keywords"),
                 Value::Bytes(format!("0x{:016X}", event.keywords).into()),
             );
 
@@ -199,28 +238,31 @@ impl EventLogParser {
                     .iter()
                     .map(|s| Value::Bytes(s.clone().into()))
                     .collect();
-                log_event.insert("keyword_names", Value::Array(kw_values));
+                log_event.insert(event_path!("keyword_names"), Value::Array(kw_values));
             }
         }
 
         if let Some(ref activity_id) = event.activity_id {
-            log_event.insert("activity_id", Value::Bytes(activity_id.clone().into()));
+            log_event.insert(
+                event_path!("activity_id"),
+                Value::Bytes(activity_id.clone().into()),
+            );
         }
 
         if let Some(ref related_activity_id) = event.related_activity_id {
             log_event.insert(
-                "related_activity_id",
+                event_path!("related_activity_id"),
                 Value::Bytes(related_activity_id.clone().into()),
             );
         }
 
         // New FluentBit-compatible fields
         if let Some(version) = event.version {
-            log_event.insert("version", Value::Integer(version as i64));
+            log_event.insert(event_path!("version"), Value::Integer(version as i64));
         }
 
         if let Some(qualifiers) = event.qualifiers {
-            log_event.insert("qualifiers", Value::Integer(qualifiers as i64));
+            log_event.insert(event_path!("qualifiers"), Value::Integer(qualifiers as i64));
         }
 
         // StringInserts field for FluentBit compatibility
@@ -230,12 +272,15 @@ impl EventLogParser {
                 .iter()
                 .map(|s| Value::Bytes(s.clone().into()))
                 .collect();
-            log_event.insert("string_inserts", Value::Array(string_inserts));
+            log_event.insert(event_path!("string_inserts"), Value::Array(string_inserts));
         }
 
         // Include raw XML if requested
         if self.config.include_xml && !event.raw_xml.is_empty() {
-            log_event.insert("xml", Value::Bytes(event.raw_xml.clone().into()));
+            log_event.insert(
+                event_path!("xml"),
+                Value::Bytes(event.raw_xml.clone().into()),
+            );
         }
 
         // Include event data if configured
@@ -245,7 +290,7 @@ impl EventLogParser {
                 let typed_value = self.coerce_field_value(key, value);
                 event_data_map.insert(key.clone().into(), typed_value);
             }
-            log_event.insert("event_data", Value::Object(event_data_map));
+            log_event.insert(event_path!("event_data"), Value::Object(event_data_map));
         }
 
         // Include user data if configured
@@ -255,7 +300,7 @@ impl EventLogParser {
                 let typed_value = self.coerce_field_value(key, value);
                 user_data_map.insert(key.clone().into(), typed_value);
             }
-            log_event.insert("user_data", Value::Object(user_data_map));
+            log_event.insert(event_path!("user_data"), Value::Object(user_data_map));
         }
 
         Ok(())
@@ -509,38 +554,44 @@ mod tests {
         let log_event = parser.parse_event(event.clone()).unwrap();
 
         // Check core fields
-        assert_eq!(log_event.get("event_id").unwrap(), &Value::Integer(1000));
-        assert_eq!(log_event.get("record_id").unwrap(), &Value::Integer(12345));
         assert_eq!(
-            log_event.get("level").unwrap(),
+            log_event.get(event_path!("event_id")).unwrap(),
+            &Value::Integer(1000)
+        );
+        assert_eq!(
+            log_event.get(event_path!("record_id")).unwrap(),
+            &Value::Integer(12345)
+        );
+        assert_eq!(
+            log_event.get(event_path!("level")).unwrap(),
             &Value::Bytes("Information".into())
         );
         assert_eq!(
-            log_event.get("channel").unwrap(),
+            log_event.get(event_path!("channel")).unwrap(),
             &Value::Bytes("TestChannel".into())
         );
         assert_eq!(
-            log_event.get("provider_name").unwrap(),
+            log_event.get(event_path!("provider_name")).unwrap(),
             &Value::Bytes("TestProvider".into())
         );
         assert_eq!(
-            log_event.get("computer").unwrap(),
+            log_event.get(event_path!("computer")).unwrap(),
             &Value::Bytes("TEST-PC".into())
         );
 
         // Enriched fields from the new resolution methods
         // opcode=2 -> "Stop"
         assert_eq!(
-            log_event.get("opcode_name").unwrap(),
+            log_event.get(event_path!("opcode_name")).unwrap(),
             &Value::Bytes("Stop".into())
         );
         // keywords=0x8000000000000000 -> ["Classic"]
         assert_eq!(
-            log_event.get("keyword_names").unwrap(),
+            log_event.get(event_path!("keyword_names")).unwrap(),
             &Value::Array(vec![Value::Bytes("Classic".into())])
         );
         // task=1 with provider "TestProvider" has no known mapping
-        assert!(log_event.get("task_name").is_none());
+        assert!(log_event.get(event_path!("task_name")).is_none());
     }
 
     #[test]
@@ -582,26 +633,29 @@ mod tests {
 
         // Level 0 should map to "Information" (not "Unknown")
         assert_eq!(
-            log_event.get("level").unwrap(),
+            log_event.get(event_path!("level")).unwrap(),
             &Value::Bytes("Information".into())
         );
-        assert_eq!(log_event.get("level_value").unwrap(), &Value::Integer(0));
+        assert_eq!(
+            log_event.get(event_path!("level_value")).unwrap(),
+            &Value::Integer(0)
+        );
 
         // Task 12544 -> "Logon"
         assert_eq!(
-            log_event.get("task_name").unwrap(),
+            log_event.get(event_path!("task_name")).unwrap(),
             &Value::Bytes("Logon".into())
         );
 
         // keywords=Audit Success
         assert_eq!(
-            log_event.get("keyword_names").unwrap(),
+            log_event.get(event_path!("keyword_names")).unwrap(),
             &Value::Array(vec![Value::Bytes("Audit Success".into())])
         );
 
         // opcode=0 is not emitted since the condition is `if event.opcode != 0`
-        assert!(log_event.get("opcode").is_none());
-        assert!(log_event.get("opcode_name").is_none());
+        assert!(log_event.get(event_path!("opcode")).is_none());
+        assert!(log_event.get(event_path!("opcode_name")).is_none());
     }
 
     #[test]
@@ -614,9 +668,9 @@ mod tests {
 
         let log_event = parser.parse_event(event.clone()).unwrap();
 
-        assert!(log_event.get("xml").is_some());
+        assert!(log_event.get(event_path!("xml")).is_some());
         assert_eq!(
-            log_event.get("xml").unwrap(),
+            log_event.get(event_path!("xml")).unwrap(),
             &Value::Bytes(event.raw_xml.into())
         );
     }
@@ -631,7 +685,7 @@ mod tests {
 
         let log_event = parser.parse_event(event.clone()).unwrap();
 
-        if let Some(Value::Object(event_data)) = log_event.get("event_data") {
+        if let Some(Value::Object(event_data)) = log_event.get(event_path!("event_data")) {
             assert_eq!(event_data.get("key1"), Some(&Value::Bytes("value1".into())));
             assert_eq!(event_data.get("key2"), Some(&Value::Bytes("value2".into())));
         } else {
@@ -653,7 +707,7 @@ mod tests {
 
         // event_id should be converted to string
         assert_eq!(
-            log_event.get("event_id").unwrap(),
+            log_event.get(event_path!("event_id")).unwrap(),
             &Value::Bytes("1000".into())
         );
     }
@@ -670,8 +724,8 @@ mod tests {
         let log_event = parser.parse_event(event).unwrap();
 
         // Only included fields should be present
-        assert!(log_event.get("event_id").is_some());
-        assert!(log_event.get("level").is_some());
+        assert!(log_event.get(event_path!("event_id")).is_some());
+        assert!(log_event.get(event_path!("level")).is_some());
         // Other fields should be filtered out
         // Note: This test might need adjustment based on actual field filtering implementation
     }
@@ -688,10 +742,10 @@ mod tests {
         let log_event = parser.parse_event(event).unwrap();
 
         // Excluded fields should not be present
-        assert!(log_event.get("raw_xml").is_none());
-        assert!(log_event.get("provider_guid").is_none());
+        assert!(log_event.get(event_path!("raw_xml")).is_none());
+        assert!(log_event.get(event_path!("provider_guid")).is_none());
         // Other fields should still be there
-        assert!(log_event.get("event_id").is_some());
+        assert!(log_event.get(event_path!("event_id")).is_some());
     }
 
     #[test]
@@ -768,13 +822,13 @@ mod tests {
         let log_event = parser.parse_event(event).unwrap();
 
         // event_id and level should be present (in include list, not in exclude list)
-        assert!(log_event.get("event_id").is_some());
-        assert!(log_event.get("level").is_some());
+        assert!(log_event.get(event_path!("event_id")).is_some());
+        assert!(log_event.get(event_path!("level")).is_some());
         // channel should be excluded (in both include and exclude, exclude wins)
-        assert!(log_event.get("channel").is_none());
+        assert!(log_event.get(event_path!("channel")).is_none());
         // Fields not in include list should be absent
-        assert!(log_event.get("computer").is_none());
-        assert!(log_event.get("record_id").is_none());
+        assert!(log_event.get(event_path!("computer")).is_none());
+        assert!(log_event.get(event_path!("record_id")).is_none());
     }
 
     #[test]

--- a/src/sources/windows_event_log/parser.rs
+++ b/src/sources/windows_event_log/parser.rs
@@ -58,33 +58,24 @@ impl EventLogParser {
         let log_schema = log_schema();
 
         // Set timestamp
-        if let Some(timestamp_key) = log_schema.timestamp_key() {
-            log_event.try_insert(
-                timestamp_key.to_string().as_str(),
-                Value::Timestamp(event.time_created),
-            );
+        if let Some(timestamp_key) = log_schema.timestamp_key_target_path() {
+            log_event.try_insert(timestamp_key, Value::Timestamp(event.time_created));
         }
 
         // Set message (rendered message or event data)
-        if let Some(message_key) = log_schema.message_key() {
+        if let Some(message_key) = log_schema.message_key_target_path() {
             let message = event
                 .rendered_message
                 .as_ref()
                 .cloned()
                 .unwrap_or_else(|| self.extract_message_from_event_data(event));
 
-            log_event.try_insert(
-                message_key.to_string().as_str(),
-                Value::Bytes(message.into()),
-            );
+            log_event.try_insert(message_key, Value::Bytes(message.into()));
         }
 
         // Set source/host
-        if let Some(host_key) = log_schema.host_key() {
-            log_event.try_insert(
-                host_key.to_string().as_str(),
-                Value::Bytes(event.computer.clone().into()),
-            );
+        if let Some(host_key) = log_schema.host_key_target_path() {
+            log_event.try_insert(host_key, Value::Bytes(event.computer.clone().into()));
         }
 
         // Set Windows-specific fields
@@ -102,31 +93,22 @@ impl EventLogParser {
         let log_schema = log_schema();
 
         // Set standard fields
-        if let Some(timestamp_key) = log_schema.timestamp_key() {
-            log_event.try_insert(
-                timestamp_key.to_string().as_str(),
-                Value::Timestamp(event.time_created),
-            );
+        if let Some(timestamp_key) = log_schema.timestamp_key_target_path() {
+            log_event.try_insert(timestamp_key, Value::Timestamp(event.time_created));
         }
 
-        if let Some(message_key) = log_schema.message_key() {
+        if let Some(message_key) = log_schema.message_key_target_path() {
             let message = event
                 .rendered_message
                 .as_ref()
                 .cloned()
                 .unwrap_or_else(|| self.extract_message_from_event_data(event));
 
-            log_event.try_insert(
-                message_key.to_string().as_str(),
-                Value::Bytes(message.into()),
-            );
+            log_event.try_insert(message_key, Value::Bytes(message.into()));
         }
 
-        if let Some(host_key) = log_schema.host_key() {
-            log_event.try_insert(
-                host_key.to_string().as_str(),
-                Value::Bytes(event.computer.clone().into()),
-            );
+        if let Some(host_key) = log_schema.host_key_target_path() {
+            log_event.try_insert(host_key, Value::Bytes(event.computer.clone().into()));
         }
 
         // Set Windows-specific fields at root level
@@ -389,14 +371,18 @@ impl EventLogParser {
                 .collect();
 
             for key in keys_to_remove {
-                log_event.remove(key.as_str());
+                if let Ok(path) = vrl::path::parse_target_path(&key) {
+                    log_event.remove(&path);
+                }
             }
         }
 
         // Remove fields in exclude_fields list - single pass removal
         if let Some(ref exclude_fields) = filter.exclude_fields {
             for field in exclude_fields {
-                log_event.remove(field.as_str());
+                if let Ok(path) = vrl::path::parse_target_path(field) {
+                    log_event.remove(&path);
+                }
             }
         }
 
@@ -408,9 +394,12 @@ impl EventLogParser {
         log_event: &mut LogEvent,
     ) -> Result<(), WindowsEventLogError> {
         for (field_name, format) in &self.config.event_data_format {
-            if let Some(current_value) = log_event.get(field_name.as_str()) {
+            let Ok(path) = vrl::path::parse_target_path(field_name) else {
+                continue;
+            };
+            if let Some(current_value) = log_event.get(&path) {
                 let formatted_value = self.format_value(current_value, format)?;
-                log_event.insert(field_name.as_str(), formatted_value);
+                log_event.insert(&path, formatted_value);
             }
         }
 

--- a/src/sources/windows_event_log/tests.rs
+++ b/src/sources/windows_event_log/tests.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, time::Duration};
 
 use chrono::Utc;
 use vector_lib::config::LogNamespace;
-use vrl::value::Value;
+use vrl::{event_path, value::Value};
 
 use super::{config::*, error::*, parser::*, xml_parser::*};
 use crate::{
@@ -300,27 +300,42 @@ mod parser_tests {
         let log_event = parser.parse_event(event.clone()).unwrap();
 
         // Check core fields
-        assert_eq!(log_event.get("event_id"), Some(&Value::Integer(4624)));
-        assert_eq!(log_event.get("record_id"), Some(&Value::Integer(12345)));
         assert_eq!(
-            log_event.get("level"),
+            log_event.get(event_path!("event_id")),
+            Some(&Value::Integer(4624))
+        );
+        assert_eq!(
+            log_event.get(event_path!("record_id")),
+            Some(&Value::Integer(12345))
+        );
+        assert_eq!(
+            log_event.get(event_path!("level")),
             Some(&Value::Bytes("Information".into()))
         );
-        assert_eq!(log_event.get("level_value"), Some(&Value::Integer(4)));
         assert_eq!(
-            log_event.get("channel"),
+            log_event.get(event_path!("level_value")),
+            Some(&Value::Integer(4))
+        );
+        assert_eq!(
+            log_event.get(event_path!("channel")),
             Some(&Value::Bytes("Security".into()))
         );
         assert_eq!(
-            log_event.get("provider_name"),
+            log_event.get(event_path!("provider_name")),
             Some(&Value::Bytes("Microsoft-Windows-Security-Auditing".into()))
         );
         assert_eq!(
-            log_event.get("computer"),
+            log_event.get(event_path!("computer")),
             Some(&Value::Bytes("WIN-SERVER-01".into()))
         );
-        assert_eq!(log_event.get("process_id"), Some(&Value::Integer(716)));
-        assert_eq!(log_event.get("thread_id"), Some(&Value::Integer(796)));
+        assert_eq!(
+            log_event.get(event_path!("process_id")),
+            Some(&Value::Integer(716))
+        );
+        assert_eq!(
+            log_event.get(event_path!("thread_id")),
+            Some(&Value::Integer(796))
+        );
     }
 
     #[test]
@@ -334,8 +349,8 @@ mod parser_tests {
         let log_event = parser.parse_event(event.clone()).unwrap();
 
         // XML should be included
-        assert!(log_event.get("xml").is_some());
-        if let Some(Value::Bytes(xml_bytes)) = log_event.get("xml") {
+        assert!(log_event.get(event_path!("xml")).is_some());
+        if let Some(Value::Bytes(xml_bytes)) = log_event.get(event_path!("xml")) {
             let xml_string = String::from_utf8_lossy(xml_bytes);
             assert!(xml_string.contains("<Event xmlns"));
             assert!(xml_string.contains("EventID>4624<"));
@@ -353,7 +368,7 @@ mod parser_tests {
         let log_event = parser.parse_event(event.clone()).unwrap();
 
         // Event data should be included
-        if let Some(Value::Object(event_data)) = log_event.get("event_data") {
+        if let Some(Value::Object(event_data)) = log_event.get(event_path!("event_data")) {
             assert_eq!(
                 event_data.get("TargetUserName"),
                 Some(&Value::Bytes("admin".into()))
@@ -381,12 +396,12 @@ mod parser_tests {
 
         // event_id should be formatted as string
         assert_eq!(
-            log_event.get("event_id"),
+            log_event.get(event_path!("event_id")),
             Some(&Value::Bytes("4624".into()))
         );
 
         // process_id should be formatted as float
-        if let Some(Value::Float(process_id)) = log_event.get("process_id") {
+        if let Some(Value::Float(process_id)) = log_event.get(event_path!("process_id")) {
             assert_eq!(process_id.into_inner(), 716.0);
         } else {
             panic!("process_id should be formatted as float");
@@ -1440,7 +1455,7 @@ mod message_rendering_tests {
         let log_event = parser.parse_event(event.clone()).unwrap();
 
         // Should have fallback message format: "Event ID X from Provider on Computer"
-        if let Some(message) = log_event.get("message") {
+        if let Some(message) = log_event.get(event_path!("message")) {
             let msg_str = message.to_string_lossy();
             assert!(
                 msg_str.contains("Event ID") || msg_str.contains(&event.event_id.to_string()),
@@ -1465,7 +1480,7 @@ mod message_rendering_tests {
 
         let log_event = parser.parse_event(event).unwrap();
 
-        if let Some(message) = log_event.get("message") {
+        if let Some(message) = log_event.get(event_path!("message")) {
             let msg_str = message.to_string_lossy();
             assert_eq!(
                 msg_str, "The service started successfully.",
@@ -1546,7 +1561,7 @@ mod truncation_tests {
         let log_event = parser.parse_event(event).unwrap();
 
         let inserts = log_event
-            .get("string_inserts")
+            .get(event_path!("string_inserts"))
             .expect("string_inserts should be present");
         if let Value::Array(arr) = inserts {
             assert!(!arr.is_empty(), "string_inserts should not be empty");
@@ -1575,7 +1590,7 @@ mod truncation_tests {
 
         let log_event = parser.parse_event(event).unwrap();
 
-        if let Some(Value::Bytes(xml)) = log_event.get("xml") {
+        if let Some(Value::Bytes(xml)) = log_event.get(event_path!("xml")) {
             // XML should be truncated or limited
             assert!(
                 xml.len() <= 40000,

--- a/src/template.rs
+++ b/src/template.rs
@@ -701,7 +701,7 @@ mod tests {
     #[test]
     fn render_log_unsigned_number_dynamic() {
         let mut event = Event::Log(LogEvent::from("hello world"));
-        event.as_mut_log().insert("foo", 123);
+        event.as_mut_log().insert(event_path!("foo"), 123);
 
         let template = UnsignedIntTemplate::try_from("{{ foo }}").unwrap();
         assert_eq!(Ok(123), template.render(&event))
@@ -710,7 +710,9 @@ mod tests {
     #[test]
     fn render_log_dynamic() {
         let mut event = Event::Log(LogEvent::from("hello world"));
-        event.as_mut_log().insert("log_stream", "stream");
+        event
+            .as_mut_log()
+            .insert(event_path!("log_stream"), "stream");
         let template = Template::try_from("{{log_stream}}").unwrap();
 
         assert_eq!(Ok(Bytes::from("stream")), template.render(&event))
@@ -730,7 +732,9 @@ mod tests {
     #[test]
     fn render_log_dynamic_with_prefix() {
         let mut event = Event::Log(LogEvent::from("hello world"));
-        event.as_mut_log().insert("log_stream", "stream");
+        event
+            .as_mut_log()
+            .insert(event_path!("log_stream"), "stream");
         let template = Template::try_from("abcd-{{log_stream}}").unwrap();
 
         assert_eq!(Ok(Bytes::from("abcd-stream")), template.render(&event))
@@ -739,7 +743,9 @@ mod tests {
     #[test]
     fn render_log_dynamic_with_postfix() {
         let mut event = Event::Log(LogEvent::from("hello world"));
-        event.as_mut_log().insert("log_stream", "stream");
+        event
+            .as_mut_log()
+            .insert(event_path!("log_stream"), "stream");
         let template = Template::try_from("{{log_stream}}-abcd").unwrap();
 
         assert_eq!(Ok(Bytes::from("stream-abcd")), template.render(&event))
@@ -761,8 +767,8 @@ mod tests {
     #[test]
     fn render_log_dynamic_multiple_keys() {
         let mut event = Event::Log(LogEvent::from("hello world"));
-        event.as_mut_log().insert("foo", "bar");
-        event.as_mut_log().insert("baz", "quux");
+        event.as_mut_log().insert(event_path!("foo"), "bar");
+        event.as_mut_log().insert(event_path!("baz"), "quux");
         let template = Template::try_from("stream-{{foo}}-{{baz}}.log").unwrap();
 
         assert_eq!(
@@ -774,8 +780,8 @@ mod tests {
     #[test]
     fn render_log_dynamic_weird_junk() {
         let mut event = Event::Log(LogEvent::from("hello world"));
-        event.as_mut_log().insert("foo", "bar");
-        event.as_mut_log().insert("baz", "quux");
+        event.as_mut_log().insert(event_path!("foo"), "bar");
+        event.as_mut_log().insert(event_path!("baz"), "quux");
         let template = Template::try_from(r"{stream}{\{{}}}-{{foo}}-{{baz}}.log").unwrap();
 
         assert_eq!(
@@ -809,9 +815,14 @@ mod tests {
             .expect("invalid timestamp");
 
         let mut event = Event::Log(LogEvent::from("hello world"));
-        event.as_mut_log().insert("@timestamp", ts);
+        event.as_mut_log().insert(event_path!("@timestamp"), ts);
         // use Vector namespace instead of legacy
-        LogNamespace::Vector.insert_vector_metadata(event.as_mut_log(), Some("foo"), "foo", "bar");
+        LogNamespace::Vector.insert_vector_metadata(
+            event.as_mut_log(),
+            Some(vrl::path!("foo")),
+            vrl::path!("foo"),
+            "bar",
+        );
         let new_schema = event
             .as_mut_log()
             .metadata()
@@ -857,7 +868,7 @@ mod tests {
             .expect("invalid timestamp");
 
         let mut event = Event::Log(LogEvent::from("hello world"));
-        event.as_mut_log().insert("foo", "butts");
+        event.as_mut_log().insert(event_path!("foo"), "butts");
         event.as_mut_log().insert(
             (PathPrefix::Event, log_schema().timestamp_key().unwrap()),
             ts,
@@ -879,7 +890,7 @@ mod tests {
             .expect("invalid timestamp");
 
         let mut event = Event::Log(LogEvent::from("hello world"));
-        event.as_mut_log().insert("format", "%F");
+        event.as_mut_log().insert(event_path!("format"), "%F");
         event.as_mut_log().insert(
             (PathPrefix::Event, log_schema().timestamp_key().unwrap()),
             ts,
@@ -901,7 +912,9 @@ mod tests {
             .expect("invalid timestamp");
 
         let mut event = Event::Log(LogEvent::from("hello world"));
-        event.as_mut_log().insert("\"%F\"", "foo");
+        event
+            .as_mut_log()
+            .insert(&parse_target_path("\"%F\"").unwrap(), "foo");
         event.as_mut_log().insert(
             (PathPrefix::Event, log_schema().timestamp_key().unwrap()),
             ts,

--- a/src/test_util/mod.rs
+++ b/src/test_util/mod.rs
@@ -88,7 +88,7 @@ macro_rules! log_event {
             let mut event = $crate::event::Event::Log($crate::event::LogEvent::default());
             let log = event.as_mut_log();
             $(
-                log.insert($key, $value);
+                log.insert(::vrl::event_path!($key), $value);
             )*
             event
         }

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -484,7 +484,7 @@ mod tests {
                     .next()
                     .await
                     .expect("broadcast stream ended unexpectedly");
-                if let Some(msg) = event.get("message") {
+                if let Some(msg) = event.get(event_path!("message")) {
                     let msg = msg.to_string_lossy().into_owned();
                     if msg.contains("Rate limited broadcast message") {
                         collected.push(msg);

--- a/src/transforms/aws_ec2_metadata.rs
+++ b/src/transforms/aws_ec2_metadata.rs
@@ -759,7 +759,10 @@ mod integration_tests {
             lookup_v2::{OwnedSegment, OwnedValuePath},
         },
     };
-    use vrl::value::{ObjectMap, Value};
+    use vrl::{
+        path::parse_target_path,
+        value::{ObjectMap, Value},
+    };
     use warp::Filter;
 
     use super::*;
@@ -1027,10 +1030,16 @@ mod integration_tests {
 
             let log = LogEvent::default();
             let mut expected_log = log.clone();
-            expected_log.insert(format!("\"{PUBLIC_IPV4_KEY}\"").as_str(), "192.0.2.54");
-            expected_log.insert(format!("\"{REGION_KEY}\"").as_str(), "us-east-1");
             expected_log.insert(
-                format!("\"{TAGS_KEY}\"").as_str(),
+                &vrl::path::parse_target_path(&format!("\"{PUBLIC_IPV4_KEY}\"")).unwrap(),
+                "192.0.2.54",
+            );
+            expected_log.insert(
+                &vrl::path::parse_target_path(&format!("\"{REGION_KEY}\"")).unwrap(),
+                "us-east-1",
+            );
+            expected_log.insert(
+                &vrl::path::parse_target_path(&format!("\"{TAGS_KEY}\"")).unwrap(),
                 ObjectMap::from([
                     ("Name".into(), Value::from("test-instance")),
                     ("Test".into(), Value::from("test-tag")),
@@ -1119,7 +1128,9 @@ mod integration_tests {
                 let event = out.recv().await.unwrap();
 
                 assert_eq!(
-                    event.as_log().get("ec2.metadata.\"availability-zone\""),
+                    event
+                        .as_log()
+                        .get(&parse_target_path("ec2.metadata.\"availability-zone\"").unwrap()),
                     Some(&"us-east-1a".into())
                 );
 

--- a/src/transforms/dedupe/config.rs
+++ b/src/transforms/dedupe/config.rs
@@ -172,24 +172,26 @@ mod tests {
     }
 
     async fn basic(transform_config: DedupeConfig, first_path: &str, second_path: &str) {
+        let first_path = vrl::path::parse_target_path(first_path).unwrap();
+        let second_path = vrl::path::parse_target_path(second_path).unwrap();
         assert_transform_compliance(async {
             let (tx, rx) = mpsc::channel(1);
             let (topology, mut out) =
                 create_topology(ReceiverStream::new(rx), transform_config).await;
 
             let mut event1 = Event::Log(LogEvent::from("message"));
-            event1.as_mut_log().insert(first_path, "some value");
-            event1.as_mut_log().insert(second_path, "another value");
+            event1.as_mut_log().insert(&first_path, "some value");
+            event1.as_mut_log().insert(&second_path, "another value");
 
             // Test that unmatched field isn't considered
             let mut event2 = Event::Log(LogEvent::from("message"));
-            event2.as_mut_log().insert(first_path, "some value2");
-            event2.as_mut_log().insert(second_path, "another value");
+            event2.as_mut_log().insert(&first_path, "some value2");
+            event2.as_mut_log().insert(&second_path, "another value");
 
             // Test that matched field is considered
             let mut event3 = Event::Log(LogEvent::from("message"));
-            event3.as_mut_log().insert(first_path, "some value");
-            event3.as_mut_log().insert(second_path, "another value2");
+            event3.as_mut_log().insert(&first_path, "some value");
+            event3.as_mut_log().insert(&second_path, "another value2");
 
             // First event should always be passed through as-is.
             tx.send(event1.clone()).await.unwrap();
@@ -236,10 +238,14 @@ mod tests {
                 create_topology(ReceiverStream::new(rx), transform_config).await;
 
             let mut event1 = Event::Log(LogEvent::from("message"));
-            event1.as_mut_log().insert("matched1", "some value");
+            event1
+                .as_mut_log()
+                .insert(vrl::event_path!("matched1"), "some value");
 
             let mut event2 = Event::Log(LogEvent::from("message"));
-            event2.as_mut_log().insert("matched2", "some value");
+            event2
+                .as_mut_log()
+                .insert(vrl::event_path!("matched2"), "some value");
 
             // First event should always be passed through as-is.
             tx.send(event1.clone()).await.unwrap();
@@ -286,13 +292,21 @@ mod tests {
                 create_topology(ReceiverStream::new(rx), transform_config).await;
 
             let mut event1 = Event::Log(LogEvent::from("message"));
-            event1.as_mut_log().insert("matched1", "value1");
-            event1.as_mut_log().insert("matched2", "value2");
+            event1
+                .as_mut_log()
+                .insert(vrl::event_path!("matched1"), "value1");
+            event1
+                .as_mut_log()
+                .insert(vrl::event_path!("matched2"), "value2");
 
             // Add fields in opposite order
             let mut event2 = Event::Log(LogEvent::from("message"));
-            event2.as_mut_log().insert("matched2", "value2");
-            event2.as_mut_log().insert("matched1", "value1");
+            event2
+                .as_mut_log()
+                .insert(vrl::event_path!("matched2"), "value2");
+            event2
+                .as_mut_log()
+                .insert(vrl::event_path!("matched1"), "value1");
 
             // First event should always be passed through as-is.
             tx.send(event1.clone()).await.unwrap();
@@ -334,10 +348,14 @@ mod tests {
                 create_topology(ReceiverStream::new(rx), transform_config).await;
 
             let mut event1 = Event::Log(LogEvent::from("message"));
-            event1.as_mut_log().insert("matched", "some value");
+            event1
+                .as_mut_log()
+                .insert(vrl::event_path!("matched"), "some value");
 
             let mut event2 = Event::Log(LogEvent::from("message"));
-            event2.as_mut_log().insert("matched", "some value2");
+            event2
+                .as_mut_log()
+                .insert(vrl::event_path!("matched"), "some value2");
 
             // First event should always be passed through as-is.
             tx.send(event1.clone()).await.unwrap();
@@ -404,7 +422,9 @@ mod tests {
                 create_topology(ReceiverStream::new(rx), transform_config).await;
 
             let mut event1 = Event::Log(LogEvent::from("message"));
-            event1.as_mut_log().insert("matched", "some value");
+            event1
+                .as_mut_log()
+                .insert(vrl::event_path!("matched"), "some value");
 
             // First event should always be passed through as-is.
             tx.send(event1.clone()).await.unwrap();
@@ -454,10 +474,12 @@ mod tests {
                 create_topology(ReceiverStream::new(rx), transform_config).await;
 
             let mut event1 = Event::Log(LogEvent::from("message"));
-            event1.as_mut_log().insert("matched", "123");
+            event1
+                .as_mut_log()
+                .insert(vrl::event_path!("matched"), "123");
 
             let mut event2 = Event::Log(LogEvent::from("message"));
-            event2.as_mut_log().insert("matched", 123);
+            event2.as_mut_log().insert(vrl::event_path!("matched"), 123);
 
             // First event should always be passed through as-is.
             tx.send(event1.clone()).await.unwrap();
@@ -505,12 +527,16 @@ mod tests {
             let mut map1 = ObjectMap::new();
             map1.insert("key".into(), "123".into());
             let mut event1 = Event::Log(LogEvent::from("message"));
-            event1.as_mut_log().insert("matched", map1);
+            event1
+                .as_mut_log()
+                .insert(vrl::event_path!("matched"), map1);
 
             let mut map2 = ObjectMap::new();
             map2.insert("key".into(), 123.into());
             let mut event2 = Event::Log(LogEvent::from("message"));
-            event2.as_mut_log().insert("matched", map2);
+            event2
+                .as_mut_log()
+                .insert(vrl::event_path!("matched"), map2);
 
             // First event should always be passed through as-is.
             tx.send(event1.clone()).await.unwrap();
@@ -554,7 +580,9 @@ mod tests {
                 create_topology(ReceiverStream::new(rx), transform_config).await;
 
             let mut event1 = Event::Log(LogEvent::from("message"));
-            event1.as_mut_log().insert("matched", Value::Null);
+            event1
+                .as_mut_log()
+                .insert(vrl::event_path!("matched"), Value::Null);
 
             let mut event2 = Event::Log(LogEvent::from("message"));
 

--- a/src/transforms/log_to_metric.rs
+++ b/src/transforms/log_to_metric.rs
@@ -1005,9 +1005,10 @@ mod tests {
     }
 
     fn create_event(key: &str, value: impl Into<Value> + std::fmt::Debug) -> Event {
+        use vrl::path::{OwnedSegment, OwnedTargetPath, OwnedValuePath};
         let mut log = Event::Log(LogEvent::from("i am a log"));
-        log.as_mut_log()
-            .insert(&vrl::path::parse_target_path(key).unwrap(), value);
+        let path = OwnedTargetPath::event(OwnedValuePath::from(vec![OwnedSegment::field(key)]));
+        log.as_mut_log().insert(&path, value);
         log.as_mut_log()
             .insert(log_schema().timestamp_key_target_path().unwrap(), ts());
         log

--- a/src/transforms/log_to_metric.rs
+++ b/src/transforms/log_to_metric.rs
@@ -1006,7 +1006,8 @@ mod tests {
 
     fn create_event(key: &str, value: impl Into<Value> + std::fmt::Debug) -> Event {
         let mut log = Event::Log(LogEvent::from("i am a log"));
-        log.as_mut_log().insert(key, value);
+        log.as_mut_log()
+            .insert(&vrl::path::parse_target_path(key).unwrap(), value);
         log.as_mut_log()
             .insert(log_schema().timestamp_key_target_path().unwrap(), ts());
         log
@@ -1113,8 +1114,8 @@ mod tests {
         );
 
         let mut event = create_event("message", "i am log");
-        event.as_mut_log().insert("method", "post");
-        event.as_mut_log().insert("code", "200");
+        event.as_mut_log().insert(event_path!("method"), "post");
+        event.as_mut_log().insert(event_path!("code"), "200");
         let mut metadata =
             event
                 .metadata()
@@ -1167,7 +1168,7 @@ mod tests {
         let mut test_dict = ObjectMap::default();
         test_dict.insert("one".into(), Value::from("foo"));
         test_dict.insert("two".into(), Value::from("baz"));
-        log.insert("dict", Value::from(test_dict));
+        log.insert(event_path!("dict"), Value::from(test_dict));
 
         let mut metadata =
             event
@@ -1218,11 +1219,11 @@ mod tests {
 
         let mut map1 = ObjectMap::default();
         map1.insert("key1".into(), Value::from("val1"));
-        log.insert("map1", Value::from(map1));
+        log.insert(event_path!("map1"), Value::from(map1));
 
         let mut map2 = ObjectMap::default();
         map2.insert("l1_key1".into(), Value::from("val2"));
-        log.insert("map2", Value::from(map2));
+        log.insert(event_path!("map2"), Value::from(map2));
 
         let mut metadata =
             event
@@ -1294,7 +1295,7 @@ mod tests {
 
         let mut test_dict = ObjectMap::default();
         test_dict.insert("one".into(), Value::from(vec!["foo", "baz"]));
-        log.insert("dict", Value::from(test_dict));
+        log.insert(event_path!("dict"), Value::from(test_dict));
 
         let metric = do_transform(config, event).await.unwrap().into_metric();
         let tags = metric.tags().expect("Metric should have tags");
@@ -1576,8 +1577,10 @@ mod tests {
         event
             .as_mut_log()
             .insert(log_schema().timestamp_key_target_path().unwrap(), ts());
-        event.as_mut_log().insert("status", "42");
-        event.as_mut_log().insert("backtrace", "message");
+        event.as_mut_log().insert(event_path!("status"), "42");
+        event
+            .as_mut_log()
+            .insert(event_path!("backtrace"), "message");
         let mut metadata =
             event
                 .metadata()
@@ -1638,11 +1641,13 @@ mod tests {
         event
             .as_mut_log()
             .insert(log_schema().timestamp_key_target_path().unwrap(), ts());
-        event.as_mut_log().insert("status", "42");
-        event.as_mut_log().insert("backtrace", "message");
-        event.as_mut_log().insert("host", "local");
-        event.as_mut_log().insert("worker", "abc");
-        event.as_mut_log().insert("service", "xyz");
+        event.as_mut_log().insert(event_path!("status"), "42");
+        event
+            .as_mut_log()
+            .insert(event_path!("backtrace"), "message");
+        event.as_mut_log().insert(event_path!("host"), "local");
+        event.as_mut_log().insert(event_path!("worker"), "abc");
+        event.as_mut_log().insert(event_path!("service"), "xyz");
         let mut metadata =
             event
                 .metadata()
@@ -1819,10 +1824,10 @@ mod tests {
     fn create_log_event_with_namespace(json_str: &str, namespace: Option<&str>) -> Event {
         let mut log_value: Value =
             serde_json::from_str(json_str).expect("JSON was not well-formatted");
-        log_value.insert("timestamp", ts());
+        log_value.insert(vrl::path!("timestamp"), ts());
 
         if let Some(namespace) = namespace {
-            log_value.insert("namespace", namespace);
+            log_value.insert(vrl::path!("namespace"), namespace);
         }
 
         let mut metadata = EventMetadata::default();

--- a/src/transforms/lua/v1/mod.rs
+++ b/src/transforms/lua/v1/mod.rs
@@ -324,6 +324,8 @@ pub fn format_error(error: &mlua::Error) -> String {
 mod tests {
     use std::sync::Arc;
 
+    use vrl::event_path;
+
     use super::*;
     use crate::{
         config::ComponentKey,
@@ -361,7 +363,7 @@ mod tests {
     #[test]
     fn lua_remove_field() {
         let mut log = LogEvent::default();
-        log.insert("name", "Bob");
+        log.insert(event_path!("name"), "Bob");
         let event = transform_one(
             r#"
               event["name"] = nil
@@ -370,13 +372,13 @@ mod tests {
         )
         .unwrap();
 
-        assert!(event.as_log().get("name").is_none());
+        assert!(event.as_log().get(event_path!("name")).is_none());
     }
 
     #[test]
     fn lua_drop_event() {
         let mut log = LogEvent::default();
-        log.insert("name", "Bob");
+        log.insert(event_path!("name"), "Bob");
         let event = transform_one(
             r"
               event = nil
@@ -449,7 +451,7 @@ mod tests {
             LogEvent::default(),
         )
         .unwrap();
-        assert_eq!(event.as_log().get("junk"), None);
+        assert_eq!(event.as_log().get(event_path!("junk")), None);
     }
 
     #[test]
@@ -566,8 +568,8 @@ mod tests {
     #[test]
     fn lua_pairs() {
         let mut event = LogEvent::default();
-        event.insert("name", "Bob");
-        event.insert("friend", "Alice");
+        event.insert(event_path!("name"), "Bob");
+        event.insert(event_path!("friend"), "Alice");
 
         let event = transform_one(
             r"

--- a/src/transforms/lua/v2/mod.rs
+++ b/src/transforms/lua/v2/mod.rs
@@ -468,6 +468,8 @@ mod tests {
     };
     use tokio_stream::wrappers::ReceiverStream;
 
+    use vrl::event_path;
+
     use super::*;
     use crate::{
         event::{
@@ -626,11 +628,17 @@ mod tests {
             "#},
             |tx, out| async move {
                 let mut event = LogEvent::default();
-                event.insert("name", "Bob");
+                event.insert(event_path!("name"), "Bob");
 
                 tx.send(event.into()).await.unwrap();
 
-                assert_eq!(next_event(&out, "in").await.as_log().get("name"), None);
+                assert_eq!(
+                    next_event(&out, "in")
+                        .await
+                        .as_log()
+                        .get(event_path!("name")),
+                    None
+                );
             },
         )
         .await;
@@ -671,7 +679,7 @@ mod tests {
             "#},
             |tx, out| async move {
                 let mut event = LogEvent::default();
-                event.insert("host", "127.0.0.1");
+                event.insert(event_path!("host"), "127.0.0.1");
                 tx.send(event.into()).await.unwrap();
 
                 assert!(out.lock().await.recv().await.is_some());
@@ -801,7 +809,13 @@ mod tests {
                 let event = LogEvent::default();
                 tx.send(event.into()).await.unwrap();
 
-                assert_eq!(next_event(&out, "in").await.as_log().get("junk"), None);
+                assert_eq!(
+                    next_event(&out, "in")
+                        .await
+                        .as_log()
+                        .get(event_path!("junk")),
+                    None
+                );
             },
         )
         .await;
@@ -847,7 +861,13 @@ mod tests {
                 let event = LogEvent::default();
                 tx.send(event.into()).await.unwrap();
 
-                assert_eq!(next_event(&out, "in").await.as_log().get("result"), None);
+                assert_eq!(
+                    next_event(&out, "in")
+                        .await
+                        .as_log()
+                        .get(event_path!("result")),
+                    None
+                );
             },
         )
         .await;
@@ -954,8 +974,8 @@ mod tests {
             "#},
             |tx, out| async move {
                 let mut event = LogEvent::default();
-                event.insert("name", "Bob");
-                event.insert("friend", "Alice");
+                event.insert(event_path!("name"), "Bob");
+                event.insert(event_path!("friend"), "Alice");
                 tx.send(event.into()).await.unwrap();
 
                 let output = next_event(&out, "in").await;

--- a/src/transforms/metric_to_log.rs
+++ b/src/transforms/metric_to_log.rs
@@ -683,7 +683,7 @@ mod tests {
             ));
             // The resulting tag must be either a single string value or not present.
             let value = values.into_single().map(|value| Value::Bytes(value.into()));
-            assert_eq!(tags.get(&*name), value.as_ref());
+            assert_eq!(tags.get(vrl::path!(&*name)), value.as_ref());
         }
 
         #[test]
@@ -695,7 +695,7 @@ mod tests {
                     .map(|value| (name.clone(), TagValue::from(value.map(String::from))))
                     .collect(),
             ));
-            let tag = tags.get(&*name);
+            let tag = tags.get(vrl::path!(&*name));
             match values.len() {
                 // Empty tag set => missing tag
                 0 => assert_eq!(tag, None),

--- a/src/transforms/reduce/merge_strategy.rs
+++ b/src/transforms/reduce/merge_strategy.rs
@@ -367,7 +367,7 @@ impl ReduceValueMerger for TimestampWindowMerger {
         v: &mut LogEvent,
     ) -> Result<(), String> {
         v.insert(
-            format!("{path}_end").as_str(),
+            &vrl::path::parse_target_path(&format!("{path}_end")).unwrap(),
             Value::Timestamp(self.latest),
         );
         v.insert(path, Value::Timestamp(self.started));

--- a/src/transforms/reduce/merge_strategy.rs
+++ b/src/transforms/reduce/merge_strategy.rs
@@ -5,7 +5,7 @@ use chrono::{DateTime, Utc};
 use dyn_clone::DynClone;
 use ordered_float::NotNan;
 use vector_lib::configurable::configurable_component;
-use vrl::path::OwnedTargetPath;
+use vrl::path::{OwnedSegment, OwnedTargetPath};
 
 use crate::event::{LogEvent, Value};
 
@@ -366,10 +366,14 @@ impl ReduceValueMerger for TimestampWindowMerger {
         path: &OwnedTargetPath,
         v: &mut LogEvent,
     ) -> Result<(), String> {
-        v.insert(
-            &vrl::path::parse_target_path(&format!("{path}_end")).unwrap(),
-            Value::Timestamp(self.latest),
-        );
+        // Build "<path>_end" by suffixing the last segment. String
+        // round-tripping via Display fails on quoted/literal paths whose
+        // rendered form isn't valid path syntax once "_end" is appended.
+        let mut end_path = path.clone();
+        if let Some(OwnedSegment::Field(last)) = end_path.path.segments.last_mut() {
+            *last = format!("{last}_end").into();
+        }
+        v.insert(&end_path, Value::Timestamp(self.latest));
         v.insert(path, Value::Timestamp(self.started));
         Ok(())
     }
@@ -937,5 +941,27 @@ mod test {
         let out_path = owned_event_path!("out");
         merger.insert_into(&out_path, &mut output)?;
         Ok(output.remove(&out_path).unwrap())
+    }
+
+    // Regression: `TimestampWindowMerger::insert_into` used to build the
+    // "<path>_end" companion path by round-tripping through `Display` and
+    // `parse_target_path`, which panics when the rendered path form isn't
+    // valid syntax (e.g. quoted/literal segments containing a dot).
+    #[test]
+    fn timestamp_window_merger_handles_quoted_path() {
+        let t1 = Utc::now();
+        let t2 = t1 + chrono::Duration::seconds(5);
+
+        // TimestampWindowMerger is selected implicitly for Timestamp values.
+        let mut merger: Box<dyn ReduceValueMerger> = Value::Timestamp(t1).into();
+        merger.add(Value::Timestamp(t2)).unwrap();
+
+        let mut out = LogEvent::default();
+        let path = vrl::path::parse_target_path("\"foo.bar\"").unwrap();
+        merger.insert_into(&path, &mut out).expect("insert_into");
+
+        assert_eq!(out.get(&path), Some(&Value::Timestamp(t1)));
+        let end_path = vrl::path::parse_target_path("\"foo.bar_end\"").unwrap();
+        assert_eq!(out.get(&end_path), Some(&Value::Timestamp(t2)));
     }
 }

--- a/src/transforms/reduce/transform.rs
+++ b/src/transforms/reduce/transform.rs
@@ -362,6 +362,7 @@ mod test {
     use tokio::sync::mpsc;
     use tokio_stream::wrappers::ReceiverStream;
     use vector_lib::{enrichment::TableRegistry, lookup::owned_value_path};
+    use vrl::event_path;
     use vrl::value::Kind;
 
     use super::*;
@@ -418,33 +419,33 @@ mod test {
             let (topology, mut out) = create_topology(ReceiverStream::new(rx), reduce_config).await;
 
             let mut e_1 = LogEvent::from("test message 1");
-            e_1.insert("counter", 1);
-            e_1.insert("request_id", "1");
+            e_1.insert(event_path!("counter"), 1);
+            e_1.insert(event_path!("request_id"), "1");
             let mut metadata_1 = e_1.metadata().clone();
             metadata_1.set_upstream_id(Arc::new(OutputId::from("transform")));
             metadata_1.set_schema_definition(&Arc::new(new_schema_definition.clone()));
 
             let mut e_2 = LogEvent::from("test message 2");
-            e_2.insert("counter", 2);
-            e_2.insert("request_id", "2");
+            e_2.insert(event_path!("counter"), 2);
+            e_2.insert(event_path!("request_id"), "2");
             let mut metadata_2 = e_2.metadata().clone();
             metadata_2.set_upstream_id(Arc::new(OutputId::from("transform")));
             metadata_2.set_schema_definition(&Arc::new(new_schema_definition.clone()));
 
             let mut e_3 = LogEvent::from("test message 3");
-            e_3.insert("counter", 3);
-            e_3.insert("request_id", "1");
+            e_3.insert(event_path!("counter"), 3);
+            e_3.insert(event_path!("request_id"), "1");
 
             let mut e_4 = LogEvent::from("test message 4");
-            e_4.insert("counter", 4);
-            e_4.insert("request_id", "1");
-            e_4.insert("test_end", "yep");
+            e_4.insert(event_path!("counter"), 4);
+            e_4.insert(event_path!("request_id"), "1");
+            e_4.insert(event_path!("test_end"), "yep");
 
             let mut e_5 = LogEvent::from("test message 5");
-            e_5.insert("counter", 5);
-            e_5.insert("request_id", "2");
-            e_5.insert("extra_field", "value1");
-            e_5.insert("test_end", "yep");
+            e_5.insert(event_path!("counter"), 5);
+            e_5.insert(event_path!("request_id"), "2");
+            e_5.insert(event_path!("extra_field"), "value1");
+            e_5.insert(event_path!("test_end"), "yep");
 
             for event in [e_1.into(), e_2.into(), e_3.into(), e_4.into(), e_5.into()] {
                 tx.send(event).await.unwrap();
@@ -505,28 +506,28 @@ mod test {
             let (topology, mut out) = create_topology(ReceiverStream::new(rx), reduce_config).await;
 
             let mut e_1 = LogEvent::from("test message 1");
-            e_1.insert("foo", "first foo");
-            e_1.insert("bar", "first bar");
-            e_1.insert("baz", 2);
-            e_1.insert("request_id", "1");
+            e_1.insert(event_path!("foo"), "first foo");
+            e_1.insert(event_path!("bar"), "first bar");
+            e_1.insert(event_path!("baz"), 2);
+            e_1.insert(event_path!("request_id"), "1");
             let mut metadata = e_1.metadata().clone();
             metadata.set_upstream_id(Arc::new(OutputId::from("transform")));
             metadata.set_schema_definition(&Arc::new(new_schema_definition.clone()));
             tx.send(e_1.into()).await.unwrap();
 
             let mut e_2 = LogEvent::from("test message 2");
-            e_2.insert("foo", "second foo");
-            e_2.insert("bar", 2);
-            e_2.insert("baz", "not number");
-            e_2.insert("request_id", "1");
+            e_2.insert(event_path!("foo"), "second foo");
+            e_2.insert(event_path!("bar"), 2);
+            e_2.insert(event_path!("baz"), "not number");
+            e_2.insert(event_path!("request_id"), "1");
             tx.send(e_2.into()).await.unwrap();
 
             let mut e_3 = LogEvent::from("test message 3");
-            e_3.insert("foo", 10);
-            e_3.insert("bar", "third bar");
-            e_3.insert("baz", 3);
-            e_3.insert("request_id", "1");
-            e_3.insert("test_end", "yep");
+            e_3.insert(event_path!("foo"), 10);
+            e_3.insert(event_path!("bar"), "third bar");
+            e_3.insert(event_path!("baz"), 3);
+            e_3.insert(event_path!("request_id"), "1");
+            e_3.insert(event_path!("test_end"), "yep");
             tx.send(e_3.into()).await.unwrap();
 
             let output_1 = out.recv().await.unwrap().into_log();
@@ -572,35 +573,35 @@ mod test {
             let (topology, mut out) = create_topology(ReceiverStream::new(rx), reduce_config).await;
 
             let mut e_1 = LogEvent::from("test message 1");
-            e_1.insert("counter", 1);
-            e_1.insert("request_id", "1");
+            e_1.insert(event_path!("counter"), 1);
+            e_1.insert(event_path!("request_id"), "1");
             let mut metadata_1 = e_1.metadata().clone();
             metadata_1.set_upstream_id(Arc::new(OutputId::from("transform")));
             metadata_1.set_schema_definition(&Arc::new(new_schema_definition.clone()));
             tx.send(e_1.into()).await.unwrap();
 
             let mut e_2 = LogEvent::from("test message 2");
-            e_2.insert("counter", 2);
+            e_2.insert(event_path!("counter"), 2);
             let mut metadata_2 = e_2.metadata().clone();
             metadata_2.set_upstream_id(Arc::new(OutputId::from("transform")));
             metadata_2.set_schema_definition(&Arc::new(new_schema_definition));
             tx.send(e_2.into()).await.unwrap();
 
             let mut e_3 = LogEvent::from("test message 3");
-            e_3.insert("counter", 3);
-            e_3.insert("request_id", "1");
+            e_3.insert(event_path!("counter"), 3);
+            e_3.insert(event_path!("request_id"), "1");
             tx.send(e_3.into()).await.unwrap();
 
             let mut e_4 = LogEvent::from("test message 4");
-            e_4.insert("counter", 4);
-            e_4.insert("request_id", "1");
-            e_4.insert("test_end", "yep");
+            e_4.insert(event_path!("counter"), 4);
+            e_4.insert(event_path!("request_id"), "1");
+            e_4.insert(event_path!("test_end"), "yep");
             tx.send(e_4.into()).await.unwrap();
 
             let mut e_5 = LogEvent::from("test message 5");
-            e_5.insert("counter", 5);
-            e_5.insert("extra_field", "value1");
-            e_5.insert("test_end", "yep");
+            e_5.insert(event_path!("counter"), 5);
+            e_5.insert(event_path!("extra_field"), "value1");
+            e_5.insert(event_path!("test_end"), "yep");
             tx.send(e_5.into()).await.unwrap();
 
             let output_1 = out.recv().await.unwrap().into_log();
@@ -657,13 +658,13 @@ mod test {
             let (topology, mut out) = create_topology(ReceiverStream::new(rx), reduce_config).await;
 
             let mut e_1 = LogEvent::from("test 1");
-            e_1.insert("id", "1");
+            e_1.insert(event_path!("id"), "1");
 
             let mut e_2 = LogEvent::from("test 2");
-            e_2.insert("id", "1");
+            e_2.insert(event_path!("id"), "1");
 
             let mut e_3 = LogEvent::from("test 3");
-            e_3.insert("id", "1");
+            e_3.insert(event_path!("id"), "1");
 
             for event in [e_1.into(), e_2.into(), e_3.into()] {
                 tx.send(event).await.unwrap();
@@ -701,22 +702,22 @@ mod test {
             let (topology, mut out) = create_topology(ReceiverStream::new(rx), reduce_config).await;
 
             let mut e_1 = LogEvent::from("test 1");
-            e_1.insert("id", "1");
+            e_1.insert(event_path!("id"), "1");
 
             let mut e_2 = LogEvent::from("test 2");
-            e_2.insert("id", "1");
+            e_2.insert(event_path!("id"), "1");
 
             let mut e_3 = LogEvent::from("test 3");
-            e_3.insert("id", "1");
+            e_3.insert(event_path!("id"), "1");
 
             let mut e_4 = LogEvent::from("test 4");
-            e_4.insert("id", "1");
+            e_4.insert(event_path!("id"), "1");
 
             let mut e_5 = LogEvent::from("test 5");
-            e_5.insert("id", "1");
+            e_5.insert(event_path!("id"), "1");
 
             let mut e_6 = LogEvent::from("test 6");
-            e_6.insert("id", "1");
+            e_6.insert(event_path!("id"), "1");
 
             for event in [
                 e_1.into(),
@@ -778,9 +779,9 @@ mod test {
             let (topology, mut out) = create_topology(ReceiverStream::new(rx), reduce_config).await;
 
             let mut e_1 = LogEvent::from("test message 1");
-            e_1.insert("foo", json!([1, 3]));
-            e_1.insert("bar", json!([1, 3]));
-            e_1.insert("request_id", "1");
+            e_1.insert(event_path!("foo"), json!([1, 3]));
+            e_1.insert(event_path!("bar"), json!([1, 3]));
+            e_1.insert(event_path!("request_id"), "1");
             let mut metadata_1 = e_1.metadata().clone();
             metadata_1.set_upstream_id(Arc::new(OutputId::from("transform")));
             metadata_1.set_schema_definition(&Arc::new(new_schema_definition.clone()));
@@ -788,38 +789,38 @@ mod test {
             tx.send(e_1.into()).await.unwrap();
 
             let mut e_2 = LogEvent::from("test message 2");
-            e_2.insert("foo", json!([2, 4]));
-            e_2.insert("bar", json!([2, 4]));
-            e_2.insert("request_id", "2");
+            e_2.insert(event_path!("foo"), json!([2, 4]));
+            e_2.insert(event_path!("bar"), json!([2, 4]));
+            e_2.insert(event_path!("request_id"), "2");
             let mut metadata_2 = e_2.metadata().clone();
             metadata_2.set_upstream_id(Arc::new(OutputId::from("transform")));
             metadata_2.set_schema_definition(&Arc::new(new_schema_definition));
             tx.send(e_2.into()).await.unwrap();
 
             let mut e_3 = LogEvent::from("test message 3");
-            e_3.insert("foo", json!([5, 7]));
-            e_3.insert("bar", json!([5, 7]));
-            e_3.insert("request_id", "1");
+            e_3.insert(event_path!("foo"), json!([5, 7]));
+            e_3.insert(event_path!("bar"), json!([5, 7]));
+            e_3.insert(event_path!("request_id"), "1");
             tx.send(e_3.into()).await.unwrap();
 
             let mut e_4 = LogEvent::from("test message 4");
-            e_4.insert("foo", json!("done"));
-            e_4.insert("bar", json!("done"));
-            e_4.insert("request_id", "1");
-            e_4.insert("test_end", "yep");
+            e_4.insert(event_path!("foo"), json!("done"));
+            e_4.insert(event_path!("bar"), json!("done"));
+            e_4.insert(event_path!("request_id"), "1");
+            e_4.insert(event_path!("test_end"), "yep");
             tx.send(e_4.into()).await.unwrap();
 
             let mut e_5 = LogEvent::from("test message 5");
-            e_5.insert("foo", json!([6, 8]));
-            e_5.insert("bar", json!([6, 8]));
-            e_5.insert("request_id", "2");
+            e_5.insert(event_path!("foo"), json!([6, 8]));
+            e_5.insert(event_path!("bar"), json!([6, 8]));
+            e_5.insert(event_path!("request_id"), "2");
             tx.send(e_5.into()).await.unwrap();
 
             let mut e_6 = LogEvent::from("test message 6");
-            e_6.insert("foo", json!("done"));
-            e_6.insert("bar", json!("done"));
-            e_6.insert("request_id", "2");
-            e_6.insert("test_end", "yep");
+            e_6.insert(event_path!("foo"), json!("done"));
+            e_6.insert(event_path!("bar"), json!("done"));
+            e_6.insert(event_path!("request_id"), "2");
+            e_6.insert(event_path!("test_end"), "yep");
             tx.send(e_6.into()).await.unwrap();
 
             let output_1 = out.recv().await.unwrap().into_log();
@@ -890,7 +891,7 @@ mod test {
 
             // Remove timestamp fields which were automatically added.
             output.remove_timestamp();
-            output.remove("timestamp_end");
+            output.remove(event_path!("timestamp_end"));
 
             assert_eq!(
                 *output.value(),
@@ -966,8 +967,8 @@ mod test {
             let mut e_1 = LogEvent::from(Value::from(
                 btreemap! {"id" => 777, "another" => btreemap!{ "a" => 1}},
             ));
-            e_1.insert("events", v_1.clone());
-            e_1.insert("\"a-b\"", 2);
+            e_1.insert(event_path!("events"), v_1.clone());
+            e_1.insert(&vrl::path::parse_target_path("\"a-b\"").unwrap(), 2);
             tx.send(e_1.into()).await.unwrap();
 
             let v_2 = Value::from(btreemap! {
@@ -979,8 +980,8 @@ mod test {
             let mut e_2 = LogEvent::from(Value::from(
                 btreemap! {"id" => 777, "test_end" => "done", "another" => btreemap!{ "b" => 2}},
             ));
-            e_2.insert("events", v_2.clone());
-            e_2.insert("\"a-b\"", 2);
+            e_2.insert(event_path!("events"), v_2.clone());
+            e_2.insert(&vrl::path::parse_target_path("\"a-b\"").unwrap(), 2);
             tx.send(e_2.into()).await.unwrap();
 
             let output = out.recv().await.unwrap().into_log();

--- a/src/transforms/remap.rs
+++ b/src/transforms/remap.rs
@@ -778,7 +778,7 @@ mod tests {
     fn get_field_string(event: &Event, field: &str) -> String {
         event
             .as_log()
-            .get(field)
+            .get(&vrl::path::parse_target_path(field).unwrap())
             .unwrap()
             .to_string_lossy()
             .into_owned()
@@ -798,7 +798,7 @@ mod tests {
 
         let event1 = {
             let mut event1 = LogEvent::from("event1");
-            event1.insert("sentinel", "bar");
+            event1.insert(vrl::event_path!("sentinel"), "bar");
             Event::from(event1)
         };
         let result1 = transform_one(&mut tform, event1).unwrap();
@@ -812,7 +812,7 @@ mod tests {
         };
         let result2 = transform_one(&mut tform, event2).unwrap();
         assert_eq!(get_field_string(&result2, "message"), "event2");
-        assert_eq!(result2.as_log().get("foo"), Some(&Value::Null));
+        assert_eq!(result2.as_log().get(event_path!("foo")), Some(&Value::Null));
         assert!(tform.runner().runtime.is_empty());
     }
 
@@ -829,7 +829,7 @@ mod tests {
                 .insert(&owned_value_path!("vector"), BTreeMap::new());
 
             let mut event = LogEvent::new_with_metadata(metadata);
-            event.insert("copy_from", "buz");
+            event.insert(event_path!("copy_from"), "buz");
             Event::from(event)
         };
 
@@ -862,7 +862,7 @@ mod tests {
     fn check_remap_adds() {
         let event = {
             let mut event = LogEvent::from("augment me");
-            event.insert("copy_from", "buz");
+            event.insert(event_path!("copy_from"), "buz");
             Event::from(event)
         };
 
@@ -893,7 +893,7 @@ mod tests {
         let event = {
             let mut event = LogEvent::from("augment me");
             event.insert(
-                "events",
+                event_path!("events"),
                 vec![btreemap!("message" => "foo"), btreemap!("message" => "bar")],
             );
             Event::from(event)
@@ -927,7 +927,7 @@ mod tests {
     fn check_remap_error() {
         let event = {
             let mut event = Event::Log(LogEvent::from("augment me"));
-            event.as_mut_log().insert("bar", "is a string");
+            event.as_mut_log().insert(event_path!("bar"), "is a string");
             event
         };
 
@@ -946,16 +946,19 @@ mod tests {
 
         let event = transform_one(&mut tform, event).unwrap();
 
-        assert_eq!(event.as_log().get("bar"), Some(&Value::from("is a string")));
-        assert!(event.as_log().get("foo").is_none());
-        assert!(event.as_log().get("baz").is_none());
+        assert_eq!(
+            event.as_log().get(event_path!("bar")),
+            Some(&Value::from("is a string"))
+        );
+        assert!(event.as_log().get(event_path!("foo")).is_none());
+        assert!(event.as_log().get(event_path!("baz")).is_none());
     }
 
     #[test]
     fn check_remap_error_drop() {
         let event = {
             let mut event = Event::Log(LogEvent::from("augment me"));
-            event.as_mut_log().insert("bar", "is a string");
+            event.as_mut_log().insert(event_path!("bar"), "is a string");
             event
         };
 
@@ -979,7 +982,7 @@ mod tests {
     fn check_remap_error_infallible() {
         let event = {
             let mut event = Event::Log(LogEvent::from("augment me"));
-            event.as_mut_log().insert("bar", "is a string");
+            event.as_mut_log().insert(event_path!("bar"), "is a string");
             event
         };
 
@@ -997,16 +1000,25 @@ mod tests {
 
         let event = transform_one(&mut tform, event).unwrap();
 
-        assert_eq!(event.as_log().get("foo"), Some(&Value::from("foo")));
-        assert_eq!(event.as_log().get("bar"), Some(&Value::from("is a string")));
-        assert_eq!(event.as_log().get("baz"), Some(&Value::from(12)));
+        assert_eq!(
+            event.as_log().get(event_path!("foo")),
+            Some(&Value::from("foo"))
+        );
+        assert_eq!(
+            event.as_log().get(event_path!("bar")),
+            Some(&Value::from("is a string"))
+        );
+        assert_eq!(
+            event.as_log().get(event_path!("baz")),
+            Some(&Value::from(12))
+        );
     }
 
     #[test]
     fn check_remap_abort() {
         let event = {
             let mut event = Event::Log(LogEvent::from("augment me"));
-            event.as_mut_log().insert("bar", "is a string");
+            event.as_mut_log().insert(event_path!("bar"), "is a string");
             event
         };
 
@@ -1025,16 +1037,19 @@ mod tests {
 
         let event = transform_one(&mut tform, event).unwrap();
 
-        assert_eq!(event.as_log().get("bar"), Some(&Value::from("is a string")));
-        assert!(event.as_log().get("foo").is_none());
-        assert!(event.as_log().get("baz").is_none());
+        assert_eq!(
+            event.as_log().get(event_path!("bar")),
+            Some(&Value::from("is a string"))
+        );
+        assert!(event.as_log().get(event_path!("foo")).is_none());
+        assert!(event.as_log().get(event_path!("baz")).is_none());
     }
 
     #[test]
     fn check_remap_abort_drop() {
         let event = {
             let mut event = Event::Log(LogEvent::from("augment me"));
-            event.as_mut_log().insert("bar", "is a string");
+            event.as_mut_log().insert(event_path!("bar"), "is a string");
             event
         };
 
@@ -1970,7 +1985,7 @@ mod tests {
             event
                 .metadata_mut()
                 .value_mut()
-                .insert("vector", BTreeMap::new());
+                .insert(vrl::path!("vector"), BTreeMap::new());
             Event::from(event)
         };
 
@@ -1989,7 +2004,7 @@ mod tests {
         let result = transform_one(&mut tform, event).unwrap();
 
         // Legacy namespace nests this under "message", Vector should set it as the root
-        assert_eq!(result.as_log().get("."), Some(&Value::Null));
+        assert_eq!(result.as_log().get(event_path!()), Some(&Value::Null));
 
         let outputs1 = conf.outputs(
             &Default::default(),

--- a/src/transforms/sample/tests.rs
+++ b/src/transforms/sample/tests.rs
@@ -3,7 +3,7 @@ use indoc::indoc;
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 use vector_lib::lookup::lookup_v2::OptionalValuePath;
-use vrl::owned_value_path;
+use vrl::{event_path, owned_value_path};
 
 use crate::{
     conditions::{Condition, ConditionalConfig, VrlConfig},
@@ -166,7 +166,7 @@ fn handles_group_by() {
     for group_by in &[None, Some(Template::try_from("{{ other_field }}").unwrap())] {
         let mut event = Event::Log(LogEvent::from("nananana"));
         let log = event.as_mut_log();
-        log.insert("other_field", "foo");
+        log.insert(event_path!("other_field"), "foo");
         let mut sampler = Sample::new(
             "sample".to_string(),
             SampleMode::new_rate(0),
@@ -193,7 +193,7 @@ fn handles_key_field() {
     for key_field in &[None, Some("other_field".into())] {
         let mut event = Event::Log(LogEvent::from("nananana"));
         let log = event.as_mut_log();
-        log.insert("other_field", "foo");
+        log.insert(event_path!("other_field"), "foo");
         let mut sampler = Sample::new(
             "sample".to_string(),
             SampleMode::new_ratio(0.0),
@@ -247,7 +247,7 @@ fn sampler_adds_sampling_rate_to_event() {
             .find_map(|event| transform_one(&mut sampler, event))
             .unwrap();
         assert_eq!(passing.as_log()["custom_sample_rate"], "25".into());
-        assert!(passing.as_log().get("sample_rate").is_none());
+        assert!(passing.as_log().get(event_path!("sample_rate")).is_none());
 
         let events = random_events(10000);
         let mut sampler = Sample::new(
@@ -263,7 +263,7 @@ fn sampler_adds_sampling_rate_to_event() {
             .filter(|s| !s.as_log()[&message_key].to_string_lossy().contains("na"))
             .find_map(|event| transform_one(&mut sampler, event))
             .unwrap();
-        assert!(passing.as_log().get("sample_rate").is_none());
+        assert!(passing.as_log().get(event_path!("sample_rate")).is_none());
 
         // If the event passed the regex check, don't include the sampling rate
         let mut sampler = Sample::new(
@@ -276,7 +276,7 @@ fn sampler_adds_sampling_rate_to_event() {
         );
         let event = Event::Log(LogEvent::from("nananana"));
         let passing = transform_one(&mut sampler, event).unwrap();
-        assert!(passing.as_log().get("sample_rate").is_none());
+        assert!(passing.as_log().get(event_path!("sample_rate")).is_none());
     }
 }
 
@@ -343,7 +343,7 @@ fn dynamic_ratio_field_overrides_static_ratio() {
 
     let mut event = Event::Log(LogEvent::from("hello"));
     let log = event.as_mut_log();
-    log.insert("dynamic_ratio", 1.0);
+    log.insert(event_path!("dynamic_ratio"), 1.0);
 
     let output = transform_one(&mut sampler, event).expect("event should be sampled");
     assert_eq!(output.as_log()["sample_rate"], "1".into());
@@ -384,7 +384,7 @@ fn dynamic_rate_field_overrides_static_ratio() {
 
     let mut event = Event::Log(LogEvent::from("hello"));
     let log = event.as_mut_log();
-    log.insert("dynamic_rate", 1);
+    log.insert(event_path!("dynamic_rate"), 1);
 
     let output = transform_one(&mut sampler, event).expect("event should be sampled");
     assert_eq!(output.as_log()["sample_rate"], "1".into());
@@ -425,7 +425,7 @@ fn dynamic_rate_field_rejects_float_and_falls_back_to_static_ratio() {
 
     let mut event = Event::Log(LogEvent::from("hello"));
     let log = event.as_mut_log();
-    log.insert("dynamic_rate", 2.0);
+    log.insert(event_path!("dynamic_rate"), 2.0);
 
     let output = transform_one(&mut sampler, event).expect("event should be sampled");
     assert_eq!(output.as_log()["sample_rate"], "1".into());
@@ -453,8 +453,8 @@ fn dynamic_ratio_honors_group_by_key() {
         for service in ["service-a", "service-b"] {
             let mut event = Event::Log(LogEvent::from("hello"));
             let log = event.as_mut_log();
-            log.insert("service", service);
-            log.insert("dynamic_ratio", ratio);
+            log.insert(event_path!("service"), service);
+            log.insert(event_path!("dynamic_ratio"), ratio);
             if let Some(output) = transform_one(&mut sampler, event) {
                 assert_eq!(output.as_log()["sample_rate"], "0.5".into());
                 if service == "service-a" {
@@ -500,8 +500,8 @@ fn dynamic_rate_honors_group_by_key() {
         for service in ["service-a", "service-b"] {
             let mut event = Event::Log(LogEvent::from("hello"));
             let log = event.as_mut_log();
-            log.insert("service", service);
-            log.insert("dynamic_rate", rate);
+            log.insert(event_path!("service"), service);
+            log.insert(event_path!("dynamic_rate"), rate);
             if let Some(output) = transform_one(&mut sampler, event) {
                 assert_eq!(output.as_log()["sample_rate"], "2".into());
                 if service == "service-a" {
@@ -546,8 +546,8 @@ fn dynamic_ratio_group_by_samples_mixed_ratios_at_expected_rates() {
         for (ratio, is_low_ratio) in [(0.25_f64, true), (0.75_f64, false)] {
             let mut event = Event::Log(LogEvent::from("hello"));
             let log = event.as_mut_log();
-            log.insert("service", "service-a");
-            log.insert("dynamic_ratio", ratio);
+            log.insert(event_path!("service"), "service-a");
+            log.insert(event_path!("dynamic_ratio"), ratio);
             if let Some(output) = transform_one(&mut sampler, event) {
                 assert_eq!(output.as_log()["sample_rate"], ratio.to_string().into());
                 if is_low_ratio {
@@ -596,8 +596,8 @@ fn dynamic_rate_group_by_samples_mixed_rates_at_expected_rates() {
         for rate in [2_i64, 3_i64] {
             let mut event = Event::Log(LogEvent::from("hello"));
             let log = event.as_mut_log();
-            log.insert("service", "service-a");
-            log.insert("dynamic_rate", rate);
+            log.insert(event_path!("service"), "service-a");
+            log.insert(event_path!("dynamic_rate"), rate);
             if let Some(output) = transform_one(&mut sampler, event) {
                 assert_eq!(output.as_log()["sample_rate"], rate.to_string().into());
                 if rate == 2 {
@@ -638,7 +638,7 @@ async fn dynamic_field_config_drives_dynamic_sampling() {
         let (topology, mut out) = create_topology(ReceiverStream::new(rx), config).await;
 
         let mut log = LogEvent::from("hello");
-        log.insert("dynamic_ratio", 1.0);
+        log.insert(event_path!("dynamic_ratio"), 1.0);
         tx.send(log.into()).await.unwrap();
 
         let event = out.recv().await.expect("event should be sampled");

--- a/src/transforms/throttle/transform.rs
+++ b/src/transforms/throttle/transform.rs
@@ -153,6 +153,7 @@ mod tests {
     use indoc::indoc;
     use tokio::sync::mpsc;
     use tokio_stream::wrappers::ReceiverStream;
+    use vrl::event_path;
 
     use super::*;
     use crate::{
@@ -274,7 +275,7 @@ mod tests {
         assert_eq!(Poll::Pending, futures::poll!(out_stream.next()));
 
         let mut special_log = LogEvent::default();
-        special_log.insert("special", "true");
+        special_log.insert(event_path!("special"), "true");
         tx.send(special_log.into()).await.unwrap();
         // The rate limiter should allow this log through regardless of current limit
         match out_stream.next().await {
@@ -329,9 +330,9 @@ mod tests {
         assert_eq!(Poll::Pending, futures::poll!(out_stream.next()));
 
         let mut log_a = LogEvent::default();
-        log_a.insert("bucket", "a");
+        log_a.insert(event_path!("bucket"), "a");
         let mut log_b = LogEvent::default();
-        log_b.insert("bucket", "b");
+        log_b.insert(event_path!("bucket"), "b");
         tx.send(log_a.into()).await.unwrap();
         tx.send(log_b.into()).await.unwrap();
 

--- a/src/transforms/window/transform.rs
+++ b/src/transforms/window/transform.rs
@@ -103,7 +103,7 @@ mod test {
         mpsc::{Receiver, Sender},
     };
     use tokio_stream::wrappers::ReceiverStream;
-    use vrl::core::Value;
+    use vrl::{core::Value, event_path};
 
     use crate::{
         conditions::{AnyCondition, ConditionConfig, VrlConfig},
@@ -395,7 +395,7 @@ mod test {
     async fn assert_event(message: &str, event: Option<Event>) {
         assert_eq!(
             &Value::from(message),
-            event.unwrap().as_log().get("message").unwrap()
+            event.unwrap().as_log().get(event_path!("message")).unwrap()
         );
     }
 


### PR DESCRIPTION
## Summary

Replace all `&str as ValuePath/TargetPath` usages in test code with explicit `event_path!()` and `metadata_path!()` macros across 24 files.

This is the Vector-side prerequisite for removing the `string_path` feature from the VRL crate (see #18753). When `string_path` is eventually dropped from VRL, no Vector test will need to change.

## Vector configuration

N/A — test-only changes.

## How did you test this PR?

`make check-clippy` passes. No behavior changes; all existing tests continue to exercise the same logical paths.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Closes: #18753 (partial — VRL-side work remains)