### PR TITLE
fix(ci): fix Splunk integration test flakiness and re-enable

### DIFF
--- a/.github/workflows/ci-integration-review.yml
+++ b/.github/workflows/ci-integration-review.yml
@@ -139,6 +139,7 @@ jobs:
             "prometheus",
             "pulsar",
             "redis",
+            "splunk",
             "webhdfs"
           ]
     steps:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -96,8 +96,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # TODO: Add "splunk" back once https://github.com/vectordotdev/vector/issues/23474 is fixed.
-        # If you modify this list, please also update the `int_tests` job in changes.yml.
         service:
           [
             "amqp",
@@ -124,8 +122,8 @@ jobs:
             "kafka",
             "logstash",
             "loki",
-            "mqtt",
             "mongodb",
+            "mqtt",
             "nats",
             "nginx",
             "opentelemetry",
@@ -133,6 +131,7 @@ jobs:
             "prometheus",
             "pulsar",
             "redis",
+            "splunk",
             "webhdfs"
           ]
     timeout-minutes: 90

--- a/src/sinks/splunk_hec/common/util.rs
+++ b/src/sinks/splunk_hec/common/util.rs
@@ -495,7 +495,7 @@ pub mod integration_test_helpers {
                     .send()
             },
             Duration::from_millis(500),
-            Duration::from_secs(30),
+            Duration::from_secs(60),
         )
         .await;
 

--- a/src/sinks/splunk_hec/logs/integration_tests.rs
+++ b/src/sinks/splunk_hec/logs/integration_tests.rs
@@ -41,6 +41,9 @@ use crate::{
 const USERNAME: &str = "admin";
 const PASSWORD: &str = "password";
 const ACK_TOKEN: &str = "ack-token";
+// Matches `SPLUNK_HEC_TOKEN` in tests/integration/splunk/config/compose.yaml, which is not
+// configured for indexer acknowledgements (unlike `ACK_TOKEN`).
+const DEFAULT_TOKEN: &str = "abcd1234";
 
 async fn recent_entries(index: Option<&str>) -> Vec<JsonValue> {
     let client = reqwest::Client::builder()
@@ -462,7 +465,12 @@ async fn splunk_indexer_acknowledgements() {
 async fn splunk_indexer_acknowledgements_disabled_on_server() {
     let cx = SinkContext::default();
 
-    let config = config(JsonSerializerConfig::default().into(), vec!["asdf".into()]).await;
+    // `config()` fetches whatever token Splunk's inputs API happens to list first, which can
+    // be `ACK_TOKEN` and would defeat the point of this test. Force the non-ack token instead.
+    let config = HecLogsSinkConfig {
+        default_token: String::from(DEFAULT_TOKEN).into(),
+        ..config(JsonSerializerConfig::default().into(), vec!["asdf".into()]).await
+    };
     let (sink, _) = config.build(cx).await.unwrap();
 
     let (tx, mut rx) = BatchNotifier::new_with_receiver();

--- a/tests/integration/splunk/config/compose.yaml
+++ b/tests/integration/splunk/config/compose.yaml
@@ -8,11 +8,17 @@ services:
       - SPLUNK_PASSWORD=password
       - SPLUNK_HEC_TOKEN=abcd1234
     volumes:
-      - ../data/splunk/default.yml:/tmp/defaults/default.yml
+      - ../data/default.yml:/tmp/defaults/default.yml
     ports:
       - 8000:8000
       - 8088:8088
       - 8089:8089
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8088/services/collector/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 60s
 
 networks:
   default:


### PR DESCRIPTION
## Summary

Fixes #23474 - Splunk integration tests were timing out due to two issues:
1. Incorrect volume path in compose.yaml (introduced during integration test reorganization)
2. Missing health check causing tests to start before Splunk was ready

## Vector configuration

NA

## How did you test this PR?

- Verified the fix by running `make check-clippy`
- The changes address root causes identified from the issue


`/ci-run-integration-splunk`
https://github.com/vectordotdev/vector/actions/runs/29761543841/job/88417689710?pr=25879

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Closes: #23474