### PR TITLE
fix(logstash source): reject nested compressed frames to prevent stack exhaustion

### DIFF
--- a/changelog.d/logstash_nested_compression_recursion.security.md
+++ b/changelog.d/logstash_nested_compression_recursion.security.md
@@ -1,0 +1,3 @@
+The `logstash` source now rejects compressed frames that are nested inside other compressed frames. Previously, a malicious sender could nest compressed (`C`) frames arbitrarily deep, driving unbounded recursion in the decoder until the process exhausted its stack and aborted. Compressed payloads may now contain only a single layer of compression; no known Lumberjack/Beats client (e.g. Filebeat) ever emits more than one.
+
+authors: thomasqueirozb

--- a/src/sources/logstash.rs
+++ b/src/sources/logstash.rs
@@ -335,6 +335,13 @@ struct LogstashDecoder {
     // preserve sender window boundaries even if ReadyFrames later batches
     // multiple decoded windows together before ACKing.
     window_events_remaining: Option<NonZeroUsize>,
+    // Set for the decoder used to parse a decompressed payload. No known
+    // Lumberjack/Beats client emits a compressed frame nested inside another,
+    // so a nested `C` frame here is rejected rather than recursed into.
+    // Without this, an attacker could nest compressed frames arbitrarily deep
+    // and drive unbounded recursion in `decode_compressed_frame`, exhausting
+    // the stack (CWE-674).
+    nested: bool,
 }
 
 impl LogstashDecoder {
@@ -348,6 +355,15 @@ impl LogstashDecoder {
         Self {
             state: LogstashDecoderReadState::ReadProtocol,
             window_events_remaining,
+            nested: false,
+        }
+    }
+
+    const fn new_nested(window_events_remaining: Option<NonZeroUsize>) -> Self {
+        Self {
+            state: LogstashDecoderReadState::ReadProtocol,
+            window_events_remaining,
+            nested: true,
         }
     }
 
@@ -396,6 +412,8 @@ pub enum DecodeError {
         "Received a WindowSize frame before the current window completed ({remaining} events still expected)"
     ))]
     PrematureWindowSize { remaining: usize },
+    #[snafu(display("Compressed frame contains a nested compressed frame"))]
+    NestedCompressedFrame,
 }
 
 impl StreamDecodingError for DecodeError {
@@ -639,6 +657,10 @@ impl Decoder for LogstashDecoder {
                 // overwrite any WindowSize boundaries that were established inside the compressed
                 // payload and can also lose progress from a partially consumed outer window.
                 LogstashDecoderReadState::ReadFrame(_protocol, LogstashFrameType::Compressed) => {
+                    if self.nested {
+                        return Err(DecodeError::NestedCompressedFrame);
+                    }
+
                     let Some(decoded) = decode_compressed_frame(src, self.window_events_remaining)?
                     else {
                         return Ok(None);
@@ -794,7 +816,7 @@ fn decode_compressed_frame(
 
     let mut buf = res?;
 
-    let mut decoder = LogstashDecoder::new_with_window_events_remaining(window_events_remaining);
+    let mut decoder = LogstashDecoder::new_nested(window_events_remaining);
 
     let mut frames = VecDeque::new();
 
@@ -1161,6 +1183,23 @@ mod test {
             !err.can_continue(),
             "a premature WindowSize inside a compressed frame must be fatal",
         );
+    }
+
+    #[test]
+    fn nested_compressed_frame_is_a_fatal_decode_error() {
+        let mut inner = BytesMut::new();
+        push_req(&mut inner, 1, &[("message", "should never be reached")]);
+
+        let mut middle = BytesMut::new();
+        push_compressed(&mut middle, &inner);
+
+        let mut req = BytesMut::new();
+        push_compressed(&mut req, &middle);
+
+        let mut decoder = LogstashDecoder::new();
+        let err = decoder.decode(&mut req).unwrap_err();
+        assert!(matches!(err, DecodeError::NestedCompressedFrame));
+        assert!(!err.can_continue());
     }
 
     #[tokio::test]

--- a/website/cue/reference/components/sources/logstash.cue
+++ b/website/cue/reference/components/sources/logstash.cue
@@ -301,6 +301,20 @@ components: sources: logstash: {
 				acknowledgements.
 				"""
 		}
+
+		compressed_frames: {
+			title: "Compressed frame limits"
+			body: """
+				The Lumberjack/Beats protocol's compressed (`C`) frame type allows a sender to wrap other frames,
+				including data, JSON, and window-size frames, in a single compressed envelope. This source only
+				accepts a single layer of compression per frame: a compressed frame whose decompressed payload
+				itself contains another compressed frame is rejected as a decode error and the connection is
+				closed. No known Lumberjack/Beats client, such as Filebeat, ever emits more than one layer of
+				compression, so this does not affect interoperability with legitimate senders. The restriction
+				exists to prevent a malicious sender from nesting compressed frames arbitrarily deep to exhaust
+				the stack of the thread decoding the connection.
+				"""
+		}
 	}
 
 	telemetry: metrics: {


### PR DESCRIPTION
## Summary
The `logstash` source now rejects compressed frames nested inside other compressed frames. Previously a malicious sender could nest compressed (`C`) frames arbitrarily deep, driving unbounded recursion in the decoder until the process exhausted its stack. Compressed payloads may now contain only a single layer of compression.

## Vector configuration
NA

## How did you test this PR?
Added unit tests covering nested compressed frames.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

NA