### PR TITLE
docs(rfc): separate structural validation from component build

### DIFF
--- a/rfcs/2026-07-15-split-component-build-lifecycle.md
+++ b/rfcs/2026-07-15-split-component-build-lifecycle.md
@@ -13,21 +13,24 @@ where side effects are allowed.
 ## Context
 
 - Immediate motivation: [#25161](https://github.com/vectordotdev/vector/pull/25161) fixed
-  `vector validate --no-environment` silently skipping VRL/condition errors, but needed ~540 lines
-  (`validate_env()` plus `TransformContext::key` guard clauses) to work around the lack of a clean
-  trait contract.
+  `vector validate --no-environment` silently skipping VRL/condition errors. It worked around the
+  lack of a clean trait contract by adding `validate_env()` and the stub-enrichment plumbing that
+  lets it run without a live environment (plus tests); the resulting split between `validate()` and
+  `validate_env()` is what this RFC tidies.
 - `TransformConfig` already carries two structural hooks that this RFC renames and cleans up:
   `validate()` (`src/config/transform.rs`) runs context-free structural checks (reserved output
-  names, duplicate routes, sample rates) during config compilation, and `validate_env()` runs
-  VRL/condition compilation only from `vector validate`. Because `validate()` is called with a
-  `TransformContext::default()` during compilation (`src/config/validation.rs`), transforms that
-  need real context must guard on `context.key.is_some()` and skip checks; that guard is the ~540
-  lines #25161 added. Splitting by whether a check needs the context (see Scope) lets the
-  context-free hook drop its context parameter entirely, so those guards disappear.
+  names, duplicate routes, sample rates), and `validate_env()` runs VRL/condition compilation only
+  from `vector validate`. `validate()` takes a `&TransformContext` it largely ignores; at
+  compilation it is handed a `TransformContext::default()` (`src/config/validation.rs`), and
+  context-dependent checks are relegated to `validate_env()` rather than being guarded inline. The
+  redundancy this RFC removes is therefore the unused context parameter on the structural hook and
+  the two divergent call paths, not a large block of guard clauses. Splitting by whether a check
+  needs the context (see Scope) lets the context-free hook drop its context parameter entirely.
 - `SinkConfig` has neither hook: it exposes only `build()` (`src/config/sink.rs`). `build()` already
   returns `(VectorSink, Healthcheck)`, an unstarted sink plus a deferred environment probe, and the
-  topology builder already treats `Healthcheck` as a distinct step (`run_healthchecks` gates
-  topology commit in `src/topology/running.rs`, before `spawn_diff` actually starts driving events).
+  topology builder already treats `Healthcheck` as a distinct step (`run_healthchecks` in
+  `src/topology/running.rs` awaits healthchecks before `spawn_diff` only when `require_healthy` is
+  set; otherwise it detaches them, see the healthcheck note below).
   What sinks lack is the structural phase: a way to validate config-level construction
   without also reaching the real endpoint.
 
@@ -36,9 +39,9 @@ where side effects are allowed.
 ### In scope
 
 - For `TransformConfig`: rename the two existing hooks and split them by whether they need the
-  context. `validate()` becomes `validate_structure(&self)` for context-free checks; because it no
-  longer takes a context, the `context.key.is_some()` guard clauses are removed. `validate_env()`
-  becomes `validate_with_context(&self, context)` for checks that compile against the assembled
+  context. `validate()` becomes `validate_structure(&self)` for context-free checks; it drops the
+  `&TransformContext` parameter it currently ignores. `validate_env()` becomes
+  `validate_with_context(&self, context)` for checks that compile against the assembled
   `TransformContext` (VRL programs, conditions, enrichment references), run wherever that context
   exists: `vector validate` (both modes) and startup. This is a rename and clarifying split, not new
   surface; the signatures now enforce which checks may touch the context.
@@ -70,7 +73,7 @@ where side effects are allowed.
 ## Motivation
 
 - `vector validate` has no clean way to "check VRL without starting threads." The current workaround
-  (stub enrichment tables, `validate_env()`, `context.key` guards) must be replicated per-transform.
+  (stub enrichment tables plus a separate `validate_env()` hook) must be replicated per-transform.
 - `build()` spawns background tokio tasks before a topology reload is committed. If the reload is
   rolled back, those tasks leak. This RFC establishes that such spawns belong in startup, not
   `build()`, owned by the component future so they terminate when the component is removed. Sinks
@@ -136,11 +139,12 @@ any method with external side effects is named for the construction it performs.
 //   Sinks:      build(context) -> (VectorSink, Healthcheck)   // as today
 //   Transforms: build(context) -> Transform                   // as today
 
-// Startup, unchanged. Note the rollback boundary: healthchecks run PRE-commit,
-// component start runs POST-commit.
+// Startup, unchanged.
 //   Pre-commit:
-//     Sinks:      the topology builder runs the returned Healthcheck
-//                 (per require_healthy and the enabled gates).
+//     Sinks:      the topology builder handles the returned Healthcheck. With
+//                 require_healthy=true it AWAITS it and gates commit on success;
+//                 with require_healthy=false it DETACHES it (tokio::spawn) and
+//                 proceeds, so the probe may finish after startup.
 //     Transforms: TopologyPiecesBuilder::build_transform() wires channels and
 //                 wraps the Transform into a Task.
 //   Post-commit:
