### PR TITLE
fix(windows platform): report SERVICE_STOPPED to SCM when startup fails

### DIFF
--- a/changelog.d/windows_service_stopped_on_failed_start.fix.md
+++ b/changelog.d/windows_service_stopped_on_failed_start.fix.md
@@ -1,0 +1,3 @@
+The Windows service now reports `SERVICE_STOPPED` with a service-specific exit code to the Service Control Manager when Vector fails to start (for example, when the configuration is invalid). Previously the service was left stuck in the `START_PENDING` state indefinitely and configured service recovery actions never ran.
+
+authors: klondikedragon

--- a/src/vector_windows.rs
+++ b/src/vector_windows.rs
@@ -436,6 +436,24 @@ fn run_service(_arguments: Vec<OsString>) -> Result<()> {
 
             Ok(())
         }
-        _ => Ok(()),
+        Err(exit_code) => {
+            // Startup failed (for example, an invalid configuration). Register a control
+            // handler and report SERVICE_STOPPED with a nonzero exit code: if ServiceMain
+            // returns without ever reporting a status, the service is left stuck in the
+            // START_PENDING state and configured recovery actions never run.
+            let event_handler = move |_control_event| ServiceControlHandlerResult::NoError;
+            let status_handle =
+                windows_service::service_control_handler::register(SERVICE_NAME, event_handler)?;
+            status_handle.set_service_status(ServiceStatus {
+                service_type: SERVICE_TYPE,
+                current_state: ServiceState::Stopped,
+                controls_accepted: ServiceControlAccept::empty(),
+                exit_code: ServiceExitCode::ServiceSpecific(exit_code.unsigned_abs()),
+                checkpoint: 0,
+                wait_hint: Duration::default(),
+                process_id: None,
+            })?;
+            Ok(())
+        }
     }
 }


### PR DESCRIPTION
## Summary

Fixes #25809.

When Vector runs as a Windows service and startup fails (for example, an invalid configuration), `run_service` returned without registering a service control handler or reporting any status to the Service Control Manager. The SCM left the service stuck in `START_PENDING` indefinitely: the `vector.exe` process stays alive, the service is `NOT_STOPPABLE` (so `sc stop` cannot clear it), no SCM error event is logged, and configured recovery actions never run. Clearing the state required disabling the service and terminating the process by hand.

This PR handles the `Err` arm of `Application::prepare_start` in `run_service`: register a minimal control handler and report `SERVICE_STOPPED` with the startup exit code as a service-specific exit code. The SCM then shows the failure (`WIN32_EXIT_CODE 1066`, `SERVICE_EXIT_CODE` = Vector's exit code, e.g. 78 for a config error), logs event 7024, and service recovery can act on it. The success path (report `Running`, run, report `Stopped`) is unchanged.

## Vector configuration

The bug reproduces with any configuration that fails to load; tested by appending a syntactically invalid line to a previously working config:

```yaml
# ...any valid config...
broken: [
```

## How did you test this PR?

Windows 11 x64, Vector registered as a Windows service (`vector`), config made invalid as above.

Before (stock v0.56.0 release binary): stuck forever, process alive, no events.

```text
> sc.exe start vector ; sc.exe query vector
SERVICE_NAME: vector
        STATE              : 2  START_PENDING
                                (NOT_STOPPABLE, NOT_PAUSABLE, IGNORES_SHUTDOWN)
        WIN32_EXIT_CODE    : 0  (0x0)
        SERVICE_EXIT_CODE  : 0  (0x0)
        WAIT_HINT          : 0x7d0
# state identical minutes later; vector.exe still running; cleared only by
# disabling the service and terminating the process
```

After (this branch, `cargo build --release`): immediate honest stop.

```text
> sc.exe start vector ; sc.exe query vector
SERVICE_NAME: vector
        STATE              : 1  STOPPED
        WIN32_EXIT_CODE    : 1066  (0x42a)
        SERVICE_EXIT_CODE  : 78  (0x4e)
```

System event log now records the failure:

```text
Id 7024: The Vector Service service terminated with the following
         service-specific error: %%78
```

Service recovery now works. With a recovery ladder configured (`sc.exe failure vector reset= 86400 actions= restart/10000/restart/30000/restart/60000` plus `sc.exe failureflag vector 1`, which Windows requires for non-crash failures), the SCM retries per the ladder:

```text
Id 7031: The Vector Service service terminated unexpectedly. It has done this
         2 time(s). The following corrective action will be taken in 30000
         milliseconds: Restart the service.
Id 7024: ... service-specific error: %%78
Id 7031: ... 3 time(s) ... 60000 milliseconds: Restart the service.
```

After correcting the configuration, the SCM's scheduled restart brought the service back to `RUNNING` with no operator action (a subsequent manual `sc.exe start` returned `FAILED 1056: An instance of the service is already running`).

Regression check with a valid configuration: `sc.exe start` reaches `RUNNING` and `sc.exe stop` reaches `STOPPED` with exit code 0, repeatedly.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

Closes: #25809 
