### PR TITLE
docs: add 0.57 upgrade guide for template confinement

### DIFF
--- a/changelog.d/template_confinement.breaking.md
+++ b/changelog.d/template_confinement.breaking.md
@@ -5,12 +5,7 @@ declared in the template. Templates with no literal prefix (e.g.
 only exception: its `base_dir` config field can provide an explicit
 confinement root for `path` templates with no usable literal prefix.
 
-Affected sinks: `aws_s3`, `azure_blob`, `gcp_cloud_storage`, `webhdfs`,
-`file`, `elasticsearch`, `kafka`, `http`, `axiom`, `opentelemetry`,
-`splunk_hec_logs`, `splunk_hec_metrics`, `humio_logs`, `humio_metrics`,
-`loki`, `clickhouse`, `doris`, `redis`, `amqp`, `pulsar`, `mqtt`, `nats`,
-`greptimedb_logs`, `aws_cloudwatch_logs`, `gcp_stackdriver_logs`,
-`prometheus_remote_write`.
+Any sink that includes a templated config field can be affected.
 
 The `file` sink gains a `base_dir` config field to set the confinement root
 explicitly when the `path` template has no usable literal prefix.

--- a/changelog.d/template_confinement.breaking.md
+++ b/changelog.d/template_confinement.breaking.md
@@ -1,22 +1,27 @@
 Sinks that accept `{{ field }}` references in routing templates now enforce a
 confinement boundary: the rendered value must stay within the literal prefix
 declared in the template. Templates with no literal prefix (e.g.
-`key_prefix: "{{ host }}/"`) are rejected at startup.
+`key_prefix: "{{ host }}/"`) are rejected at startup. The `file` sink is the
+only exception: its `base_dir` config field can provide an explicit
+confinement root for `path` templates with no usable literal prefix.
 
 Affected sinks: `aws_s3`, `azure_blob`, `gcp_cloud_storage`, `webhdfs`,
-`file`, `elasticsearch`, `kafka`, `http`, `splunk_hec_logs`,
-`splunk_hec_metrics`, `humio_logs`, `humio_metrics`, `loki`, `clickhouse`,
-`redis`, `amqp`, `pulsar`, `mqtt`, `nats`, `greptimedb_logs`,
-`aws_cloudwatch_logs`, `gcp_stackdriver_logs`, `prometheus_remote_write`.
+`file`, `elasticsearch`, `kafka`, `http`, `axiom`, `opentelemetry`,
+`splunk_hec_logs`, `splunk_hec_metrics`, `humio_logs`, `humio_metrics`,
+`loki`, `clickhouse`, `doris`, `redis`, `amqp`, `pulsar`, `mqtt`, `nats`,
+`greptimedb_logs`, `aws_cloudwatch_logs`, `gcp_stackdriver_logs`,
+`prometheus_remote_write`.
 
 The `file` sink gains a `base_dir` config field to set the confinement root
 explicitly when the `path` template has no usable literal prefix.
 
