### PR TITLE
chore(ci): bundle minor dependabot bumps into ecosystem groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,71 +22,128 @@ updates:
       amq:
         patterns:
           - "amq-*"
+        update-types:
+          - "patch"
+          - "minor"
       aws:
         patterns:
           - "aws-*"
+        update-types:
+          - "patch"
+          - "minor"
       azure:
         patterns:
           - "azure_*"
+        update-types:
+          - "patch"
+          - "minor"
       clap:
         patterns:
           - "clap*"
+        update-types:
+          - "patch"
+          - "minor"
       crossbeam:
         patterns:
           - "crossbeam*"
+        update-types:
+          - "patch"
+          - "minor"
       csv:
         patterns:
           - "csv*"
+        update-types:
+          - "patch"
+          - "minor"
       futures:
         patterns:
           - "futures"
           - "futures-util"
+        update-types:
+          - "patch"
+          - "minor"
       metrics:
         patterns:
           - "metrics"
           - "metrics-tracing-context"
           - "metrics-util"
+        update-types:
+          - "patch"
+          - "minor"
       netlink:
         patterns:
           - "netlink-*"
+        update-types:
+          - "patch"
+          - "minor"
       phf:
         patterns:
           - "phf*"
+        update-types:
+          - "patch"
+          - "minor"
       prost:
         patterns:
           - "prost"
           - "prost-*"
+        update-types:
+          - "patch"
+          - "minor"
       serde:
         patterns:
           - "serde"
           - "serde_*"
+        update-types:
+          - "patch"
+          - "minor"
       tokio:
         patterns:
           - "tokio"
           - "tokio-*"
+        update-types:
+          - "patch"
+          - "minor"
       tonic:
         patterns:
           - "tonic"
           - "tonic-*"
+        update-types:
+          - "patch"
+          - "minor"
       tower:
         patterns:
           - "tower"
           - "tower-*"
+        update-types:
+          - "patch"
+          - "minor"
       tracing:
         patterns:
           - "tracing"
           - "tracing-*"
+        update-types:
+          - "patch"
+          - "minor"
       wasm-bindgen:
         patterns:
           - "wasm-bindgen-*"
+        update-types:
+          - "patch"
+          - "minor"
       zstd:
         patterns:
           - "zstd*"
+        update-types:
+          - "patch"
+          - "minor"
 
       cargo-other:
         applies-to: version-updates
         patterns:
           - "*"
+        update-types:
+          - "patch"
+          - "minor"
       cargo-security:
         applies-to: security-updates
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -144,6 +144,12 @@ updates:
         update-types:
           - "patch"
           - "minor"
+      cargo-major:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "major"
       cargo-security:
         applies-to: security-updates
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -144,6 +144,8 @@ updates:
         update-types:
           - "patch"
           - "minor"
+      # Without this group, major bumps matching any group pattern are silently
+      # dropped instead of falling through to individual PRs (dependabot-core#14202).
       cargo-major:
         applies-to: version-updates
         patterns:


### PR DESCRIPTION
## Summary

Dependabot is consistently one of the top PR authors on this repo — in the last ~4.5 months it ranks #3 with 77 merged PRs, behind only the two most active human contributors ([contributor heatmap](https://vectordotdev.github.io/github-tools/vector/)). Each merged PR is a Cargo.lock commit on master, a CI run, and a review click for a maintainer.

The current config bundles patch bumps into a wildcard `patches` group, but leaves minor bumps ungrouped for named ecosystems that don't have an explicit `update-types` filter. This PR makes the grouping explicit and complete:

| Group | Covers | Result |
|---|---|---|
| `patches` | patch only, packages not matched by a named group | one PR for remaining patches |
| named groups (`aws`, `tokio`, `serde`, …) | ecosystem packages, patch + minor (named groups take precedence over `patches`) | one PR per ecosystem |
| `cargo-other` | minor only, packages not matched by a named group | one PR for remaining minors |
| `cargo-major` | all packages, major only | one PR for all major bumps |
| `cargo-security` | all packages, security updates | one PR for all security updates |

The `cargo-major` group is necessary to avoid a silent-drop bug in Dependabot ([dependabot-core#14202](https://github.com/dependabot/dependabot-core/issues/14202)): when a package matches a group pattern but its version type is excluded by `update-types`, Dependabot marks it as handled and never generates an individual PR for it. Without `cargo-major`, major bumps for packages that match any group pattern would be silently skipped.

**On revert risk:** Looking at the last 2 years, there were 2 distinct dep-bump reverts (async-nats x2, azure). Of those, 2 out of 3 revert commits never made it into a release — caught same-day or within a window with no release. The azure revert did ship in v0.46.x, but it was a manually authored bump, and the crate would have been equally identifiable inside a group PR.

## How did you test this PR?

Config-only change; no runtime behavior affected.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.