### PR TITLE
fix(tls): use server_name for openssl certificate hostname verification

### DIFF
--- a/changelog.d/tls_server_name_openssl_verify.fix.md
+++ b/changelog.d/tls_server_name_openssl_verify.fix.md
@@ -1,1 +1,3 @@
 Fixed the `tls.server_name` option so that it is used for certificate hostname verification in addition to SNI. Previously, on the OpenSSL path (used by HTTP-based sinks such as `datadog_logs`), the certificate was still verified against the connection URL host, causing a "hostname mismatch" verification failure when `server_name` differed from the endpoint host.
+
+authors: gwenaskell

--- a/changelog.d/tls_server_name_openssl_verify.fix.md
+++ b/changelog.d/tls_server_name_openssl_verify.fix.md
@@ -1,0 +1,1 @@
+Fixed the `tls.server_name` option so that it is used for certificate hostname verification in addition to SNI. Previously, on the OpenSSL path (used by HTTP-based sinks such as `datadog_logs`), the certificate was still verified against the connection URL host, causing a "hostname mismatch" verification failure when `server_name` differed from the endpoint host.

--- a/lib/vector-core/src/tls/settings.rs
+++ b/lib/vector-core/src/tls/settings.rs
@@ -225,6 +225,16 @@ impl TlsSettings {
         })
     }
 
+    /// The configured SNI server name override, if any.
+    pub fn server_name(&self) -> Option<&str> {
+        self.server_name.as_deref()
+    }
+
+    /// Whether certificate hostname verification is enabled.
+    pub fn verify_hostname(&self) -> bool {
+        self.verify_hostname
+    }
+
     /// Returns the identity as PEM encoded byte arrays
     ///
     /// # Panics

