### PR TITLE
fix(sink socket): fix regression for udp socket recovery after error (#25804)

### DIFF
--- a/src/sinks/util/datagram.rs
+++ b/src/sinks/util/datagram.rs
@@ -47,6 +47,7 @@ pub async fn send_datagrams<E: Encoder<Event, Error = vector_lib::codecs::encodi
             continue;
         }
 
+        let mut socket_error = false;
         let delivered = if let Some(chunker) = chunker {
             let data_size = bytes.len();
             match chunker.chunk(bytes.freeze()) {
@@ -55,6 +56,7 @@ pub async fn send_datagrams<E: Encoder<Event, Error = vector_lib::codecs::encodi
                     for bytes in chunks {
                         if !send_and_emit(&mut socket, &bytes, bytes_sent).await {
                             chunks_delivered = false;
+                            socket_error = true;
                             break;
                         }
                     }
@@ -68,14 +70,20 @@ pub async fn send_datagrams<E: Encoder<Event, Error = vector_lib::codecs::encodi
                     false
                 }
             }
+        } else if send_and_emit(&mut socket, &bytes.freeze(), bytes_sent).await {
+            true
         } else {
-            send_and_emit(&mut socket, &bytes.freeze(), bytes_sent).await
+            socket_error = true;
+            false
         };
 
         if delivered {
             finalizers.update_status(EventStatus::Delivered);
         } else {
             finalizers.update_status(EventStatus::Errored);
+            if socket_error {
+                return;
+            }
         }
     }
 }


### PR DESCRIPTION

## Summary
This PR restores the behavior with a configured UDP socket to rebuild the socket after detecting an error.

## Vector configuration
<!-- Include Vector configuration(s) you used to test and debug your changes. -->

## How did you test this PR?
* https://github.com/openshift/cluster-logging-operator/pull/3346
Steps:
* Deploy vector to write  UDP over socket
* Verify logs are received
* Kill the receiver multiple times
* Confirm logs are no longer received.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Closes: #25804
- This PR fixes the regression introduced by #23728

## Notes

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details on the [dd-rust-license-tool](https://crates.io/crates/dd-rust-license-tool).

