### PR TITLE
feat(vdev): automate release upgrade guide from breaking fragments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8900,9 +8900,9 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
+checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
 dependencies = [
  "bitflags 2.10.0",
  "memchr",
@@ -12913,7 +12913,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vdev"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "anyhow",
  "cfg-if",

--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -7,6 +7,34 @@ The conventions used for this changelog logic follow [towncrier](https://towncri
 
 The changelog fragments are located in `changelog.d/`.
 
+## Quick start
+
+The scaffolder is the recommended workflow for all fragment types, but devs can also hand-write changelog fragments.
+
+Install `vdev`:
+
+    cargo binstall --manifest-path vdev/Cargo.toml vdev
+    # or
+    # cargo install vdev
+    # or use the prefix
+    # cargo vdev <command>
+
+Then scaffold a fragment:
+
+    vdev changelog new <type> <slug>
+
+> `vdev` fills in the filename, the required structure, and your authors line (auto-detected from `git config github.user`, `gh api user`, or a `users.noreply.github.com` email)
+
+Edit the file and validate:
+
+    vdev check changelog-fragments
+
+Examples:
+
+    vdev changelog new fix 42_kafka_ack_race
+    vdev changelog new enhancement retry_backoff_config
+    vdev changelog new breaking env_var_interpolation
+
 ## Process
 
 Fragments for un-released changes are placed in the root of this directory during PRs.
@@ -23,7 +51,7 @@ This is enforced during CI.
 To mark a PR as not requiring user-facing changelog notes, add the label 'no-changelog'.
 
 To run the same check that is run in CI to validate that your changelog fragments have
-the correct syntax, commit the fragment additions and then run `make check-changelog-fragments`.
+the correct syntax, commit the fragment additions and then run `vdev check changelog-fragments`.
 
 The format for fragments is: `<unique_name>.<fragment_type>.md`
 
@@ -61,9 +89,10 @@ as a heading in the main changelog and not the list. Instead, separate content w
 
 ### Breaking changes
 
-When using the type 'breaking' to add notes for a breaking change, these should be more verbose than
-other entries typically. It should include all details that would be relevant for the user to need
-to handle upgrading to the breaking change.
+Breaking fragments (`*.breaking.md`) carry extra structured fields (title, optional anchor, and
+`## Summary` / `## Migration` sections) so the release process can auto-generate the upgrade
+guide from them. See [Examples](#examples) below for the exact shape — or just run the
+scaffolder from [Quick start](#quick-start).
 
 ## Community Contributors
 
@@ -78,12 +107,55 @@ The process for adding this is simply to have the last line of the file be in th
 
 Do not include a leading `@` when specifying your username.
 
-## Example
+## Examples
 
-Here is an example of a changelog fragment that adds a breaking change explanation.
+### Non-breaking
 
-    $ cat changelog.d/42_very_good_words.breaking.md
-    This change is so great. It's such a great change that this sentence
-    explaining the change has to span multiple lines of text.
+`fix`, `feature`, `enhancement`, and `security` fragments are free-form markdown followed by an
+`authors:` line. The whole body becomes a single bullet in the release changelog list, so avoid
+markdown headings inside the body.
 
-    It even necessitates a line break. It is a breaking change after all.
+    $ cat changelog.d/42_kafka_ack_race.fix.md
+    Fix a race in the kafka source where offsets could be committed before acknowledgements were
+    flushed. This resurfaced under high partition rebalance frequency.
+
+    authors: some_contributor
+
+### Breaking
+
+Breaking fragments start with an H1 title (optionally with a Hugo-style `{#anchor}` for a stable
+backlink) followed by `## Summary` and `## Migration` sections. Only the `## Summary` content
+lands in the changelog list; the title, anchor, and `## Migration` body feed the
+auto-generated upgrade guide.
+
+    $ cat changelog.d/env_var_interpolation.breaking.md
+    # Environment variable interpolation disabled by default {#env-var-interpolation}
+
+    ## Summary
+
+    Environment variable interpolation in configuration files is now disabled by default.
+    The `--disable-env-var-interpolation` flag and `VECTOR_DISABLE_ENV_VAR_INTERPOLATION`
+    environment variable have been removed.
+
+    ## Migration
+
+    Pass `--dangerously-allow-env-var-interpolation` (or set
+    `VECTOR_DANGEROUSLY_ALLOW_ENV_VAR_INTERPOLATION=true`) on startup to restore the previous
+    behavior:
+
+    #### Old
+
+    ```bash
+    vector --config vector.yaml
+    ```
+
+    #### New
+
+    ```bash
+    vector --config vector.yaml --dangerously-allow-env-var-interpolation
+    ```
+
+    authors: some_contributor
+
+Put `N/A` under `## Migration` for informational-only breakers with nothing to do on the user's
+side.

--- a/vdev/Cargo.toml
+++ b/vdev/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vdev"
-version = "0.3.8"
+version = "0.3.9"
 edition = "2024"
 authors = ["Vector Contributors <vector@datadoghq.com>"]
 license = "MPL-2.0"

--- a/vdev/src/commands/changelog/mod.rs
+++ b/vdev/src/commands/changelog/mod.rs
@@ -1,0 +1,288 @@
+pub(crate) mod new;
+
+use anyhow::{Result, bail};
+
+crate::cli_subcommands! {
+    "Scaffold and inspect changelog fragments..."
+    new,
+}
+
+/// Structured view of a `*.breaking.md` fragment. Shared by the checker and the release
+/// CUE generator so both agree on what counts as title / Summary / Migration.
+#[derive(Debug)]
+pub(crate) struct BreakingSections {
+    pub title: String,
+    pub anchor: Option<String>,
+    pub summary: String,
+    pub migration: String,
+}
+
+const SUMMARY_MARKER: &str = "\n## Summary\n";
+const MIGRATION_MARKER: &str = "\n## Migration\n";
+
+/// Anchors that would collide with fixed headings emitted by the upgrade-guide renderer.
+/// Fragments may not choose these as their `{#anchor}` override, or produce them via slugify.
+pub(crate) const RESERVED_ANCHORS: &[&str] = &["vector-breaking-changes", "vector-upgrade-guide"];
+
+/// Slug rule shared by the CI checker and the release generator: lowercase ASCII alnum
+/// with `-` separators, non-empty, no leading/trailing hyphen, not a reserved name.
+pub(crate) fn is_valid_anchor(anchor: &str) -> bool {
+    !anchor.is_empty()
+        && !RESERVED_ANCHORS.contains(&anchor)
+        && !anchor.starts_with('-')
+        && !anchor.ends_with('-')
+        && anchor
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+}
+
+/// Kebab-case slugify — the derivation used when a breaking fragment omits `{#anchor}`.
+pub(crate) fn slugify(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut last_was_dash = true; // suppress leading dash
+    for c in s.chars() {
+        if c.is_ascii_alphanumeric() {
+            out.push(c.to_ascii_lowercase());
+            last_was_dash = false;
+        } else if !last_was_dash {
+            out.push('-');
+            last_was_dash = true;
+        }
+    }
+    while out.ends_with('-') {
+        out.pop();
+    }
+    out
+}
+
+/// Parse a breaking-fragment body (H1 title + `## Summary` + `## Migration`) via plain
+/// string splits. Only the H1 title, the `## Summary` header, and the `## Migration` header
+/// are mandatory; content inside each section is returned verbatim (any sub-headings the
+/// author wrote — `### Old`, `### New`, whatever — pass through untouched).
+pub(crate) fn parse_breaking_sections(body: &str) -> Result<BreakingSections> {
+    // Normalize CRLF → LF so Windows checkouts parse identically. Also pad the input so
+    // section markers like `\n## Migration\n` still match when the last section is empty
+    // and the file ends right after the header line.
+    let mut normalized = body.replace("\r\n", "\n");
+    if !normalized.ends_with('\n') {
+        normalized.push('\n');
+    }
+    let body: &str = &normalized;
+
+    // 1) File must begin with an H1 title on the first line — no leading blank lines.
+    let title_body = body
+        .strip_prefix("# ")
+        .ok_or_else(|| anyhow::anyhow!("first line must be an H1 title (`# ...`)"))?;
+    let (title_line, after_title) = title_body.split_once('\n').unwrap_or((title_body, ""));
+    let (title_text, anchor) = split_title_and_anchor(title_line);
+    let title = title_text.to_string();
+    if title.is_empty() {
+        bail!("H1 title must not be empty");
+    }
+
+    // 2) Exactly one `## Summary` and one `## Migration`, in that order.
+    if after_title.matches(SUMMARY_MARKER).count() != 1 {
+        bail!("exactly one `## Summary` section is required");
+    }
+    if after_title.matches(MIGRATION_MARKER).count() != 1 {
+        bail!("exactly one `## Migration` section is required");
+    }
+    let s_pos = after_title.find(SUMMARY_MARKER).unwrap();
+    let m_pos = after_title.find(MIGRATION_MARKER).unwrap();
+    if s_pos >= m_pos {
+        bail!("`## Summary` must come before `## Migration`");
+    }
+
+    // Reject any prose between the H1 title and `## Summary`. Someone hand-migrating an
+    // old free-form breaking fragment could carry over the previous body here and it
+    // would silently disappear from both the release CUE and the upgrade guide.
+    // Everything before Summary must be whitespace (`\n## Summary\n` starts with the
+    // leading newline, so `s_pos` includes it).
+    if let Some(prefix) = after_title.get(..s_pos)
+        && !prefix.trim().is_empty()
+    {
+        bail!(
+            "content between the title and `## Summary` is not allowed — move it into `## Summary` or `## Migration`."
+        );
+    }
+
+    let summary = after_title
+        .get(s_pos + SUMMARY_MARKER.len()..m_pos)
+        .unwrap_or("")
+        .trim()
+        .to_string();
+    let migration = after_title
+        .get(m_pos + MIGRATION_MARKER.len()..)
+        .unwrap_or("")
+        .trim()
+        .to_string();
+
+    if summary.is_empty() {
+        bail!("`## Summary` must not be empty");
+    }
+
+    Ok(BreakingSections {
+        title,
+        anchor: anchor.map(str::to_string),
+        summary,
+        migration,
+    })
+}
+
+/// Split `"Title Text {#anchor}"` into `("Title Text", Some("anchor"))`.
+/// The `{#anchor}` suffix is a `Hugo`-style attribute list; `CommonMark` treats it as
+/// plain text so we peel it off here.
+pub(crate) fn split_title_and_anchor(line: &str) -> (&str, Option<&str>) {
+    let trimmed = line.trim_end();
+    if let Some(prefix) = trimmed.strip_suffix('}')
+        && let Some(open) = prefix.rfind("{#")
+    {
+        let title = prefix.get(..open).unwrap_or("").trim();
+        let anchor = prefix.get(open + 2..).unwrap_or("");
+        return (title, Some(anchor));
+    }
+    (trimmed, None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use indoc::indoc;
+
+    #[test]
+    fn parses_full_breaking_fragment() {
+        let body = indoc! {"
+            # Env var interpolation off {#env-var}
+
+            ## Summary
+
+            Off by default now.
+
+            ## Migration
+
+            Pass the flag.
+
+            ### Old
+
+            ```bash
+            vector --config vector.yaml
+            ```
+
+            ### New
+
+            ```bash
+            vector --config vector.yaml --dangerously-allow-env-var-interpolation
+            ```
+        "};
+        let s = parse_breaking_sections(body).unwrap();
+        assert_eq!(s.title, "Env var interpolation off");
+        assert_eq!(s.anchor.as_deref(), Some("env-var"));
+        assert_eq!(s.summary, "Off by default now.");
+        assert!(s.migration.contains("### Old"));
+        assert!(s.migration.contains("### New"));
+        assert!(
+            s.migration
+                .contains("--dangerously-allow-env-var-interpolation")
+        );
+    }
+
+    #[test]
+    fn parses_minimal_fragment_without_anchor() {
+        let body = indoc! {"
+            # A change
+
+            ## Summary
+
+            Summary.
+
+            ## Migration
+        "};
+        let s = parse_breaking_sections(body).unwrap();
+        assert_eq!(s.title, "A change");
+        assert_eq!(s.anchor, None);
+        assert_eq!(s.summary, "Summary.");
+        assert_eq!(s.migration, "");
+    }
+
+    #[test]
+    fn missing_title_errors() {
+        let body = "## Summary\n\nx\n\n## Migration\n\ny\n";
+        let err = parse_breaking_sections(body).unwrap_err();
+        assert!(err.to_string().contains("H1 title"), "{err}");
+    }
+
+    #[test]
+    fn empty_title_errors() {
+        let body = "# \n\n## Summary\n\nx\n\n## Migration\n";
+        let err = parse_breaking_sections(body).unwrap_err();
+        assert!(err.to_string().contains("must not be empty"), "{err}");
+    }
+
+    #[test]
+    fn missing_summary_errors() {
+        let body = "# x\n\n## Migration\n\ny\n";
+        let err = parse_breaking_sections(body).unwrap_err();
+        assert!(err.to_string().contains("`## Summary`"), "{err}");
+    }
+
+    #[test]
+    fn missing_migration_errors() {
+        let body = "# x\n\n## Summary\n\ny\n";
+        let err = parse_breaking_sections(body).unwrap_err();
+        assert!(err.to_string().contains("`## Migration`"), "{err}");
+    }
+
+    #[test]
+    fn empty_summary_errors() {
+        let body = "# x\n\n## Summary\n\n## Migration\n";
+        let err = parse_breaking_sections(body).unwrap_err();
+        assert!(
+            err.to_string().contains("Summary` must not be empty"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn empty_migration_is_allowed() {
+        let body = "# x\n\n## Summary\n\nSummary.\n\n## Migration\n";
+        let s = parse_breaking_sections(body).unwrap();
+        assert_eq!(s.migration, "");
+    }
+
+    #[test]
+    fn migration_before_summary_errors() {
+        let body = "# x\n\n## Migration\n\ny\n\n## Summary\n\nz\n";
+        let err = parse_breaking_sections(body).unwrap_err();
+        assert!(err.to_string().contains("must come before"), "{err}");
+    }
+
+    #[test]
+    fn crlf_fragment_parses() {
+        let body = "# x\r\n\r\n## Summary\r\n\r\ny\r\n\r\n## Migration\r\n\r\nz\r\n";
+        let s = parse_breaking_sections(body).unwrap();
+        assert_eq!(s.title, "x");
+        assert_eq!(s.summary, "y");
+        assert_eq!(s.migration, "z");
+    }
+
+    #[test]
+    fn duplicate_section_marker_errors() {
+        let body = "# x\n\n## Summary\n\ny\n\n## Summary\n\nz\n\n## Migration\n";
+        let err = parse_breaking_sections(body).unwrap_err();
+        assert!(err.to_string().contains("exactly one"), "{err}");
+    }
+
+    #[test]
+    fn split_title_and_anchor_extracts_anchor() {
+        let (t, a) = split_title_and_anchor("Some Title {#my-anchor}");
+        assert_eq!(t, "Some Title");
+        assert_eq!(a, Some("my-anchor"));
+    }
+
+    #[test]
+    fn split_title_and_anchor_without_anchor() {
+        let (t, a) = split_title_and_anchor("Some Title");
+        assert_eq!(t, "Some Title");
+        assert_eq!(a, None);
+    }
+}

--- a/vdev/src/commands/changelog/new.rs
+++ b/vdev/src/commands/changelog/new.rs
@@ -1,0 +1,201 @@
+use std::fs;
+use std::process::Command;
+
+use anyhow::{Context, Result, bail};
+use indoc::formatdoc;
+
+use crate::utils::paths;
+
+const CHANGELOG_DIR: &str = "changelog.d";
+const FRAGMENT_TYPES: &[&str] = &["breaking", "security", "feature", "enhancement", "fix"];
+
+/// Placeholder written for the author line when no handle can be detected.
+/// The checker rejects fragments still containing this sentinel.
+pub(crate) const TODO_HANDLE: &str = "TODO_your_gh_handle";
+
+/// Scaffold a new changelog fragment.
+#[derive(clap::Args, Debug)]
+#[command()]
+pub struct Cli {
+    /// Fragment type.
+    #[arg(value_parser = clap::builder::PossibleValuesParser::new(FRAGMENT_TYPES))]
+    fragment_type: String,
+    /// Unique slug (used as the filename prefix, e.g. `env_var_interpolation`).
+    slug: String,
+}
+
+impl Cli {
+    pub fn exec(self) -> Result<()> {
+        validate_slug(&self.slug)?;
+
+        let repo_root = paths::find_repo_root()?;
+        let dir = repo_root.join(CHANGELOG_DIR);
+        if !dir.is_dir() {
+            bail!("{} does not exist", dir.display());
+        }
+        let file = dir.join(format!("{}.{}.md", self.slug, self.fragment_type));
+        if file.exists() {
+            bail!("{} already exists", file.display());
+        }
+
+        let author = detect_gh_handle().unwrap_or_else(|| TODO_HANDLE.to_string());
+        let content = render_template(&self.fragment_type, &author);
+        fs::write(&file, content)?;
+
+        // `git add` the new fragment so the checker (which scans `git diff --diff-filter=A`)
+        // picks it up immediately without a manual staging step. Report the failure if it
+        // happens — the file is on disk, but the checker won't see it until it's staged.
+        let status = Command::new("git")
+            .args(["add", "--"])
+            .arg(&file)
+            .status()
+            .with_context(|| format!("failed to run `git add {}`", file.display()))?;
+        if !status.success() {
+            bail!(
+                "wrote {} but `git add` failed — stage it manually before running `vdev check changelog-fragments`.",
+                file.display()
+            );
+        }
+
+        info!("Created {}", relative(&repo_root, &file).display());
+        info!("Edit the file, then run `vdev check changelog-fragments` to validate.");
+        Ok(())
+    }
+}
+
+/// A slug must be one filename component: ASCII alnum, `_`, or `-` only.
+/// Rejects path separators, `..`, absolute paths, and anything with punctuation.
+fn validate_slug(slug: &str) -> Result<()> {
+    if slug.is_empty() {
+        bail!("slug must not be empty");
+    }
+    if !slug
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+    {
+        bail!(
+            "invalid slug '{slug}': only ASCII letters, digits, '_', and '-' are allowed (got a path separator or punctuation?)"
+        );
+    }
+    Ok(())
+}
+
+fn render_template(fragment_type: &str, author: &str) -> String {
+    match fragment_type {
+        "breaking" => formatdoc! {"
+            # TODO one-line title
+
+            ## Summary
+
+            TODO one-paragraph summary that lands in the release changelog list.
+
+            ## Migration
+
+            TODO how to migrate. Use `N/A` for informational-only breakers.
+
+            For config changes, show a before/after with fenced code blocks:
+
+            #### Old
+
+            ```yaml
+            sinks:
+              my_sink:
+                option: old_value
+            ```
+
+            #### New
+
+            ```yaml
+            sinks:
+              my_sink:
+                option: new_value
+            ```
+
+            authors: {author}
+        "},
+        _ => formatdoc! {"
+            TODO one-item description of the change.
+
+            authors: {author}
+        "},
+    }
+}
+
+/// Best-effort GitHub handle detection:
+/// 1. `git config --get github.user` (explicit override)
+/// 2. `gh api user --jq .login` (uses the authenticated `gh` CLI if installed)
+/// 3. `git config user.email` when it matches `<id>+<handle>@users.noreply.github.com`
+///    or `<handle>@users.noreply.github.com`
+fn detect_gh_handle() -> Option<String> {
+    if let Some(h) = git_config("github.user") {
+        return Some(h);
+    }
+    if let Some(h) = gh_authenticated_login() {
+        return Some(h);
+    }
+    let email = git_config("user.email")?;
+    handle_from_noreply(&email)
+}
+
+fn git_config(key: &str) -> Option<String> {
+    let out = Command::new("git")
+        .args(["config", "--get", key])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let v = String::from_utf8(out.stdout).ok()?.trim().to_string();
+    (!v.is_empty()).then_some(v)
+}
+
+fn gh_authenticated_login() -> Option<String> {
+    let out = Command::new("gh")
+        .args(["api", "user", "--jq", ".login"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let v = String::from_utf8(out.stdout).ok()?.trim().to_string();
+    (!v.is_empty()).then_some(v)
+}
+
+fn handle_from_noreply(email: &str) -> Option<String> {
+    let local = email
+        .split_once('@')
+        .filter(|(_, d)| *d == "users.noreply.github.com")?
+        .0;
+    let handle = local.split_once('+').map_or(local, |(_, h)| h);
+    (!handle.is_empty()).then(|| handle.to_string())
+}
+
+fn relative<'a>(base: &std::path::Path, path: &'a std::path::Path) -> &'a std::path::Path {
+    path.strip_prefix(base).unwrap_or(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_normal_slugs() {
+        validate_slug("env_var_interpolation").unwrap();
+        validate_slug("12345_kafka_ack").unwrap();
+        validate_slug("Foo-Bar-1").unwrap();
+    }
+
+    #[test]
+    fn rejects_traversal() {
+        assert!(validate_slug("../outside").is_err());
+        assert!(validate_slug("foo/bar").is_err());
+        assert!(validate_slug("/etc/passwd").is_err());
+    }
+
+    #[test]
+    fn rejects_empty_and_punctuation() {
+        assert!(validate_slug("").is_err());
+        assert!(validate_slug("foo.bar").is_err());
+        assert!(validate_slug("foo bar").is_err());
+    }
+}

--- a/vdev/src/commands/check/changelog_fragments.rs
+++ b/vdev/src/commands/check/changelog_fragments.rs
@@ -1,7 +1,14 @@
+//! Best-effort validator for changelog fragments. The upgrade-guide generator stitches
+//! small markdown files together into a bigger markdown file; whatever renders safely in
+//! a fragment renders identically in the guide. PR review handles content quality.
+
 use std::path::PathBuf;
 
 use anyhow::{Result, bail};
 
+use crate::commands::changelog::{
+    is_valid_anchor, new::TODO_HANDLE, parse_breaking_sections, slugify,
+};
 use crate::utils::{git, paths};
 
 const CHANGELOG_DIR: &str = "changelog.d";
@@ -37,30 +44,40 @@ impl Cli {
             );
         }
 
-        let fragments = added_fragments(&self.merge_base)?;
-        if fragments.is_empty() {
+        // The gate "did the PR add a new fragment?" uses A (added) only — modifying an
+        // existing on-master fragment doesn't count toward the required changelog entry.
+        // Schema validation, on the other hand, must see M (modified) fragments too.
+        let is_real_fragment =
+            |p: &PathBuf| p.file_name().and_then(|s| s.to_str()) != Some("README.md");
+        let added_real: Vec<PathBuf> = diff_fragments(&self.merge_base, "A")?
+            .into_iter()
+            .filter(is_real_fragment)
+            .collect();
+        if added_real.is_empty() {
             bail!(
                 "No changelog fragments detected. \
                  If no changes necessitate user-facing explanations, add the 'no-changelog' label. \
                  Otherwise, add fragments to {CHANGELOG_DIR}/ (see {CHANGELOG_DIR}/README.md)."
             );
         }
-        if fragments.len() > self.max_fragments {
+        if added_real.len() > self.max_fragments {
             bail!(
                 "Too many changelog fragments ({} > {}).",
-                fragments.len(),
+                added_real.len(),
                 self.max_fragments
             );
         }
 
+        // Every touched fragment (added or modified) must pass the schema check.
+        let modified: Vec<PathBuf> = diff_fragments(&self.merge_base, "M")?
+            .into_iter()
+            .filter(is_real_fragment)
+            .collect();
         let expected_parent = std::path::Path::new(CHANGELOG_DIR);
-        for path in &fragments {
+        for path in added_real.iter().chain(modified.iter()) {
             let Some(name) = path.file_name().and_then(|s| s.to_str()) else {
                 bail!("Unexpected fragment path: {}", path.display());
             };
-            if name == "README.md" {
-                continue;
-            }
             if path.parent() != Some(expected_parent) {
                 bail!(
                     "invalid fragment path '{}': fragments must live directly under {CHANGELOG_DIR}/, not in a subdirectory.",
@@ -68,21 +85,61 @@ impl Cli {
                 );
             }
             info!("Validating '{name}'");
-            validate_filename(name)?;
-            validate_contents(&repo_root.join(path), name)?;
+            let fragment_type = validate_filename(name)?;
+            validate_contents(&repo_root.join(path), name, fragment_type)?;
         }
+
+        // Cross-fragment check: derived-or-explicit anchors across every breaking fragment
+        // currently in `changelog.d/` must be unique and non-empty. Catches conflicts at CI
+        // time rather than at release time (when a partial CUE may already exist).
+        validate_breaking_anchor_set(&changelog_dir)?;
 
         info!("changelog additions are valid.");
         Ok(())
     }
 }
 
-/// `git diff --name-only --diff-filter=A --merge-base <merge_base> changelog.d`
-fn added_fragments(merge_base: &str) -> Result<Vec<PathBuf>> {
+/// Load every `*.breaking.md` in `changelog.d/`, compute its anchor (explicit override or
+/// slugified title), and verify the resulting set is non-empty, well-formed, and unique.
+fn validate_breaking_anchor_set(changelog_dir: &std::path::Path) -> Result<()> {
+    let mut seen: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+    for entry in std::fs::read_dir(changelog_dir)? {
+        let path = entry?.path();
+        let name = match path.file_name().and_then(|s| s.to_str()) {
+            Some(n) if n.ends_with(".breaking.md") => n.to_string(),
+            _ => continue,
+        };
+        let content = std::fs::read_to_string(&path)?;
+        let body_before_authors = content
+            .rsplit_once("\nauthors: ")
+            .map_or(content.as_str(), |(before, _)| before);
+        let sections = parse_breaking_sections(body_before_authors)
+            .map_err(|e| anyhow::anyhow!("invalid breaking fragment '{name}': {e}"))?;
+        let anchor = sections.anchor.unwrap_or_else(|| slugify(&sections.title));
+        if !is_valid_anchor(&anchor) {
+            bail!(
+                "invalid breaking fragment '{name}': derived anchor '{anchor}' is not a valid kebab-case slug (add an explicit `{{#some-slug}}` after the title)."
+            );
+        }
+        if let Some(other) = seen.insert(anchor.clone(), name.clone()) {
+            bail!(
+                "duplicate upgrade-guide anchor '#{anchor}' shared by breaking fragments '{other}' and '{name}'. Override one with an explicit `{{#unique-slug}}`."
+            );
+        }
+    }
+    Ok(())
+}
+
+/// `git diff --name-only --diff-filter=<filter> --merge-base <merge_base> changelog.d`
+///
+/// `filter` is a `git diff` `--diff-filter` value: `A` for added-only, `M` for
+/// modified-only, `AM` for both, etc.
+fn diff_fragments(merge_base: &str, filter: &str) -> Result<Vec<PathBuf>> {
+    let filter_arg = format!("--diff-filter={filter}");
     let out = git::run_and_check_output(&[
         "diff",
         "--name-only",
-        "--diff-filter=A",
+        &filter_arg,
         "--merge-base",
         merge_base,
         CHANGELOG_DIR,
@@ -94,7 +151,7 @@ fn added_fragments(merge_base: &str) -> Result<Vec<PathBuf>> {
         .collect())
 }
 
-fn validate_filename(filename: &str) -> Result<()> {
+fn validate_filename(filename: &str) -> Result<&'static str> {
     let parts: Vec<&str> = filename.split('.').collect();
     if parts.len() != 3 {
         bail!(
@@ -102,19 +159,19 @@ fn validate_filename(filename: &str) -> Result<()> {
         );
     }
     let fragment_type = parts[1];
-    if !FRAGMENT_TYPES.contains(&fragment_type) {
+    let Some(known) = FRAGMENT_TYPES.iter().find(|t| **t == fragment_type) else {
         bail!(
             "invalid fragment filename '{filename}': fragment type must be one of ({}).",
             FRAGMENT_TYPES.join("|")
         );
-    }
+    };
     if parts[2] != "md" {
         bail!("invalid fragment filename '{filename}': extension must be markdown (.md).");
     }
-    Ok(())
+    Ok(*known)
 }
 
-fn validate_contents(path: &std::path::Path, filename: &str) -> Result<()> {
+fn validate_contents(path: &std::path::Path, filename: &str, fragment_type: &str) -> Result<()> {
     let content = std::fs::read_to_string(path)?;
     // Match generate_cue.rs, which reads `lines().last()` verbatim: the authors
     // line must be the last line, no trailing blank lines allowed.
@@ -139,5 +196,213 @@ fn validate_contents(path: &std::path::Path, filename: &str) -> Result<()> {
             "invalid fragment contents for '{filename}': authors should be space delimited, not comma delimited."
         );
     }
+    if names.split_whitespace().any(|n| n == TODO_HANDLE) {
+        bail!(
+            "invalid fragment contents for '{filename}': the scaffolder placeholder '{TODO_HANDLE}' must be replaced with a real GitHub handle."
+        );
+    }
+
+    // Reject any scaffolded body placeholder that the author forgot to fill in.
+    // All templates start their placeholder lines with a literal `TODO ` at column 0,
+    // which is rare in real fragment text.
+    if let Some(bad) = content.lines().find(|l| l.starts_with("TODO ")) {
+        bail!(
+            "invalid fragment contents for '{filename}': scaffolder placeholder line still present ({bad:?}). Replace it with real content."
+        );
+    }
+
+    if fragment_type == "breaking" {
+        validate_breaking_fragment(&content, filename)?;
+    }
+
     Ok(())
+}
+
+/// Schema for `*.breaking.md`:
+///
+/// ```text
+/// # <Title> [{#optional-anchor}]
+///
+/// ## Summary
+///
+/// <markdown — one paragraph, lands in the release changelog list>
+///
+/// ## Migration
+///
+/// <markdown — "Action needed" body for the upgrade guide, or "N/A">
+///
+/// authors: <name> [<name> ...]
+/// ```
+fn validate_breaking_fragment(content: &str, filename: &str) -> Result<()> {
+    // Strip the trailing `authors:` line before parsing — it's not part of the markdown
+    // structure and would otherwise land inside the Migration section.
+    let body_before_authors = content
+        .rsplit_once("\nauthors: ")
+        .map_or(content, |(before, _)| before);
+
+    let sections = parse_breaking_sections(body_before_authors)
+        .map_err(|e| anyhow::anyhow!("invalid breaking fragment '{filename}': {e}"))?;
+
+    if sections.title.is_empty() {
+        bail!("invalid breaking fragment '{filename}': title must not be empty.");
+    }
+    if sections.title.contains("TODO") {
+        bail!(
+            "invalid breaking fragment '{filename}': title still contains the scaffolder placeholder 'TODO'."
+        );
+    }
+    if let Some(anchor) = sections.anchor.as_deref()
+        && !is_valid_anchor(anchor)
+    {
+        bail!(
+            "invalid breaking fragment '{filename}': anchor must be a lowercase kebab-case slug (a-z, 0-9, hyphens); got '{anchor}'."
+        );
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use indoc::{formatdoc, indoc};
+
+    /// Build a full breaking-fragment file body from the given title line and section content.
+    fn wrap(title_line: &str, summary: &str, migration: &str) -> String {
+        formatdoc! {"
+            {title_line}
+
+            ## Summary
+
+            {summary}
+
+            ## Migration
+
+            {migration}
+
+            authors: pront
+        "}
+    }
+
+    #[test]
+    fn valid_breaking_fragment() {
+        let raw = wrap(
+            "# Env var interpolation disabled {#env-var}",
+            "Off by default now.",
+            "Pass the flag.",
+        );
+        validate_breaking_fragment(&raw, "x.breaking.md").unwrap();
+    }
+
+    #[test]
+    fn valid_without_anchor() {
+        let raw = wrap("# A change", "Change happened.", "N/A");
+        validate_breaking_fragment(&raw, "x.breaking.md").unwrap();
+    }
+
+    #[test]
+    fn missing_title() {
+        let raw = indoc! {"
+            not an H1 line
+
+            ## Summary
+
+            x
+
+            ## Migration
+
+            N/A
+
+            authors: pront
+        "};
+        let err = validate_breaking_fragment(raw, "x.breaking.md").unwrap_err();
+        assert!(err.to_string().contains("H1 title"), "{err}");
+    }
+
+    #[test]
+    fn empty_title() {
+        let raw = wrap("# ", "x", "N/A");
+        let err = validate_breaking_fragment(&raw, "x.breaking.md").unwrap_err();
+        assert!(err.to_string().contains("title must not be empty"), "{err}");
+    }
+
+    #[test]
+    fn missing_summary_header() {
+        let raw = indoc! {"
+            # x
+
+            ## Migration
+
+            N/A
+
+            authors: pront
+        "};
+        let err = validate_breaking_fragment(raw, "x.breaking.md").unwrap_err();
+        assert!(err.to_string().contains("`## Summary`"), "{err}");
+    }
+
+    #[test]
+    fn missing_migration_header() {
+        let raw = indoc! {"
+            # x
+
+            ## Summary
+
+            y
+
+            authors: pront
+        "};
+        let err = validate_breaking_fragment(raw, "x.breaking.md").unwrap_err();
+        assert!(err.to_string().contains("`## Migration`"), "{err}");
+    }
+
+    #[test]
+    fn empty_summary_section() {
+        let raw = wrap("# x", "", "N/A");
+        let err = validate_breaking_fragment(&raw, "x.breaking.md").unwrap_err();
+        assert!(
+            err.to_string().contains("Summary` must not be empty"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn empty_migration_section_is_allowed() {
+        // Fragments may leave `## Migration` empty (nothing for the user to do).
+        let raw = wrap("# x", "y", "");
+        validate_breaking_fragment(&raw, "x.breaking.md").unwrap();
+    }
+
+    #[test]
+    fn wrong_section_order() {
+        let raw = indoc! {"
+            # x
+
+            ## Migration
+
+            do this
+
+            ## Summary
+
+            hi
+
+            authors: pront
+        "};
+        let err = validate_breaking_fragment(raw, "x.breaking.md").unwrap_err();
+        assert!(err.to_string().contains("must come before"), "{err}");
+    }
+
+    #[test]
+    fn bad_anchor() {
+        let raw = wrap("# x {#Not Valid!}", "y", "N/A");
+        let err = validate_breaking_fragment(&raw, "x.breaking.md").unwrap_err();
+        assert!(err.to_string().contains("kebab-case slug"), "{err}");
+    }
+
+    #[test]
+    fn todo_title_rejected() {
+        let raw = wrap("# TODO one-line title", "y", "N/A");
+        let err = validate_breaking_fragment(&raw, "x.breaking.md").unwrap_err();
+        assert!(err.to_string().contains("placeholder 'TODO'"), "{err}");
+    }
 }

--- a/vdev/src/commands/mod.rs
+++ b/vdev/src/commands/mod.rs
@@ -68,6 +68,7 @@ pub struct Cli {
 }
 
 mod build;
+pub(crate) mod changelog;
 mod check;
 mod complete;
 mod crate_versions;
@@ -88,6 +89,7 @@ mod version;
 
 cli_commands! {
     build,
+    changelog,
     check,
     complete,
     crate_versions,

--- a/vdev/src/commands/release/generate_cue.rs
+++ b/vdev/src/commands/release/generate_cue.rs
@@ -16,6 +16,7 @@ use crate::utils::{git, paths};
 
 const RELEASES_DIR: &str = "website/cue/reference/releases";
 const CHANGELOG_DIR: &str = "changelog.d";
+const HIGHLIGHTS_DIR: &str = "website/content/en/highlights";
 
 /// Allowed conventional-commit types.
 const ALLOWED_TYPES: &[&str] = &[
@@ -29,7 +30,31 @@ const ALLOWED_TYPES: &[&str] = &[
     "security",
 ];
 
+/// Generate the release CUE file (and, if there are breaking fragments, the upgrade guide)
+/// for the given version. Handy for testing the changelog pipeline without running the
+/// full `release prepare` flow.
+///
+/// This subcommand is generation-only: it never mutates `changelog.d/`. `release prepare`
+/// invokes `retire_changelog_fragments` as a separate follow-up step.
+#[derive(clap::Args, Debug)]
+#[command()]
+pub struct Cli {
+    /// The version being released (e.g. `0.58.0`).
+    #[arg(long)]
+    version: Version,
+}
+
+impl Cli {
+    pub fn exec(self) -> Result<()> {
+        run(&self.version)?;
+        Ok(())
+    }
+}
+
 /// Generate the release CUE file for the given new version. Returns the path that was written.
+///
+/// Pure generation: does not touch `changelog.d/`. Callers that want the fragments retired
+/// after a successful release run should call [`retire_all_fragments`] afterward.
 pub(super) fn run(new_version: &Version) -> Result<PathBuf> {
     let repo_root = paths::find_repo_root()?;
     env::set_current_dir(&repo_root)?;
@@ -42,15 +67,26 @@ pub(super) fn run(new_version: &Version) -> Result<PathBuf> {
     validate_single_bump(&last_version, new_version)?;
     let new_version = new_version.clone();
 
+    // Capture today's date ONCE so the highlights filename and its frontmatter can never
+    // disagree if the run crosses UTC midnight.
+    let today = Utc::now().format("%Y-%m-%d").to_string();
+
     let cue_path = repo_root
         .join(RELEASES_DIR)
         .join(format!("{new_version}.cue"));
+    let highlights_path = repo_root
+        .join(HIGHLIGHTS_DIR)
+        .join(upgrade_guide_filename(&today, &new_version));
+
     if cue_path.exists() {
         bail!(
             "{} already exists. Delete it (or move it aside) and re-run.",
             cue_path.display()
         );
     }
+    // Note: the highlights collision is checked later, only if we're actually going to
+    // write it — so a manually-authored upgrade guide doesn't block a release with no
+    // breaking fragments.
 
     // Drop any commits that have already been recorded in a previous
     // release CUE file. `--cherry-pick --right-only` only catches
@@ -78,12 +114,45 @@ pub(super) fn run(new_version: &Version) -> Result<PathBuf> {
     let changelog_dir = repo_root.join(CHANGELOG_DIR);
     let changelog_entries = read_changelog_fragments(&changelog_dir)?;
 
+    // Validate + render everything IN MEMORY before touching disk, so a validation
+    // failure doesn't leave a partial CUE file behind (which would then trip the
+    // "file already exists" guard on the next run).
     let cue_text = render_release_cue(&new_version, &changelog_entries, &commits);
-    fs::write(&cue_path, cue_text)
-        .with_context(|| format!("Failed to write {}", cue_path.display()))?;
+    let breaking: Vec<&BreakingDetails> = changelog_entries
+        .iter()
+        .filter_map(|e| e.breaking_details.as_ref())
+        .collect();
+    let highlights_md = if breaking.is_empty() {
+        None
+    } else {
+        // Guard against clobbering an existing upgrade guide for this release. We match on
+        // the version-suffix rather than the exact `today`-prefixed filename so a partial
+        // run from a previous UTC day (or a maintainer-authored guide dated earlier) is
+        // still detected. The single-page release layout would otherwise render two
+        // "upgrade guide" cards for the same release.
+        if let Some(existing) =
+            find_existing_upgrade_guide(&repo_root.join(HIGHLIGHTS_DIR), &new_version)?
+        {
+            bail!(
+                "{} already exists for release {new_version}. Delete it (or move it aside) and re-run.",
+                existing.display()
+            );
+        }
+        validate_breaking_anchors(&breaking)?;
+        Some(render_upgrade_guide(&today, &new_version, &breaking))
+    };
 
-    // Retire the changelog fragments via `git rm` (preserves README.md).
-    retire_changelog_fragments(&changelog_dir)?;
+    // Everything valid — commit the writes atomically via .tmp + rename.
+    atomic_write(&cue_path, &cue_text)?;
+    if let Some(md) = highlights_md {
+        if let Err(e) = atomic_write(&highlights_path, &md) {
+            // Highlights write failed after CUE succeeded — roll the CUE back so the next
+            // attempt doesn't hit the "file already exists" guard.
+            drop(fs::remove_file(&cue_path));
+            return Err(e);
+        }
+        success!("Wrote {}", highlights_path.display());
+    }
 
     // Format with `cue fmt` (best-effort: warn but do not fail if cue is missing).
     if let Err(e) = run_cue_fmt(&cue_path) {
@@ -375,6 +444,19 @@ struct ChangelogEntry {
     breaking: bool,
     description: String,
     contributors: Vec<String>,
+    /// For `*.breaking.md` fragments, the structured upgrade-guide details.
+    breaking_details: Option<BreakingDetails>,
+}
+
+#[derive(Debug, Clone)]
+struct BreakingDetails {
+    title: String,
+    anchor: String,
+    /// Content of the fragment's `## Summary` section — reused in the guide so each
+    /// breaking change stands on its own without the reader hunting for the release notes.
+    summary: String,
+    /// Content of the fragment's `## Migration` section (headers, code fences, etc.).
+    migration: String,
 }
 
 fn read_changelog_fragments(dir: &Path) -> Result<Vec<ChangelogEntry>> {
@@ -425,22 +507,76 @@ fn parse_changelog_fragment(path: &Path) -> Result<ChangelogEntry> {
     let raw =
         fs::read_to_string(path).with_context(|| format!("Failed to read {}", path.display()))?;
 
-    let mut lines: Vec<&str> = raw.lines().collect();
-    let mut contributors: Vec<String> = Vec::new();
-    if let Some(last) = lines.last()
-        && let Some(rest) = last.strip_prefix("authors: ")
-    {
-        contributors = rest.split_whitespace().map(String::from).collect();
-        lines.pop();
+    // Strip the `authors:` trailer first — used by every fragment type.
+    let (body, contributors) = split_authors(&raw);
+
+    if breaking {
+        let (summary, details) = parse_breaking_body(body)
+            .with_context(|| format!("Failed to parse breaking fragment {}", path.display()))?;
+        return Ok(ChangelogEntry {
+            cue_type: cue_type.to_string(),
+            breaking,
+            description: summary,
+            contributors,
+            breaking_details: Some(details),
+        });
     }
-    let description = lines.join("\n").trim().to_string();
 
     Ok(ChangelogEntry {
         cue_type: cue_type.to_string(),
         breaking,
-        description,
+        description: body.trim().to_string(),
         contributors,
+        breaking_details: None,
     })
+}
+
+/// Split off the trailing `authors: <handles...>` line, returning the body preceding it
+/// (as a slice into `raw`) plus the parsed handle list. Works with both LF and CRLF line
+/// endings — we locate the marker directly in the original byte stream rather than
+/// reconstructing offsets from `str::lines()`.
+fn split_authors(raw: &str) -> (&str, Vec<String>) {
+    let trimmed = raw.trim_end_matches(['\n', '\r']);
+    let (body_end, handles_start) = match trimmed.rfind("\nauthors: ") {
+        Some(nl) => (nl, nl + 1),
+        None if trimmed.starts_with("authors: ") => (0, 0),
+        None => return (raw, Vec::new()),
+    };
+    let body = raw.get(..body_end).unwrap_or("");
+    let tail = raw.get(handles_start..).unwrap_or("");
+    let handles_line = tail.split(['\n', '\r']).next().unwrap_or(tail);
+    let rest = handles_line
+        .strip_prefix("authors: ")
+        .unwrap_or(handles_line);
+    let contributors = rest.split_whitespace().map(String::from).collect();
+    (body, contributors)
+}
+
+/// Parse the body of a `*.breaking.md` fragment (H1 title + `## Summary` + `## Migration`).
+/// Returns `(summary_markdown, breaking_details)`.
+fn parse_breaking_body(body: &str) -> Result<(String, BreakingDetails)> {
+    let sections = crate::commands::changelog::parse_breaking_sections(body)?;
+    let anchor = sections
+        .anchor
+        .unwrap_or_else(|| crate::commands::changelog::slugify(&sections.title));
+
+    Ok((
+        sections.summary.clone(),
+        BreakingDetails {
+            title: sections.title,
+            anchor,
+            summary: sections.summary,
+            migration: sections.migration,
+        },
+    ))
+}
+
+/// `git rm` every `*.md` under `changelog.d/` except `README.md`. Called by
+/// `release prepare` after a successful `run()` — never by the standalone
+/// `release generate-cue` subcommand.
+pub(super) fn retire_all_fragments() -> Result<()> {
+    let repo_root = paths::find_repo_root()?;
+    retire_changelog_fragments(&repo_root.join(CHANGELOG_DIR))
 }
 
 fn retire_changelog_fragments(dir: &Path) -> Result<()> {
@@ -477,21 +613,23 @@ fn render_release_cue(
         .collect::<Vec<_>>()
         .join(",\n    ");
 
-    format!(
-        "package metadata\n\
-         \n\
-         releases: \"{version}\": {{\n\
-         \tdate:     \"{date}\"\n\
-         \n\
-         \twhats_next: []\n\
-         \n\
-         \tchangelog: [\n\
-         {changelog_block}\n\
-         \t]\n\
-         \n\
-         \tcommits: [\n    {commits_block}\n\t]\n\
-         }}\n"
-    )
+    indoc::formatdoc! {"
+        package metadata
+
+        releases: \"{version}\": {{
+        \tdate:     \"{date}\"
+
+        \twhats_next: []
+
+        \tchangelog: [
+        {changelog_block}
+        \t]
+
+        \tcommits: [
+            {commits_block}
+        \t]
+        }}
+    "}
 }
 
 fn render_changelog(entries: &[ChangelogEntry]) -> String {
@@ -526,6 +664,113 @@ fn run_cue_fmt(path: &Path) -> Result<()> {
         bail!("cue fmt exited with {status}");
     }
     Ok(())
+}
+
+// ---------- Upgrade-guide (highlights) rendering ----------
+
+/// Return the first file in `highlights_dir` whose name ends in the version-suffix used
+/// by upgrade guides (e.g. `-0-58-0-upgrade-guide.md`), regardless of the date prefix.
+fn find_existing_upgrade_guide(
+    highlights_dir: &Path,
+    version: &Version,
+) -> Result<Option<PathBuf>> {
+    if !highlights_dir.is_dir() {
+        return Ok(None);
+    }
+    let suffix = format!(
+        "-{}-{}-{}-upgrade-guide.md",
+        version.major, version.minor, version.patch
+    );
+    for entry in fs::read_dir(highlights_dir)? {
+        let path = entry?.path();
+        if path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .is_some_and(|n| n.ends_with(&suffix))
+        {
+            return Ok(Some(path));
+        }
+    }
+    Ok(None)
+}
+
+fn upgrade_guide_filename(date: &str, version: &Version) -> String {
+    let version_slug = format!("{}-{}-{}", version.major, version.minor, version.patch);
+    format!("{date}-{version_slug}-upgrade-guide.md")
+}
+
+/// Fail the release if any breaking fragment produced an invalid, empty, or duplicate
+/// anchor. Uses the same anchor rules as `vdev check changelog-fragments` (shared through
+/// `commands::changelog::is_valid_anchor`) so a fragment that passes CI can't fail here.
+fn validate_breaking_anchors(breaking: &[&BreakingDetails]) -> Result<()> {
+    let mut seen = std::collections::HashMap::<&str, &str>::new();
+    for b in breaking {
+        if !crate::commands::changelog::is_valid_anchor(&b.anchor) {
+            bail!(
+                "breaking fragment '{}' has an invalid anchor '{}'. Add `{{#some-valid-slug}}` after the title.",
+                b.title,
+                b.anchor,
+            );
+        }
+        if let Some(other) = seen.insert(b.anchor.as_str(), b.title.as_str()) {
+            bail!(
+                "duplicate upgrade-guide anchor '#{}' shared by breaking fragments '{other}' and '{}'. Override one with `{{#unique-slug}}`.",
+                b.anchor,
+                b.title,
+            );
+        }
+    }
+    Ok(())
+}
+
+/// Write `content` to `path` via a `.tmp` sibling then atomic rename. Prevents leaving a
+/// partial output behind if the process is killed mid-write.
+fn atomic_write(path: &Path, content: &str) -> Result<()> {
+    let tmp = path.with_extension(format!(
+        "{}.tmp",
+        path.extension().and_then(|e| e.to_str()).unwrap_or("")
+    ));
+    fs::write(&tmp, content).with_context(|| format!("Failed to write {}", tmp.display()))?;
+    fs::rename(&tmp, path)
+        .with_context(|| format!("Failed to rename {} -> {}", tmp.display(), path.display()))?;
+    Ok(())
+}
+
+fn render_upgrade_guide(date: &str, version: &Version, breaking: &[&BreakingDetails]) -> String {
+    let title = format!("{}.{} Upgrade Guide", version.major, version.minor);
+    let description = format!("An upgrade guide that addresses breaking changes in {version}");
+
+    // No `authors:` in the frontmatter — this file is auto-generated; a "byline" would
+    // misattribute a multi-author guide to a single contributor.
+    let mut out = String::new();
+    out.push_str("---\n");
+    writeln!(out, "date: \"{date}\"").unwrap();
+    writeln!(out, "title: \"{title}\"").unwrap();
+    writeln!(out, "description: \"{description}\"").unwrap();
+    writeln!(out, "release: \"{version}\"").unwrap();
+    out.push_str("hide_on_release_notes: false\n");
+    out.push_str("badges:\n  type: breaking change\n");
+    out.push_str("---\n\n");
+
+    // Each fragment becomes an H2 (`## Title`), with Summary/Migration under it at H3.
+    // Fragment authors write sub-headings at H4+ (`#### Old` / `#### New`) per the
+    // scaffolder's template so nothing needs to be bumped here — Migration content
+    // passes through verbatim.
+    //
+    // Heading levels matter for the highlights page's Tocbot config
+    // (`website/assets/js/below.js`, which indexes h2-h5): fragment titles at H2 show up
+    // in the TOC as the top-level entries for the guide.
+    for b in breaking {
+        writeln!(out, "## {} {{#{}}}\n", b.title, b.anchor).unwrap();
+        writeln!(out, "### Summary\n\n{}\n", b.summary).unwrap();
+        if b.migration.is_empty() {
+            writeln!(out, "### Migration\n").unwrap();
+        } else {
+            writeln!(out, "### Migration\n\n{}\n", b.migration).unwrap();
+        }
+    }
+
+    out
 }
 
 #[cfg(test)]
@@ -621,12 +866,30 @@ mod tests {
         fs::write(dir.join("README.md"), "ignored").unwrap();
         fs::write(
             dir.join("123_my_change.feature.md"),
-            "Adds a thing.\n\nIssue: https://example/123\n\nauthors: alice bob\n",
+            indoc::indoc! {"
+                Adds a thing.
+
+                Issue: https://example/123
+
+                authors: alice bob
+            "},
         )
         .unwrap();
         fs::write(
             dir.join("legacy_break.breaking.md"),
-            "Removed legacy thing.\n",
+            indoc::indoc! {"
+                # Legacy thing removed
+
+                ## Summary
+
+                Removed legacy thing.
+
+                ## Migration
+
+                N/A
+
+                authors: dave
+            "},
         )
         .unwrap();
         fs::write(dir.join("sec.security.md"), "Patched a CVE.\n").unwrap();
@@ -646,10 +909,17 @@ mod tests {
         assert!(feat.description.starts_with("Adds a thing."));
         assert!(!feat.description.contains("authors:"));
 
-        // No-author entries get empty contributor list.
-        assert!(entries[1].contributors.is_empty());
-        // Breaking fragments must be marked as such.
-        assert!(entries[1].breaking);
+        // Breaking fragments must be marked as such and carry structured details.
+        let breaking = &entries[1];
+        assert!(breaking.breaking);
+        assert!(breaking.breaking_details.is_some());
+        let details = breaking.breaking_details.as_ref().unwrap();
+        assert_eq!(details.title, "Legacy thing removed");
+        assert_eq!(details.anchor, "legacy-thing-removed");
+        assert_eq!(details.migration.trim(), "N/A");
+        // Breaking description in the CUE is the Summary, not the whole body.
+        assert_eq!(breaking.description, "Removed legacy thing.");
+        assert_eq!(breaking.contributors, vec!["dave".to_string()]);
         assert!(!entries[0].breaking);
     }
 
@@ -668,12 +938,14 @@ mod tests {
                 breaking: false,
                 description: "Adds a thing.\nMulti-line.".into(),
                 contributors: vec!["alice".into()],
+                breaking_details: None,
             },
             ChangelogEntry {
                 cue_type: "fix".into(),
                 breaking: false,
                 description: "Fixed it.".into(),
                 contributors: vec![],
+                breaking_details: None,
             },
         ];
         let commits = vec![Commit {
@@ -800,5 +1072,288 @@ releases: "0.55.0": {
         let ids = collect_released_identifiers(Path::new("/nonexistent")).unwrap();
         assert!(ids.shas.is_empty());
         assert!(ids.pr_numbers.is_empty());
+    }
+
+    #[test]
+    fn split_authors_lf() {
+        let raw = "line one\nline two\n\nauthors: alice bob\n";
+        let (body, authors) = split_authors(raw);
+        assert_eq!(body, "line one\nline two\n");
+        assert_eq!(authors, vec!["alice".to_string(), "bob".to_string()]);
+    }
+
+    #[test]
+    fn split_authors_crlf() {
+        // Windows checkouts commit fragments with CRLF endings — the previous impl
+        // used `str::lines()` (strips \r) plus a `+1` byte-per-line accumulator,
+        // which truncated the body by one byte per line. Verify the whole body
+        // survives now.
+        let raw = "line one\r\nline two\r\n\r\nauthors: alice bob\r\n";
+        let (body, authors) = split_authors(raw);
+        assert!(body.contains("line one"));
+        assert!(body.contains("line two"));
+        assert!(!body.contains("authors:"));
+        assert_eq!(authors, vec!["alice".to_string(), "bob".to_string()]);
+    }
+
+    #[test]
+    fn split_authors_no_authors_line() {
+        let raw = "just body text\nmore body\n";
+        let (body, authors) = split_authors(raw);
+        assert_eq!(body, raw);
+        assert!(authors.is_empty());
+    }
+
+    #[test]
+    fn parse_breaking_body_extracts_summary_and_migration() {
+        let body = indoc::indoc! {"
+            # Env var interpolation off {#env-var}
+
+            ## Summary
+
+            Off by default now.
+
+            ## Migration
+
+            Pass the flag.
+
+            ```bash
+            vector --config vector.yaml
+            ```
+        "};
+        let (summary, details) = parse_breaking_body(body).unwrap();
+        assert_eq!(summary, "Off by default now.");
+        assert_eq!(details.title, "Env var interpolation off");
+        assert_eq!(details.anchor, "env-var");
+        assert!(details.migration.starts_with("Pass the flag."));
+        assert!(details.migration.contains("```bash"));
+    }
+
+    #[test]
+    fn parse_breaking_body_derives_anchor_from_title() {
+        let body = indoc::indoc! {"
+            # A Big Change!
+
+            ## Summary
+
+            x
+
+            ## Migration
+
+            N/A
+        "};
+        let (_, details) = parse_breaking_body(body).unwrap();
+        assert_eq!(details.anchor, "a-big-change");
+    }
+
+    #[test]
+    fn slugify_examples() {
+        assert_eq!(
+            crate::commands::changelog::slugify("A Big Change!"),
+            "a-big-change"
+        );
+        assert_eq!(
+            crate::commands::changelog::slugify("  --Foo/Bar--  "),
+            "foo-bar"
+        );
+        assert_eq!(
+            crate::commands::changelog::slugify("already-good"),
+            "already-good"
+        );
+        assert_eq!(
+            crate::commands::changelog::slugify("Numbers 123 OK"),
+            "numbers-123-ok"
+        );
+    }
+
+    #[test]
+    fn upgrade_guide_filename_uses_version() {
+        let name = upgrade_guide_filename("2026-07-17", &Version::parse("0.58.0").unwrap());
+        assert!(name.ends_with("-0-58-0-upgrade-guide.md"), "{name}");
+    }
+
+    #[test]
+    fn find_existing_upgrade_guide_matches_any_date() {
+        let tmp = tempfile::tempdir().unwrap();
+        // A guide dated on some past day (simulating a failed run yesterday, or a
+        // maintainer-authored guide dated earlier than today).
+        fs::write(
+            tmp.path().join("2026-07-19-0-58-0-upgrade-guide.md"),
+            "---\nrelease: 0.58.0\n---",
+        )
+        .unwrap();
+        // An unrelated highlight for a different release must NOT match.
+        fs::write(
+            tmp.path().join("2026-07-19-0-57-0-upgrade-guide.md"),
+            "---\nrelease: 0.57.0\n---",
+        )
+        .unwrap();
+
+        let hit =
+            find_existing_upgrade_guide(tmp.path(), &Version::parse("0.58.0").unwrap()).unwrap();
+        assert!(
+            hit.as_ref()
+                .and_then(|p| p.file_name())
+                .and_then(|n| n.to_str())
+                == Some("2026-07-19-0-58-0-upgrade-guide.md"),
+            "{hit:?}"
+        );
+
+        let miss =
+            find_existing_upgrade_guide(tmp.path(), &Version::parse("0.59.0").unwrap()).unwrap();
+        assert!(miss.is_none(), "{miss:?}");
+    }
+
+    #[test]
+    fn find_existing_upgrade_guide_handles_missing_dir() {
+        let hit = find_existing_upgrade_guide(
+            std::path::Path::new("/nonexistent-dir-for-test"),
+            &Version::parse("0.58.0").unwrap(),
+        )
+        .unwrap();
+        assert!(hit.is_none());
+    }
+
+    fn bd(title: &str, anchor: &str, summary: &str, migration: &str) -> BreakingDetails {
+        BreakingDetails {
+            title: title.into(),
+            anchor: anchor.into(),
+            summary: summary.into(),
+            migration: migration.into(),
+        }
+    }
+
+    #[test]
+    fn validate_breaking_anchors_rejects_duplicates() {
+        let a = bd("First", "same", "", "");
+        let b = bd("Second", "same", "", "");
+        let err = validate_breaking_anchors(&[&a, &b]).unwrap_err();
+        assert!(err.to_string().contains("duplicate"), "{err}");
+    }
+
+    #[test]
+    fn validate_breaking_anchors_rejects_empty() {
+        let a = bd("非ASCII", "", "", "");
+        let err = validate_breaking_anchors(&[&a]).unwrap_err();
+        assert!(err.to_string().contains("invalid anchor"), "{err}");
+    }
+
+    #[test]
+    fn validate_breaking_anchors_accepts_uniques() {
+        let a = bd("First", "first", "", "");
+        let b = bd("Second", "second", "", "");
+        validate_breaking_anchors(&[&a, &b]).unwrap();
+    }
+
+    #[test]
+    fn render_upgrade_guide_shape() {
+        let version = Version::parse("0.58.0").unwrap();
+        // First fragment models the scaffolder's default template: prose plus
+        // `### Old` / `### New` fenced code examples. These sub-headings must pass
+        // through into the guide verbatim (no bumping, no rewriting). Uses generic
+        // placeholders instead of real Vector flags so the test doesn't churn on
+        // unrelated CLI renames.
+        let d1 = bd(
+            "First breaking change",
+            "first",
+            "Something changed.",
+            // Fragment authors write H4 sub-sections so no bumping is needed in the
+            // generator — Migration content passes through verbatim.
+            indoc::indoc! {"
+                Pass `--new-flag` on startup to restore the previous behavior.
+
+                #### Old
+
+                ```bash
+                vector --config vector.yaml
+                ```
+
+                #### New
+
+                ```bash
+                vector --config vector.yaml --new-flag
+                ```"}
+            .trim_end(),
+        );
+        let d2 = bd(
+            "Second breaking change",
+            "second",
+            "A deprecated label is gone.",
+            "N/A",
+        );
+        let md = render_upgrade_guide("2026-07-17", &version, &[&d1, &d2]);
+        let expected = indoc::indoc! {r#"
+            ---
+            date: "2026-07-17"
+            title: "0.58 Upgrade Guide"
+            description: "An upgrade guide that addresses breaking changes in 0.58.0"
+            release: "0.58.0"
+            hide_on_release_notes: false
+            badges:
+              type: breaking change
+            ---
+
+            ## First breaking change {#first}
+
+            ### Summary
+
+            Something changed.
+
+            ### Migration
+
+            Pass `--new-flag` on startup to restore the previous behavior.
+
+            #### Old
+
+            ```bash
+            vector --config vector.yaml
+            ```
+
+            #### New
+
+            ```bash
+            vector --config vector.yaml --new-flag
+            ```
+
+            ## Second breaking change {#second}
+
+            ### Summary
+
+            A deprecated label is gone.
+
+            ### Migration
+
+            N/A
+
+        "#};
+        assert_eq!(md, expected);
+    }
+
+    #[test]
+    fn render_upgrade_guide_empty_migration() {
+        let version = Version::parse("0.58.0").unwrap();
+        let d = bd("A change", "a-change", "Something changed.", "");
+        let md = render_upgrade_guide("2026-07-17", &version, &[&d]);
+        let expected = indoc::indoc! {r#"
+            ---
+            date: "2026-07-17"
+            title: "0.58 Upgrade Guide"
+            description: "An upgrade guide that addresses breaking changes in 0.58.0"
+            release: "0.58.0"
+            hide_on_release_notes: false
+            badges:
+              type: breaking change
+            ---
+
+            ## A change {#a-change}
+
+            ### Summary
+
+            Something changed.
+
+            ### Migration
+
+        "#};
+        assert_eq!(md, expected);
     }
 }

--- a/vdev/src/commands/release/mod.rs
+++ b/vdev/src/commands/release/mod.rs
@@ -8,6 +8,7 @@ crate::cli_subcommands! {
     "Manage the release process..."
     channel,
     docker,
+    generate_cue,
     github,
     homebrew,
     prepare,

--- a/vdev/src/commands/release/prepare.rs
+++ b/vdev/src/commands/release/prepare.rs
@@ -226,6 +226,7 @@ impl Prepare {
     fn generate_release_cue(&self) -> Result<()> {
         debug!("generate_release_cue");
         generate_cue::run(&self.new_vector_version)?;
+        generate_cue::retire_all_fragments()?;
 
         self.append_vrl_changelog_to_release_cue()?;
         git::add_files_in_current_dir()?;


### PR DESCRIPTION
## Motivation

- **Easier for devs to write changelog fragments.** New `vdev changelog new <type> <slug>` scaffolder that fills in the filename, the required structure, and the `authors:` line (auto-detected from `git config github.user`, `gh api user`, or a `users.noreply.github.com` email). Works for every fragment type — no more copying an existing fragment as a template.
- **Easier for maintainers to produce breaking guides.** The release process now auto-generates `website/content/en/highlights/<date>-<v>-upgrade-guide.md` from `*.breaking.md` fragments. No more hand-writing the upgrade guide every minor release.

## What changed

- `*.breaking.md` fragments follow a small schema — H1 title (with optional Hugo-style `{#anchor}`), `## Summary` section (lands in the release changelog list), `## Migration` section (feeds the upgrade guide), trailing `authors:` line. Non-breaking fragments are unchanged.
- **Scaffolder**: `vdev changelog new <type> <slug>` writes a prefilled template and `git add`s it. Slug is validated (blocks path traversal, etc). The `TODO_your_gh_handle` placeholder and any `TODO` at column 0 in the body fail the checker.
- **Checker**: `vdev check changelog-fragments` (already CI-wired) enforces the schema on added AND modified fragments, and validates cross-fragment anchor uniqueness across every `*.breaking.md` in `changelog.d/`. Prose between the H1 title and `## Summary` is rejected so it can't silently disappear from the release output.
- **Generator**: `vdev release generate-cue` parses breaking fragments, feeds only the `## Summary` into the release CUE changelog list, and stitches all fragments verbatim into the highlights markdown (each fragment becomes an H1 section with its own H2 Summary and H2 Migration underneath — sub-headings like `### Old`/`### New` pass through untouched). Both output files are written via `.tmp` + atomic rename; the CUE is rolled back if the highlights write fails. Anchor validation is shared with the checker (kebab-case + reserved names for `vector-breaking-changes` / `vector-upgrade-guide`).
- **Standalone entry point**: `vdev release generate-cue --version <v>` is exposed as a subcommand so the pipeline can be exercised without running the full `release prepare`. Fragment retirement (`git rm`) is a separate step called only from `release prepare`.

The parser is deliberately dumb — three string splits over `\n## Summary\n` and `\n## Migration\n` plus the `authors:` trailer. CRLF checkouts normalize to LF up front. No `pulldown-cmark`, no heading bumping, no HTML sanitization — PR review handles content quality.

Forward-only — no `*.breaking.md` fragments in `changelog.d/` on master today.

## How did you test this PR?

- 111 vdev unit tests. Full byte-exact `assert_eq!` on the generated upgrade-guide markdown (uses `indoc!` fixtures) covers the multi-fragment shape, `### Old`/`### New` pass-through, empty Migration, cross-fragment anchor uniqueness/validation, CRLF fragments, missing/duplicate section markers, prose-before-Summary rejection.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean.
- End-to-end locally: scaffolded fragments → `vdev check changelog-fragments` → `vdev release generate-cue --version 0.58.0` → rendered on a local Hugo preview. Verified the release CUE (only Summary in the changelog list, no frontmatter/migration leaked) and the highlights markdown.

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## Follow-ups

- `website/cue/reference/versions.cue` (hand-maintained ordered version list) and `website/content/en/releases/<v>.md` (per-release Hugo stub) are still manual — captured in `.claude/ideas/auto-generate-versions-cue.md`. Small ~30-line follow-up: enumerate `releases/*.cue`, semver-sort, rewrite both from vdev.