### PR TITLE
fix(logstash source): cap payload size to prevent OOM

### DIFF
--- a/changelog.d/logstash_compressed_frame_oom.security.md
+++ b/changelog.d/logstash_compressed_frame_oom.security.md
@@ -1,0 +1,3 @@
+The `logstash` source now caps the size of compressed frame payloads. Previously, the 32-bit payload size field of a compressed (`C`) frame was read straight from the wire and used to reserve a buffer, so a 6-byte malformed frame advertising a multi-gigabyte size could trigger an allocation large enough to abort the process. The size of the decompressed output is now 100MiB by default and can be configured by `--max-decompressed-size-bytes` or `VECTOR_MAX_DECOMPRESSED_SIZE_BYTES`. Oversized frames are rejected as a decode error.
+
+authors: thomasqueirozb

--- a/src/app.rs
+++ b/src/app.rs
@@ -205,8 +205,7 @@ impl Application {
     ) -> Result<(Runtime, Self), ExitCode> {
         opts.root.init_global();
 
-        #[cfg(feature = "sources-utils-http-encoding")]
-        crate::sources::util::http::set_max_decompressed_size_bytes(
+        crate::sources::util::set_max_decompressed_size_bytes(
             opts.root.max_decompressed_size_bytes,
         );
 

--- a/src/sources/logstash.rs
+++ b/src/sources/logstash.rs
@@ -22,6 +22,9 @@ use vector_lib::{
 };
 use vrl::value::{KeyString, Kind, kind::Collection};
 
+use super::util::decompression::{
+    max_decompressed_size_bytes, max_zlib_compressed_frame_size_bytes,
+};
 use super::util::net::{SocketListenAddr, TcpSource, TcpSourceAck, TcpSourceAcker};
 use crate::{
     config::{
@@ -760,9 +763,22 @@ fn decode_compressed_frame(
         return Ok(None);
     }
     let payload_size = rest.get_u32() as usize;
+    let limit = max_decompressed_size_bytes();
+
+    // Reject an oversized declared payload before buffering it, so a peer cannot force multi-GB
+    // buffering by advertising a huge length and slow-streaming its bytes. The bound includes
+    // zlib's worst-case expansion so a valid frame whose decompressed content is within `limit`
+    // is never rejected here; the decompressed cap itself is still enforced below.
+    let compressed_limit = max_zlib_compressed_frame_size_bytes();
+    if payload_size > compressed_limit {
+        return Err(DecodeError::DecompressionFailed {
+            source: io::Error::other(format!(
+                "compressed frame payload size {payload_size} exceeds limit of {compressed_limit} bytes"
+            )),
+        });
+    }
 
     if rest.remaining() < payload_size {
-        src.reserve(payload_size);
         return Ok(None);
     }
 
@@ -771,10 +787,22 @@ fn decode_compressed_frame(
 
     let mut buf = Vec::new();
 
+    // Read one byte beyond the cap to detect overflow without ambiguity.
     let res = ZlibDecoder::new(io::Cursor::new(slice))
+        .take((limit as u64).saturating_add(1))
         .read_to_end(&mut buf)
         .context(DecompressionFailedSnafu)
-        .map(|_| BytesMut::from(&buf[..]));
+        .and_then(|_| {
+            if buf.len() > limit {
+                Err(DecodeError::DecompressionFailed {
+                    source: io::Error::other(format!(
+                        "decompressed size exceeds limit of {limit} bytes"
+                    )),
+                })
+            } else {
+                Ok(BytesMut::from(&buf[..]))
+            }
+        });
 
     let byte_size = bytes_remaining(src, rest);
     src.advance(byte_size);

--- a/src/sources/util/decompression.rs
+++ b/src/sources/util/decompression.rs
@@ -43,7 +43,7 @@ pub fn max_decompressed_size_bytes() -> usize {
 }
 
 /// Returns the maximum compressed frame wire size we are willing to buffer, derived from the
-/// decompressed cap plus zlib's worst-case expansion. See [`zlib_compressed_frame_limit`].
+/// decompressed cap plus zlib's worst-case expansion. See `zlib_compressed_frame_limit`.
 pub fn max_zlib_compressed_frame_size_bytes() -> usize {
     *MAX_ZLIB_COMPRESSED_FRAME_SIZE_BYTES
         .get()

--- a/src/sources/util/decompression.rs
+++ b/src/sources/util/decompression.rs
@@ -1,0 +1,51 @@
+use std::sync::OnceLock;
+
+/// Default cap on the size of any decompressed payload.
+///
+/// Prevents a compressed "bomb" from causing unbounded memory growth.
+pub const DEFAULT_MAX_DECOMPRESSED_SIZE_BYTES: usize = 100 * 1024 * 1024;
+
+static MAX_DECOMPRESSED_SIZE_BYTES: OnceLock<usize> = OnceLock::new();
+static MAX_ZLIB_COMPRESSED_FRAME_SIZE_BYTES: OnceLock<usize> = OnceLock::new();
+
+/// Maps a decompressed cap to the largest compressed frame that can legitimately produce output
+/// within it, using zlib's worst-case expansion of 13.5% + 11 bytes. This lets us reject an
+/// oversized declared payload before buffering it, without rejecting a valid frame whose
+/// decompressed content stays within the decompressed cap.
+///
+/// See <https://zlib.net/zlib_tech.html> ("the worst case ... can result in an expansion of at
+/// most 13.5%, plus eleven bytes").
+const fn zlib_compressed_frame_limit(decompressed_limit: usize) -> usize {
+    (decompressed_limit as u64)
+        .saturating_mul(1135)
+        .saturating_div(1000)
+        .saturating_add(11) as usize
+}
+
+const DEFAULT_MAX_ZLIB_COMPRESSED_FRAME_SIZE_BYTES: usize =
+    zlib_compressed_frame_limit(DEFAULT_MAX_DECOMPRESSED_SIZE_BYTES);
+
+/// Override the global decompressed payload size cap. Must be called before any sources start.
+pub fn set_max_decompressed_size_bytes(size: usize) {
+    MAX_DECOMPRESSED_SIZE_BYTES
+        .set(size)
+        .expect("max_decompressed_size_bytes already set");
+    MAX_ZLIB_COMPRESSED_FRAME_SIZE_BYTES
+        .set(zlib_compressed_frame_limit(size))
+        .expect("max_zlib_compressed_frame_size_bytes already set");
+}
+
+/// Returns the currently configured decompressed payload size cap.
+pub fn max_decompressed_size_bytes() -> usize {
+    *MAX_DECOMPRESSED_SIZE_BYTES
+        .get()
+        .unwrap_or(&DEFAULT_MAX_DECOMPRESSED_SIZE_BYTES)
+}
+
+/// Returns the maximum compressed frame wire size we are willing to buffer, derived from the
+/// decompressed cap plus zlib's worst-case expansion. See [`zlib_compressed_frame_limit`].
+pub fn max_zlib_compressed_frame_size_bytes() -> usize {
+    *MAX_ZLIB_COMPRESSED_FRAME_SIZE_BYTES
+        .get()
+        .unwrap_or(&DEFAULT_MAX_ZLIB_COMPRESSED_FRAME_SIZE_BYTES)
+}

--- a/src/sources/util/http/encoding.rs
+++ b/src/sources/util/http/encoding.rs
@@ -1,4 +1,4 @@
-use std::{io::Read, sync::OnceLock};
+use std::io::Read;
 
 use bytes::{Buf, Bytes};
 #[cfg(any(
@@ -22,28 +22,11 @@ use warp::http::StatusCode;
 ))]
 use warp::{Filter, filters::BoxedFilter};
 
+#[cfg(test)]
+use crate::sources::util::decompression::DEFAULT_MAX_DECOMPRESSED_SIZE_BYTES;
+use crate::sources::util::decompression::max_decompressed_size_bytes;
+pub use crate::sources::util::decompression::set_max_decompressed_size_bytes;
 use crate::{common::http::ErrorMessage, internal_events::HttpDecompressError};
-
-/// Default cap on the decompressed body size produced by [`decompress_body`].
-///
-/// Prevents a compressed "bomb" payload from causing unbounded memory growth.
-pub(crate) const DEFAULT_MAX_DECOMPRESSED_BODY_SIZE: usize = 100 * 1024 * 1024;
-
-static MAX_DECOMPRESSED_BODY_SIZE: OnceLock<usize> = OnceLock::new();
-
-/// Override the global decompressed body size cap. Must be called before any sources start.
-pub fn set_max_decompressed_size_bytes(size: usize) {
-    MAX_DECOMPRESSED_BODY_SIZE
-        .set(size)
-        .expect("max_decompressed_size_bytes already set");
-}
-
-/// Returns the currently configured decompressed body size cap.
-pub(crate) fn max_decompressed_size_bytes() -> usize {
-    *MAX_DECOMPRESSED_BODY_SIZE
-        .get()
-        .unwrap_or(&DEFAULT_MAX_DECOMPRESSED_BODY_SIZE)
-}
 
 /// Collects a request body into [`Bytes`] while enforcing an in-memory size cap.
 #[cfg(any(
@@ -393,7 +376,7 @@ mod tests {
         assert_eq!(zstd_window_log_max(1024), Some(10));
         assert_eq!(zstd_window_log_max(1025), Some(11));
         assert_eq!(
-            zstd_window_log_max(DEFAULT_MAX_DECOMPRESSED_BODY_SIZE),
+            zstd_window_log_max(DEFAULT_MAX_DECOMPRESSED_SIZE_BYTES),
             Some(27)
         );
     }

--- a/src/sources/util/http/mod.rs
+++ b/src/sources/util/http/mod.rs
@@ -16,10 +16,12 @@ mod prelude;
 ))]
 mod query;
 