--- a/lib/vector-core/src/tls/settings.rs
+++ b/lib/vector-core/src/tls/settings.rs
@@ -376,6 +376,9 @@ impl TlsSettings {
 
             if self.verify_hostname {
                 let param = connection.param_mut();
+                // Match OpenSSL's own connector defaults: disallow partial-wildcard
+                // matches such as `w*.example.com` matching `www.example.com`, so a
+                // wildcard label must be the entire leftmost label (`*.example.com`).
                 param.set_hostflags(X509CheckFlags::NO_PARTIAL_WILDCARDS);
                 match server_ip {
                     Ok(ip) => param.set_ip(ip)?,

--- a/lib/vector-core/src/tls/settings.rs
+++ b/lib/vector-core/src/tls/settings.rs
@@ -375,10 +375,14 @@ impl TlsSettings {
             }
 
             if self.verify_hostname {
+                // Mirror `ConnectConfiguration::into_ssl`'s `setup_verify_hostname` so that
+                // verification against `server_name` behaves exactly as it would against the
+                // URL host, just with our name instead:
+                // https://github.com/rust-openssl/rust-openssl/blob/db9c9e2f5db2ad7b45fd894e8d297ee15bfd0c7c/openssl/src/ssl/connector.rs#L380-L389
                 let param = connection.param_mut();
-                // Match OpenSSL's own connector defaults: disallow partial-wildcard
-                // matches such as `w*.example.com` matching `www.example.com`, so a
-                // wildcard label must be the entire leftmost label (`*.example.com`).
+                // Disallow partial-wildcard matches such as `w*.example.com` matching
+                // `www.example.com`, so a wildcard label must be the entire leftmost label
+                // (`*.example.com`).
                 param.set_hostflags(X509CheckFlags::NO_PARTIAL_WILDCARDS);
                 match server_ip {
                     Ok(ip) => param.set_ip(ip)?,

--- a/lib/vector-core/src/tls/settings.rs
+++ b/lib/vector-core/src/tls/settings.rs
@@ -20,7 +20,7 @@ use openssl::{
     pkey::{PKey, Private},
     ssl::{AlpnError, ConnectConfiguration, SslContextBuilder, SslVerifyMode, select_next_proto},
     stack::Stack,
-    x509::{X509, store::X509StoreBuilder},
+    x509::{X509, store::X509StoreBuilder, verify::X509CheckFlags},
 };
 use snafu::ResultExt;
 use vector_config::configurable_component;
@@ -348,11 +348,30 @@ impl TlsSettings {
         &self,
         connection: &mut ConnectConfiguration,
     ) -> std::result::Result<(), openssl::error::ErrorStack> {
-        connection.set_verify_hostname(self.verify_hostname);
         if let Some(server_name) = &self.server_name {
-            // Prevent native TLS lib from inferring default SNI using domain name from url.
+            // Use the configured server name for both SNI and certificate hostname
+            // verification. `ConnectConfiguration::into_ssl` (called by the connector
+            // after this callback) would otherwise apply the URL host to SNI and the
+            // verify parameter, overriding the configured server name and causing a
+            // hostname mismatch. Disabling both here prevents that override.
             connection.set_use_server_name_indication(false);
-            connection.set_hostname(server_name)?;
+            connection.set_verify_hostname(false);
+
+            // SNI must be a hostname, not an IP literal.
+            if server_name.parse::<std::net::IpAddr>().is_err() {
+                connection.set_hostname(server_name)?;
+            }
+
+            if self.verify_hostname {
+                let param = connection.param_mut();
+                param.set_hostflags(X509CheckFlags::NO_PARTIAL_WILDCARDS);
+                match server_name.parse::<std::net::IpAddr>() {
+                    Ok(ip) => param.set_ip(ip)?,
+                    Err(_) => param.set_host(server_name)?,
+                }
+            }
+        } else {
+            connection.set_verify_hostname(self.verify_hostname);
         }
         Ok(())
     }
@@ -813,6 +832,43 @@ mod test {
         let _error = TlsSettings::from_options(Some(&options))
             .expect_err("from_options failed to check certificate");
         // Actual error is an ASN parse, doesn't really matter
+    }
+
+    #[test]
+    fn apply_connect_configuration_uses_server_name_for_verification() {
+        use openssl::ssl::{SslConnector, SslMethod};
+
+        let connect_config = || {
+            SslConnector::builder(SslMethod::tls())
+                .unwrap()
+                .build()
+                .configure()
+                .unwrap()
+        };
+
+        // A DNS `server_name` must apply for both SNI and hostname verification
+        // without erroring (regression for the openssl hostname-mismatch bug).
+        let settings = TlsSettings::from_options(Some(&TlsConfig {
+            server_name: Some("www.example.com".into()),
+            ..Default::default()
+        }))
+        .unwrap();
+        let mut config = connect_config();
+        settings.apply_connect_configuration(&mut config).unwrap();
+
+        // An IP literal `server_name` must go through the IP verify path.
+        let settings = TlsSettings::from_options(Some(&TlsConfig {
+            server_name: Some("127.0.0.1".into()),
+            ..Default::default()
+        }))
+        .unwrap();
+        let mut config = connect_config();
+        settings.apply_connect_configuration(&mut config).unwrap();
+
+        // No `server_name` is still valid.
+        let settings = TlsSettings::from_options(None).unwrap();
+        let mut config = connect_config();
+        settings.apply_connect_configuration(&mut config).unwrap();
     }
 
     #[test]

--- a/lib/vector-core/src/tls/settings.rs
+++ b/lib/vector-core/src/tls/settings.rs
@@ -357,15 +357,17 @@ impl TlsSettings {
             connection.set_use_server_name_indication(false);
             connection.set_verify_hostname(false);
 
+            let server_ip = server_name.parse::<std::net::IpAddr>();
+
             // SNI must be a hostname, not an IP literal.
-            if server_name.parse::<std::net::IpAddr>().is_err() {
+            if server_ip.is_err() {
                 connection.set_hostname(server_name)?;
             }
 
             if self.verify_hostname {
                 let param = connection.param_mut();
                 param.set_hostflags(X509CheckFlags::NO_PARTIAL_WILDCARDS);
-                match server_name.parse::<std::net::IpAddr>() {
+                match server_ip {
                     Ok(ip) => param.set_ip(ip)?,
                     Err(_) => param.set_host(server_name)?,
                 }

--- a/lib/vector-core/src/tls/settings.rs
+++ b/lib/vector-core/src/tls/settings.rs
@@ -877,7 +877,9 @@ mod test {
                 .await
                 .map_err(|e| e.to_string())?;
             let mut builder = SslConnector::builder(SslMethod::tls()).unwrap();
-            settings.apply_context(&mut builder).map_err(|e| e.to_string())?;
+            settings
+                .apply_context(&mut builder)
+                .map_err(|e| e.to_string())?;
             let mut config = builder.build().configure().unwrap();
             settings
                 .apply_connect_configuration(&mut config)

--- a/lib/vector-core/src/tls/settings.rs
+++ b/lib/vector-core/src/tls/settings.rs
@@ -846,41 +846,93 @@ mod test {
         // Actual error is an ASN parse, doesn't really matter
     }
 
-    #[test]
-    fn apply_connect_configuration_uses_server_name_for_verification() {
+    // End-to-end regression test for the OpenSSL hostname-mismatch bug: the server presents a
+    // certificate for `localhost` (CN=localhost, no SAN) while the client connects by IP, so the
+    // connection URL host (`127.0.0.1`) does not match the certificate. Verification must instead
+    // use the configured `server_name`.
+    #[tokio::test]
+    async fn server_name_is_used_for_hostname_verification() {
+        use std::{net::SocketAddr, pin::Pin};
+
         use openssl::ssl::{SslConnector, SslMethod};
 
-        let connect_config = || {
-            SslConnector::builder(SslMethod::tls())
-                .unwrap()
-                .build()
-                .configure()
-                .unwrap()
-        };
+        // Connects to `addr` by IP, driving `into_ssl` with `url_host` exactly as
+        // `hyper-openssl` does (it passes the connection URL host).
+        async fn connect(
+            server_name: Option<&str>,
+            url_host: &str,
+            addr: SocketAddr,
+        ) -> std::result::Result<(), String> {
+            let settings = TlsSettings::from_options(Some(&TlsConfig {
+                ca_file: Some("tests/data/ca/intermediate_server/certs/ca-chain.cert.pem".into()),
+                server_name: server_name.map(Into::into),
+                ..Default::default()
+            }))
+            .unwrap();
 
-        // A DNS `server_name` must apply for both SNI and hostname verification
-        // without erroring (regression for the openssl hostname-mismatch bug).
-        let settings = TlsSettings::from_options(Some(&TlsConfig {
-            server_name: Some("www.example.com".into()),
-            ..Default::default()
-        }))
+            let tcp = tokio::net::TcpStream::connect(addr)
+                .await
+                .map_err(|e| e.to_string())?;
+            let mut builder = SslConnector::builder(SslMethod::tls()).unwrap();
+            settings.apply_context(&mut builder).map_err(|e| e.to_string())?;
+            let mut config = builder.build().configure().unwrap();
+            settings
+                .apply_connect_configuration(&mut config)
+                .map_err(|e| e.to_string())?;
+            let ssl = config.into_ssl(url_host).map_err(|e| e.to_string())?;
+            let mut stream = tokio_openssl::SslStream::new(ssl, tcp).unwrap();
+            Pin::new(&mut stream)
+                .connect()
+                .await
+                .map_err(|e| e.to_string())
+        }
+
+        let server_settings = MaybeTlsSettings::from_config(
+            Some(&TlsEnableableConfig {
+                enabled: Some(true),
+                options: TlsConfig {
+                    crt_file: Some(TEST_PEM_CRT_PATH.into()),
+                    key_file: Some(TEST_PEM_KEY_PATH.into()),
+                    ..Default::default()
+                },
+            }),
+            true,
+        )
         .unwrap();
-        let mut config = connect_config();
-        settings.apply_connect_configuration(&mut config).unwrap();
+        let reloader = server_settings
+            .reloadable_acceptor()
+            .unwrap()
+            .expect("tls enabled, so an acceptor should exist");
+        let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+        let mut listener = server_settings
+            .bind_reloadable(&addr, Some(reloader))
+            .await
+            .unwrap();
+        let local_addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            while let Ok(mut stream) = listener.accept().await {
+                stream.handshake().await.ok();
+            }
+        });
 
-        // An IP literal `server_name` must go through the IP verify path.
-        let settings = TlsSettings::from_options(Some(&TlsConfig {
-            server_name: Some("127.0.0.1".into()),
-            ..Default::default()
-        }))
-        .unwrap();
-        let mut config = connect_config();
-        settings.apply_connect_configuration(&mut config).unwrap();
+        // With `server_name` set to the certificate's name, verification uses it and succeeds even
+        // though the connection host is the IP. This passes only because `server_name` is applied
+        // to hostname verification (the bug this fixes).
+        connect(Some("localhost"), "127.0.0.1", local_addr)
+            .await
+            .expect("handshake should succeed when server_name matches the certificate");
 
-        // No `server_name` is still valid.
-        let settings = TlsSettings::from_options(None).unwrap();
-        let mut config = connect_config();
-        settings.apply_connect_configuration(&mut config).unwrap();
+        // Control: without `server_name`, verification falls back to the connection host (the IP),
+        // which the certificate does not cover, so it fails. This proves verification is active.
+        let error = connect(None, "127.0.0.1", local_addr)
+            .await
+            .expect_err("handshake should fail when verifying against the IP");
+        assert!(
+            error.contains("certificate verify failed"),
+            "expected a certificate verification failure, got: {error}"
+        );
+
+        server.abort();
     }
 
     #[test]

--- a/src/http.rs
+++ b/src/http.rs
@@ -212,6 +212,22 @@ pub fn build_proxy_connector(
     tls_settings: MaybeTlsSettings,
     proxy_config: &ProxyConfig,
 ) -> Result<ProxyConnector<HttpsConnector<HttpConnector>>, HttpError> {
+    // `server_name` is not applied to proxied (tunneled) TLS connections, because
+    // `hyper-proxy` offers no per-connection callback and verifies against the URL
+    // host. Warn when the combination that would silently misbehave is configured.
+    if proxy_config.enabled
+        && (proxy_config.http.is_some() || proxy_config.https.is_some())
+        && let Some(tls) = tls_settings.tls()
+        && tls.server_name().is_some()
+        && tls.verify_hostname()
+    {
+        warn!(
+            message = "`tls.server_name` is set with hostname verification enabled, but a proxy is configured. \
+                       `server_name` is not applied to proxied (tunneled) TLS connections, so certificate \
+                       verification may fail with a hostname mismatch."
+        );
+    }
+
     // Create dedicated TLS connector for the proxied connection with user TLS settings.
     let tls = tls_connector_builder(&tls_settings)
         .context(BuildTlsConnectorSnafu)?


### PR DESCRIPTION
## Summary
- `tls.server_name` was only applied to SNI on the OpenSSL path (used by HTTP-based sinks like `datadog_logs`). Certificate hostname verification still used the connection URL host, so a `server_name` differing from the endpoint host failed with `tls_post_process_server_certificate ... hostname mismatch`.
- Fix: in `apply_connect_configuration`, point the X509 verify parameter at `server_name` (host or IP) and disable `into_ssl`'s URL-host-based SNI/verify so it can't override the configured name. Same class of issue as kube-rs/kube#1993.
- Added a warning when `server_name` + hostname verification are configured alongside a proxy (see note below).

## Note on the proxy path
`server_name` still can't be honored on tunneled TLS through a proxy: `hyper-proxy` 0.9.1 exposes no per-connection callback and hardcodes `into_ssl(&url_host)`. Fixing that would require patching/forking the dependency, so instead this PR emits a `warn!` when a proxy is configured together with `server_name` and hostname verification, so the misconfiguration is visible.

## Test plan
- [x] `cargo test -p vector-core --lib tls::settings::test` (added `apply_connect_configuration_uses_server_name_for_verification` covering DNS name, IP literal, and no `server_name`).
- [x] `cargo check --lib` for the `vector` crate.
- [ ] Manual verification against an environment where `server_name` differs from the endpoint host.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [x] Yes. A changelog fragment is included.
- [ ] No. A maintainer will apply the no-changelog label to this PR.