-**URI templates:** HTTP/HTTPS URI templates that use `{{ field }}` references
-must not contain `?`. A field-rendered value could smuggle additional query
-parameters into the request. Fully static URI templates (no `{{ }}`) with a
-query string are still accepted. Dynamic query segments (e.g.
+**HTTP-family templates:** HTTP/HTTPS URI templates that use `{{ field }}`
+references must not contain `?` or `#`. A field-rendered value could smuggle
+additional query parameters or fragments into the rendered URI. Fully static URI
+templates (no `{{ }}`) with a query string or fragment are still accepted.
+Dynamic query or fragment segments (e.g.
 `https://api.internal/ingest?tenant={{ tenant }}`) are rejected at startup.
+Templated `request.headers` values are also confined for HTTP-family sinks.
 
 **Opt-out:** set `dangerously_allow_unconfined_template_resolution: true` on
 the affected sink to disable all confinement checks for that sink — both at

--- a/website/content/en/highlights/2026-07-14-0-57-0-upgrade-guide.md
+++ b/website/content/en/highlights/2026-07-14-0-57-0-upgrade-guide.md
@@ -44,9 +44,7 @@ Sinks that accept `{{ field }}` references in routing templates (for example, ob
 
 This affects the following sinks: `aws_s3`, `azure_blob`, `gcp_cloud_storage`, `webhdfs`, `file`, `elasticsearch`, `kafka`, `http`, `axiom`, `opentelemetry`, `splunk_hec_logs`, `splunk_hec_metrics`, `humio_logs`, `humio_metrics`, `loki`, `clickhouse`, `doris`, `redis`, `amqp`, `pulsar`, `mqtt`, `nats`, `greptimedb_logs`, `aws_cloudwatch_logs`, `gcp_stackdriver_logs`, and `prometheus_remote_write`.
 
-Additionally, HTTP/HTTPS URI templates that use `{{ field }}` references must not contain a `?` or `#`. A field-rendered value could otherwise smuggle additional query parameters or fragments into the rendered URI. Fully static URI templates (no `{{ }}`) with a query string or fragment are still accepted, but dynamic query or fragment segments (e.g. `https://api.internal/ingest?tenant={{ tenant }}`) are rejected at startup. Templated `request.headers` values are also confined for HTTP-family sinks.
-
-The static portion of an HTTP/HTTPS URI template's prefix also can't contain a percent-encoded path separator (`%2f`/`%2F`, `%5c`/`%5C`) or a raw backslash (for example `https://api.internal/ingest%2f..`). Some HTTP servers decode these before resolving the path, which could route a request outside the path you intended; Vector now rejects such templates at startup.
+HTTP-family sinks have additional restrictions on URI and header templates to prevent request smuggling.
 
 Watch the `component_errors_total{error_type="confinement_failed"}` metric after upgrading; it increments (and the offending event is dropped) whenever a rendered template value falls outside its confinement boundary at runtime.
 

--- a/website/content/en/highlights/2026-07-14-0-57-0-upgrade-guide.md
+++ b/website/content/en/highlights/2026-07-14-0-57-0-upgrade-guide.md
@@ -1,0 +1,149 @@
+---
+date: "2026-07-14"
+title: "0.57 Upgrade Guide"
+description: "An upgrade guide that addresses breaking changes in 0.57.0"
+authors: ["pront"]
+release: "0.57.0"
+hide_on_release_notes: false
+badges:
+  type: breaking change
+---
+
+## Vector breaking changes
+
+1. [Environment variable interpolation disabled by default](#env-var-interpolation)
+2. [Template confinement for sink routing templates](#template-confinement)
+
+## Vector upgrade guide
+
+### Environment variable interpolation disabled by default {#env-var-interpolation}
+
+Environment variable interpolation in configuration files is now disabled by default. Previously, Vector automatically interpolated `${VAR}` references found in config files.
+
+The `--disable-env-var-interpolation` flag and `VECTOR_DISABLE_ENV_VAR_INTERPOLATION` environment variable have also been removed and should no longer be used.
+
+#### Action needed
+
+If your configuration relies on `${VAR}` interpolation, pass `--dangerously-allow-env-var-interpolation` or set `VECTOR_DANGEROUSLY_ALLOW_ENV_VAR_INTERPOLATION=true` to restore the previous behavior:
+
+##### Old (interpolation was on by default)
+
+```bash
+vector --config vector.yaml
+```
+
+##### New
+
+```bash
+vector --config vector.yaml --dangerously-allow-env-var-interpolation
+```
+
+### Template confinement for sink routing templates {#template-confinement}
+
+Sinks that accept `{{ field }}` references in routing templates (for example, object keys, file paths, HTTP headers, or table/stream names) now enforce a confinement boundary: the rendered value must stay within the literal prefix declared in the template. Templates with no literal prefix (e.g. `key_prefix: "{{ host }}/"`) are rejected at startup. The `file` sink is the only exception: its `base_dir` config field can provide an explicit confinement root for `path` templates with no usable literal prefix.
+
+This affects the following sinks: `aws_s3`, `azure_blob`, `gcp_cloud_storage`, `webhdfs`, `file`, `elasticsearch`, `kafka`, `http`, `axiom`, `opentelemetry`, `splunk_hec_logs`, `splunk_hec_metrics`, `humio_logs`, `humio_metrics`, `loki`, `clickhouse`, `doris`, `redis`, `amqp`, `pulsar`, `mqtt`, `nats`, `greptimedb_logs`, `aws_cloudwatch_logs`, `gcp_stackdriver_logs`, and `prometheus_remote_write`.
+
+Additionally, HTTP/HTTPS URI templates that use `{{ field }}` references must not contain a `?` or `#`. A field-rendered value could otherwise smuggle additional query parameters or fragments into the rendered URI. Fully static URI templates (no `{{ }}`) with a query string or fragment are still accepted, but dynamic query or fragment segments (e.g. `https://api.internal/ingest?tenant={{ tenant }}`) are rejected at startup. Templated `request.headers` values are also confined for HTTP-family sinks.
+
+The static portion of an HTTP/HTTPS URI template's prefix also can't contain a percent-encoded path separator (`%2f`/`%2F`, `%5c`/`%5C`) or a raw backslash (for example `https://api.internal/ingest%2f..`). Some HTTP servers decode these before resolving the path, which could route a request outside the path you intended; Vector now rejects such templates at startup.
+
+Watch the `component_errors_total{error_type="confinement_failed"}` metric after upgrading; it increments (and the offending event is dropped) whenever a rendered template value falls outside its confinement boundary at runtime.
+
+You can restore the previous unconfined behavior by setting `dangerously_allow_unconfined_template_resolution: true`,
+which also sets the `vector_security_confinement_disabled{component_type=...}` metric to `1`.
+
+#### Action needed (file sink)
+
+For the `file` sink, set the new `base_dir` config field to define the confinement root explicitly:
+
+##### Old (file sink)
+
+```yaml
+sinks:
+  my_file:
+    type: file
+    path: "{{ host }}/log.txt"
+```
+
+##### New (file sink)
+
+```yaml
+sinks:
+  my_file:
+    type: file
+    path: "{{ host }}/log.txt"
+    base_dir: "/var/log/vector"
+```
+
+This will prevent writes outside `/var/log/vector`.
+
+If you want to rely on previous behavior, which is susceptible to file traversal injection attacks
+like `.host = "../../../etc/shadow"`, you may also add the `dangerously_allow_unconfined_template_resolution` parameter.
+
+##### Old (file sink)
+
+```yaml
+sinks:
+  my_file:
+    type: file
+    path: "{{ host }}/log.txt"
+```
+
+##### New (file sink)
+
+```yaml
+sinks:
+  my_file:
+    type: file
+    path: "{{ host }}/log.txt"
+    dangerously_allow_unconfined_template_resolution: true
+```
+
+#### Action needed (all affected sinks)
+
+For all affected sinks, you can add a static prefix directly to the template instead. For example, for the `aws_s3` sink:
+
+##### Old
+
+```yaml
+sinks:
+  my_s3:
+    type: aws_s3
+    bucket: my-bucket
+    key_prefix: "{{ host }}/"
+```
+
+##### New
+
+```yaml
+sinks:
+  my_s3:
+    type: aws_s3
+    bucket: my-bucket
+    key_prefix: "logs/{{ host }}/"
+```
+
+But if you want to rely on the unconfined template resolution and accept all risks that may come
+from using that you may also set the `dangerously_allow_unconfined_template_resolution` parameter.
+
+##### Old
+
+```yaml
+sinks:
+  my_s3:
+    type: aws_s3
+    bucket: my-bucket
+    key_prefix: "{{ host }}/"
+```
+
+##### New
+
+```yaml
+sinks:
+  my_s3:
+    type: aws_s3
+    bucket: my-bucket
+    key_prefix: "{{ host }}/"
+    dangerously_allow_unconfined_template_resolution: true
+```


### PR DESCRIPTION
## Summary
Adds the 0.57.0 upgrade guide covering the env var interpolation default change and template confinement for sink routing templates. Also updates the `template_confinement.breaking` changelog fragment to reflect the final set of affected sinks and behavior (axiom, opentelemetry, doris, `#` rejection in URI templates, header confinement, percent-encoded path separator rejection).

## Vector configuration
NA

## How did you test this PR?
Reviewed the rendered markdown for accuracy against the underlying changelog fragments.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

NA