### PR TITLE
fix(sinks): use real wire bytes for OTLP batch sizing in the http sink

### DIFF
--- a/src/sinks/http/batch.rs
+++ b/src/sinks/http/batch.rs
@@ -1,5 +1,7 @@
 //! Batch settings for the `http` sink.
 
+use bytes::BytesMut;
+use tokio_util::codec::Encoder as _;
 use vector_lib::{
     ByteSizeOf, EstimatedJsonEncodedSizeOf, codecs::encoding::Framer, event::Event,
     stream::batcher::limiter::ItemBatchSize,
@@ -20,7 +22,98 @@ impl ItemBatchSize<Event> for HttpBatchSizer {
             | vector_lib::codecs::encoding::Serializer::NativeJson(_) => {
                 item.estimated_json_encoded_size_of().get()
             }
+            // The OTLP serializer produces a compact protobuf payload from a much larger
+            // in-memory JSON-shaped `Event::Log`, so `size_of()` (used by the fallback arm
+            // below) overstates the real wire size by an order of magnitude and causes
+            // `max_bytes` to trigger far too early. Encode the item for real to get an
+            // accurate size; cloning the serializer and the item are both cheap (Arc bumps),
+            // and OTLP framing is a no-op, so this mirrors exactly what the real request
+            // encoder does per-event.
+            #[cfg(feature = "codecs-opentelemetry")]
+            vector_lib::codecs::encoding::Serializer::Otlp(_) => {
+                let mut serializer = self.encoder.serializer().clone();
+                let mut buffer = BytesMut::new();
+                match serializer.encode(item.clone(), &mut buffer) {
+                    Ok(()) => buffer.len(),
+                    Err(_) => item.size_of(),
+                }
+            }
             _ => item.size_of(),
         }
+    }
+}
+
+#[cfg(all(test, feature = "codecs-opentelemetry"))]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use vector_lib::codecs::encoding::{BytesEncoder, OtlpSerializerConfig, Serializer};
+    use vector_lib::event::LogEvent;
+
+    fn otlp_metric_event() -> Event {
+        let json = json!({
+            "resourceMetrics": [{
+                "resource": {
+                    "attributes": [{
+                        "key": "service.name",
+                        "value": { "stringValue": "test-service" },
+                    }],
+                },
+                "scopeMetrics": [{
+                    "scope": { "name": "test-scope" },
+                    "metrics": [{
+                        "name": "test.metric",
+                        "sum": {
+                            "dataPoints": [{
+                                "attributes": [{
+                                    "key": "env",
+                                    "value": { "stringValue": "prod" },
+                                }],
+                                "startTimeUnixNano": 0,
+                                "timeUnixNano": 0,
+                                "asDouble": 42.0,
+                            }],
+                            "aggregationTemporality": 1,
+                            "isMonotonic": true,
+                        },
+                    }],
+                }],
+            }],
+        });
+
+        Event::Log(LogEvent::try_from(json).expect("valid OTLP JSON converts to a LogEvent"))
+    }
+
+    #[test]
+    fn otlp_batch_size_matches_real_wire_bytes_and_beats_size_of() {
+        let event = otlp_metric_event();
+
+        let serializer = Serializer::Otlp(
+            OtlpSerializerConfig::default()
+                .build()
+                .expect("serializer builds"),
+        );
+        let sizer = HttpBatchSizer {
+            encoder: Encoder::<Framer>::new(BytesEncoder.into(), serializer.clone()),
+        };
+
+        let mut serializer = serializer;
+        let mut wire_bytes = BytesMut::new();
+        serializer
+            .encode(event.clone(), &mut wire_bytes)
+            .expect("event encodes to OTLP protobuf");
+
+        assert_eq!(
+            sizer.size(&event),
+            wire_bytes.len(),
+            "HttpBatchSizer must report the real OTLP wire size"
+        );
+        assert!(
+            sizer.size(&event) < event.size_of(),
+            "OTLP wire size ({}) should be far smaller than the in-memory size_of() ({}) \
+             that the batcher previously (incorrectly) used for max_bytes accounting",
+            sizer.size(&event),
+            event.size_of(),
+        );
     }
 }


### PR DESCRIPTION
## Summary

`HttpBatchSizer::size()` (used by the generic `http` sink, and by extension the `opentelemetry` sink which wraps it) falls back to `Event::size_of()` for any serializer it doesn't special-case. For the OTLP protobuf serializer, that in-memory `size_of()` estimate overstates the real wire size by roughly an order of magnitude, because it's sizing the much larger JSON-shaped `Event::Log` representation rather than the compact protobuf payload actually sent.

Since `max_bytes` batch accounting is driven by this estimate, batches close far earlier than the configured byte budget intends — in a production deployment we measured this causing ~6.6x more HTTP requests per second than the byte cap should have allowed for a given event stream, because each batch was hitting the (over-estimated) size ceiling long before it reached the real 380KB configured max.

This PR adds an OTLP-specific branch to `HttpBatchSizer::size()` that clones the configured serializer and actually encodes the event to get its true protobuf-encoded length, falling back to `size_of()` only if encoding fails. This mirrors exactly what the real per-request encoder does, so batch-close decisions now reflect the real wire size.

## Why not just special-case a cheaper estimate?

OTLP protobuf encoding doesn't have a cheap structural shortcut analogous to JSON's estimated-size helpers — arbitrary numbers of repeated fields, varint-encoded lengths, and attribute maps mean an accurate estimate essentially requires doing the encode. Encoding here is cheap in practice (Arc-backed clones of the serializer/item, no additional allocation churn beyond the actual encode buffer), and it's the same work the request path does moments later anyway.

## Test plan

- [x] Added a unit test (`otlp_batch_size_matches_real_wire_bytes_and_beats_size_of`) asserting the sizer's reported size exactly matches a real OTLP-protobuf encode of the same event, and is meaningfully smaller than `size_of()`.
- [x] Built a custom Vector with this fix and canary-tested it against a live production-like OTLP metrics pipeline; confirmed request rate dropped to the expected ~1 req/s (previously ~6.6 req/s) with zero errors.