### PR TITLE
fix(mqtt sink, mqtt source): honor tls.alpn_protocols instead of hardcoding "mqtt"

### DIFF
--- a/changelog.d/25805_mqtt_alpn_protocols.fix.md
+++ b/changelog.d/25805_mqtt_alpn_protocols.fix.md
@@ -1,0 +1,3 @@
+The `mqtt` sink and source now honor the configured `tls.alpn_protocols` option instead of always advertising the hardcoded `mqtt` ALPN protocol. This allows connecting to endpoints that require a specific ALPN protocol name, such as AWS IoT Core over port 443 which requires `x-amzn-mqtt-ca`. When `tls.alpn_protocols` is not set, the previous `mqtt` default is preserved.
+
+authors: frank-hivewatch

--- a/src/sinks/mqtt/config.rs
+++ b/src/sinks/mqtt/config.rs
@@ -163,11 +163,20 @@ impl MqttSinkConfig {
         if let Some(tls) = tls.tls() {
             let ca = tls.authorities_pem().flatten().collect();
             let client_auth = tls.identity_pem();
-            let alpn = Some(vec!["mqtt".into()]);
+            // Honor the user-configured `tls.alpn_protocols` (e.g. `x-amzn-mqtt-ca`, required to
+            // reach AWS IoT Core over port 443), falling back to `mqtt` when it is not set.
+            let alpn = self
+                .common
+                .tls
+                .as_ref()
+                .and_then(|tls| tls.options.alpn_protocols.as_ref())
+                .filter(|protocols| !protocols.is_empty())
+                .map(|protocols| protocols.iter().map(|p| p.clone().into_bytes()).collect())
+                .unwrap_or_else(|| vec![b"mqtt".to_vec()]);
             options.set_transport(Transport::Tls(TlsConfiguration::Simple {
                 ca,
                 client_auth,
-                alpn,
+                alpn: Some(alpn),
             }));
         }
         Ok(MqttConnector::new(options))

--- a/src/sources/mqtt/config.rs
+++ b/src/sources/mqtt/config.rs
@@ -149,11 +149,20 @@ impl MqttSourceConfig {
         if let Some(tls) = tls.tls() {
             let ca = tls.authorities_pem().flatten().collect();
             let client_auth = tls.identity_pem();
-            let alpn = Some(vec!["mqtt".into()]);
+            // Honor the user-configured `tls.alpn_protocols` (e.g. `x-amzn-mqtt-ca`, required to
+            // reach AWS IoT Core over port 443), falling back to `mqtt` when it is not set.
+            let alpn = self
+                .common
+                .tls
+                .as_ref()
+                .and_then(|tls| tls.options.alpn_protocols.as_ref())
+                .filter(|protocols| !protocols.is_empty())
+                .map(|protocols| protocols.iter().map(|p| p.clone().into_bytes()).collect())
+                .unwrap_or_else(|| vec![b"mqtt".to_vec()]);
             options.set_transport(Transport::Tls(TlsConfiguration::Simple {
                 ca,
                 client_auth,
-                alpn,
+                alpn: Some(alpn),
             }));
         }
 


### PR DESCRIPTION
## Summary

The `mqtt` sink and source built the `rumqttc` TLS transport with a hardcoded ALPN list of `["mqtt"]`, ignoring the user-configured `tls.alpn_protocols` even though it is a documented and accepted TLS option. As a result, setting `tls.alpn_protocols` had no effect on MQTT connections.

The most common impact is that the MQTT sink/source cannot connect to **AWS IoT Core over port 443**. On its default endpoints, AWS IoT Core requires clients using X.509 client-certificate authentication on port 443 to negotiate the ALPN protocol name `x-amzn-mqtt-ca`; the bare `mqtt` name is only accepted for custom authentication. Port 443 is often the only reachable option for deployments behind firewalls that block the non-standard MQTT port 8883.

This PR threads the configured `tls.alpn_protocols` into the `rumqttc` `TlsConfiguration::Simple { alpn, .. }`, falling back to `["mqtt"]` only when the option is unset — so existing behavior is preserved for anyone who did not set it.

## Vector configuration

```yaml
sinks:
  iot_core:
    type: mqtt
    inputs: [events]
    host: "REDACTED-ats.iot.us-west-2.amazonaws.com"
    port: 443
    topic: "example/topic"
    encoding:
      codec: json
    tls:
      enabled: true
      ca_file: /etc/vector/AmazonRootCA1.pem
      crt_file: /etc/vector/thing-cert.pem
      key_file: /etc/vector/thing-key.pem
      server_name: "REDACTED-ats.iot.us-west-2.amazonaws.com"
      alpn_protocols: ["x-amzn-mqtt-ca"]   # now honored (previously ignored)
```

## How did you test this PR?

- `cargo check --no-default-features --features sinks-mqtt,sources-mqtt` passes.
- Confirmed the configured `tls.alpn_protocols` values are passed through as the ALPN
  protocol list (each protocol name as raw bytes), and that an unset option still yields
  the previous `["mqtt"]` default.
- The AWS IoT Core side was independently verified to accept the `x-amzn-mqtt-ca` ALPN on
  port 443 with the same X.509 client certificate via
  `openssl s_client -connect <endpoint>:443 -alpn x-amzn-mqtt-ca -servername <endpoint> -CAfile AmazonRootCA1.pem -cert thingCert.crt -key privKey.key`
  (`Verify return code: 0`), which is the negotiation Vector previously could not perform.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Closes: #25805

## Notes

- The same one-line hardcode existed in both `src/sinks/mqtt/config.rs` and
  `src/sources/mqtt/config.rs`; both are fixed here.
- No dependency changes (`Cargo.lock` untouched).
