### PR TITLE
fix(ci): retry test runner image pull on transient ghcr.io failures

### DIFF
--- a/.github/actions/pull-test-runner/action.yml
+++ b/.github/actions/pull-test-runner/action.yml
@@ -26,5 +26,16 @@ runs:
         REMOTE_IMAGE="ghcr.io/${{ github.repository }}/test-runner:${{ inputs.commit_sha }}"
         LOCAL_IMAGE="vector-test-runner-${RUST_VERSION}:latest"
 
-        docker pull "${REMOTE_IMAGE}"
+        for attempt in 1 2 3; do
+          if docker pull "${REMOTE_IMAGE}"; then
+            break
+          fi
+          if [[ "${attempt}" == 3 ]]; then
+            echo "::error::Failed to pull ${REMOTE_IMAGE} after ${attempt} attempts"
+            exit 1
+          fi
+          echo "Pull failed (attempt ${attempt}/3), retrying in 10s..."
+          sleep 10
+        done
+
         docker tag "${REMOTE_IMAGE}" "${LOCAL_IMAGE}"

--- a/.github/actions/pull-test-runner/action.yml
+++ b/.github/actions/pull-test-runner/action.yml
@@ -26,16 +26,18 @@ runs:
         REMOTE_IMAGE="ghcr.io/${{ github.repository }}/test-runner:${{ inputs.commit_sha }}"
         LOCAL_IMAGE="vector-test-runner-${RUST_VERSION}:latest"
 
-        for attempt in 1 2 3; do
+        max_attempts=7
+        for attempt in $(seq 1 "${max_attempts}"); do
           if docker pull "${REMOTE_IMAGE}"; then
             break
           fi
-          if [[ "${attempt}" == 3 ]]; then
+          if [[ "${attempt}" == "${max_attempts}" ]]; then
             echo "::error::Failed to pull ${REMOTE_IMAGE} after ${attempt} attempts"
             exit 1
           fi
-          echo "Pull failed (attempt ${attempt}/3), retrying in 10s..."
-          sleep 10
+          backoff=$((2 ** (attempt - 1)))
+          echo "Pull failed (attempt ${attempt}/${max_attempts}), retrying in ${backoff}s..."
+          sleep "${backoff}"
         done
 
         docker tag "${REMOTE_IMAGE}" "${LOCAL_IMAGE}"


### PR DESCRIPTION
## Summary
`docker pull` of the test runner image occasionally fails with a transient `ghcr.io` EOF error, failing the entire integration/e2e job (~15+ min) for an unrelated network blip. Retry the pull up to 3 times with a 10s backoff before failing the step.

## Vector configuration
NA

## How did you test this PR?
`/ci-run-integration-all`

https://github.com/vectordotdev/vector/actions/runs/29451787238?pr=25851
## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: https://github.com/vectordotdev/vector/actions/runs/29435369040/job/87422233332