### PR TITLE
docs: Add valid character restrictions for env var interpolation

### DIFF
--- a/website/content/en/docs/reference/environment_variables.md
+++ b/website/content/en/docs/reference/environment_variables.md
@@ -57,6 +57,11 @@ You can escape environment variables by prefacing them with a `$` character. For
 example `$${HOSTNAME}` or `$$HOSTNAME` is treated literally in the above
 environment variable example.
 
+## Variable name restrictions
+
+Environment variable names used in interpolation are restricted to letters, digits plus `_`  and `.` characters. 
+Names containing other characters (such as hyphens `-`) will not be interpolated.
+
 ## Security Restrictions
 
 Vector prevents security issues related to environment variable interpolation by rejecting environment variables that contain newline


### PR DESCRIPTION
## Summary

Vector's environment variable interpolation silently ignores variable names containing hyphens  (e.g. ${my-var}), passing them through as literal strings. This is because the interpolation regex in [src/config/vars.rs (lines 5–17)](https://github.com/vectordotdev/vector/blob/master/src/config/vars.rs#L5-L17) restricts variable names to  letters (upper and lowercase), digits, underscores, and dots. This constraint was undocumented, making it hard to 
 debug.
 This PR adds a note to the environment variables reference to document this restriction.

## Vector configuration
NA

## How did you test this PR?
Ran the website locally with make serve and verified the guide renders correctly, including the embedded configuration files.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [ x] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References
NA