@@ -149,11 +153,11 @@ any method with external side effects is named for the construction it performs.
 ```
 
 `build()` keeps its current signature for both traits, so no return-type reshaping is required. For
-transforms this renames `validate()` to `validate_structure()` (now context-free, so the
-`context.key.is_some()` guards are removed) and `validate_env()` to `validate_with_context()`. For
-sinks it is additive: a new `validate_structure()` in front of `build()`. In both cases `build()`
-gains the discipline that it does not spawn, with task transforms carved out until the
-topology-builder change lands (see Scope); this RFC does not deliver task-transform rollback safety.
+transforms this renames `validate()` to `validate_structure()` (dropping the `&TransformContext`
+parameter it currently ignores) and `validate_env()` to `validate_with_context()`. For sinks it is
+additive: a new `validate_structure()` in front of `build()`. In both cases `build()` gains the
+discipline that it does not spawn, with task transforms carved out until the topology-builder change
+lands (see Scope); this RFC does not deliver task-transform rollback safety.
 
 Existing component wiring and serialization registration are unaffected.
 
@@ -186,7 +190,7 @@ returns the raw probe future unchanged; nothing about healthcheck gating moves o
    `validate_structure` takes no context, the compilation-time call needs no context assembly, and
    config-only consumers keep their structural coverage.
 2. Migrate transforms one at a time: rename `validate()` to `validate_structure()` (dropping its
-   context parameter and any `context.key` guards) and `validate_env()` to
+   unused context parameter) and `validate_env()` to
    `validate_with_context()`, splitting any remaining context-dependent logic out of the former into
    the latter. Start with `remap` (VRL) and `filter` / `route` (conditions). Prerequisite for
    `remap`: move VRL file reading (`file:`/`files:` options) to config load time so
@@ -211,7 +215,10 @@ returns the raw probe future unchanged; nothing about healthcheck gating moves o
    given structured ownership (an abort-on-drop `JoinHandle` or an explicit cancellation signal tied
    to the component future), with a reload/removal regression test proving the task stops. A
    rolled-back reload then leaves nothing running. (Task-transform spawns such as
-   `aws_ec2_metadata`'s are excluded; see Motivation.)
+   `aws_ec2_metadata`'s are excluded; see Motivation.) When the same credentials back a healthcheck,
+   note that a `require_healthy=false` healthcheck is detached (`tokio::spawn`) and may run
+   concurrently with, or after, `run()`; the credential handle moved into `run()` must remain valid
+   for that detached probe.
    The no-spawn contract may only be claimed for sinks once the tracking issue's sink audit is
    complete: every sink that spawns in `build()` has been relocated and has a cancellation/removal
    test. Until then it is a per-migrated-sink property, not a trait-wide guarantee.
@@ -238,9 +245,10 @@ returns the raw probe future unchanged; nothing about healthcheck gating moves o
   site, including generic `ConfigBuilder` compilation, which today only has
   `TransformContext::default()`. Building the merged schema there needs the input graph and is a
   substantial change. The rejected fallback, passing a partial/default context and guarding on
-  `context.key.is_some()`, is exactly the ~540-line guard pattern #25161 added and this RFC removes.
-  The chosen split keeps context-free checks context-free (no assembly, no guards) and confines the
-  context requirement to `validate_with_context`, which only runs where the context already exists.
+  `context.key.is_some()`, is the guard pattern the current `validate()`/`validate_env()` split was
+  designed to avoid; folding both into one context-carrying method would reintroduce it. The chosen
+  split keeps context-free checks context-free (no assembly, no guards) and confines the context
+  requirement to `validate_with_context`, which only runs where the context already exists.
 
 ## Outstanding Questions
 

--- a/rfcs/2026-07-15-split-component-build-lifecycle.md
+++ b/rfcs/2026-07-15-split-component-build-lifecycle.md
@@ -182,9 +182,10 @@ Existing component wiring and serialization registration are unaffected.
 | Startup / reload (pre-commit) | `validate_structure` + `build` + `build_transform` (channel wiring) | `validate_structure` + `build`, then run or spawn the `Healthcheck` per `require_healthy` |
 | Startup / reload (post-commit) | `spawn_diff` starts the Task | `VectorSink::run` |
 
-`validate_structure` (context-free) also runs during generic `ConfigBuilder` compilation, before any
-context exists. `validate_with_context` runs in `vector validate` (both modes, against a stub
-context). It is deliberately *not* run at startup: `build()` already compiles the same VRL programs
+The table shows which validation *applies* on each path, not a fresh invocation per row.
+`validate_structure` (context-free) is executed once, owned by generic `ConfigBuilder` compilation;
+because every path above compiles the `Config` first, they inherit its result rather than re-running
+it. `validate_with_context` runs in `vector validate` (both modes, against a stub context). It is deliberately *not* run at startup: `build()` already compiles the same VRL programs
 and conditions against the real context (e.g. `filter::build` calls `condition.build`), so running
 `validate_with_context` there would double-compile and could repeat enrichment-index registration.
 This matches today's behavior, where `validate_env()` is not called at startup. Note the two paths
@@ -202,14 +203,15 @@ returns the raw probe future unchanged; nothing about healthcheck gating moves o
 
 1. Add both hooks with defaults that return `Ok(())`: `validate_structure(&self)` on both
    `SinkConfig` and `TransformConfig`, and `validate_with_context(&self, context)` on
-   `TransformConfig`. No component changes are required to compile. Wire them into every place the
-   legacy hooks run today, so no consumer loses coverage. `validate_structure` (context-free) is
-   called during generic `ConfigBuilder` compilation (`src/config/validation.rs`) as well as from
-   `vector validate` and `TopologyPiecesBuilder`; `validate_with_context` is called from
-   `vector validate` (`src/validate.rs`), matching where `validate_env()` runs today, and not at
-   startup where `build()` already compiles the same programs. Because
-   `validate_structure` takes no context, the compilation-time call needs no context assembly, and
-   config-only consumers keep their structural coverage.
+   `TransformConfig`. No component changes are required to compile. Give each hook a single owner so
+   there are no divergent call paths. `validate_structure` (context-free) is owned by generic
+   `ConfigBuilder` compilation (`src/config/validation.rs`); `vector validate` and
+   `TopologyPiecesBuilder` both consume an already-compiled `Config`, so they receive its result
+   transitively and do not re-invoke it. `validate_with_context` is owned by `vector validate`
+   (`src/validate.rs`), matching where `validate_env()` runs today; it is not run at startup because
+   `build()` already compiles the same programs. Because `validate_structure` takes no context, the
+   compilation-time call needs no context assembly, and every consumer keeps its structural coverage
+   through compilation.
 2. Migrate transforms one at a time: rename `validate()` to `validate_structure()` (dropping its
    unused context parameter) and `validate_env()` to
    `validate_with_context()`, splitting any remaining context-dependent logic out of the former into
@@ -238,14 +240,16 @@ returns the raw probe future unchanged; nothing about healthcheck gating moves o
    - `redis`, whose connection repair task is spawned transitively via `build_connection()`
      (`src/sinks/redis/sink.rs`, `src/sinks/redis/config.rs`); it is abort-on-drop today but still
      violates the strict no-spawn contract.
-   For each spawn: (a) move the worker into the sink's `run()` future so the sink owns it and it
-   terminates when the sink task is dropped; and (b) decouple the healthcheck from that worker,
-   giving the healthcheck its own short-lived resources rather than a clone of the sink's live
-   connection or refresher (see the side-effect-free healthcheck contract in Scope). Because the
-   healthcheck no longer shares the worker, a detached `require_healthy=false` probe can outlive
-   `run()` harmlessly, and there is no topology-owned lifecycle to manage. Add a reload/removal
-   regression test proving the worker stops when the sink is dropped, including the
-   detached-healthcheck case. (Task-transform spawns such as `aws_ec2_metadata`'s are excluded; see
+   For each spawn: (a) bring the worker under the sink's `run()` future using structured concurrency
+   so it actually stops when that future ends. A bare `tokio::spawn` inside `run()` stays detached
+   and would preserve the leak; instead poll the worker as a child future (e.g. in a `select!`) or
+   hold an abort-on-drop handle that is aborted/awaited during shutdown. And (b) decouple the
+   healthcheck from that worker, giving the healthcheck its own short-lived resources rather than a
+   clone of the sink's live connection or refresher (see the side-effect-free healthcheck contract in
+   Scope). Because the healthcheck no longer shares the worker, a detached `require_healthy=false`
+   probe can outlive `run()` harmlessly, and there is no topology-owned lifecycle to manage. Add
+   regression tests for both rollback and removal proving the worker stops when the sink is dropped,
+   including the detached-healthcheck case. (Task-transform spawns such as `aws_ec2_metadata`'s are excluded; see
    Motivation.) The no-spawn contract may only be claimed for sinks once the tracking issue's sink
    audit is complete: every sink that spawns directly or transitively in `build()` has been relocated
    into `run()` and decoupled from its healthcheck, with a rollback/removal test. Until then it is a
@@ -282,10 +286,14 @@ returns the raw probe future unchanged; nothing about healthcheck gating moves o
 
 - Regression coverage: add tests showing that generic config compilation, `vector validate
   --no-environment`, and startup report equivalent errors, so the split between `validate_structure`
-  and `validate_with_context` cannot silently drop a check on one path. This must cover contextual
-  validation, not only structural: `validate_with_context` compiles against stub enrichment tables
-  while startup `build()` uses real ones, so parity requires both to share the compilation helper and
-  to be tested for enrichment-dependent errors, not just VRL syntax.
+  and `validate_with_context` cannot silently drop a check on one path. Parity is defined narrowly, to
+  the checks that do not depend on real environment state: VRL/condition syntax, types, and
+  table-name resolution. It cannot extend to errors that only a real table produces:
+  `validate_with_context` compiles against stub enrichment tables (whose `add_index()` always
+  succeeds) while startup `build()` uses real ones (which can reject an index), so those
+  real-table-only errors are tested separately as surfacing during full validation/startup, not as
+  parity with `--no-environment`. Both paths should still share one compilation helper so the
+  parity-scoped checks cannot drift.
 - Task-transform rollback safety (deferring `TaskTransform::transform()` to post-commit) is left to
   a follow-up; see Future Improvements. Should it block removing the migration's task-transform
   carve-out, or ship independently?

--- a/rfcs/2026-07-15-split-component-build-lifecycle.md
+++ b/rfcs/2026-07-15-split-component-build-lifecycle.md
@@ -1,0 +1,275 @@
+# RFC - Separate Structural Validation from Component Build
+
+Component config traits conflate two concerns in a single `build()` method: pure structural
+validation (safe to run any time, including under `vector validate --no-environment`) and
+side-effecting construction (resolving credentials, opening clients, building healthcheck probes).
+This is most acute for `TransformConfig`, but the same shape of problem exists for `SinkConfig`.
+This RFC introduces environment-free validation hooks alongside the existing `build()`: a shared
+`validate_structure()` for context-free checks, plus (for transforms) a `validate_with_context()`
+for checks that compile against the schema/enrichment context. `vector validate` can then check
+configuration without touching the environment, and `build()` has a clear contract: it is the phase
+where side effects are allowed.
+
+## Context
+
+- Immediate motivation: [#25161](https://github.com/vectordotdev/vector/pull/25161) fixed
+  `vector validate --no-environment` silently skipping VRL/condition errors, but needed ~540 lines
+  (`validate_env()` plus `TransformContext::key` guard clauses) to work around the lack of a clean
+  trait contract.
+- `TransformConfig` already carries two structural hooks that this RFC renames and cleans up:
+  `validate()` (`src/config/transform.rs`) runs context-free structural checks (reserved output
+  names, duplicate routes, sample rates) during config compilation, and `validate_env()` runs
+  VRL/condition compilation only from `vector validate`. Because `validate()` is called with a
+  `TransformContext::default()` during compilation (`src/config/validation.rs`), transforms that
+  need real context must guard on `context.key.is_some()` and skip checks; that guard is the ~540
+  lines #25161 added. Splitting by whether a check needs the context (see Scope) lets the
+  context-free hook drop its context parameter entirely, so those guards disappear.
+- `SinkConfig` has neither hook: it exposes only `build()` (`src/config/sink.rs`). `build()` already
+  returns `(VectorSink, Healthcheck)`, an unstarted sink plus a deferred environment probe, and the
+  topology builder already treats `Healthcheck` as a distinct step (`run_healthchecks` gates
+  topology commit in `src/topology/running.rs`, before `spawn_diff` actually starts driving events).
+  What sinks lack is the structural phase: a way to validate config-level construction
+  without also reaching the real endpoint.
+
+## Scope
+
+### In scope
+
+- For `TransformConfig`: rename the two existing hooks and split them by whether they need the
+  context. `validate()` becomes `validate_structure(&self)` for context-free checks; because it no
+  longer takes a context, the `context.key.is_some()` guard clauses are removed. `validate_env()`
+  becomes `validate_with_context(&self, context)` for checks that compile against the assembled
+  `TransformContext` (VRL programs, conditions, enrichment references), run wherever that context
+  exists: `vector validate` (both modes) and startup. This is a rename and clarifying split, not new
+  surface; the signatures now enforce which checks may touch the context.
+- For `SinkConfig`: add `validate_structure()` only (new; defaults to a no-op). Sinks have no
+  schema-dependent structural checks, so they do not need `validate_with_context`. Move the lexical
+  checks currently trapped in `build()` (e.g. the routing-field confinement check) into
+  `validate_structure()` so `--no-environment` catches them.
+- Establishing the contract that `build()` may have side effects but must not spawn background
+  tasks; anything that spawns moves to startup (`run()` for sinks) so a rolled-back reload leaves
+  nothing running. This contract is enforced for sinks and for migrated function/sync transforms.
+  Task transforms are the known exception: `aws_ec2_metadata` spawns from `TransformConfig::build()`
+  and others spawn from `TaskTransform::transform()`, both invoked pre-commit by
+  `TopologyPiecesBuilder::build_task_transform()`. Enforcing the contract there requires a
+  topology-builder change and is out of scope (see Motivation and Future Improvements). The contract
+  is therefore stated as "must not spawn" with task transforms explicitly carved out until that
+  change lands, rather than claimed as universally true on introduction.
+- Update `TopologyPiecesBuilder` and `vector validate` to call `validate_structure()` at the right
+  point for both transforms and sinks.
+- Migrate all existing transforms and sinks.
+
+### Out of scope
+
+- `SourceConfig` is deferred. `Source` is defined as `BoxFuture<'static, Result<(), ()>>`
+  (`lib/vector-core/src/source.rs`), so `build()`'s return value *is* the run loop rather than an
+  inert handle. Adding `validate_structure()` to sources is doable but a larger effort than this
+  RFC's scope; see Future Improvements.
+- Changes to user-visible configuration format or component behavior.
+
+## Motivation
+
+- `vector validate` has no clean way to "check VRL without starting threads." The current workaround
+  (stub enrichment tables, `validate_env()`, `context.key` guards) must be replicated per-transform.
+- `build()` spawns background tokio tasks before a topology reload is committed. If the reload is
+  rolled back, those tasks leak. This RFC establishes that such spawns belong in startup, not
+  `build()`, owned by the component future so they terminate when the component is removed. Sinks
+  are clean here: their `build() -> run()` boundary is genuinely post-commit, so relocating a spawn
+  such as `gcp_pubsub`'s token-regeneration task fixes the leak. Task transforms are not: their
+  spawns (whether in `build()` like `aws_ec2_metadata`'s metadata-refresh loop, or in `transform()`
+  like `throttle`'s rate-limiter flush) run pre-commit because `TopologyPiecesBuilder::build_task_transform()`
+  invokes `transform()` before commit. Fixing task-transform rollback needs a topology-builder
+  change (deferring `transform()` to post-commit) and is out of scope here.
+- Testing transform logic requires spinning up background machinery because construction and startup
+  are inseparable.
+- For sinks, `--no-environment` is all-or-nothing: `vector validate` either skips `build()` entirely
+  for every sink (no config validation beyond deserialization) or calls the real `build()`, which
+  today also resolves real credentials and constructs a live `Healthcheck` future
+  (e.g. `src/sinks/http/config.rs`, `src/sinks/kafka/config.rs`). There is no way to validate a
+  sink's config-level construction (auth parsing, encoder setup, lexical checks) without also being
+  able to reach the real endpoint.
+- [#25840](https://github.com/vectordotdev/vector/issues/25840) is a concrete, currently-open
+  instance of this gap. The routing-field template confinement check is purely lexical (no I/O), but
+  it lives in `SinkConfig::build()` (e.g. `src/sinks/aws_s3/config.rs`), so `--no-environment` skips
+  it and a confinement-violating config is only caught at real boot.
+
+## Proposal
+
+### User Experience
+
+No change to configuration format or component behavior. The one observable difference is stricter
+validation: `vector validate --no-environment` now runs `validate_structure` for sinks, so configs
+with structural errors (e.g. the routing-field confinement check) that previously passed
+`--no-environment` and only failed at boot will now be rejected earlier. This is a correctness
+improvement, but it means a config that formerly passed `--no-environment` may now fail it.
+
+### Implementation
+
+The config-time phases are validation (context-free plus, for transforms, context-dependent checks)
+and build, with a strict naming rule: a `validate_` method does no external I/O and spawns no tasks
+(it may build derived in-memory state, e.g. enrichment indexes via `TableRegistry::add_index`), and
+any method with external side effects is named for the construction it performs. Startup
+(post-commit) is unchanged.
+
+```text
+// Phase 1: validation. No external I/O, no network, no spawning.
+// (May build derived in-memory state such as enrichment indexes.)
+// Split by whether a check needs the schema/enrichment context:
+
+// 1a. Context-free checks: malformed URIs, out-of-range values, duplicate keys,
+//     reserved output names. Runs everywhere, including generic config compilation.
+//   Transforms + Sinks: validate_structure(&self) -> Result<(), Vec<String>>
+//     (transforms: renamed from validate(); sinks: new, today sinks have no hook)
+
+// 1b. Context-dependent checks: VRL/condition compilation against the assembled
+//     context, whose enrichment tables may be stubs. Runs wherever that context
+//     exists: `vector validate` (both modes) and startup. Transforms only.
+//   Transforms: validate_with_context(&self, context) -> Result<(), Vec<String>>
+//     (renamed from validate_env())
+
+// Phase 2: construct the component. Side effects are allowed (resolve
+// credentials, open clients). Returns the built component and, for sinks, a
+// deferred Healthcheck probe. Must NOT spawn background tasks (enforced for
+// sinks and migrated function/sync transforms; task transforms are carved out,
+// see Scope): anything that spawns moves to startup so a rolled-back reload
+// leaves nothing running.
+//   Sinks:      build(context) -> (VectorSink, Healthcheck)   // as today
+//   Transforms: build(context) -> Transform                   // as today
+
+// Startup, unchanged. Note the rollback boundary: healthchecks run PRE-commit,
+// component start runs POST-commit.
+//   Pre-commit:
+//     Sinks:      the topology builder runs the returned Healthcheck
+//                 (per require_healthy and the enabled gates).
+//     Transforms: TopologyPiecesBuilder::build_transform() wires channels and
+//                 wraps the Transform into a Task.
+//   Post-commit:
+//     Sinks:      VectorSink::run().
+//     Transforms: spawn_diff() starts the Task.
+```
+
+`build()` keeps its current signature for both traits, so no return-type reshaping is required. For
+transforms this renames `validate()` to `validate_structure()` (now context-free, so the
+`context.key.is_some()` guards are removed) and `validate_env()` to `validate_with_context()`. For
+sinks it is additive: a new `validate_structure()` in front of `build()`. In both cases `build()`
+gains the discipline that it does not spawn, with task transforms carved out until the
+topology-builder change lands (see Scope); this RFC does not deliver task-transform rollback safety.
+
+Existing component wiring and serialization registration are unaffected.
+
+**Call sites:**
+
+| Call site | Transforms | Sinks |
+| --- | --- | --- |
+| `vector validate --no-environment` | `validate_structure` + `validate_with_context` | `validate_structure` |
+| `vector validate` (full) | `validate_structure` + `validate_with_context` + `build` | `validate_structure` + `build`, then run the returned `Healthcheck` |
+| Startup / reload (pre-commit) | `validate_structure` + `validate_with_context` + `build` + `build_transform` (channel wiring) | `validate_structure` + `build`, then run or spawn the `Healthcheck` per `require_healthy` |
+| Startup / reload (post-commit) | `spawn_diff` starts the Task | `VectorSink::run` |
+
+`validate_structure` (context-free) also runs during generic `ConfigBuilder` compilation, before any
+context exists. `validate_with_context` runs only where the assembled context is available, which is
+every path above (both `vector validate` modes build a stub context; startup builds the real one).
+
+`--skip-healthchecks` and the per-sink and global `healthcheck.enabled` gates and the configured
+timeout remain the caller's responsibility (`TopologyPiecesBuilder`), exactly as today. `build()`
+returns the raw probe future unchanged; nothing about healthcheck gating moves onto the component.
+
+**Migration:**
+
+1. Add both hooks with defaults that return `Ok(())`: `validate_structure(&self)` on both
+   `SinkConfig` and `TransformConfig`, and `validate_with_context(&self, context)` on
+   `TransformConfig`. No component changes are required to compile. Wire them into every place the
+   legacy hooks run today, so no consumer loses coverage. `validate_structure` (context-free) is
+   called during generic `ConfigBuilder` compilation (`src/config/validation.rs`) as well as from
+   `vector validate` and `TopologyPiecesBuilder`; `validate_with_context` is called wherever the
+   assembled context is built (`src/validate.rs`, `src/topology/builder.rs`). Because
+   `validate_structure` takes no context, the compilation-time call needs no context assembly, and
+   config-only consumers keep their structural coverage.
+2. Migrate transforms one at a time: rename `validate()` to `validate_structure()` (dropping its
+   context parameter and any `context.key` guards) and `validate_env()` to
+   `validate_with_context()`, splitting any remaining context-dependent logic out of the former into
+   the latter. Start with `remap` (VRL) and `filter` / `route` (conditions). Prerequisite for
+   `remap`: move VRL file reading (`file:`/`files:` options) to config load time so
+   `compile_vrl_program` never does file I/O. Until a transform is migrated, `vector validate`
+   continues calling its legacy `validate()`/`validate_env()` so no check is silently dropped during
+   the migration window.
+3. Migrate sinks one at a time: add the sink-side lexical checks (e.g. the #25840 routing-field
+   confinement check in `aws_s3`) to `validate_structure()` so `--no-environment` catches them. Note
+   that `Template::confine()` is not a pure check: it consumes the template and returns a protected
+   copy with a runtime escape checker attached, which `build()` then passes to the partitioner
+   (`src/template.rs`, `src/sinks/aws_s3/config.rs`). `validate_structure()` therefore performs a
+   preflight confinement check on a clone; `build()` must still attach confinement to the runtime
+   template. The security boundary stays in `build()`; `validate_structure()` only surfaces the
+   error earlier.
+4. Enforce the no-spawn contract on sink `build()` per component. The eager spawn is not unique to
+   `gcp_pubsub`: `spawn_regenerate_token()` is called from `build()` in at least `gcp_pubsub`,
+   `gcp_cloud_storage`, `gcp_stackdriver_logs`, `gcp_stackdriver_metrics`, and `gcp_chronicle`
+   (`src/sinks/gcp/*`, `src/sinks/gcp_chronicle/*`). Each must move into `run()`, and relocation
+   alone is not sufficient for rollback safety: `spawn_regenerate_token()` today detaches the task
+   and returns only a `watch::Receiver`, and its credential loop never observes closure
+   (`src/gcp.rs`), so the task would keep running after the sink is dropped. Each such spawn must be
+   given structured ownership (an abort-on-drop `JoinHandle` or an explicit cancellation signal tied
+   to the component future), with a reload/removal regression test proving the task stops. A
+   rolled-back reload then leaves nothing running. (Task-transform spawns such as
+   `aws_ec2_metadata`'s are excluded; see Motivation.)
+   The no-spawn contract may only be claimed for sinks once the tracking issue's sink audit is
+   complete: every sink that spawns in `build()` has been relocated and has a cancellation/removal
+   test. Until then it is a per-migrated-sink property, not a trait-wide guarantee.
+5. Remove `validate()` and `validate_env()` only after every transform has been migrated off them;
+   until then the default no-op `validate_structure()` on un-migrated transforms must not replace the
+   legacy checks. This is a blocking prerequisite, tracked per the Plan of Attack below.
+
+## Alternatives
+
+- **Keep the current approach and add more per-transform workarounds.** Already proven insufficient:
+  the fix PR added hundreds of lines of guard logic with no improvement to the trait contract.
+- **Add a separate `validate_environment` phase between `validate_structure` and `build`.** An
+  earlier draft of this RFC did exactly that. It was rejected for two reasons. First, naming: a
+  `validate_` method that resolves credentials, opens connections, and spawns a token-refresh task
+  is not validating, it is constructing; the name would lie about its side effects. Second, the
+  shared-resource problem: for sinks where the healthcheck and the sink use the same resolved client
+  (common for auth'd HTTP sinks that clone one `HttpClient` into both), splitting healthcheck
+  construction out of `build()` forces either resolving credentials twice or adding a state-transfer
+  channel to carry the resolved client from the environment phase into `build()`. Keeping healthcheck construction
+  inside `build()`, exactly as the code does today, avoids both. The genuine environment check, the
+  healthcheck probe, stays a deferred future the topology builder runs; running it is the validation.
+- **A single `validate_structure(context)` for transforms instead of the two-hook split.** This
+  would require the assembled `TransformContext` (stub enrichment plus merged schema) at every call
+  site, including generic `ConfigBuilder` compilation, which today only has
+  `TransformContext::default()`. Building the merged schema there needs the input graph and is a
+  substantial change. The rejected fallback, passing a partial/default context and guarding on
+  `context.key.is_some()`, is exactly the ~540-line guard pattern #25161 added and this RFC removes.
+  The chosen split keeps context-free checks context-free (no assembly, no guards) and confines the
+  context requirement to `validate_with_context`, which only runs where the context already exists.
+
+## Outstanding Questions
+
+- Regression coverage: add tests showing that generic config compilation, `vector validate
+  --no-environment`, and startup report equivalent structural errors, so the split between
+  `validate_structure` and `validate_with_context` cannot silently drop a check on one path.
+- Task-transform rollback safety (deferring `TaskTransform::transform()` to post-commit) is left to
+  a follow-up; see Future Improvements. Should it block removing the migration's task-transform
+  carve-out, or ship independently?
+
+## Plan Of Attack
+
+1. Add `validate_structure()` (both traits) and `validate_with_context()` (transforms) with no-op
+   defaults, and wire them into generic compilation, `vector validate`, and `TopologyPiecesBuilder`.
+   Prove the pattern with one transform (`remap`) and one sink (moving the `aws_s3` confinement
+   check).
+2. Open a tracking issue listing every transform still on `validate()`/`validate_env()` and every
+   sink with lexical checks or spawns inside `build()`; migrate them incrementally, checking each off.
+3. Remove `validate()` and `validate_env()` only after every transform on the tracking issue is
+   migrated. This is a blocking prerequisite: while any transform still relies on the legacy checks,
+   the no-op default `validate_structure()` would silently drop its VRL/condition validation.
+
+## Future Improvements
+
+- Add `validate_structure()` to `SourceConfig`. Sources have no `build()`-returns-inert-handle shape
+  today (`Source` is `BoxFuture<'static, Result<(), ()>>`, the run loop itself), so the pure-check
+  phase is the natural first step there too: some sources (e.g. `socket`) already defer all work into
+  the returned future; others (e.g. `file`) perform environment-dependent work eagerly and would
+  need that separated from their structural checks.
+- Rollback safety for task transforms: `TopologyPiecesBuilder::build_task_transform()` calls
+  `t.transform(...)` pre-commit, and some task transforms spawn there (e.g. `throttle`). Deferring
+  that invocation to post-commit is a separate change to the topology builder.

--- a/rfcs/2026-07-15-split-component-build-lifecycle.md
+++ b/rfcs/2026-07-15-split-component-build-lifecycle.md
@@ -42,9 +42,11 @@ where side effects are allowed.
   context. `validate()` becomes `validate_structure(&self)` for context-free checks; it drops the
   `&TransformContext` parameter it currently ignores. `validate_env()` becomes
   `validate_with_context(&self, context)` for checks that compile against the assembled
-  `TransformContext` (VRL programs, conditions, enrichment references), run wherever that context
-  exists: `vector validate` (both modes) and startup. This is a rename and clarifying split, not new
-  surface; the signatures now enforce which checks may touch the context.
+  `TransformContext` (VRL programs, conditions, enrichment references), run in `vector validate`
+  (both modes). At startup `build()` performs the equivalent compilation, so
+  `validate_with_context` is not run there (avoiding a double compile; see the call-site note). This
+  is a rename and clarifying split, not new surface; the signatures now enforce which checks may
+  touch the context.
 - For `SinkConfig`: add `validate_structure()` only (new; defaults to a no-op). Sinks have no
   schema-dependent structural checks, so they do not need `validate_with_context`. Move the lexical
   checks currently trapped in `build()` (e.g. the routing-field confinement check) into
@@ -125,8 +127,9 @@ any method with external side effects is named for the construction it performs.
 //     (transforms: renamed from validate(); sinks: new, today sinks have no hook)
 
 // 1b. Context-dependent checks: VRL/condition compilation against the assembled
-//     context, whose enrichment tables may be stubs. Runs wherever that context
-//     exists: `vector validate` (both modes) and startup. Transforms only.
+//     context, whose enrichment tables may be stubs. Runs in `vector validate`
+//     (both modes); at startup build() does the equivalent, so this is not
+//     re-run there. Transforms only.
 //   Transforms: validate_with_context(&self, context) -> Result<(), Vec<String>>
 //     (renamed from validate_env())
 
@@ -167,12 +170,16 @@ Existing component wiring and serialization registration are unaffected.
 | --- | --- | --- |
 | `vector validate --no-environment` | `validate_structure` + `validate_with_context` | `validate_structure` |
 | `vector validate` (full) | `validate_structure` + `validate_with_context` + `build` | `validate_structure` + `build`, then run the returned `Healthcheck` |
-| Startup / reload (pre-commit) | `validate_structure` + `validate_with_context` + `build` + `build_transform` (channel wiring) | `validate_structure` + `build`, then run or spawn the `Healthcheck` per `require_healthy` |
+| Startup / reload (pre-commit) | `validate_structure` + `build` + `build_transform` (channel wiring) | `validate_structure` + `build`, then run or spawn the `Healthcheck` per `require_healthy` |
 | Startup / reload (post-commit) | `spawn_diff` starts the Task | `VectorSink::run` |
 
 `validate_structure` (context-free) also runs during generic `ConfigBuilder` compilation, before any
-context exists. `validate_with_context` runs only where the assembled context is available, which is
-every path above (both `vector validate` modes build a stub context; startup builds the real one).
+context exists. `validate_with_context` runs in `vector validate` (both modes, against a stub
+context). It is deliberately *not* run at startup: `build()` already compiles the same VRL programs
+and conditions against the real context (e.g. `filter::build` calls `condition.build`), so running
+`validate_with_context` there would double-compile and could repeat enrichment-index registration.
+The two paths cannot diverge because both go through the same `compile_vrl_program` / `condition.build`
+routines. This matches today's behavior, where `validate_env()` is not called at startup.
 
 `--skip-healthchecks` and the per-sink and global `healthcheck.enabled` gates and the configured
 timeout remain the caller's responsibility (`TopologyPiecesBuilder`), exactly as today. `build()`
@@ -185,8 +192,9 @@ returns the raw probe future unchanged; nothing about healthcheck gating moves o
    `TransformConfig`. No component changes are required to compile. Wire them into every place the
    legacy hooks run today, so no consumer loses coverage. `validate_structure` (context-free) is
    called during generic `ConfigBuilder` compilation (`src/config/validation.rs`) as well as from
-   `vector validate` and `TopologyPiecesBuilder`; `validate_with_context` is called wherever the
-   assembled context is built (`src/validate.rs`, `src/topology/builder.rs`). Because
+   `vector validate` and `TopologyPiecesBuilder`; `validate_with_context` is called from
+   `vector validate` (`src/validate.rs`), matching where `validate_env()` runs today, and not at
+   startup where `build()` already compiles the same programs. Because
    `validate_structure` takes no context, the compilation-time call needs no context assembly, and
    config-only consumers keep their structural coverage.
 2. Migrate transforms one at a time: rename `validate()` to `validate_structure()` (dropping its
@@ -281,8 +289,13 @@ returns the raw probe future unchanged; nothing about healthcheck gating moves o
    Prove the pattern with one transform (`remap`) and one sink (moving the `aws_s3` confinement
    check).
 2. Open a tracking issue listing every transform still on `validate()`/`validate_env()` and every
-   sink with lexical checks or spawns inside `build()`; migrate them incrementally, checking each off.
-3. Remove `validate()` and `validate_env()` only after every transform on the tracking issue is
+   sink with lexical checks or with a direct/transitive spawn inside `build()`; migrate them
+   incrementally, checking each off.
+3. Complete the sink no-spawn audit as a blocking gate before declaring the RFC implemented: every
+   sink that spawns directly or transitively from `build()` (see migration step 4) has been
+   relocated into `run()` with structured ownership and a rollback/removal test. Until this gate is
+   met, the no-spawn contract is a per-migrated-sink property, not a trait-wide guarantee.
+4. Remove `validate()` and `validate_env()` only after every transform on the tracking issue is
    migrated. This is a blocking prerequisite: while any transform still relies on the legacy checks,
    the no-op default `validate_structure()` would silently drop its VRL/condition validation.
 

--- a/rfcs/2026-07-15-split-component-build-lifecycle.md
+++ b/rfcs/2026-07-15-split-component-build-lifecycle.md
@@ -60,6 +60,19 @@ where side effects are allowed.
   topology-builder change and is out of scope (see Motivation and Future Improvements). The contract
   is therefore stated as "must not spawn" with task transforms explicitly carved out until that
   change lands, rather than claimed as universally true on introduction.
+- Healthchecks are side-effect-free probes, like Kubernetes readiness/liveness probes. A component's
+  healthcheck must not share live background workers or mutable runtime state with the component; it
+  may acquire its own short-lived resources (a token, a probe connection) and must release them
+  promptly when it completes. Background workers are therefore owned by the sink inside its own
+  `run()` future and terminate when that future is dropped, so there is no topology-owned lifecycle
+  to manage even for a detached `require_healthy=false` probe. Two accepted tradeoffs: acquiring its
+  own resources means the probe validates that auth/endpoint *can* work rather than the sink's exact
+  wired client (this still catches bad credentials and unreachable endpoints); and it briefly opens
+  its own connection instead of sharing the sink's, so it must release it promptly to avoid doubling
+  connection count under constrained limits (e.g. Redis `maxclients=1`). Where a sink today couples
+  its healthcheck to live sink state (Redis clones its Sentinel repair connection into the
+  healthcheck; GCP shares a credential refresher), that coupling is a pre-existing code smell fixed
+  as part of migrating that sink.
 - Update `TopologyPiecesBuilder` and `vector validate` to call `validate_structure()` at the right
   point for both transforms and sinks.
 - Migrate all existing transforms and sinks.
@@ -229,17 +242,18 @@ returns the raw probe future unchanged; nothing about healthcheck gating moves o
    - `redis`, whose connection repair task is spawned transitively via `build_connection()`
      (`src/sinks/redis/sink.rs`, `src/sinks/redis/config.rs`); it is abort-on-drop today but still
      violates the strict no-spawn contract.
-   Each such spawn must move into `run()` and be given structured ownership (an abort-on-drop
-   `JoinHandle` or an explicit cancellation signal tied to the component future), with a
-   reload/removal regression test proving the task stops. A rolled-back reload then leaves nothing
-   running. (Task-transform spawns such as `aws_ec2_metadata`'s are excluded; see Motivation.) Where
-   the same credentials back a healthcheck, the ownership model interacts with healthcheck timing (a
-   required healthcheck runs before `run()` exists; a detached one can outlive it); that interaction
-   is called out as an Outstanding Question to resolve per sink before relocating its refresher.
-   The no-spawn contract may only be claimed for sinks once the tracking issue's sink audit is
-   complete: every sink that spawns directly or transitively in `build()` has been relocated and has
-   a cancellation/removal test. Until then it is a per-migrated-sink property, not a trait-wide
-   guarantee.
+   For each spawn: (a) move the worker into the sink's `run()` future so the sink owns it and it
+   terminates when the sink task is dropped; and (b) decouple the healthcheck from that worker,
+   giving the healthcheck its own short-lived resources rather than a clone of the sink's live
+   connection or refresher (see the side-effect-free healthcheck contract in Scope). Because the
+   healthcheck no longer shares the worker, a detached `require_healthy=false` probe can outlive
+   `run()` harmlessly, and there is no topology-owned lifecycle to manage. Add a reload/removal
+   regression test proving the worker stops when the sink is dropped, including the
+   detached-healthcheck case. (Task-transform spawns such as `aws_ec2_metadata`'s are excluded; see
+   Motivation.) The no-spawn contract may only be claimed for sinks once the tracking issue's sink
+   audit is complete: every sink that spawns directly or transitively in `build()` has been relocated
+   into `run()` and decoupled from its healthcheck, with a rollback/removal test. Until then it is a
+   per-migrated-sink property, not a trait-wide guarantee.
 5. Remove `validate()` and `validate_env()` only after every transform has been migrated off them;
    until then the default no-op `validate_structure()` on un-migrated transforms must not replace the
    legacy checks. This is a blocking prerequisite, tracked per the Plan of Attack below.
@@ -251,13 +265,13 @@ returns the raw probe future unchanged; nothing about healthcheck gating moves o
 - **Add a separate `validate_environment` phase between `validate_structure` and `build`.** An
   earlier draft of this RFC did exactly that. It was rejected for two reasons. First, naming: a
   `validate_` method that resolves credentials, opens connections, and spawns a token-refresh task
-  is not validating, it is constructing; the name would lie about its side effects. Second, the
-  shared-resource problem: for sinks where the healthcheck and the sink use the same resolved client
-  (common for auth'd HTTP sinks that clone one `HttpClient` into both), splitting healthcheck
-  construction out of `build()` forces either resolving credentials twice or adding a state-transfer
-  channel to carry the resolved client from the environment phase into `build()`. Keeping healthcheck construction
-  inside `build()`, exactly as the code does today, avoids both. The genuine environment check, the
-  healthcheck probe, stays a deferred future the topology builder runs; running it is the validation.
+  is not validating, it is constructing; the name would lie about its side effects. Second, a
+  separate phase adds machinery for no gain: `build()` already returns a self-contained `Healthcheck`
+  future that the topology builder runs, and under the side-effect-free healthcheck contract that
+  future owns its own short-lived probe resources anyway. Keeping healthcheck construction inside
+  `build()`, exactly as the `(VectorSink, Healthcheck)` shape does today, needs no state-transfer
+  channel and no extra phase. The genuine environment check, the healthcheck probe, stays a deferred
+  future the topology builder runs; running it is the validation.
 - **A single `validate_structure(context)` for transforms instead of the two-hook split.** This
   would require the assembled `TransformContext` (stub enrichment plus merged schema) at every call
   site, including generic `ConfigBuilder` compilation, which today only has
@@ -279,19 +293,6 @@ returns the raw probe future unchanged; nothing about healthcheck gating moves o
 - Task-transform rollback safety (deferring `TaskTransform::transform()` to post-commit) is left to
   a follow-up; see Future Improvements. Should it block removing the migration's task-transform
   carve-out, or ship independently?
-- Ownership model for any background resource shared between the healthcheck and the sink, not just
-  credential/token refreshers. Credential refreshers (GCP `spawn_regenerate_token`) are one case;
-  another is Redis, which builds its Sentinel connection repair task during connection construction
-  and then clones that connection into the pre-run healthcheck. In all such cases a required
-  healthcheck is awaited before `run()` starts, so a resource owned by `run()` is not yet available
-  to it; a `require_healthy=false` healthcheck is detached and can outlive `run()`, so tying the
-  resource's lifetime to the sink future either cuts the detached probe off or, if kept alive for it,
-  recreates the post-removal leak. Two candidate resolutions to pick per sink: (a) the healthcheck
-  uses only freshly acquired resources and never needs the shared worker, so the worker can be owned
-  outright by `run()`; or (b) a topology-owned lifecycle object spans both the healthcheck and the
-  sink and is cancelled on rollback/removal. The same decision must apply to every shared background
-  resource surfaced by the migration step 4 audit. Add tests for required healthchecks, detached
-  healthchecks, early sink exit, and reload rollback.
 
 ## Plan Of Attack
 

--- a/rfcs/2026-07-15-split-component-build-lifecycle.md
+++ b/rfcs/2026-07-15-split-component-build-lifecycle.md
@@ -65,14 +65,10 @@ where side effects are allowed.
   may acquire its own short-lived resources (a token, a probe connection) and must release them
   promptly when it completes. Background workers are therefore owned by the sink inside its own
   `run()` future and terminate when that future is dropped, so there is no topology-owned lifecycle
-  to manage even for a detached `require_healthy=false` probe. Two accepted tradeoffs: acquiring its
-  own resources means the probe validates that auth/endpoint *can* work rather than the sink's exact
-  wired client (this still catches bad credentials and unreachable endpoints); and it briefly opens
-  its own connection instead of sharing the sink's, so it must release it promptly to avoid doubling
-  connection count under constrained limits (e.g. Redis `maxclients=1`). Where a sink today couples
-  its healthcheck to live sink state (Redis clones its Sentinel repair connection into the
-  healthcheck; GCP shares a credential refresher), that coupling is a pre-existing code smell fixed
-  as part of migrating that sink.
+  to manage even for a detached `require_healthy=false` probe. Existing sinks that violate this
+  principle (by sharing a live worker or connection between their healthcheck and the sink) should be
+  refactored to conform, altering their healthcheck behavior if necessary so it acquires and releases
+  its own short-lived resources.
 - Update `TopologyPiecesBuilder` and `vector validate` to call `validate_structure()` at the right
   point for both transforms and sinks.
 - Migrate all existing transforms and sinks.

--- a/rfcs/2026-07-15-split-component-build-lifecycle.md
+++ b/rfcs/2026-07-15-split-component-build-lifecycle.md
@@ -178,8 +178,12 @@ context exists. `validate_with_context` runs in `vector validate` (both modes, a
 context). It is deliberately *not* run at startup: `build()` already compiles the same VRL programs
 and conditions against the real context (e.g. `filter::build` calls `condition.build`), so running
 `validate_with_context` there would double-compile and could repeat enrichment-index registration.
-The two paths cannot diverge because both go through the same `compile_vrl_program` / `condition.build`
-routines. This matches today's behavior, where `validate_env()` is not called at startup.
+This matches today's behavior, where `validate_env()` is not called at startup. Note the two paths
+are not identical: `validate_with_context` compiles against *stub* enrichment tables (whose
+`add_index()` always succeeds) while `build()` uses the *real* tables (which can reject an index), so
+they can still disagree on enrichment-dependent errors. To keep them from drifting, both must route
+through the same compilation helper, and contextual (not just structural) parity between
+`vector validate` and startup must be covered by tests (see Outstanding Questions).
 
 `--skip-healthchecks` and the per-sink and global `healthcheck.enabled` gates and the configured
 timeout remain the caller's responsibility (`TopologyPiecesBuilder`), exactly as today. `build()`
@@ -267,20 +271,27 @@ returns the raw probe future unchanged; nothing about healthcheck gating moves o
 ## Outstanding Questions
 
 - Regression coverage: add tests showing that generic config compilation, `vector validate
-  --no-environment`, and startup report equivalent structural errors, so the split between
-  `validate_structure` and `validate_with_context` cannot silently drop a check on one path.
+  --no-environment`, and startup report equivalent errors, so the split between `validate_structure`
+  and `validate_with_context` cannot silently drop a check on one path. This must cover contextual
+  validation, not only structural: `validate_with_context` compiles against stub enrichment tables
+  while startup `build()` uses real ones, so parity requires both to share the compilation helper and
+  to be tested for enrichment-dependent errors, not just VRL syntax.
 - Task-transform rollback safety (deferring `TaskTransform::transform()` to post-commit) is left to
   a follow-up; see Future Improvements. Should it block removing the migration's task-transform
   carve-out, or ship independently?
-- Credential/token-refresh lifecycle versus healthcheck timing, for sinks that share credentials
-  between the healthcheck and the sink. A required healthcheck is awaited before `run()` starts, so
-  a refresher owned by `run()` is not yet available to it; a `require_healthy=false` healthcheck is
-  detached and can outlive `run()`, so tying the refresher's lifetime to the sink future either cuts
-  the detached probe off or, if kept alive for it, recreates the post-removal leak. Two candidate
-  resolutions to pick per sink: (a) the healthcheck uses only a freshly acquired token and never
-  needs the refresher, so the refresher can be owned outright by `run()`; or (b) a topology-owned
-  lifecycle object spans both the healthcheck and the sink and is cancelled on rollback/removal. Add
-  tests for required healthchecks, detached healthchecks, early sink exit, and reload rollback.
+- Ownership model for any background resource shared between the healthcheck and the sink, not just
+  credential/token refreshers. Credential refreshers (GCP `spawn_regenerate_token`) are one case;
+  another is Redis, which builds its Sentinel connection repair task during connection construction
+  and then clones that connection into the pre-run healthcheck. In all such cases a required
+  healthcheck is awaited before `run()` starts, so a resource owned by `run()` is not yet available
+  to it; a `require_healthy=false` healthcheck is detached and can outlive `run()`, so tying the
+  resource's lifetime to the sink future either cuts the detached probe off or, if kept alive for it,
+  recreates the post-removal leak. Two candidate resolutions to pick per sink: (a) the healthcheck
+  uses only freshly acquired resources and never needs the shared worker, so the worker can be owned
+  outright by `run()`; or (b) a topology-owned lifecycle object spans both the healthcheck and the
+  sink and is cancelled on rollback/removal. The same decision must apply to every shared background
+  resource surfaced by the migration step 4 audit. Add tests for required healthchecks, detached
+  healthchecks, early sink exit, and reload rollback.
 
 ## Plan Of Attack
 

--- a/rfcs/2026-07-15-split-component-build-lifecycle.md
+++ b/rfcs/2026-07-15-split-component-build-lifecycle.md
@@ -215,10 +215,10 @@ returns the raw probe future unchanged; nothing about healthcheck gating moves o
    given structured ownership (an abort-on-drop `JoinHandle` or an explicit cancellation signal tied
    to the component future), with a reload/removal regression test proving the task stops. A
    rolled-back reload then leaves nothing running. (Task-transform spawns such as
-   `aws_ec2_metadata`'s are excluded; see Motivation.) When the same credentials back a healthcheck,
-   note that a `require_healthy=false` healthcheck is detached (`tokio::spawn`) and may run
-   concurrently with, or after, `run()`; the credential handle moved into `run()` must remain valid
-   for that detached probe.
+   `aws_ec2_metadata`'s are excluded; see Motivation.) Where the same credentials back a healthcheck,
+   the ownership model interacts with healthcheck timing (a required healthcheck runs before `run()`
+   exists; a detached one can outlive it); that interaction is called out as an Outstanding Question
+   to resolve per sink before relocating its refresher.
    The no-spawn contract may only be claimed for sinks once the tracking issue's sink audit is
    complete: every sink that spawns in `build()` has been relocated and has a cancellation/removal
    test. Until then it is a per-migrated-sink property, not a trait-wide guarantee.
@@ -258,6 +258,15 @@ returns the raw probe future unchanged; nothing about healthcheck gating moves o
 - Task-transform rollback safety (deferring `TaskTransform::transform()` to post-commit) is left to
   a follow-up; see Future Improvements. Should it block removing the migration's task-transform
   carve-out, or ship independently?
+- Credential/token-refresh lifecycle versus healthcheck timing, for sinks that share credentials
+  between the healthcheck and the sink. A required healthcheck is awaited before `run()` starts, so
+  a refresher owned by `run()` is not yet available to it; a `require_healthy=false` healthcheck is
+  detached and can outlive `run()`, so tying the refresher's lifetime to the sink future either cuts
+  the detached probe off or, if kept alive for it, recreates the post-removal leak. Two candidate
+  resolutions to pick per sink: (a) the healthcheck uses only a freshly acquired token and never
+  needs the refresher, so the refresher can be owned outright by `run()`; or (b) a topology-owned
+  lifecycle object spans both the healthcheck and the sink and is cancelled on rollback/removal. Add
+  tests for required healthchecks, detached healthchecks, early sink exit, and reload rollback.
 
 ## Plan Of Attack
 

--- a/rfcs/2026-07-15-split-component-build-lifecycle.md
+++ b/rfcs/2026-07-15-split-component-build-lifecycle.md
@@ -205,23 +205,29 @@ returns the raw probe future unchanged; nothing about healthcheck gating moves o
    preflight confinement check on a clone; `build()` must still attach confinement to the runtime
    template. The security boundary stays in `build()`; `validate_structure()` only surfaces the
    error earlier.
-4. Enforce the no-spawn contract on sink `build()` per component. The eager spawn is not unique to
-   `gcp_pubsub`: `spawn_regenerate_token()` is called from `build()` in at least `gcp_pubsub`,
-   `gcp_cloud_storage`, `gcp_stackdriver_logs`, `gcp_stackdriver_metrics`, and `gcp_chronicle`
-   (`src/sinks/gcp/*`, `src/sinks/gcp_chronicle/*`). Each must move into `run()`, and relocation
-   alone is not sufficient for rollback safety: `spawn_regenerate_token()` today detaches the task
-   and returns only a `watch::Receiver`, and its credential loop never observes closure
-   (`src/gcp.rs`), so the task would keep running after the sink is dropped. Each such spawn must be
-   given structured ownership (an abort-on-drop `JoinHandle` or an explicit cancellation signal tied
-   to the component future), with a reload/removal regression test proving the task stops. A
-   rolled-back reload then leaves nothing running. (Task-transform spawns such as
-   `aws_ec2_metadata`'s are excluded; see Motivation.) Where the same credentials back a healthcheck,
-   the ownership model interacts with healthcheck timing (a required healthcheck runs before `run()`
-   exists; a detached one can outlive it); that interaction is called out as an Outstanding Question
-   to resolve per sink before relocating its refresher.
+4. Enforce the no-spawn contract on sink `build()` per component. The audit must cover every task
+   spawned directly or transitively from `SinkConfig::build()`, not just one helper. Known examples
+   span more than the GCP sinks:
+   - `spawn_regenerate_token()`, called from `build()` in at least `gcp_pubsub`, `gcp_cloud_storage`,
+     `gcp_stackdriver_logs`, `gcp_stackdriver_metrics`, and `gcp_chronicle` (`src/sinks/gcp/*`,
+     `src/sinks/gcp_chronicle/*`). It detaches the task and returns only a `watch::Receiver`, and its
+     credential loop never observes closure (`src/gcp.rs`), so the task outlives a dropped sink.
+   - `datadog_traces`, which starts the APM stats flush thread during `build()`
+     (`src/sinks/datadog/traces/config.rs`).
+   - `redis`, whose connection repair task is spawned transitively via `build_connection()`
+     (`src/sinks/redis/sink.rs`, `src/sinks/redis/config.rs`); it is abort-on-drop today but still
+     violates the strict no-spawn contract.
+   Each such spawn must move into `run()` and be given structured ownership (an abort-on-drop
+   `JoinHandle` or an explicit cancellation signal tied to the component future), with a
+   reload/removal regression test proving the task stops. A rolled-back reload then leaves nothing
+   running. (Task-transform spawns such as `aws_ec2_metadata`'s are excluded; see Motivation.) Where
+   the same credentials back a healthcheck, the ownership model interacts with healthcheck timing (a
+   required healthcheck runs before `run()` exists; a detached one can outlive it); that interaction
+   is called out as an Outstanding Question to resolve per sink before relocating its refresher.
    The no-spawn contract may only be claimed for sinks once the tracking issue's sink audit is
-   complete: every sink that spawns in `build()` has been relocated and has a cancellation/removal
-   test. Until then it is a per-migrated-sink property, not a trait-wide guarantee.
+   complete: every sink that spawns directly or transitively in `build()` has been relocated and has
+   a cancellation/removal test. Until then it is a per-migrated-sink property, not a trait-wide
+   guarantee.
 5. Remove `validate()` and `validate_env()` only after every transform has been migrated off them;
    until then the default no-op `validate_structure()` on un-migrated transforms must not replace the
    legacy checks. This is a blocking prerequisite, tracked per the Plan of Attack below.

--- a/rfcs/2026-07-15-split-component-build-lifecycle.md
+++ b/rfcs/2026-07-15-split-component-build-lifecycle.md
@@ -167,7 +167,7 @@ the same VRL/conditions at startup, so running it again there would double-compi
 enrichment-index registration. Note: `validate_with_context` compiles against stub enrichment tables
 (whose `add_index()` always succeeds) while `build()` uses the real ones (which can reject an
 index), so they can disagree on enrichment-dependent errors; both must share the same compilation
-helper (see Outstanding Questions).
+helper.
 
 `--skip-healthchecks` and the per-sink and global `healthcheck.enabled` gates and the configured
 timeout remain the caller's responsibility (`TopologyPiecesBuilder`), exactly as today. `build()`
@@ -202,14 +202,13 @@ returns the raw probe future unchanged; nothing about healthcheck gating moves o
 
 **Migration for transforms:**
 
-1. Add `validate_structure(&self)` and `validate_with_context(&self, context)` to `TransformConfig`
-   with default `Ok(())`. Wire `validation.rs` to call `validate_structure()` and call `validate()`
-   alongside it during the migration window. Wire `validate.rs` to call `validate_with_context()`
-   alongside `validate_env()`. `validate_structure` is owned by `ConfigBuilder` compilation;
-   `validate_with_context` is owned by `vector validate`, matching where `validate_env()` runs today.
+1. Add `validate_structure(&self)` to `TransformConfig` with default `Ok(())`. Wire `validation.rs`
+   to call it alongside `validate()` during the migration window. `validate_structure` is owned by
+   `ConfigBuilder` compilation.
 2. Rename `validate_env()` to `validate_with_context()` in a single PR: update the trait default,
    the one call site in `validate.rs`, and all implementors. Signatures are identical so no
-   migration window is needed.
+   migration window is needed. `validate_with_context` is owned by `vector validate`, matching
+   where `validate_env()` runs today.
 3. Migrate `validate()` to `validate_structure()` one transform at a time. The signature drops
    `&TransformContext`, so this cannot be a straight rename. Six transforms implement `validate()`
    with real logic (`route`, `throttle`, `reduce`, `exclusive_route`, `delay`, `sample`): move the

--- a/rfcs/2026-07-15-split-component-build-lifecycle.md
+++ b/rfcs/2026-07-15-split-component-build-lifecycle.md
@@ -13,26 +13,14 @@ where side effects are allowed.
 ## Context
 
 - Immediate motivation: [#25161](https://github.com/vectordotdev/vector/pull/25161) fixed
-  `vector validate --no-environment` silently skipping VRL/condition errors. It worked around the
-  lack of a clean trait contract by adding `validate_env()` and the stub-enrichment plumbing that
-  lets it run without a live environment (plus tests); the resulting split between `validate()` and
-  `validate_env()` is what this RFC tidies.
-- `TransformConfig` already carries two structural hooks that this RFC renames and cleans up:
-  `validate()` (`src/config/transform.rs`) runs context-free structural checks (reserved output
-  names, duplicate routes, sample rates), and `validate_env()` runs VRL/condition compilation only
-  from `vector validate`. `validate()` takes a `&TransformContext` it largely ignores; at
-  compilation it is handed a `TransformContext::default()` (`src/config/validation.rs`), and
-  context-dependent checks are relegated to `validate_env()` rather than being guarded inline. The
-  redundancy this RFC removes is therefore the unused context parameter on the structural hook and
-  the two divergent call paths, not a large block of guard clauses. Splitting by whether a check
-  needs the context (see Scope) lets the context-free hook drop its context parameter entirely.
-- `SinkConfig` has neither hook: it exposes only `build()` (`src/config/sink.rs`). `build()` already
-  returns `(VectorSink, Healthcheck)`, an unstarted sink plus a deferred environment probe, and the
-  topology builder already treats `Healthcheck` as a distinct step (`run_healthchecks` in
-  `src/topology/running.rs` awaits healthchecks before `spawn_diff` only when `require_healthy` is
-  set; otherwise it detaches them, see the healthcheck note below).
-  What sinks lack is the structural phase: a way to validate config-level construction
-  without also reaching the real endpoint.
+  `vector validate --no-environment` silently skipping VRL/condition errors by adding `validate_env()`
+  and stub-enrichment plumbing. The resulting split between `validate()` (context-free, ignores its
+  `&TransformContext` parameter) and `validate_env()` (VRL/condition compilation) is what this RFC
+  cleans up.
+- `TransformConfig` already has both hooks; this RFC renames them and formalizes the split by
+  whether a check needs the context. `SinkConfig` has neither: it exposes only `build()`, which
+  returns `(VectorSink, Healthcheck)`. What sinks lack is a structural phase that validates
+  config-level construction without reaching the real endpoint.
 
 ## Scope
 
@@ -142,26 +130,16 @@ any method with external side effects is named for the construction it performs.
 //   Transforms: validate_with_context(&self, context) -> Result<(), Vec<String>>
 //     (renamed from validate_env())
 
-// Phase 2: construct the component. Side effects are allowed (resolve
-// credentials, open clients). Returns the built component and, for sinks, a
-// deferred Healthcheck probe. Must NOT spawn background tasks (enforced for
-// sinks and migrated function/sync transforms; task transforms are carved out,
-// see Scope): anything that spawns moves to startup so a rolled-back reload
-// leaves nothing running.
+// Phase 2: construct the component. Side effects are allowed (resolve credentials, open
+// clients). Must NOT spawn background tasks (task transforms excepted, see Scope):
+// spawns move to startup so a rolled-back reload leaves nothing running.
 //   Sinks:      build(context) -> (VectorSink, Healthcheck)   // as today
 //   Transforms: build(context) -> Transform                   // as today
 
 // Startup, unchanged.
-//   Pre-commit:
-//     Sinks:      the topology builder handles the returned Healthcheck. With
-//                 require_healthy=true it AWAITS it and gates commit on success;
-//                 with require_healthy=false it DETACHES it (tokio::spawn) and
-//                 proceeds, so the probe may finish after startup.
-//     Transforms: TopologyPiecesBuilder::build_transform() wires channels and
-//                 wraps the Transform into a Task.
-//   Post-commit:
-//     Sinks:      VectorSink::run().
-//     Transforms: spawn_diff() starts the Task.
+//   Pre-commit:  topology builder runs Healthcheck (awaited if require_healthy; detached
+//                otherwise). TopologyPiecesBuilder::build_transform() wires channels.
+//   Post-commit: VectorSink::run() / spawn_diff() starts the Task.
 ```
 
 `build()` keeps its current signature for both traits, so no return-type reshaping is required. For
@@ -183,80 +161,17 @@ Existing component wiring and serialization registration are unaffected.
 | Startup / reload (post-commit) | `spawn_diff` starts the Task | `VectorSink::run` |
 
 The table shows which validation *applies* on each path, not a fresh invocation per row.
-`validate_structure` (context-free) is executed once, owned by generic `ConfigBuilder` compilation;
-because every path above compiles the `Config` first, they inherit its result rather than re-running
-it. `validate_with_context` runs in `vector validate` (both modes, against a stub context). It is deliberately *not* run at startup: `build()` already compiles the same VRL programs
-and conditions against the real context (e.g. `filter::build` calls `condition.build`), so running
-`validate_with_context` there would double-compile and could repeat enrichment-index registration.
-This matches today's behavior, where `validate_env()` is not called at startup. Note the two paths
-are not identical: `validate_with_context` compiles against *stub* enrichment tables (whose
-`add_index()` always succeeds) while `build()` uses the *real* tables (which can reject an index), so
-they can still disagree on enrichment-dependent errors. To keep them from drifting, both must route
-through the same compilation helper, and contextual (not just structural) parity between
-`vector validate` and startup must be covered by tests (see Outstanding Questions).
+`validate_structure` is owned by generic `ConfigBuilder` compilation; all paths inherit its result
+transitively. `validate_with_context` runs in `vector validate` only: `build()` already compiles
+the same VRL/conditions at startup, so running it again there would double-compile and could repeat
+enrichment-index registration. Note: `validate_with_context` compiles against stub enrichment tables
+(whose `add_index()` always succeeds) while `build()` uses the real ones (which can reject an
+index), so they can disagree on enrichment-dependent errors; both must share the same compilation
+helper (see Outstanding Questions).
 
 `--skip-healthchecks` and the per-sink and global `healthcheck.enabled` gates and the configured
 timeout remain the caller's responsibility (`TopologyPiecesBuilder`), exactly as today. `build()`
 returns the raw probe future unchanged; nothing about healthcheck gating moves onto the component.
-
-**Migration:**
-
-1. Add both hooks with defaults that return `Ok(())`: `validate_structure(&self)` on both
-   `SinkConfig` and `TransformConfig`, and `validate_with_context(&self, context)` on
-   `TransformConfig`. No component changes are required to compile. Give each hook a single owner so
-   there are no divergent call paths. `validate_structure` (context-free) is owned by generic
-   `ConfigBuilder` compilation (`src/config/validation.rs`); `vector validate` and
-   `TopologyPiecesBuilder` both consume an already-compiled `Config`, so they receive its result
-   transitively and do not re-invoke it. `validate_with_context` is owned by `vector validate`
-   (`src/validate.rs`), matching where `validate_env()` runs today; it is not run at startup because
-   `build()` already compiles the same programs. Because `validate_structure` takes no context, the
-   compilation-time call needs no context assembly, and every consumer keeps its structural coverage
-   through compilation.
-2. Migrate transforms one at a time: rename `validate()` to `validate_structure()` (dropping its
-   unused context parameter) and `validate_env()` to
-   `validate_with_context()`, splitting any remaining context-dependent logic out of the former into
-   the latter. Start with `remap` (VRL) and `filter` / `route` (conditions). Prerequisite for
-   `remap`: move VRL file reading (`file:`/`files:` options) to config load time so
-   `compile_vrl_program` never does file I/O. Until a transform is migrated, `vector validate`
-   continues calling its legacy `validate()`/`validate_env()` so no check is silently dropped during
-   the migration window.
-3. Migrate sinks one at a time: add the sink-side lexical checks (e.g. the #25840 routing-field
-   confinement check in `aws_s3`) to `validate_structure()` so `--no-environment` catches them. Note
-   that `Template::confine()` is not a pure check: it consumes the template and returns a protected
-   copy with a runtime escape checker attached, which `build()` then passes to the partitioner
-   (`src/template.rs`, `src/sinks/aws_s3/config.rs`). `validate_structure()` therefore performs a
-   preflight confinement check on a clone; `build()` must still attach confinement to the runtime
-   template. The security boundary stays in `build()`; `validate_structure()` only surfaces the
-   error earlier.
-4. Enforce the no-spawn contract on sink `build()` per component. The audit must cover every task
-   spawned directly or transitively from `SinkConfig::build()`, not just one helper. Known examples
-   span more than the GCP sinks:
-   - `spawn_regenerate_token()`, called from `build()` in at least `gcp_pubsub`, `gcp_cloud_storage`,
-     `gcp_stackdriver_logs`, `gcp_stackdriver_metrics`, and `gcp_chronicle` (`src/sinks/gcp/*`,
-     `src/sinks/gcp_chronicle/*`). It detaches the task and returns only a `watch::Receiver`, and its
-     credential loop never observes closure (`src/gcp.rs`), so the task outlives a dropped sink.
-   - `datadog_traces`, which starts the APM stats flush thread during `build()`
-     (`src/sinks/datadog/traces/config.rs`).
-   - `redis`, whose connection repair task is spawned transitively via `build_connection()`
-     (`src/sinks/redis/sink.rs`, `src/sinks/redis/config.rs`); it is abort-on-drop today but still
-     violates the strict no-spawn contract.
-   For each spawn: (a) bring the worker under the sink's `run()` future using structured concurrency
-   so it actually stops when that future ends. A bare `tokio::spawn` inside `run()` stays detached
-   and would preserve the leak; instead poll the worker as a child future (e.g. in a `select!`) or
-   hold an abort-on-drop handle that is aborted/awaited during shutdown. And (b) decouple the
-   healthcheck from that worker, giving the healthcheck its own short-lived resources rather than a
-   clone of the sink's live connection or refresher (see the side-effect-free healthcheck contract in
-   Scope). Because the healthcheck no longer shares the worker, a detached `require_healthy=false`
-   probe can outlive `run()` harmlessly, and there is no topology-owned lifecycle to manage. Add
-   regression tests for both rollback and removal proving the worker stops when the sink is dropped,
-   including the detached-healthcheck case. (Task-transform spawns such as `aws_ec2_metadata`'s are excluded; see
-   Motivation.) The no-spawn contract may only be claimed for sinks once the tracking issue's sink
-   audit is complete: every sink that spawns directly or transitively in `build()` has been relocated
-   into `run()` and decoupled from its healthcheck, with a rollback/removal test. Until then it is a
-   per-migrated-sink property, not a trait-wide guarantee.
-5. Remove `validate()` and `validate_env()` only after every transform has been migrated off them;
-   until then the default no-op `validate_structure()` on un-migrated transforms must not replace the
-   legacy checks. This is a blocking prerequisite, tracked per the Plan of Attack below.
 
 ## Alternatives
 
@@ -282,38 +197,47 @@ returns the raw probe future unchanged; nothing about healthcheck gating moves o
   split keeps context-free checks context-free (no assembly, no guards) and confines the context
   requirement to `validate_with_context`, which only runs where the context already exists.
 
-## Outstanding Questions
-
-- Regression coverage: add tests showing that generic config compilation, `vector validate
-  --no-environment`, and startup report equivalent errors, so the split between `validate_structure`
-  and `validate_with_context` cannot silently drop a check on one path. Parity is defined narrowly, to
-  the checks that do not depend on real environment state: VRL/condition syntax, types, and
-  table-name resolution. It cannot extend to errors that only a real table produces:
-  `validate_with_context` compiles against stub enrichment tables (whose `add_index()` always
-  succeeds) while startup `build()` uses real ones (which can reject an index), so those
-  real-table-only errors are tested separately as surfacing during full validation/startup, not as
-  parity with `--no-environment`. Both paths should still share one compilation helper so the
-  parity-scoped checks cannot drift.
-- Task-transform rollback safety (deferring `TaskTransform::transform()` to post-commit) is left to
-  a follow-up; see Future Improvements. Should it block removing the migration's task-transform
-  carve-out, or ship independently?
 
 ## Plan Of Attack
 
-1. Add `validate_structure()` (both traits) and `validate_with_context()` (transforms) with no-op
-   defaults, and wire them into generic compilation, `vector validate`, and `TopologyPiecesBuilder`.
-   Prove the pattern with one transform (`remap`) and one sink (moving the `aws_s3` confinement
-   check).
-2. Open a tracking issue listing every transform still on `validate()`/`validate_env()` and every
-   sink with lexical checks or with a direct/transitive spawn inside `build()`; migrate them
-   incrementally, checking each off.
-3. Complete the sink no-spawn audit as a blocking gate before declaring the RFC implemented: every
-   sink that spawns directly or transitively from `build()` (see migration step 4) has been
-   relocated into `run()` with structured ownership and a rollback/removal test. Until this gate is
-   met, the no-spawn contract is a per-migrated-sink property, not a trait-wide guarantee.
-4. Remove `validate()` and `validate_env()` only after every transform on the tracking issue is
-   migrated. This is a blocking prerequisite: while any transform still relies on the legacy checks,
-   the no-op default `validate_structure()` would silently drop its VRL/condition validation.
+**Migration for transforms:**
+
+1. Add `validate_structure(&self)` and `validate_with_context(&self, context)` to `TransformConfig`
+   with default `Ok(())`. Wire `validation.rs` to call `validate_structure()` and call `validate()`
+   alongside it during the migration window. Wire `validate.rs` to call `validate_with_context()`
+   alongside `validate_env()`. `validate_structure` is owned by `ConfigBuilder` compilation;
+   `validate_with_context` is owned by `vector validate`, matching where `validate_env()` runs today.
+2. Rename `validate_env()` to `validate_with_context()` in a single PR: update the trait default,
+   the one call site in `validate.rs`, and all implementors. Signatures are identical so no
+   migration window is needed.
+3. Migrate `validate()` to `validate_structure()` one transform at a time. The signature drops
+   `&TransformContext`, so this cannot be a straight rename. Six transforms implement `validate()`
+   with real logic (`route`, `throttle`, `reduce`, `exclusive_route`, `delay`, `sample`): move the
+   body to `validate_structure()` and override `validate()` to `Ok(())`. All other transforms hit
+   the default and need no override -- only add `validate_structure()` if there are structural checks
+   to pull from elsewhere (e.g. `remap`'s source/file/files exclusivity check buried in
+   `compile_vrl_program`; prerequisite: move VRL file reading to config load time so
+   `compile_vrl_program` never does I/O). Open a tracking issue listing every transform to migrate
+   and check them off incrementally. Once all are done, remove `validate()` from the call sites and
+   then from the trait.
+
+**Migration for sinks:**
+
+1. Add `validate_structure(&self)` to `SinkConfig` with default `Ok(())`. Wire `validation.rs` to
+   call it. Migrate lexical checks out of `build()` one sink at a time (e.g. the
+   [#25840](https://github.com/vectordotdev/vector/issues/25840) routing-field confinement check in
+   `aws_s3`). Where a check is not a pure predicate (e.g. `Template::confine()` consumes its input
+   and returns a protected copy), `validate_structure()` runs the check on a clone; `build()` still
+   attaches the real runtime guard.
+2. Enforce the no-spawn contract on sink `build()` per component. The audit must cover every task
+   spawned directly or transitively from `SinkConfig::build()`. Examples: the GCP sinks
+   (via `spawn_regenerate_token()`), `datadog_traces` (APM stats flush thread), and `redis`
+   (connection repair task via `build_connection()`). Track the full list in a dedicated tracking
+   issue. For each spawn: (a) bring the worker under the sink's `run()` future using structured
+   concurrency (poll it in a `select!` or hold an abort-on-drop handle) so it stops when that
+   future ends; and (b) decouple the healthcheck so the probe acquires and releases its own
+   short-lived resources. Add regression tests for rollback and removal. The no-spawn contract may
+   only be claimed trait-wide once every sink in the tracking issue has been migrated.
 
 ## Future Improvements
 

--- a/rfcs/2026-07-15-split-component-build-lifecycle.md
+++ b/rfcs/2026-07-15-split-component-build-lifecycle.md
@@ -36,7 +36,7 @@ where side effects are allowed.
   is a rename and clarifying split, not new surface; the signatures now enforce which checks may
   touch the context.
 - For `SinkConfig`: add `validate_structure()` only (new; defaults to a no-op). Sinks have no
-  schema-dependent structural checks, so they do not need `validate_with_context`. Move the lexical
+  no VRL/condition compilation checks, so they do not need `validate_with_context`. Move the lexical
   checks currently trapped in `build()` (e.g. the routing-field confinement check) into
   `validate_structure()` so `--no-environment` catches them.
 - Establishing the contract that `build()` may have side effects but must not spawn background
@@ -67,7 +67,7 @@ where side effects are allowed.
   (`lib/vector-core/src/source.rs`), so `build()`'s return value *is* the run loop rather than an
   inert handle. Adding `validate_structure()` to sources is doable but a larger effort than this
   RFC's scope; see Future Improvements.
-- Changes to user-visible configuration format or component behavior.
+- Changes to user-visible configuration format.
 
 ## Motivation
 
@@ -99,7 +99,7 @@ where side effects are allowed.
 
 ### User Experience
 
-No change to configuration format or component behavior. The one observable difference is stricter
+No change to configuration format. The one observable difference is stricter
 validation: `vector validate --no-environment` now runs `validate_structure` for sinks, so configs
 with structural errors (e.g. the routing-field confinement check) that previously passed
 `--no-environment` and only failed at boot will now be rejected earlier. This is a correctness
@@ -210,15 +210,12 @@ returns the raw probe future unchanged; nothing about healthcheck gating moves o
    migration window is needed. `validate_with_context` is owned by `vector validate`, matching
    where `validate_env()` runs today.
 3. Migrate `validate()` to `validate_structure()` one transform at a time. The signature drops
-   `&TransformContext`, so this cannot be a straight rename. Six transforms implement `validate()`
-   with real logic (`route`, `throttle`, `reduce`, `exclusive_route`, `delay`, `sample`): move the
-   body to `validate_structure()` and override `validate()` to `Ok(())`. All other transforms hit
-   the default and need no override -- only add `validate_structure()` if there are structural checks
-   to pull from elsewhere (e.g. `remap`'s source/file/files exclusivity check buried in
-   `compile_vrl_program`; prerequisite: move VRL file reading to config load time so
-   `compile_vrl_program` never does I/O). Open a tracking issue listing every transform to migrate
-   and check them off incrementally. Once all are done, remove `validate()` from the call sites and
-   then from the trait.
+   `&TransformContext`, so this cannot be a straight rename. Transforms with real `validate()` logic
+   need the full move-and-override treatment; all others only need `validate_structure()` added if
+   they have structural checks hidden elsewhere (e.g. buried in `build()`). Open a tracking issue
+   covering all affected transforms -- including those with no `validate()` but with pure checks in
+   `build()` -- and check them off incrementally. Once all are done, remove `validate()` from the
+   call sites and then from the trait.
 
 **Migration for sinks:**
 


### PR DESCRIPTION
## Summary

Adds an RFC proposing a two-phase separation of structural validation from component build across `TransformConfig` and `SinkConfig`.

**Motivation:** `build()` conflates context-free structural checks (safe to run under `vector validate --no-environment`) with side-effecting construction (credentials, clients, healthcheck probes). This blocks `--no-environment` from catching config-level errors in sinks, and allows background tasks spawned in `build()` to leak on topology reload rollback.

**Design:**

- `validate_structure(&self)` — context-free checks (no I/O, no spawning). Owned by `ConfigBuilder` compilation; all call sites inherit the result transitively.
- `validate_with_context(&self, context)` — transforms only; compiles VRL/conditions against the assembled `TransformContext`. Mechanical rename of existing `validate_env()`.
- `build()` — unchanged signature; gains a no-spawn contract (task transforms excepted until a separate topology-builder change).
- Healthchecks — side-effect-free probes (like Kubernetes readiness/liveness probes); must not share live workers with the component.

**Scope:** `TransformConfig` and `SinkConfig`. `SourceConfig` deferred to future work.


[Rendered
](https://github.com/vectordotdev/vector/blob/pront-rfc-split-transform-lifecycle/rfcs/2026-07-15-split-component-build-lifecycle.md)

## Vector configuration

N/A — no configuration format changes.

## How did you test this PR?

RFC only — no code changes.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.