### PR TITLE
chore: replace unsafe NonZeroUsize::new_unchecked with safe const block

### DIFF
--- a/lib/vector-buffers/src/config.rs
+++ b/lib/vector-buffers/src/config.rs
@@ -153,8 +153,11 @@ impl<'de> Deserialize<'de> for BufferType {
     }
 }
 
+/// # Panics
+///
+/// Never panics; the value 500 is non-zero.
 pub const fn memory_buffer_default_max_events() -> NonZeroUsize {
-    const { NonZeroUsize::new(500).unwrap() }
+    NonZeroUsize::new(500).expect("500 is non-zero")
 }
 
 /// Disk usage configuration for disk-backed buffers.

--- a/lib/vector-buffers/src/config.rs
+++ b/lib/vector-buffers/src/config.rs
@@ -154,7 +154,7 @@ impl<'de> Deserialize<'de> for BufferType {
 }
 
 pub const fn memory_buffer_default_max_events() -> NonZeroUsize {
-    unsafe { NonZeroUsize::new_unchecked(500) }
+    const { NonZeroUsize::new(500).unwrap() }
 }
 
 /// Disk usage configuration for disk-backed buffers.

--- a/src/sinks/websocket_server/buffering.rs
+++ b/src/sinks/websocket_server/buffering.rs
@@ -86,7 +86,7 @@ const fn default_client_key_config() -> ClientKeyConfig {
 }
 
 const fn default_max_events() -> NonZeroUsize {
-    const { NonZeroUsize::new(1000).unwrap() }
+    NonZeroUsize::new(1000).expect("1000 is non-zero")
 }
 
 const LAST_RECEIVED_QUERY_PARAM_NAME: &str = "last_received";

--- a/src/sinks/websocket_server/buffering.rs
+++ b/src/sinks/websocket_server/buffering.rs
@@ -86,7 +86,7 @@ const fn default_client_key_config() -> ClientKeyConfig {
 }
 
 const fn default_max_events() -> NonZeroUsize {
-    unsafe { NonZeroUsize::new_unchecked(1000) }
+    const { NonZeroUsize::new(1000).unwrap() }
 }
 
 const LAST_RECEIVED_QUERY_PARAM_NAME: &str = "last_received";


### PR DESCRIPTION
## Summary

Replaces two uses of `unsafe { NonZeroUsize::new_unchecked(_) }` with safe `const { NonZeroUsize::new(_).unwrap() }` blocks.

The `const { ... }` form is evaluated entirely at compile time, so the `unwrap` becomes a compile error rather than a runtime panic.
## Vector configuration

## How did you test this PR?

`make check-clippy` passes cleanly.

N/A — no behavior change.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.