### PR TITLE
fix(ci): allow env var interpolation in datadog-metrics e2e vector config

### DIFF
--- a/tests/e2e/datadog-metrics/config/compose.yaml
+++ b/tests/e2e/datadog-metrics/config/compose.yaml
@@ -37,6 +37,9 @@ services:
     environment:
       - FEATURES=e2e-tests-datadog
       - CONFIG_SERIES_API_VERSION
+      # The vector.yaml config uses ${CONFIG_SERIES_API_VERSION} interpolation,
+      # which is disabled by default since #25699. Opt back in for the test.
+      - VECTOR_DANGEROUSLY_ALLOW_ENV_VAR_INTERPOLATION=true
     working_dir: /home/vector
     command:
       - "/usr/bin/vector"


### PR DESCRIPTION
## Summary

The datadog-metrics e2e test regressed after #25699 disabled config env var interpolation by default. The test's `vector.yaml` relies on `series_api_version: \"\${CONFIG_SERIES_API_VERSION}\"`, so Vector failed to start (`unknown variant \`\${CONFIG_SERIES_API_VERSION}\``), never ingested, and `fakeintake-vector` returned zero series. This opts the test's Vector back into interpolation.

## Vector configuration

NA

## How did you test this PR?

Ran both matrix legs locally against the Docker stack; each starts Vector, ingests from the Agent, and validates series in fakeintake:

- `cargo vdev e2e test datadog-metrics 7.80.4-v1` — pass
- `cargo vdev e2e test datadog-metrics 7.80.4-v2` — pass

Both fail without this change (Vector will not boot).

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: #25699