### PR TITLE
fix(ci): surface vector container logs on integration test failure

### DIFF
--- a/scripts/run-integration-test.sh
+++ b/scripts/run-integration-test.sh
@@ -15,11 +15,15 @@ vdev_cmd="${VDEV:-cargo vdev}"
 # Reconstruct the docker compose project name that `cargo vdev` uses to start
 # the environment. It must match `ComposeTest::project_name` in
 # vdev/src/testing/integration.rs:
-#   vector-{int|e2e}-{test_name}-{sanitized_env}
-# where the environment has its dots replaced by hyphens.
+#   vector-{integration|e2e}-{test_name}-{sanitized_env}
+# The project name uses the tests directory name ("integration" or "e2e"), not
+# the TEST_TYPE arg ("int" or "e2e"), and the environment has its dots replaced
+# by hyphens.
 compose_project_name() {
   local env="$1"
-  echo "vector-${TEST_TYPE}-${TEST_NAME}-${env//./-}"
+  local dir="$TEST_TYPE"
+  [[ "$dir" == "int" ]] && dir="integration"
+  echo "vector-${dir}-${TEST_NAME}-${env//./-}"
 }
 
 print_compose_logs_on_failure() {

--- a/scripts/run-integration-test.sh
+++ b/scripts/run-integration-test.sh
@@ -12,10 +12,21 @@ fi
 
 vdev_cmd="${VDEV:-cargo vdev}"
 
+# Reconstruct the docker compose project name that `cargo vdev` uses to start
+# the environment. It must match `ComposeTest::project_name` in
+# vdev/src/testing/integration.rs:
+#   vector-{int|e2e}-{test_name}-{sanitized_env}
+# where the environment has its dots replaced by hyphens.
+compose_project_name() {
+  local env="$1"
+  echo "vector-${TEST_TYPE}-${TEST_NAME}-${env//./-}"
+}
+
 print_compose_logs_on_failure() {
   local LAST_RETURN_CODE=$1
+  local env="$2"
   if [[ "$LAST_RETURN_CODE" -ne 0 || "${ACTIONS_RUNNER_DEBUG:-}" == "true" ]]; then
-    (docker compose --project-name "${TEST_NAME}" logs) || echo "Failed to collect logs"
+    (docker compose --project-name "$(compose_project_name "$env")" logs) || echo "Failed to collect logs"
   fi
 }
 
@@ -140,7 +151,7 @@ for TEST_ENV in "${TEST_ENVIRONMENTS[@]}"; do
 
   $vdev_cmd "${VERBOSITY}" "${TEST_TYPE}" start "${TEST_NAME}" "${TEST_ENV}"
   START_RET=$?
-  print_compose_logs_on_failure "$START_RET"
+  print_compose_logs_on_failure "$START_RET" "$TEST_ENV"
 
   if [[ "$START_RET" -eq 0 ]]; then
     COVERAGE_FLAG=""
@@ -148,7 +159,7 @@ for TEST_ENV in "${TEST_ENVIRONMENTS[@]}"; do
 
     $vdev_cmd "${VERBOSITY}" "${TEST_TYPE}" test --retries "$RETRIES" ${COVERAGE_FLAG} "${TEST_NAME}" "${TEST_ENV}"
     RET=$?
-    print_compose_logs_on_failure "$RET"
+    print_compose_logs_on_failure "$RET" "$TEST_ENV"
 
     # Normalize source paths in coverage report so they are relative to the repo root.
     # The test runner container mounts source at /home/vector; strip that prefix so


### PR DESCRIPTION
## Summary

`cargo vdev` starts each compose environment under the project name `vector-{int|e2e}-{test_name}-{sanitized_env}` (`ComposeTest::project_name`), but `print_compose_logs_on_failure` queried `docker compose logs` with just the bare test name. The project label never matched, so on failure no service logs were surfaced, including the Vector container. This hid config errors (e.g. failed env var interpolation) that only appear in Vector's startup logs.

## Vector configuration

NA

## How did you test this PR?

Ran `scripts/run-integration-test.sh` locally and confirmed the Vector container logs are now dumped on failure. Verified with `bash -n` and `shellcheck`.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

NA
