### PR TITLE
fix(ci): stop rejecting branch names with slashes or dots in preview trigger

### DIFF
--- a/.github/workflows/create_preview_sites.yml
+++ b/.github/workflows/create_preview_sites.yml
@@ -79,14 +79,9 @@ jobs:
             const prNumber = fs.readFileSync(path.join('pr', 'number'), 'utf8').trim();
             const integrity = fs.readFileSync(path.join('pr', 'integrity'), 'utf8').trim();
 
-            // Validate branch name again (only allow alphanumeric, dash, and underscore)
-            const branchNameRegex = /^[a-zA-Z0-9_\-]+$/;
-            if (!branchNameRegex.test(branchName)) {
-              core.setFailed(`Invalid branch name detected: ${branchName}`);
-              return;
-            }
-
-            const sanitizedBranchName = branchName.replace(/[\/\.]/g, '-');
+            // Any character outside a-zA-Z0-9 becomes a dash, so any git-legal branch name is
+            // safe to use in the Amplify subdomain regardless of its raw content.
+            const sanitizedBranchName = branchName.replace(/[^a-zA-Z0-9]/g, '-');
             core.exportVariable('SANITIZED_BRANCH_NAME', sanitizedBranchName);
             core.exportVariable('BRANCH_NAME', branchName);
             core.exportVariable('PR_NUMBER', prNumber);

--- a/.github/workflows/preview_site_trigger.yml
+++ b/.github/workflows/preview_site_trigger.yml
@@ -22,21 +22,10 @@ jobs:
         contains(github.event.pull_request.labels.*.name, 'preview: rust-doc')
       }}
     steps:
-      # Validate branch name
-      - name: Validate branch name and set output
-        id: validate
-        env:
-          BRANCH: ${{ github.head_ref }}
-        run: |
-          if [[ ! "$BRANCH" =~ ^[a-zA-Z0-9_-]+$ ]]; then
-            echo "valid=false" >> $GITHUB_OUTPUT
-          else
-            echo "valid=true" >> $GITHUB_OUTPUT
-          fi
-
-      # Save PR information (only if branch is valid)
-      - name: Validate and save PR information
-        if: steps.validate.outputs.valid == 'true'
+      # Save PR information. The raw branch name is only ever written as file data, hashed for
+      # the integrity check, or sanitized (see create_preview_sites.yml) before it reaches a URL,
+      # so there's nothing here to reject it against.
+      - name: Save PR information
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
@@ -63,9 +52,8 @@ jobs:
 
             core.info(`Saved PR #${prNumber}, branch ${branchName}, apps ${JSON.stringify(apps)}`);
 
-      # Upload the artifact using latest version (only if branch is valid)
+      # Upload the artifact using latest version
       - name: Upload PR information artifact
-        if: steps.validate.outputs.valid == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pr


### PR DESCRIPTION
## Summary
The preview-site trigger validated branch names against `^[a-zA-Z0-9_-]+$`, which rejects `/` and `.`. For branches like `deps/crossbeam-epoch-0.9.20-RUSTSEC-2026-0204`, validation failed and the save/upload steps were silently skipped via a step-level `if`, while the job itself still reported `success`. The downstream `Deploy Vector Preview Sites` workflow saw `conclusion == 'success'`, assumed an artifact existed, and crashed trying to read one that was never uploaded (run: https://github.com/vectordotdev/vector/actions/runs/28969506589).

Removes the branch-name allowlist/reject step entirely — the raw branch name is only ever written as file data, hashed for the integrity check, or sanitized before reaching a URL, so there's nothing to validate it against. Widens `create_preview_sites.yml`'s sanitizer from stripping only `/` and `.` to replacing any non-alphanumeric character with `-`, so any git-legal branch name produces a safe Amplify subdomain.

## Vector configuration
NA

## How did you test this PR?
Validated end-to-end in `vectordotdev/ci-sandbox`:
- Positive case: PR with a `preview: website` label and branch `deps/test-1.2.3` (slash + dots) — full chain went green, artifact uploaded, and the sticky comment posted the correctly sanitized URL `deps-test-1-2-3.<appId>.amplifyapp.com`.
- Negative case: label removed — trigger workflow's job-level `if` correctly skips, run conclusion is `skipped` (not `success`), downstream workflow never runs, no comment posted.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?
- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References
- Related: https://github.com/vectordotdev/ci-sandbox/pull/44