### PR TITLE
fix(ci): pin datadog-metrics e2e agent_version away from v3 series API

### DIFF
--- a/tests/e2e/datadog-metrics/config/test.yaml
+++ b/tests/e2e/datadog-metrics/config/test.yaml
@@ -14,9 +14,11 @@ runner:
 matrix:
   # Pinned to the last version before the Agent defaulted series metrics to
   # the v3 intake API (7.81.0), which our datadog_agent source doesn't yet
-  # support. Re-add a "latest" leg once v3 series support lands
+  # support. "7" is a floating tag that already resolves to >=7.81.0, so
+  # it's dropped in favor of the explicit 7.80.4 pin. Re-add an unpinned v7
+  # leg once v3 series support lands
   # (see https://github.com/vectordotdev/vector/issues/25790).
-  agent_version: ["7.80.4", "6", "7"]
+  agent_version: ["7.80.4", "6"]
   # validate both series API versions
   series_api_version: ["v1", "v2"]
 

--- a/tests/e2e/datadog-metrics/config/test.yaml
+++ b/tests/e2e/datadog-metrics/config/test.yaml
@@ -12,8 +12,11 @@ runner:
     FAKE_INTAKE_VECTOR_ENDPOINT: "http://fakeintake-vector:80"
 
 matrix:
-  # validate against the Agent latest nightly and also stable v6 and v7
-  agent_version: ["latest", "6", "7"]
+  # Pinned to the last version before the Agent defaulted series metrics to
+  # the v3 intake API (7.81.0), which our datadog_agent source doesn't yet
+  # support. Re-add a "latest" leg once v3 series support lands
+  # (see https://github.com/vectordotdev/vector/issues/25790).
+  agent_version: ["7.80.4", "6", "7"]
   # validate both series API versions
   series_api_version: ["v1", "v2"]
 

--- a/tests/e2e/datadog-metrics/data/agent.yaml
+++ b/tests/e2e/datadog-metrics/data/agent.yaml
@@ -29,13 +29,3 @@ dd_url: http://fakeintake-agent:80
 additional_endpoints:
   "http://vector:8181":
     - DEADBEEF
-
-# Since Agent 7.81.0, series metrics default to the v3 intake API, which
-# fakeintake/Vector don't speak here and which 404s on non-Datadog endpoints.
-# Keep both endpoints on v2 so the test's series_api_version matrix (v1/v2)
-# still matches what's actually submitted.
-use_v3_api:
-  series:
-    endpoints:
-      "http://fakeintake-agent:80": "false"
-      "http://vector:8181": "false"

--- a/tests/e2e/datadog-metrics/data/agent.yaml
+++ b/tests/e2e/datadog-metrics/data/agent.yaml
@@ -29,3 +29,13 @@ dd_url: http://fakeintake-agent:80
 additional_endpoints:
   "http://vector:8181":
     - DEADBEEF
+
+# Since Agent 7.81.0, series metrics default to the v3 intake API, which
+# fakeintake/Vector don't speak here and which 404s on non-Datadog endpoints.
+# Keep both endpoints on v2 so the test's series_api_version matrix (v1/v2)
+# still matches what's actually submitted.
+use_v3_api:
+  series:
+    endpoints:
+      "http://fakeintake-agent:80": "false"
+      "http://vector:8181": "false"


### PR DESCRIPTION
## Summary

Datadog Agent 7.81.0 changed the default series metrics intake to the v3 API, which Vector's `datadog_agent` source doesn't support yet. The datadog-metrics e2e test floated its `agent_version` matrix on `latest`, which now breaks since Agent-forwarded series never reach the v1/v2 routes the test polls. Pins `agent_version` to the last version before that default change (`7.80.4`) instead of fighting the new default. Tracked in #25790 for adding v3 support and re-adding an unpinned leg once it lands.

## Vector configuration

NA

## How did you test this PR?

Reviewed Datadog Agent 7.81.0 release notes confirming the v3 series intake default change, and confirmed 7.80.4 predates it.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- #25790