+#[cfg(feature = "sources-opentelemetry")]
+pub(crate) use super::decompression::max_decompressed_size_bytes;
+#[cfg(feature = "sources-opentelemetry")]
+pub(crate) use encoding::limited_body;
 #[cfg(feature = "sources-utils-http-encoding")]
 pub use encoding::{decompress_body, emit_decompress_error, set_max_decompressed_size_bytes};
-#[cfg(feature = "sources-opentelemetry")]
-pub(crate) use encoding::{limited_body, max_decompressed_size_bytes};
 #[cfg(feature = "sources-utils-http-headers")]
 pub use headers::add_headers;
 pub use method::HttpMethod;

--- a/src/sources/util/http/prelude.rs
+++ b/src/sources/util/http/prelude.rs
@@ -22,7 +22,8 @@ use warp::{
     reject::Rejection,
 };
 
-use super::encoding::{decompress_body, limited_body, max_decompressed_size_bytes};
+use super::encoding::{decompress_body, limited_body};
+use crate::sources::util::decompression::max_decompressed_size_bytes;
 use crate::{
     SourceSender,
     common::http::{ErrorMessage, server_auth::HttpServerAuthConfig},

--- a/src/sources/util/mod.rs
+++ b/src/sources/util/mod.rs
@@ -1,6 +1,7 @@
 #![allow(missing_docs)]
 #[cfg(feature = "sources-http_server")]
 mod body_decoding;
+pub mod decompression;
 #[cfg(feature = "sources-file")]
 mod encoding_config;
 #[cfg(all(unix, feature = "sources-dnstap"))]
@@ -41,6 +42,7 @@ mod unix_datagram;
 mod unix_stream;
 mod wrappers;
 
+pub use decompression::{max_decompressed_size_bytes, set_max_decompressed_size_bytes};
 #[cfg(feature = "sources-file")]
 pub use encoding_config::EncodingConfig;
 pub use multiline_config::MultilineConfig;


### PR DESCRIPTION
## Summary
The `logstash` source reads the 32-bit payload size field of a compressed (`C`) frame directly from the wire and uses it to reserve a decompression buffer. A malformed 6-byte frame advertising a multi-gigabyte size could trigger an allocation large enough to abort the process (OOM). This caps the decompressed size to 100MiB by default, configurable via `--max-decompressed-size-bytes` / `VECTOR_MAX_DECOMPRESSED_SIZE_BYTES`, and rejects oversized frames as a decode error.

## Vector configuration
NA

## How did you test this PR?
Sent malformed logstash compressed frames with an oversized advertised payload size and confirmed they are rejected with a decode error instead of causing large allocations.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

NA