### PR TITLE
chore(deps): Bump zlib-rs from 0.6.0 to 0.6.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14774,9 +14774,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.0"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7948af682ccbc3342b6e9420e8c51c1fe5d7bf7756002b4a3c6cabfe96a7e3c"
+checksum = "b142a20ec14a91d5bc708c1dc21b080c550113d8aa77afa29635673a65dd02c5"
 
 [[package]]
 name = "zmij"

--- a/changelog.d/bump_zlib_rs_aarch64_checksum.fix.md
+++ b/changelog.d/bump_zlib_rs_aarch64_checksum.fix.md
@@ -1,0 +1,3 @@
+Updated the zlib backend (`zlib-rs`) from 0.6.0 to 0.6.6, pulling in an upstream fix for an aarch64 NEON Adler-32 bug that could produce incorrect checksums. On arm64, valid zlib-format (RFC 1950) payloads, such as `deflate` content-encoding handled by HTTP-based sources, could previously be rejected as corrupt with an `incorrect data check` error.
+
+authors: Stunned1


### PR DESCRIPTION
## Summary
This is a lockfile-only bump of `zlib-rs` (the backend Vector selects for `flate2`) from 0.6.0 to 0.6.6. No new dependencies are introduced.

zlib-rs 0.6.4 fixed an aarch64 checksum bug in Adler-32 that could make valid `deflate` payloads look corrupted on arm64, which is the decode path Vector uses for zlib-format content-encoding in HTTP-based sources. We're pulling in 0.6.6 instead of 0.6.4 since 0.6.4 itself briefly broke the aarch64 build (fixed in 0.6.5). Found this while investigating #25796.

A `fix`-type changelog fragment is included so arm64 users can find this in the release notes.

## Vector configuration
N/A - dependency-only change

## How did you test this PR?
- Verified the specific bug this bump fixes: on aarch64, zlib-rs 0.6.0 and 0.6.6 produce identical output across several thousand compress/decompress round trips against a reference implementation.
- `make check-clippy` passes and the existing tests continues to exercise the same logical paths.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: #25796 