### PR TITLE
docs(secrets, release): sync secret backend docs and release notes feedback into website branch

### DIFF
--- a/website/content/en/docs/reference/configuration/secrets.md
+++ b/website/content/en/docs/reference/configuration/secrets.md
@@ -5,10 +5,36 @@ weight: 8
 show_toc: true
 ---
 
-This page documents the configuration for Vector's secrets management.
-
-Secrets allow you to securely store and reference sensitive configuration values like API keys, passwords, and tokens without exposing them in plaintext configuration files.
-
 {{< config-cross-links group="secrets" >}}
+
+Secrets management lets you keep sensitive configuration values like API keys, passwords, and tokens out of your Vector configuration files. Instead of writing a secret's plaintext value directly into a config option, you configure a secret backend and reference the secret with `SECRET[<backend name>.<secret name>]`. Vector resolves these references by querying the backend when it loads the configuration, before any other config processing happens.
+
+This is the recommended way to supply secrets to Vector, in preference to [environment variable interpolation](/docs/reference/environment_variables/). Unlike environment variables, secret values are never written to the Vector process's environment, so they can't leak to anyone with access to `/proc/<PID>/environ` or similar. Note that, like environment variable interpolation, secret resolution substitutes the retrieved value directly into the configuration text before it's parsed, so a secret value containing YAML/TOML syntax can still alter the parsed configuration; only pull secrets from backends and paths you trust.
+
+## Usage
+
+Configure one or more backends under the top-level `secret` option, then reference secrets from that backend anywhere in your configuration using the `SECRET[<backend name>.<secret name>]` syntax:
+
+```yaml
+secret:
+  backend_1:
+    type: "exec"
+    command: ["/path/to/cmd1"]
+
+sources:
+  my_source_id:
+    type: "aws_sqs"
+    region: "us-east-1"
+    queue_url: "https://sqs.us-east-2.amazonaws.com/123456789012/MyQueue"
+    auth:
+      access_key_id: "SECRET[backend_1.aws_access_key_id]"
+      secret_access_key: "SECRET[backend_1.aws_secret_access_key]"
+```
+
+Here, `auth.access_key_id` and `auth.secret_access_key` are resolved using secrets named `aws_access_key_id` and `aws_secret_access_key`, retrieved from the `backend_1` secret backend. You can reference the same backend from multiple places in your configuration, and you can configure multiple backends if you need to pull secrets from more than one source.
+
+The backend name portion supports only letters, digits, and `_`; backend names containing `-` aren't addressable from a `SECRET[...]` reference ([known issue](https://github.com/vectordotdev/vector/issues/25849)), even though `-` is otherwise a valid character in a backend's component ID. The secret name portion is more permissive and supports `.`, `-`, and `/` characters, so backends that key secrets hierarchically (such as the `directory` backend, below) can be referenced like `SECRET[backend_1.nested/secret_name]`.
+
+Text that matches the `SECRET[<backend name>.<secret name>]` grammar but can't be resolved — for example, because the backend doesn't recognize the requested secret name, returns an error, or returns an empty value — causes Vector to log the error and exit during configuration loading. Secrets are never partially applied. Text that doesn't match the grammar at all, for example a backend name containing `-`, is left in the configuration as a literal string instead, with no resolution error.
 
 {{< config/group group="secrets" >}}

