### PR TITLE
feat(website): improve release page readability

### DIFF
--- a/website/cue/reference/releases/0.57.0.cue
+++ b/website/cue/reference/releases/0.57.0.cue
@@ -21,7 +21,7 @@ releases: "0.57.0": {
 		"""
 
 	known_issues: [
-		"`vector validate --no-environment` doesn't catch unconfined routing templates (see the template confinement breaking change above) ([#25840](https://github.com/vectordotdev/vector/issues/25840)); run `vector validate` without that flag to catch confinement issues before startup.",
+		"`vector validate --no-environment` doesn't catch unconfined routing templates (see the template confinement breaking change) ([#25840](https://github.com/vectordotdev/vector/issues/25840)); run `vector validate` without that flag to catch confinement issues before startup.",
 	]
 
 	changelog: [
@@ -39,7 +39,7 @@ releases: "0.57.0": {
 				new `temperature` collector. When enabled, it emits `temperature_celsius`,
 				`temperature_max_celsius`, and `temperature_critical_celsius` gauges, each
 				tagged with the `component` label of the sensor it was read from.
-				
+
 				The collector is opt-in: add `temperature` to the `collectors` list to enable
 				it. Components that do not report a given value (for example a missing critical
 				threshold) are skipped, and environments without temperature sensors simply
@@ -169,7 +169,7 @@ releases: "0.57.0": {
 			description: #"""
 				Added a new counter metric `component_cpu_usage_ns_total` counting the CPU
 				time consumed by a transform in nanoseconds.
-				
+
 				The metric is opt-in: set `measure_cpu_usage: true` on individual transform
 				configurations to enable it. When disabled (the default), no counter is
 				registered and no per-poll clock sampling takes place.
@@ -415,7 +415,7 @@ releases: "0.57.0": {
 			type: "enhancement"
 			description: #"""
 				Improved the VRL playground UX:
-				
+
 				- Added resizable panels via draggable gutters.
 				- Added a dark/light/system theme toggle that syncs with the OS preference.
 				- Added run history persisted in localStorage, with a clear button.
@@ -436,37 +436,37 @@ releases: "0.57.0": {
 
 	vrl_changelog: #"""
 		### [0.34.0 (2026-07-13)](https://github.com/vectordotdev/vrl/releases/tag/v0.34.0)
-		
+
 		#### New Features
-		
+
 		- Added support for dynamic regex patterns in `parse_regex`, allowing variables and runtime expressions to be passed as the `pattern` argument.
-		
+
 		[PR #1809](https://github.com/vectordotdev/vrl/pull/1809) by [@thomasqueirozb](https://github.com/thomasqueirozb)
 		- Add `strict` parameter to `parse_cef` (default: `true`). When set to `false`, the function performs best-effort parsing of non-compliant CEF input, treating unescaped `=` characters within field values as literals rather than field delimiters. This improves compatibility with vendors such as Infoblox and Palo Alto Networks whose CEF output does not fully conform to the spec.
-		
+
 		[PR #1821](https://github.com/vectordotdev/vrl/pull/1821) by [@jacklongsd](https://github.com/jacklongsd)
-		
+
 		#### Enhancements
-		
+
 		- Improved performance of `parse_regex` and `parse_regex_all` by pre-computing capture group names and indices at compile time, replacing name-based hash lookups with direct index-based access at runtime.
-		
+
 		[PR #1811](https://github.com/vectordotdev/vrl/pull/1811) by [@thomasqueirozb](https://github.com/thomasqueirozb)
 		- Improved performance of `truncate` function if suffix parameter is provided.
-		
+
 		[PR #1784](https://github.com/vectordotdev/vrl/pull/1784) by [@JakubOnderka](https://github.com/JakubOnderka)
 		- Improved performance of `parse_regex_all` when using a literal regex pattern in concurrent workloads.
-		
+
 		[PR #1798](https://github.com/vectordotdev/vrl/pull/1798) by [@thomasqueirozb](https://github.com/thomasqueirozb)
-		
+
 		#### Fixes
-		
+
 		- Fixed a panic in `parse_key_value`, `parse_cef`, `decode_mime_q`, and `parse_ruby_hash` on inputs with lines ≥ 65,535 bytes. This is a workaround until [rust-bakery/nom#1867](https://github.com/rust-bakery/nom/issues/1867) is fixed.
-		
+
 		[PR #1848](https://github.com/vectordotdev/vrl/pull/1848) by [@pront](https://github.com/pront)
 		- Fixed `find`’s type definition and documentation. Previously, the function advertised its return type as an integer, but never as nullable. Now it correctly states that the function returns `null` when `value` doesn’t match `pattern`.
-		
+
 		[PR #1812](https://github.com/vectordotdev/vrl/pull/1812) by [@JakubOnderka](https://github.com/JakubOnderka)
-		
+
 		"""#
 
 	commits: [

--- a/website/layouts/releases/single.html
+++ b/website/layouts/releases/single.html
@@ -58,9 +58,7 @@
           </svg>
         </div>
         <div class="ml-6 flex flex-col m-0 space-y-1.5">
-          <span class="lg:text-lg text-base font-bold leading-tight tracking-tight">
-            Known issues
-          </span>
+          <h2 id="known-issues" class="lg:text-lg text-base font-bold leading-tight tracking-tight m-0">Known issues</h2>
           <ul class="mt-1 space-y-1">
             {{ range . }}
             <li><span>{{ . | markdownify }}</span></li>

--- a/website/layouts/releases/single.html
+++ b/website/layouts/releases/single.html
@@ -9,8 +9,8 @@
 {{ $groups := dict "enhancement" "enhancements" "feat" "new features" "fix" "bug fixes" "deprecation" "deprecations" "chore" "chore"}}
 {{ $orderedGroups := slice "feat" "enhancement" "fix" "deprecation" "chore" }}
 
-<div class="max-w-3xl md:max-w-5xl px-6 lg:px-8 mx-auto">
-  <div class="my-16">
+<div class="relative max-w-3xl lg:max-w-5xl mx-auto px-6 lg:px-8 lg:grid lg:grid-cols-5 lg:gap-8 mt-16">
+  <main id="page-content" aria-label="Release notes" class="lg:col-span-4 md:px-0 pb-32">
     <div class="mb-4 md:mb-6">
       {{ partial "breadcrumb.html" . }}
     </div>
@@ -25,6 +25,51 @@
         {{ $date }}
       </time>
     </div>
+    {{ end }}
+
+    <div class="mt-6 admonition dark:prose-dark prose rounded-xl border-3 px-3 py-3.5 lg:px-5 lg:py-4 border-blue-400">
+      <div class="flex items-center">
+        <div class="flex-shrink-0">
+          <svg class="h-6 w-6 text-blue-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+            <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"></path>
+          </svg>
+        </div>
+        <div class="ml-6 flex flex-col m-0 space-y-1.5">
+          <span class="lg:text-lg text-base font-bold leading-tight tracking-tight">
+            Upgrading Vector
+          </span>
+          <div class="tracking-tight leading-snug max-w-none">
+            When upgrading, we recommend stepping through minor versions as
+            these can each contain breaking changes while Vector is pre-1.0.
+            These breaking changes are noted in their respective upgrade
+            guides.
+          </div>
+        </div>
+      </div>
+    </div>
+
+    {{ with $release.known_issues }}
+    {{ if gt (len $release.known_issues) 0 }}
+    <div class="mt-4 admonition dark:prose-dark prose rounded-xl border-3 px-3 py-3.5 lg:px-5 lg:py-4 border-yellow-400">
+      <div class="flex items-start">
+        <div class="flex-shrink-0 mt-0.5">
+          <svg class="h-6 w-6 text-yellow-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+            <path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd"></path>
+          </svg>
+        </div>
+        <div class="ml-6 flex flex-col m-0 space-y-1.5">
+          <span class="lg:text-lg text-base font-bold leading-tight tracking-tight">
+            Known issues
+          </span>
+          <ul class="mt-1 space-y-1">
+            {{ range . }}
+            <li><span>{{ . | markdownify }}</span></li>
+            {{ end }}
+          </ul>
+        </div>
+      </div>
+    </div>
+    {{ end }}
     {{ end }}
 
     <div>
@@ -43,53 +88,6 @@
       {{ end }}
 
       {{ partial "releases/deprecations.html" (dict "version" $version) }}
-
-      <div class="mt-8">
-        <div class="admonition dark:prose-dark prose rounded-xl border-3 px-3 py-3.5 lg:px-5 lg:py-4 border-yellow-400">
-          <div class="flex items-center">
-            <div class="flex-shrink-0">
-              <svg class="h-6 w-6 text-yellow-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-                <path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd"></path>
-              </svg>
-            </div>
-            <div class="ml-6 flex flex-col m-0 space-y-1.5">
-              <span class="lg:text-lg text-base font-bold leading-tight tracking-tight">
-                Upgrading Vector
-              </span>
-              <div class="tracking-tight leading-snug max-w-none">
-                When upgrading, we recommend stepping through minor versions as
-                these can each contain breaking changes while Vector is pre-1.0.
-                These breaking changes are noted in their respective upgrade
-                guides.
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      {{ with $release.known_issues }}
-      {{ if gt (len $release.known_issues) 0 }}
-      <div class="mt-8">
-        <div class="prose dark:prose-dark max-w-none">
-          {{ partial "heading.html" (dict "text" "Known issues" "level" 2) }}
-        </div>
-
-        <div class="mt-6 flex flex-col space-y-8">
-          <div>
-            <ul class="list-disc">
-              {{ range . }}
-              <li>
-                  <span class="prose dark:prose-dark">
-                    {{ .| markdownify }}
-                  </span>
-              </li>
-              {{ end }}
-            </ul>
-          </div>
-          {{ end }}
-        </div>
-      </div>
-      {{ end }}
 
       {{ if gt (len $release.changelog) 0 }}
       <div class="mt-8">
@@ -218,6 +216,15 @@
         </div>
       </div>
     </div>
+  </main>
+
+  <div class="hidden lg:block xl:col-span-1">
+    <aside aria-label="Table of contents" class="sticky top-6">
+      <div class="pb-16">
+        <p class="uppercase font-semibold text-md dark:text-gray-200 text-gray-600 mb-3">On this page</p>
+        <div id="toc"></div>
+      </div>
+    </aside>
   </div>
 </div>
 {{ end }}

--- a/website/layouts/releases/single.html
+++ b/website/layouts/releases/single.html
@@ -58,7 +58,10 @@
           </svg>
         </div>
         <div class="ml-6 flex flex-col m-0 space-y-1.5">
-          <h2 id="known-issues" class="lg:text-lg text-base font-bold leading-tight tracking-tight m-0">Known issues</h2>
+          <a id="known-issues" aria-hidden="true"></a>
+          <span class="lg:text-lg text-base font-bold leading-tight tracking-tight">
+            Known issues
+          </span>
           <ul class="mt-1 space-y-1">
             {{ range . }}
             <li><span>{{ . | markdownify }}</span></li>

--- a/website/layouts/releases/single.html
+++ b/website/layouts/releases/single.html
@@ -51,8 +51,8 @@
     {{ with $release.known_issues }}
     {{ if gt (len $release.known_issues) 0 }}
     <div class="mt-4 admonition dark:prose-dark prose rounded-xl border-3 px-3 py-3.5 lg:px-5 lg:py-4 border-yellow-400">
-      <div class="flex items-start">
-        <div class="flex-shrink-0 mt-0.5">
+      <div class="flex items-center">
+        <div class="flex-shrink-0">
           <svg class="h-6 w-6 text-yellow-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
             <path fill-rule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clip-rule="evenodd"></path>
           </svg>


### PR DESCRIPTION
## Summary

Improves the release page layout (`website/layouts/releases/single.html`) for better user readability:

- **"Upgrading Vector" notice** moved to the very top (right below the release date) and changed from a yellow warning box to a blue info box -- it's general guidance, not a danger signal
- **"Known issues"** moved to the top (right below the upgrading notice) and changed from a plain `h2` section to a yellow warning admonition box, making it immediately visible; only rendered when non-empty
- **TOC sidebar** added using the same `lg:grid lg:grid-cols-5` layout as blog and guide pages; Tocbot auto-populates it from the page headings (Changelog, VRL Changelog, What's next, Download)

## Vector configuration

N/A -- website-only change.

## How did you test this PR?

Visually reviewed the diff against existing blog/guide page layouts which use the same grid pattern.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.