### PR TITLE
fix(sources): map capped-body rejections to client errors in firehose and splunk_hec sources

### DIFF
--- a/src/sources/aws_kinesis_firehose/filters.rs
+++ b/src/sources/aws_kinesis_firehose/filters.rs
@@ -18,6 +18,7 @@ use super::{
 };
 use crate::{
     SourceSender, codecs,
+    common::http::ErrorMessage,
     internal_events::{AwsKinesisFirehoseRequestError, AwsKinesisFirehoseRequestReceived},
     sources::http_server::HttpConfigParamKind,
     sources::util::{decompression::CappedDecoder, http::capped_body},
@@ -208,6 +209,10 @@ async fn handle_firehose_rejection(err: warp::Rejection) -> Result<impl warp::Re
         message = e.to_string();
         code = e.status();
         request_id = e.request_id();
+    } else if let Some(e) = err.find::<ErrorMessage>() {
+        code = e.status_code();
+        message = e.message().to_string();
+        request_id = None;
     } else if let Some(e) = err.find::<warp::reject::MissingHeader>() {
         code = StatusCode::BAD_REQUEST;
         message = format!("Required header missing: {}", e.name());
@@ -281,5 +286,24 @@ mod tests {
             .unwrap();
 
         assert_eq!(parsed.access_key, Some("secret123".to_owned()));
+    }
+
+    #[tokio::test]
+    async fn capped_body_rejection_maps_to_client_error() {
+        use warp::Reply;
+
+        // `capped_body()` rejects oversized payloads with an `ErrorMessage` (e.g. 413). The
+        // recovery must surface that status instead of falling through to a 500.
+        let rejection = warp::reject::custom(ErrorMessage::new(
+            StatusCode::PAYLOAD_TOO_LARGE,
+            "Request body exceeds limit of 1024 bytes.".to_owned(),
+        ));
+
+        let response = handle_firehose_rejection(rejection)
+            .await
+            .unwrap()
+            .into_response();
+
+        assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
     }
 }

--- a/src/sources/splunk_hec/mod.rs
+++ b/src/sources/splunk_hec/mod.rs
@@ -65,6 +65,7 @@ use self::{
 use crate::{
     SourceSender,
     codecs::DecodingConfig,
+    common::http::ErrorMessage,
     config::{DataType, Resource, SourceConfig, SourceContext, SourceOutput, log_schema},
     event::{Event, LogEvent, Value},
     http::{KeepaliveConfig, MaxConnectionAgeLayer, build_http_trace_layer},
@@ -2014,6 +2015,8 @@ async fn finish_err(rejection: Rejection) -> Result<(Response,), Rejection> {
                 response_json(StatusCode::BAD_REQUEST, splunk_response::ACK_IS_DISABLED)
             }
         },))
+    } else if let Some(error) = rejection.find::<ErrorMessage>() {
+        Ok((response_json(error.status_code(), error),))
     } else {
         Err(rejection)
     }
@@ -2082,6 +2085,22 @@ mod tests {
     #[test]
     fn generate_config() {
         crate::test_util::test_generate_config::<SplunkConfig>();
+    }
+
+    #[tokio::test]
+    async fn finish_err_maps_capped_body_to_client_error() {
+        // `capped_body()` rejects oversized payloads with an `ErrorMessage` (e.g. 413). The
+        // recovery must surface that status instead of letting it fall through to a 500.
+        let rejection = warp::reject::custom(ErrorMessage::new(
+            StatusCode::PAYLOAD_TOO_LARGE,
+            "Request body exceeds limit of 1024 bytes.".to_owned(),
+        ));
+
+        let (response,) = finish_err(rejection)
+            .await
+            .expect("capped-body rejection should be recovered");
+
+        assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
     }
 
     /// Splunk token


### PR DESCRIPTION
## Summary

Follow-up to #25819. The `capped_body()` filter rejects oversized request/decompressed bodies with an `ErrorMessage` (e.g. `413 Payload Too Large`), but the `aws_kinesis_firehose` and `splunk_hec` recovery paths did not recognize it and fell through to a generic `500 Internal Server Error`, which can trigger unnecessary client retries. Both recovery handlers now map `ErrorMessage` to its client-facing status. This makes reality match the behavior already described in #25819's changelog fragment.

## Vector configuration

NA

## How did you test this PR?

Added unit tests driving each recovery function with a synthetic `ErrorMessage` rejection and asserting the returned status is `413`. Verified under minimal feature sets (`cargo check --no-default-features --features sources-splunk_hec` / `sources-aws_kinesis_firehose`), plus clippy and fmt.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: #25819
