### PR TITLE
docs(vrl errors): add website pages for renumbered error codes 112, 113, 114

### DIFF
--- a/website/cue/reference/remap/errors/112_invalid_grok_pattern.cue
+++ b/website/cue/reference/remap/errors/112_invalid_grok_pattern.cue
@@ -6,7 +6,7 @@ remap: errors: "112": {
 		A [grok](\(urls.grok)) pattern passed to `parse_grok` or `parse_groks` is invalid and cannot
 		be compiled.
 		"""
-	resolution: """
+	resolution:  """
 		Correct the grok pattern syntax. Refer to the [grok pattern documentation](\(urls.grok)) for
 		valid pattern syntax and available built-in patterns.
 		"""

--- a/website/cue/reference/remap/errors/112_invalid_grok_pattern.cue
+++ b/website/cue/reference/remap/errors/112_invalid_grok_pattern.cue
@@ -1,0 +1,26 @@
+package metadata
+
+remap: errors: "112": {
+	title:       "Invalid grok pattern"
+	description: """
+		A [grok](\(urls.grok)) pattern passed to `parse_grok` or `parse_groks` is invalid and cannot
+		be compiled.
+		"""
+	resolution: """
+		Correct the grok pattern syntax. Refer to the [grok pattern documentation](\(urls.grok)) for
+		valid pattern syntax and available built-in patterns.
+		"""
+
+	examples: [
+		{
+			"title": "\(title)"
+			source: #"""
+				parse_grok!(.message, "%{NOTAPATTERN:field}")
+				"""#
+			diff: #"""
+				-parse_grok!(.message, "%{NOTAPATTERN:field}")
+				+parse_grok!(.message, "%{WORD:field}")
+				"""#
+		},
+	]
+}

--- a/website/cue/reference/remap/errors/113_non_string_abort_message.cue
+++ b/website/cue/reference/remap/errors/113_non_string_abort_message.cue
@@ -1,0 +1,25 @@
+package metadata
+
+remap: errors: "113": {
+	title:       "Non-string abort message"
+	description: """
+		The expression passed as an `abort` message does not resolve to a string.
+		"""
+	resolution: """
+		Ensure the abort message expression resolves to a string, or use a
+		[coercion function](\(urls.vrl_functions)/#coerce-functions) to convert it.
+		"""
+
+	examples: [
+		{
+			"title": "\(title)"
+			source: #"""
+				abort .
+				"""#
+			diff: #"""
+				-abort .
+				+abort string(.) ?? "abort"
+				"""#
+		},
+	]
+}

--- a/website/cue/reference/remap/errors/113_non_string_abort_message.cue
+++ b/website/cue/reference/remap/errors/113_non_string_abort_message.cue
@@ -1,7 +1,7 @@
 package metadata
 
 remap: errors: "113": {
-	title:       "Non-string abort message"
+	title: "Non-string abort message"
 	description: """
 		The expression passed as an `abort` message does not resolve to a string.
 		"""

--- a/website/cue/reference/remap/errors/114_expression_type_unavailable.cue
+++ b/website/cue/reference/remap/errors/114_expression_type_unavailable.cue
@@ -1,0 +1,13 @@
+package metadata
+
+remap: errors: "114": {
+	title:       "Expression type unavailable"
+	description: """
+		The type of an expression cannot be determined at compile time because it depends on a
+		feature that is not available in the current build configuration.
+		"""
+	resolution: """
+		Enable the required feature or replace the expression with one whose type can be
+		statically determined.
+		"""
+}

--- a/website/cue/reference/remap/errors/114_expression_type_unavailable.cue
+++ b/website/cue/reference/remap/errors/114_expression_type_unavailable.cue
@@ -1,7 +1,7 @@
 package metadata
 
 remap: errors: "114": {
-	title:       "Expression type unavailable"
+	title: "Expression type unavailable"
 	description: """
 		The type of an expression cannot be determined at compile time because it depends on a
 		feature that is not available in the current build configuration.


### PR DESCRIPTION
## Summary

Adds three missing error code pages to the VRL errors documentation site (`errors.vrl.dev`) following the code collision fixes in vectordotdev/vrl#1854.

That PR centralized all diagnostic error codes in a single enum and fixed three collisions where unrelated errors shared the same code:

| Error | Old code | New code |
|-------|----------|----------|
| `InvalidGrokPattern` | 109 | 112 |
| `NonStringAbortMessage` | 300 | 113 |
| `ExpressionTypeUnavailable` | 900 | 114 |

No existing pages need to be removed: codes 109 and 900 had no website pages, and `300_unexpected_type.cue` correctly remains for `ValueCode::ExpectedType`.

## Vector configuration

N/A — website-only change.

## How did you test this PR?

Verified the CUE structure matches existing error pages in `website/cue/reference/remap/errors/`.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: vectordotdev/vrl#1854