### PR TITLE
chore(releasing): remove deprecation changelog fragment type

### DIFF
--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -47,7 +47,6 @@ Filename rules:
 
 - `breaking`: A change that is incompatible with prior versions which requires users to make adjustments.
 - `security`: A change that is has implications for security.
-- `deprecation`: A change that is introducing a deprecation.
 - `feature`: A change that is introducing a new feature.
 - `enhancement`: A change that is enhancing existing functionality in a user perceivable way.
 - `fix`: A change that is fixing a bug.

--- a/scripts/check_changelog_fragments.sh
+++ b/scripts/check_changelog_fragments.sh
@@ -9,7 +9,7 @@ CHANGELOG_DIR="changelog.d"
 
 # NOTE: If these are altered, update both the 'changelog.d/README.md' and
 #       'vdev/src/commands/release/generate_cue.rs' accordingly.
-FRAGMENT_TYPES="breaking|security|deprecation|feature|enhancement|fix"
+FRAGMENT_TYPES="breaking|security|feature|enhancement|fix"
 
 if [ ! -d "${CHANGELOG_DIR}" ]; then
   echo "No ./${CHANGELOG_DIR} found. This tool must be invoked from the root of the repo."

--- a/vdev/src/commands/release/generate_cue.rs
+++ b/vdev/src/commands/release/generate_cue.rs
@@ -409,7 +409,7 @@ fn parse_changelog_fragment(path: &Path) -> Result<ChangelogEntry> {
     let fragment_type = parts[1];
     let breaking = fragment_type == "breaking";
     let cue_type = match fragment_type {
-        "breaking" | "deprecation" => "chore",
+        "breaking" => "chore",
         "security" | "fix" => "fix",
         "feature" => "feat",
         "enhancement" => "enhancement",


### PR DESCRIPTION
## Summary
Removes the `deprecation` changelog fragment type from `changelog.d/README.md`, `scripts/check_changelog_fragments.sh`, and `vdev/src/commands/release/generate_cue.rs`.

## Vector configuration
NA

## How did you test this PR?
Ran `cargo check -p vdev` to confirm the mapping change compiles.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Non-functional (chore, refactoring, docs)
- [ ] Dependencies
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

NA