### PR TITLE
chore(ci): trigger preview site deploys via labels instead of branch naming

### DIFF
--- a/.github/workflows/build_preview_sites.yml
+++ b/.github/workflows/build_preview_sites.yml
@@ -10,8 +10,51 @@ permissions:
   contents: read # Restrictive default
 
 jobs:
+  # Reads which "preview: <app>" labels were present on the PR at trigger time (captured into
+  # the artifact by preview_site_trigger.yml) so each deploy job below can be gated individually.
+  read_requested_apps:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read # Required for repository context
+      actions: read # Required to download artifacts
+    outputs:
+      website: ${{ steps.read.outputs.website }}
+      playground: ${{ steps.read.outputs.playground }}
+      rust_doc: ${{ steps.read.outputs.rust_doc }}
+    steps:
+      - name: Read requested preview apps from artifact
+        id: read
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const fs = require('fs');
+            const { execSync } = require('child_process');
+
+            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: ${{ github.event.workflow_run.id }},
+            });
+            const matchArtifact = artifacts.data.artifacts.find(a => a.name === 'pr');
+            const download = await github.rest.actions.downloadArtifact({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: matchArtifact.id,
+              archive_format: 'zip',
+            });
+            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/pr.zip`, Buffer.from(download.data));
+            execSync(`unzip -o pr.zip -d pr`);
+
+            const apps = JSON.parse(fs.readFileSync('pr/apps', 'utf8'));
+            core.setOutput('website', apps.website === true);
+            core.setOutput('playground', apps.playground === true);
+            core.setOutput('rust_doc', apps.rustDoc === true);
+
   deploy_vector_preview_site:
-    if: ${{ github.event.workflow_run.conclusion == 'success' && contains(github.event.workflow_run.head_branch, 'website') }}
+    needs: read_requested_apps
+    if: ${{ needs.read_requested_apps.outputs.website == 'true' }}
     permissions:
       contents: read # Required by the reusable workflow
       actions: read # Required to download artifacts
@@ -26,7 +69,8 @@ jobs:
       ENDPOINT: ${{ secrets.BUILDER_ENDPOINT }}
 
   deploy_rust_doc_preview_site:
-    if: ${{ github.event.workflow_run.conclusion == 'success' && contains(github.event.workflow_run.head_branch, 'website') }}
+    needs: read_requested_apps
+    if: ${{ needs.read_requested_apps.outputs.rust_doc == 'true' }}
     permissions:
       contents: read # Required by the reusable workflow
       actions: read # Required to download artifacts
@@ -41,7 +85,8 @@ jobs:
       ENDPOINT: ${{ secrets.BUILDER_ENDPOINT }}
 
   deploy_vrl_playground_preview_site:
-    if: ${{ github.event.workflow_run.conclusion == 'success' && contains(github.event.workflow_run.head_branch, 'website') }}
+    needs: read_requested_apps
+    if: ${{ needs.read_requested_apps.outputs.playground == 'true' }}
     permissions:
       contents: read # Required by the reusable workflow
       actions: read # Required to download artifacts
@@ -59,8 +104,9 @@ jobs:
   # Amplify builds and report their outcome via outputs, so there is never more than one job racing
   # to read-modify-write the PR comment.
   comment_preview_links:
-    if: ${{ always() && github.event.workflow_run.conclusion == 'success' && contains(github.event.workflow_run.head_branch, 'website') }}
+    if: ${{ always() && github.event.workflow_run.conclusion == 'success' }}
     needs:
+      - read_requested_apps
       - deploy_vector_preview_site
       - deploy_rust_doc_preview_site
       - deploy_vrl_playground_preview_site

--- a/.github/workflows/preview_site_trigger.yml
+++ b/.github/workflows/preview_site_trigger.yml
@@ -1,7 +1,7 @@
 name: Call Build Preview
 on:
   pull_request:
-    types: [opened, reopened, synchronize]
+    types: [opened, reopened, synchronize, labeled, unlabeled]
 
 # Restrictive default permissions
 permissions:
@@ -14,8 +14,13 @@ jobs:
     permissions:
       contents: read # Required for repository context
       actions: write # Required to upload artifacts that trigger the preview build workflow
-    # Only run for PRs with 'website' in the branch name
-    if: ${{ contains(github.head_ref, 'website') }}
+    # Only run when at least one "preview: <app>" label is present
+    if: >-
+      ${{
+        contains(github.event.pull_request.labels.*.name, 'preview: website') ||
+        contains(github.event.pull_request.labels.*.name, 'preview: playground') ||
+        contains(github.event.pull_request.labels.*.name, 'preview: rust-doc')
+      }}
     steps:
       # Validate branch name
       - name: Validate branch name and set output
@@ -40,16 +45,23 @@ jobs:
             const crypto = require('crypto');
             const prNumber = context.payload.number;
             const branchName = context.payload.pull_request.head.ref;
+            const labelNames = context.payload.pull_request.labels.map(l => l.name);
+            const apps = {
+              website: labelNames.includes('preview: website'),
+              playground: labelNames.includes('preview: playground'),
+              rustDoc: labelNames.includes('preview: rust-doc'),
+            };
 
             await fs.mkdir('./pr', { recursive: true });
             await fs.writeFile('./pr/number', prNumber.toString());
             await fs.writeFile('./pr/branch', branchName);
+            await fs.writeFile('./pr/apps', JSON.stringify(apps));
 
             const numberHash = crypto.createHash('sha256').update(prNumber.toString()).digest('hex');
             const branchHash = crypto.createHash('sha256').update(branchName).digest('hex');
             await fs.writeFile('./pr/integrity', `${numberHash}:${branchHash}`);
 
-            core.info(`Saved PR #${prNumber} and branch ${branchName}`);
+            core.info(`Saved PR #${prNumber}, branch ${branchName}, apps ${JSON.stringify(apps)}`);
 
       # Upload the artifact using latest version (only if branch is valid)
       - name: Upload PR information artifact


### PR DESCRIPTION
## Summary
Preview site deploys (vector.dev, Rust Doc, VRL Playground) previously required `website` in the branch name to trigger. Replaces that with three labels applied to the PR:

- `preview: website`
- `preview: playground`
- `preview: rust-doc`

Each label independently gates its corresponding deploy job, so a PR can request any combination of the three previews without renaming its branch.

## Vector configuration
NA

## How did you test this PR?
Validated the full chain end-to-end in `vectordotdev/ci-sandbox`: no label skips the trigger workflow entirely, a single label deploys only that app, and adding all three deploys all apps while updating the existing sticky comment in place rather than duplicating it.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References
- Related: https://github.com/vectordotdev/ci-sandbox/pull/43