--- a/website/content/en/docs/reference/environment_variables.md
+++ b/website/content/en/docs/reference/environment_variables.md
@@ -9,6 +9,13 @@ By default, environment variable interpolation is disabled (the default changed 
 `--dangerously-allow-env-var-interpolation` to the `vector` CLI, or set the environment variable
 `VECTOR_DANGEROUSLY_ALLOW_ENV_VAR_INTERPOLATION=true`.
 
+{{< warning >}}
+Environment variables can be read by any user that is able to read `/proc/<PID>/environ` (or similar
+in other operating systems) of
+the running Vector process, regardless of whether interpolation is enabled. Operators are
+advised not to include sensitive data in environment variables and are encouraged to use the
+[secrets backend](/docs/reference/configuration/secrets/) instead.
+{{< /warning >}}
 
 ## Usage
 
@@ -89,7 +96,9 @@ environment variable example.
 ## Security Restrictions
 
 Environment variable interpolation is disabled by default. Only enable it
-with `--dangerously-allow-env-var-interpolation` if you fully control every environment variable accessible to the Vector process.
+with `--dangerously-allow-env-var-interpolation` if you fully control every environment variable accessible
+to the Vector process and accept that environment variables may leak to users that have access to
+the Vector process.
 
 Even when enabled, Vector prevents some security issues related to environment variable interpolation by rejecting environment variables that contain newline
 characters. This also prevents injection of multi-line configuration blocks.
@@ -99,7 +108,9 @@ Vector does not validate or escape other characters in interpolated values. Valu
 Operators are responsible for controlling the content of interpolated environment variables.
 
 If you need to inject multi-line configuration blocks, use a config pre-processing step with a tool like `envsubst`.
-This approach gives you more control over the configuration and allows you to inspect the result before passing it to Vector:
+This approach gives you more control over the configuration and allows you to inspect the result before passing it to Vector.
+Note that `envsubst` only expands plain `$VAR` and `${VAR}` references; it does not understand Vector's extended syntax
+such as `${VAR:-default}` or `${VAR:?err}`, which are passed through unchanged.
 
 ```shell
 # config_template.yaml

--- a/website/content/en/highlights/2026-07-14-0-57-0-upgrade-guide.md
+++ b/website/content/en/highlights/2026-07-14-0-57-0-upgrade-guide.md
@@ -38,6 +38,19 @@ vector --config vector.yaml
 vector --config vector.yaml --dangerously-allow-env-var-interpolation
 ```
 
+If you'd rather not carry the `--dangerously-allow-env-var-interpolation` flag, you can keep your existing
+`${VAR}`-based configs by interpolating them yourself with a pre-processing tool such as [`envsubst`](https://man7.org/linux/man-pages/man1/envsubst.1.html)
+before handing the result to Vector. Note that `envsubst` only expands plain `$VAR` and `${VAR}` references; it
+does not understand Vector's extended syntax such as `${VAR:-default}` or `${VAR:?error}`, which will be passed
+through unchanged. See the [environment variables reference](/docs/reference/environment_variables/#security-restrictions)
+for more details.
+
+If you're using environment variable interpolation specifically to inject secrets (API keys, passwords, tokens), the
+[secrets backend](/docs/reference/configuration/secrets/) is the recommended replacement rather than
+`envsubst` or the `--dangerously-allow-env-var-interpolation` flag. It retrieves secrets from a dedicated
+provider (file, exec, AWS Secrets Manager, etc.) at load time instead of relying on process environment
+variables.
+
 ### Template confinement for sink routing templates {#template-confinement}
 
 Sinks that accept `{{ field }}` references in routing templates (for example, object keys, file paths, HTTP headers, or table/stream names) now enforce a confinement boundary: the rendered value must stay within the literal prefix declared in the template. Templates with no literal prefix (e.g. `key_prefix: "{{ host }}/"`) are rejected at startup. The `file` sink is the only exception: its `base_dir` config field can provide an explicit confinement root for `path` templates with no usable literal prefix.
@@ -45,6 +58,35 @@ Sinks that accept `{{ field }}` references in routing templates (for example, ob
 This affects the following sinks: `aws_s3`, `azure_blob`, `gcp_cloud_storage`, `webhdfs`, `file`, `elasticsearch`, `kafka`, `http`, `axiom`, `opentelemetry`, `splunk_hec_logs`, `splunk_hec_metrics`, `humio_logs`, `humio_metrics`, `loki`, `clickhouse`, `doris`, `redis`, `amqp`, `pulsar`, `mqtt`, `nats`, `greptimedb_logs`, `aws_cloudwatch_logs`, `gcp_stackdriver_logs`, and `prometheus_remote_write`.
 
 HTTP-family sinks have additional restrictions on URI and header templates to prevent request smuggling.
+
+Templates are confined as soon as they have a literal prefix. For example, a `kafka` sink with `topic: "logs-{{ log_topic }}"`
+is already confined by the `logs-` prefix and requires no changes. The confinement check will fail on fully dynamic templates
+like `topic: "{{ log_topic }}"`. To fix or restore the previous behavior, consult the "Action needed" sections below.
+
+To verify your configuration after upgrading, run `vector validate` as it builds each sink as part of validation.
+An unconfined template will make the command fail validation. Due to [a known issue](https://github.com/vectordotdev/vector/issues/25840),
+`vector validate --no-environment` skips this check; drop the flag if you want confinement errors to be caught.
+
+For example, a `kafka` sink with `topic: "{{ log_topic }}"` fails validation:
+
+```shell
+$ vector validate /tmp/vector_test_unconfined.yaml
+√ Loaded ["/tmp/vector_test_unconfined.yaml"]
+√ Transforms configuration
+
+Component errors
+----------------
+x Sink "kafka_out": template references event fields (["log_topic"]) but has no literal string prefix to derive a confinement base from. Add a static prefix to your template, or set `dangerously_allow_unconfined_template_resolution: true` to opt out.
+```
+
+While `topic: "logs-{{ log_topic }}"` passes:
+
+```shell
+$ vector validate /tmp/vector_test_confined.yaml
+√ Loaded ["/tmp/vector_test_confined.yaml"]
+√ Transforms configuration
+√ Component configuration
+```
 
 Watch the `component_errors_total{error_type="confinement_failed"}` metric after upgrading; it increments (and the offending event is dropped) whenever a rendered template value falls outside its confinement boundary at runtime.
 

--- a/website/content/en/highlights/2026-07-14-0-57-0-upgrade-guide.md
+++ b/website/content/en/highlights/2026-07-14-0-57-0-upgrade-guide.md
@@ -76,7 +76,7 @@ sinks:
 
 This will prevent writes outside `/var/log/vector`.
 
-If you want to rely on previous behavior, which is susceptible to file traversal injection attacks
+If you want to rely on the previous behavior, which is susceptible to file traversal injection attacks
 like `.host = "../../../etc/shadow"`, you may also add the `dangerously_allow_unconfined_template_resolution` parameter.
 
 ##### Old (file sink)
@@ -122,8 +122,8 @@ sinks:
     key_prefix: "logs/{{ host }}/"
 ```
 
-But if you want to rely on the unconfined template resolution and accept all risks that may come
-from using that you may also set the `dangerously_allow_unconfined_template_resolution` parameter.
+To keep the unconfined behavior and accept the associated risks, set the
+`dangerously_allow_unconfined_template_resolution` parameter instead.
 
 ##### Old
 

--- a/website/cue/reference/releases/0.57.0.cue
+++ b/website/cue/reference/releases/0.57.0.cue
@@ -20,6 +20,10 @@ releases: "0.57.0": {
 		  `dangerously_allow_unconfined_template_resolution: true` to opt out.
 		"""
 
+	known_issues: [
+		"`vector validate --no-environment` doesn't catch unconfined routing templates (see the template confinement breaking change above) ([#25840](https://github.com/vectordotdev/vector/issues/25840)); run `vector validate` without that flag to catch confinement issues before startup.",
+	]
+
 	changelog: [
 		{
 			type: "fix"

--- a/website/cue/reference/releases/0.57.0.cue
+++ b/website/cue/reference/releases/0.57.0.cue
@@ -143,7 +143,7 @@ releases: "0.57.0": {
 				Fixed the `logstash` source to ACK only completed writer windows rather than
 				sometimes emitting a partial ACK before the window is complete. While partial
 				ACKs are permitted by the official protocol spec and cause no problems for the
-				reference `go-lumber` client in Beats, they appears to confuse proxies that
+				reference `go-lumber` client in Beats, they appear to confuse proxies that
 				assume there will only be one ACK per window, causing errors on subsequent
 				batches.
 				"""#
@@ -257,7 +257,7 @@ releases: "0.57.0": {
 		{
 			type: "fix"
 			description: #"""
-				The `logstash` source now caps the size of compressed frame payloads. Previously, the 32-bit payload size field of a compressed (`C`) frame was read straight from the wire and used to reserve a buffer, so a 6-byte malformed frame advertising a multi-gigabyte size could trigger an allocation large enough to abort the process. The size of the decompressed output is now 100MiB by default and can be configured by `--max-decompressed-size-bytes` or `VECTOR_MAX_DECOMPRESSED_SIZE_BYTES`. Oversized frames are rejected as a decode error.
+				The `logstash` source now caps the size of compressed frame payloads. Previously, the 32-bit payload size field of a compressed (`C`) frame was read straight from the wire and used to reserve a buffer, so a 6-byte malformed frame advertising a multi-gigabyte size could trigger an allocation large enough to abort the process. The size of the decompressed output is now 100 MiB by default and can be configured by `--max-decompressed-size-bytes` or `VECTOR_MAX_DECOMPRESSED_SIZE_BYTES`. Oversized frames are rejected as a decode error.
 				"""#
 			contributors: ["thomasqueirozb"]
 		},
@@ -303,7 +303,7 @@ releases: "0.57.0": {
 		{
 			type: "fix"
 			description: #"""
-				Sources that can decompress potentially untrusted input now cap compressed and decompressed payload sizes, preventing a small compressed payload (e.g. a gzip/zlib/zstd bomb) from allocating unbounded memory and OOM-killing the Vector process. The decompressed-output cap defaults to 100MiB and can be configured via `--max-decompressed-size-bytes` or `VECTOR_MAX_DECOMPRESSED_SIZE_BYTES`. Affected sources: `http_server`, `heroku_logs`, `prometheus_pushgateway`, `prometheus_remote_write`, `datadog_agent`, `splunk_hec`, `aws_kinesis_firehose`, `fluent`, `logstash`, `vector`, and `opentelemetry` (both its HTTP and gRPC modes). The `datadog_agent`, `splunk_hec`, and `aws_kinesis_firehose` sources additionally now cap the size of the raw (compressed) request body they buffer in memory before decompression, matching `http_server` and `opentelemetry`; oversized requests are rejected with `413 Payload Too Large` instead of being read into memory unbounded. Relatedly, zstd decoders across all affected sources now also bound the decoder's internal window allocation, derived from the decompressed-size cap (and for HTTP-based sources, additionally clamped to the 8 MB ceiling suggested by RFC 9659), so a crafted frame can no longer declare a large `Window_Size` and drive a big allocation before the cap has a chance to trip.
+				Sources that can decompress potentially untrusted input now cap compressed and decompressed payload sizes, preventing a small compressed payload (e.g. a gzip/zlib/zstd bomb) from allocating unbounded memory and OOM-killing the Vector process. The decompressed-output cap defaults to 100 MiB and can be configured via `--max-decompressed-size-bytes` or `VECTOR_MAX_DECOMPRESSED_SIZE_BYTES`. Affected sources: `http_server`, `heroku_logs`, `prometheus_pushgateway`, `prometheus_remote_write`, `datadog_agent`, `splunk_hec`, `aws_kinesis_firehose`, `fluent`, `logstash`, `vector`, and `opentelemetry` (both its HTTP and gRPC modes). The `datadog_agent`, `splunk_hec`, and `aws_kinesis_firehose` sources additionally now cap the size of the raw (compressed) request body they buffer in memory before decompression, matching `http_server` and `opentelemetry`; oversized requests are rejected with `413 Payload Too Large` instead of being read into memory unbounded. Relatedly, zstd decoders across all affected sources now also bound the decoder's internal window allocation, derived from the decompressed-size cap (and for HTTP-based sources, additionally clamped to the 8 MB ceiling suggested by RFC 9659), so a crafted frame can no longer declare a large `Window_Size` and drive a big allocation before the cap has a chance to trip.
 				"""#
 			contributors: ["thomasqueirozb"]
 		},
@@ -337,7 +337,7 @@ releases: "0.57.0": {
 				mode that can reduce memory usage for high-cardinality tag values compared to
 				`mode: exact`. Instead of storing the full tag-value strings, only a 64 bit fingerprint hash of
 				each value is kept. The trade-off is that throughput is slightly impacted due to extra hashing
-				operations, and there is technically a (unlikely) chance of collisions at very high cardinalities
+				operations, and there is a small (unlikely) chance of collisions at very high cardinalities.
 				"""#
 			contributors: ["ArunPiduguDD"]
 		},


### PR DESCRIPTION
## Summary
Bring the following commits from master onto the website branch:
- docs(secrets, release): document secret backend usage and link from env var / release notes (#25847)
- docs(releasing): address 0.57.0 release notes review feedback (#25838)

## Vector configuration
NA

## How did you test this PR?
NA

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

NA