### PR TITLE
chore(tls reload): add `upgrade` method to `WeakTlsAcceptorReloader`

### DIFF
--- a/lib/vector-core/src/tls/reload.rs
+++ b/lib/vector-core/src/tls/reload.rs
@@ -44,10 +44,6 @@ impl TlsAcceptorReloader {
     }
 
     /// Downgrade to a [`WeakTlsAcceptorReloader`] that does not keep the served acceptor alive.
-    ///
-    /// This is what a background reload task should hold: once the bound listener (the sole strong
-    /// owner) is dropped at source shutdown, the weak handle's
-    /// [`reload`](WeakTlsAcceptorReloader::reload) reports that it is gone, so the task can stop.
     pub fn downgrade(&self) -> WeakTlsAcceptorReloader {
         WeakTlsAcceptorReloader {
             acceptor: Arc::downgrade(&self.acceptor),
@@ -62,18 +58,11 @@ pub struct WeakTlsAcceptorReloader {
 }
 
 impl WeakTlsAcceptorReloader {
-    /// Swap in a freshly built acceptor if the listener is still alive.
-    ///
-    /// Returns `Ok(true)` on a successful swap, `Ok(false)` if the listener has been dropped (the
-    /// caller should stop reloading), and `Err` if the new settings failed to build an acceptor.
-    pub fn reload(&self, settings: &TlsSettings) -> crate::tls::Result<bool> {
-        match self.acceptor.upgrade() {
-            Some(acceptor) => {
-                acceptor.store(Arc::new(settings.acceptor()?));
-                Ok(true)
-            }
-            None => Ok(false),
-        }
+    /// Return the live [`TlsAcceptorReloader`], or `None` once the bound listener has been dropped.
+    pub fn upgrade(&self) -> Option<TlsAcceptorReloader> {
+        self.acceptor
+            .upgrade()
+            .map(|acceptor| TlsAcceptorReloader { acceptor })
     }
 }
 
@@ -141,18 +130,16 @@ mod test {
             .await
             .unwrap();
 
-        // While the listener is alive, a reload swaps in freshly built material.
-        assert!(
-            weak.reload(&tls).unwrap(),
-            "reload should apply while the listener is alive"
-        );
+        weak.upgrade()
+            .expect("listener alive, so the weak handle upgrades")
+            .reload(&tls)
+            .unwrap();
 
-        // Once the listener (the last strong owner) is dropped, the weak handle reports it is gone
-        // so the reload task can stop.
+        // Once the listener (the last strong owner) is dropped, the weak handle no longer upgrades.
         drop(listener);
         assert!(
-            !weak.reload(&tls).unwrap(),
-            "reload should report the listener is gone after shutdown"
+            weak.upgrade().is_none(),
+            "weak handle must not upgrade after the listener is dropped"
         );
     }
 


### PR DESCRIPTION
## Summary
Add an `upgrade() -> Option<T>` method to `WeakTlsAcceptorReloader`, which provides a better API for managing the lifecycle of the reloader than `reload(...) -> Result<bool>`.

## How did you test this PR?
Updated unit tests.

## Change Type
- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.