### PR TITLE
chore(tls reload): wire TLS reloader into OTel and Splunk HEC sources

### DIFF
--- a/src/components/validation/runner/io.rs
+++ b/src/components/validation/runner/io.rs
@@ -165,6 +165,7 @@ pub fn spawn_grpc_server<S>(
         let server = run_grpc_server(
             listen_addr.as_socket_addr(),
             tls_settings,
+            None,
             service,
             GrpcKeepaliveConfig::default(),
             shutdown_signal,

--- a/src/sources/opentelemetry/config.rs
+++ b/src/sources/opentelemetry/config.rs
@@ -42,7 +42,7 @@ use vector_lib::{
         },
     },
     schema::Definition,
-    tls::{MaybeTlsSettings, TlsEnableableConfig},
+    tls::{MaybeTlsSettings, TlsAcceptorReloader, TlsEnableableConfig},
 };
 use vrl::value::{Kind, kind::Collection};
 
@@ -269,10 +269,14 @@ impl OpentelemetryConfig {
     }
 }
 
-#[async_trait::async_trait]
-#[typetag::serde(name = "opentelemetry")]
-impl SourceConfig for OpentelemetryConfig {
-    async fn build(&self, cx: SourceContext) -> crate::Result<Source> {
+impl OpentelemetryConfig {
+    /// Build the source serving runtime-swappable TLS acceptors for the gRPC and/or HTTP listeners.
+    pub async fn build_with_tls_reloaders(
+        &self,
+        cx: SourceContext,
+        grpc_tls_reloader: Option<TlsAcceptorReloader>,
+        http_tls_reloader: Option<TlsAcceptorReloader>,
+    ) -> crate::Result<Source> {
         let acknowledgements = cx.do_acknowledgements(self.acknowledgements);
         let events_received = register!(EventsReceived);
         let log_namespace = cx.log_namespace(self.log_namespace);
@@ -332,6 +336,7 @@ impl SourceConfig for OpentelemetryConfig {
         let grpc_source = run_grpc_server_with_routes(
             self.grpc.address,
             grpc_tls_settings,
+            grpc_tls_reloader,
             builder.routes(),
             self.grpc.keepalive.clone(),
             cx.shutdown.clone(),
@@ -361,6 +366,7 @@ impl SourceConfig for OpentelemetryConfig {
         let http_source = run_http_server(
             self.http.address,
             http_tls_settings,
+            http_tls_reloader,
             filters,
             cx.shutdown,
             self.http.keepalive.clone(),
@@ -370,6 +376,14 @@ impl SourceConfig for OpentelemetryConfig {
         });
 
         Ok(join(grpc_source, http_source).map(|_| Ok(())).boxed())
+    }
+}
+
+#[async_trait::async_trait]
+#[typetag::serde(name = "opentelemetry")]
+impl SourceConfig for OpentelemetryConfig {
+    async fn build(&self, cx: SourceContext) -> crate::Result<Source> {
+        self.build_with_tls_reloaders(cx, None, None).await
     }
 
     // TODO: appropriately handle "severity" meaning across both "severity_text" and "severity_number",

--- a/src/sources/opentelemetry/http.rs
+++ b/src/sources/opentelemetry/http.rs
@@ -41,7 +41,7 @@ use crate::{
         opentelemetry::config::{LOGS, METRICS, OpentelemetryConfig, TRACES},
         util::{add_headers, decompress_body, http::capped_body},
     },
-    tls::MaybeTlsSettings,
+    tls::{MaybeTlsSettings, TlsAcceptorReloader},
 };
 
 #[derive(Clone, Copy, Debug, Snafu)]
@@ -54,11 +54,12 @@ impl warp::reject::Reject for ApiError {}
 pub(crate) async fn run_http_server(
     address: SocketAddr,
     tls_settings: MaybeTlsSettings,
+    tls_reloader: Option<TlsAcceptorReloader>,
     filters: BoxedFilter<(Response,)>,
     shutdown: ShutdownSignal,
     keepalive_settings: KeepaliveConfig,
 ) -> crate::Result<()> {
-    let listener = tls_settings.bind(&address).await?;
+    let listener = tls_settings.bind_reloadable(&address, tls_reloader).await?;
     let routes = filters.recover(handle_rejection);
 
     info!(message = "Building HTTP server.", address = %address);

--- a/src/sources/splunk_hec/mod.rs
+++ b/src/sources/splunk_hec/mod.rs
@@ -74,7 +74,7 @@ use crate::{
     },
     serde::bool_or_struct,
     sources::util::{decompression::CappedDecoder, http::capped_body},
-    tls::{MaybeTlsSettings, TlsEnableableConfig},
+    tls::{MaybeTlsSettings, TlsAcceptorReloader, TlsEnableableConfig},
 };
 
 mod acknowledgements;
@@ -231,10 +231,19 @@ fn default_socket_address() -> SocketAddr {
     SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), 8088)
 }
 
-#[async_trait::async_trait]
-#[typetag::serde(name = "splunk_hec")]
-impl SourceConfig for SplunkConfig {
-    async fn build(&self, cx: SourceContext) -> crate::Result<super::Source> {
+impl SplunkConfig {
+    /// The source's TLS configuration, if any. Exposed so a wrapping source can build a
+    /// [`TlsAcceptorReloader`] and watch the certificate files for rotation.
+    pub const fn tls_config(&self) -> Option<&TlsEnableableConfig> {
+        self.tls.as_ref()
+    }
+
+    /// Build the source serving a runtime-swappable TLS acceptor when `tls_reloader` is set.
+    pub async fn build_with_tls_reloader(
+        &self,
+        cx: SourceContext,
+        tls_reloader: Option<TlsAcceptorReloader>,
+    ) -> crate::Result<super::Source> {
         let tls = MaybeTlsSettings::from_config(self.tls.as_ref(), true)?;
         let shutdown = cx.shutdown.clone();
         let out = cx.out.clone();
@@ -269,7 +278,7 @@ impl SourceConfig for SplunkConfig {
             )
             .or_else(finish_err);
 
-        let listener = tls.bind(&self.address).await?;
+        let listener = tls.bind_reloadable(&self.address, tls_reloader).await?;
 
         let keepalive_settings = self.keepalive.clone();
         Ok(Box::pin(async move {
@@ -298,6 +307,14 @@ impl SourceConfig for SplunkConfig {
 
             Ok(())
         }))
+    }
+}
+
+#[async_trait::async_trait]
+#[typetag::serde(name = "splunk_hec")]
+impl SourceConfig for SplunkConfig {
+    async fn build(&self, cx: SourceContext) -> crate::Result<super::Source> {
+        self.build_with_tls_reloader(cx, None).await
     }
 
     fn outputs(&self, global_log_namespace: LogNamespace) -> Vec<SourceOutput> {

--- a/src/sources/util/grpc/mod.rs
+++ b/src/sources/util/grpc/mod.rs
@@ -34,7 +34,7 @@ use tracing::Span;
 use crate::{
     internal_events::{GrpcServerRequestReceived, GrpcServerResponseSent},
     shutdown::{ShutdownSignal, ShutdownSignalToken},
-    tls::{MaybeTlsIncomingStream, MaybeTlsSettings},
+    tls::{MaybeTlsIncomingStream, MaybeTlsSettings, TlsAcceptorReloader},
 };
 use vector_lib::configurable::configurable_component;
 
@@ -356,6 +356,7 @@ where
 pub async fn run_grpc_server<S>(
     address: SocketAddr,
     tls_settings: MaybeTlsSettings,
+    tls_reloader: Option<TlsAcceptorReloader>,
     service: S,
     keepalive: GrpcKeepaliveConfig,
     shutdown: ShutdownSignal,
@@ -370,7 +371,7 @@ where
 {
     let span = Span::current();
     let (tx, rx) = tokio::sync::oneshot::channel::<ShutdownSignalToken>();
-    let listener = tls_settings.bind(&address).await?;
+    let listener = tls_settings.bind_reloadable(&address, tls_reloader).await?;
     let max_connection_lifetime = keepalive.max_connection_lifetime();
     let stream = listener
         .accept_stream()
@@ -405,13 +406,14 @@ where
 pub async fn run_grpc_server_with_routes(
     address: SocketAddr,
     tls_settings: MaybeTlsSettings,
+    tls_reloader: Option<TlsAcceptorReloader>,
     routes: Routes,
     keepalive: GrpcKeepaliveConfig,
     shutdown: ShutdownSignal,
 ) -> crate::Result<()> {
     let span = Span::current();
     let (tx, rx) = tokio::sync::oneshot::channel::<ShutdownSignalToken>();
-    let listener = tls_settings.bind(&address).await?;
+    let listener = tls_settings.bind_reloadable(&address, tls_reloader).await?;
     let max_connection_lifetime = keepalive.max_connection_lifetime();
     let stream = listener
         .accept_stream()

--- a/src/sources/vector/mod.rs
+++ b/src/sources/vector/mod.rs
@@ -220,6 +220,7 @@ impl SourceConfig for VectorConfig {
         let source = run_grpc_server_with_routes(
             self.address,
             tls_settings,
+            None,
             builder.routes(),
             self.keepalive.clone(),
             cx.shutdown,


### PR DESCRIPTION
## Summary
Wire TLS reloader into OTel and Splunk HEC sources so a reloader can be, optionally, plugged in for those sources.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.