### PR TITLE
feat(releasing): add `security` as a first-class commit type

### DIFF
--- a/.github/workflows/semantic.yml
+++ b/.github/workflows/semantic.yml
@@ -19,11 +19,11 @@ jobs:
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          pattern='^(feat|fix|docs|chore|revert|enhancement|perf)(\([a-zA-Z0-9_, -]+\))?!?: .+'
+          pattern='^(feat|fix|docs|chore|revert|enhancement|perf|security)(\([a-zA-Z0-9_, -]+\))?!?: .+'
           if ! echo "$PR_TITLE" | grep -qP "$pattern"; then
             echo "PR title does not follow Conventional Commits format."
             echo "Expected: <type>(<optional scope>): <description>"
-            echo "Valid types: feat, fix, docs, chore, revert, enhancement"
+            echo "Valid types: feat, fix, docs, chore, revert, enhancement, security"
             echo "Got: $PR_TITLE"
             exit 1
           fi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12904,7 +12904,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vdev"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "anyhow",
  "cfg-if",

--- a/vdev/Cargo.toml
+++ b/vdev/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vdev"
-version = "0.3.6"
+version = "0.3.7"
 edition = "2024"
 authors = ["Vector Contributors <vector@datadoghq.com>"]
 license = "MPL-2.0"

--- a/vdev/src/commands/release/generate_cue.rs
+++ b/vdev/src/commands/release/generate_cue.rs
@@ -26,6 +26,7 @@ const ALLOWED_TYPES: &[&str] = &[
     "enhancement",
     "perf",
     "revert",
+    "security",
 ];
 
 /// Generate the release CUE file for the given new version. Returns the path that was written.
@@ -410,7 +411,8 @@ fn parse_changelog_fragment(path: &Path) -> Result<ChangelogEntry> {
     let breaking = fragment_type == "breaking";
     let cue_type = match fragment_type {
         "breaking" => "chore",
-        "security" | "fix" => "fix",
+        "security" => "security",
+        "fix" => "fix",
         "feature" => "feat",
         "enhancement" => "enhancement",
         other => bail!(
@@ -634,7 +636,7 @@ mod tests {
 
         // Sorted by filename
         let by_type: Vec<_> = entries.iter().map(|e| e.cue_type.as_str()).collect();
-        assert_eq!(by_type, vec!["feat", "chore", "fix"]);
+        assert_eq!(by_type, vec!["feat", "chore", "security"]);
 
         let feat = &entries[0];
         assert_eq!(

--- a/website/cue/reference/releases.cue
+++ b/website/cue/reference/releases.cue
@@ -1,7 +1,7 @@
 package metadata
 
 releases: {
-	#SemanticType: "chore" | "docs" | "enhancement" | "feat" | "fix" | "perf" | "status" | "deprecation" | "revert"
+	#SemanticType: "chore" | "docs" | "enhancement" | "feat" | "fix" | "perf" | "security" | "status" | "deprecation" | "revert"
 
 	#Commit: {
 		author:           string

--- a/website/cue/reference/releases/0.57.0.cue
+++ b/website/cue/reference/releases/0.57.0.cue
@@ -206,7 +206,7 @@ releases: "0.57.0": {
 			contributors: ["gwenaskell"]
 		},
 		{
-			type:     "chore"
+			type:     "security"
 			breaking: true
 			description: #"""
 				Environment variable interpolation in configuration files is now disabled by default. Previously, Vector interpolated `${VAR}` references in config files automatically. To restore the previous behavior, pass `--dangerously-allow-env-var-interpolation` (or set `VECTOR_DANGEROUSLY_ALLOW_ENV_VAR_INTERPOLATION=true`). The `--disable-env-var-interpolation` flag and `VECTOR_DISABLE_ENV_VAR_INTERPOLATION` environment variable have been removed.
@@ -353,7 +353,7 @@ releases: "0.57.0": {
 			contributors: ["ArunPiduguDD"]
 		},
 		{
-			type:     "chore"
+			type:     "security"
 			breaking: true
 			description: #"""
 				Sinks that accept `{{ field }}` references in routing templates now enforce a

--- a/website/layouts/releases/single.html
+++ b/website/layouts/releases/single.html
@@ -7,7 +7,7 @@
 {{ $release := index site.Data.docs.releases $version }}
 {{ $highlights := where (where site.RegularPages "Section" "highlights") ".Params.release" "eq" $version }}
 {{ $groups := dict "enhancement" "enhancements" "feat" "new features" "fix" "bug fixes" "security" "security fixes" "deprecation" "deprecations" "chore" "chore"}}
-{{ $orderedGroups := slice "feat" "enhancement" "security" "fix" "deprecation" "chore" }}
+{{ $orderedGroups := slice "security" "feat" "enhancement" "fix" "deprecation" "chore" }}
 
 <div class="relative max-w-3xl lg:max-w-5xl mx-auto px-6 lg:px-8 lg:grid lg:grid-cols-5 lg:gap-8 mt-16">
   <main id="page-content" aria-label="Release notes" class="lg:col-span-4 md:px-0 pb-32">

--- a/website/layouts/releases/single.html
+++ b/website/layouts/releases/single.html
@@ -6,8 +6,8 @@
 {{ $version := .File.BaseFileName }}
 {{ $release := index site.Data.docs.releases $version }}
 {{ $highlights := where (where site.RegularPages "Section" "highlights") ".Params.release" "eq" $version }}
-{{ $groups := dict "enhancement" "enhancements" "feat" "new features" "fix" "bug fixes" "deprecation" "deprecations" "chore" "chore"}}
-{{ $orderedGroups := slice "feat" "enhancement" "fix" "deprecation" "chore" }}
+{{ $groups := dict "enhancement" "enhancements" "feat" "new features" "fix" "bug fixes" "security" "security fixes" "deprecation" "deprecations" "chore" "chore"}}
+{{ $orderedGroups := slice "feat" "enhancement" "security" "fix" "deprecation" "chore" }}
 
 <div class="relative max-w-3xl lg:max-w-5xl mx-auto px-6 lg:px-8 lg:grid lg:grid-cols-5 lg:gap-8 mt-16">
   <main id="page-content" aria-label="Release notes" class="lg:col-span-4 md:px-0 pb-32">


### PR DESCRIPTION
## Summary

Closes #25821.

Adds `security` as a first-class conventional-commit type across the three places that gate PR titles and release generation:

- `semantic.yml`: `security` accepted in the PR title regex
- `generate_cue.rs`: `"security"` added to `ALLOWED_TYPES`; `.security.md` changelog fragments now emit `cue_type: "security"` (was `"fix"`)
- `releases.cue`: `"security"` added to `#SemanticType`
- `single.html`: a dedicated **Security fixes** section rendered between Enhancements and Bug fixes on release pages

Also reclassifies two 0.57.0 changelog entries (env-var interpolation disabled by default; template confinement boundary) from `chore` to `security`, as both are security-motivated changes.

## Vector configuration

N/A

## How did you test this PR?

- `cargo test -p vdev` — all 72 tests pass (updated the `.security.md` fragment test to expect `"security"` instead of `"fix"`)
- `make check-clippy` — clean

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Closes: #25821