### PR TITLE
feat(transforms): support multiple task output ports

### DIFF
--- a/benches/lua.rs
+++ b/benches/lua.rs
@@ -64,7 +64,7 @@ fn bench_add_fields(c: &mut Criterion) {
             Transform::Synchronous(_t) => {
                 unreachable!("no sync transform used in these benches");
             }
-            Transform::Task(t) => t.transform_events(Box::pin(rx)),
+            Transform::Task(t) => t.transform_events(Box::pin(rx)).map(|output| output.events),
         };
 
         group.bench_function(name.to_owned(), |b| {
@@ -141,7 +141,7 @@ fn bench_field_filter(c: &mut Criterion) {
             Transform::Synchronous(_t) => {
                 unreachable!("no sync transform used in these benches");
             }
-            Transform::Task(t) => t.transform_events(Box::pin(rx)),
+            Transform::Task(t) => t.transform_events(Box::pin(rx)).map(|output| output.events),
         };
 
         group.bench_function(name.to_owned(), |b| {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -108,9 +108,16 @@ basically just passing the input channel into the `transform` method.
 
 To build the full task, the transform itself is built, some common filtering and
 telemetry are added by wrapping the input stream, and then the input stream is
-passed to the `transform` method. This results in an output stream, which is
-then forwarded to the transform's `Fanout` instance (task transforms do not
-support multiple outputs).
+passed to the `transform` method. This results in a stream of port-tagged output
+batches. The topology applies the selected output's schema metadata and telemetry,
+then forwards the batch to that output's `Fanout` instance. As with synchronous
+transforms, task-transform output ports must be declared ahead of time by the
+transform configuration.
+
+Synchronous transforms receive a borrowed `TransformOutputsBuf` for each call.
+Task transforms instead yield tagged batches because they may emit asynchronously,
+including after a timer fires without new input. Both paths share topology-owned
+routing and backpressure handling.
 
 ![image](https://user-images.githubusercontent.com/333505/156249430-5f82a1e0-8caa-49fe-88b8-290b6ed06ad7.png)
 

--- a/lib/vector-core/src/transform/mod.rs
+++ b/lib/vector-core/src/transform/mod.rs
@@ -100,32 +100,67 @@ pub trait FunctionTransform: Send + dyn_clone::DynClone + Sync {
 
 dyn_clone::clone_trait_object!(FunctionTransform);
 
+/// An item emitted by a [`TaskTransform`].
+///
+/// The port must correspond to an output declared by the transform's
+/// [`TransformConfig::outputs`](crate::config::TransformConfig::outputs) implementation. `None`
+/// selects the default output.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TaskTransformOutput<T> {
+    pub port: Option<Arc<str>>,
+    pub events: T,
+}
+
+impl<T> TaskTransformOutput<T> {
+    /// Creates output for the default transform port.
+    pub fn default(events: T) -> Self {
+        Self { port: None, events }
+    }
+
+    /// Creates output for a named transform port.
+    pub fn named(port: impl Into<Arc<str>>, events: T) -> Self {
+        Self {
+            port: Some(port.into()),
+            events,
+        }
+    }
+}
+
 /// Transforms that tend to be more complicated runtime style components.
 ///
-/// These require coordination and map a stream of some `T` to some `U`.
+/// These require coordination and map a stream of some `T` to port-tagged output items. The
+/// topology owns routing, schema metadata, telemetry, and backpressure handling for the selected
+/// output port.
 ///
 /// # Invariants
 ///
 /// * It is an illegal invariant to implement `FunctionTransform` for a
 ///   `TaskTransform` or vice versa.
+/// * Output ports must be declared by `TransformConfig::outputs` before the transform is built.
 pub trait TaskTransform<T: EventContainer + 'static>: Send + 'static {
     fn transform(
         self: Box<Self>,
         task: Pin<Box<dyn Stream<Item = T> + Send>>,
-    ) -> Pin<Box<dyn Stream<Item = T> + Send>>;
+    ) -> Pin<Box<dyn Stream<Item = TaskTransformOutput<T>> + Send>>;
 
-    /// Wrap the transform task to process and emit individual
-    /// events. This is used to simplify testing task transforms.
+    /// Wrap the transform task to process and emit individual events. This is used to simplify
+    /// testing task transforms while preserving their selected output ports.
     fn transform_events(
         self: Box<Self>,
         task: Pin<Box<dyn Stream<Item = Event> + Send>>,
-    ) -> Pin<Box<dyn Stream<Item = Event> + Send>>
+    ) -> Pin<Box<dyn Stream<Item = TaskTransformOutput<Event>> + Send>>
     where
         T: From<Event>,
         T::IntoIter: Send,
     {
         self.transform(task.map(Into::into).boxed())
-            .flat_map(into_event_stream)
+            .flat_map(|output| {
+                let port = output.port;
+                into_event_stream(output.events).map(move |event| TaskTransformOutput {
+                    port: port.clone(),
+                    events: event,
+                })
+            })
             .boxed()
     }
 }
@@ -202,10 +237,16 @@ impl<T: TaskTransform<Event> + Send + 'static> TaskTransform<EventArray> for Wra
     fn transform(
         self: Box<Self>,
         stream: Pin<Box<dyn Stream<Item = EventArray> + Send>>,
-    ) -> Pin<Box<dyn Stream<Item = EventArray> + Send>> {
-        // This is an awful lot of boxes
+    ) -> Pin<Box<dyn Stream<Item = TaskTransformOutput<EventArray>> + Send>> {
+        // This is an awful lot of boxes.
         let stream = stream.flat_map(into_event_stream).boxed();
-        Box::new(self.0).transform(stream).map(Into::into).boxed()
+        Box::new(self.0)
+            .transform(stream)
+            .map(|output| TaskTransformOutput {
+                port: output.port,
+                events: output.events.into(),
+            })
+            .boxed()
     }
 }
 

--- a/lib/vector-core/src/transform/outputs.rs
+++ b/lib/vector-core/src/transform/outputs.rs
@@ -98,12 +98,45 @@ impl TransformOutputs {
         TransformOutputsBuf::new_with_capacity(self.outputs_spec.clone(), capacity)
     }
 
+    /// Sends one event array to the specified output port.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the selected output fanout cannot send the event array.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the port was not declared by the transform configuration.
+    pub async fn send_event_array(
+        &mut self,
+        port: Option<&str>,
+        mut events: EventArray,
+    ) -> Result<(), Box<dyn error::Error + Send + Sync>> {
+        let output = match port {
+            Some(port) => self.named_outputs.get_mut(port),
+            None => self.primary_output.as_mut(),
+        }
+        .expect("unknown output");
+
+        for event in events.iter_events_mut() {
+            super::update_runtime_schema_definition(
+                event,
+                &output.output_id,
+                &output.log_schema_definitions,
+            );
+        }
+        let count = events.len();
+        let byte_size = events.estimated_json_encoded_size_of();
+        output.fanout.send(events, Some(Instant::now())).await?;
+        output.events_sent.emit(CountByteSize(count, byte_size));
+        Ok(())
+    }
+
     /// Sends the events in the buffer to their respective outputs.
     ///
     /// # Errors
     ///
-    /// If an error occurs while sending events to their respective output, an error variant will be
-    /// returned detailing the cause.
+    /// Returns an error if a configured output fanout cannot send its buffered events.
     pub async fn send(
         &mut self,
         buf: &mut TransformOutputsBuf,

--- a/lib/vector-core/src/transform/runtime_transform/mod.rs
+++ b/lib/vector-core/src/transform/runtime_transform/mod.rs
@@ -10,7 +10,7 @@ use tokio::time;
 use tokio_stream::wrappers::IntervalStream;
 use vec_stream::VecStreamExt;
 
-use super::{OutputBuffer, TaskTransform};
+use super::{OutputBuffer, TaskTransform, TaskTransformOutput};
 use crate::event::Event;
 
 /// A structure representing user-defined timer.
@@ -76,7 +76,7 @@ where
     fn transform(
         mut self: Box<Self>,
         input_rx: Pin<Box<dyn Stream<Item = Event> + Send>>,
-    ) -> Pin<Box<dyn Stream<Item = Event> + Send>>
+    ) -> Pin<Box<dyn Stream<Item = TaskTransformOutput<Event>> + Send>>
     where
         Self: 'static,
     {
@@ -138,6 +138,7 @@ where
                     stream::iter(acc).boxed()
                 })
                 .flatten()
+                .map(TaskTransformOutput::default)
                 .boxed(),
         )
     }

--- a/src/test_util/mock/transforms/mod.rs
+++ b/src/test_util/mock/transforms/mod.rs
@@ -22,4 +22,8 @@ pub enum TransformType {
 
     /// Transforms events in an asynchronous iterator.
     Task,
+
+    /// Transforms events in an asynchronous iterator and emits them to the default and named
+    /// outputs. Used to exercise task-transform output routing.
+    MultiOutputTask,
 }

--- a/src/test_util/mock/transforms/noop.rs
+++ b/src/test_util/mock/transforms/noop.rs
@@ -5,9 +5,9 @@ use futures_util::{Stream, StreamExt as _};
 use vector_lib::{
     config::{DataType, Input, TransformOutput},
     configurable::configurable_component,
-    event::{Event, EventContainer},
+    event::{Event, EventArray, EventContainer},
     schema::Definition,
-    transform::{FunctionTransform, OutputBuffer, TaskTransform, Transform},
+    transform::{FunctionTransform, OutputBuffer, TaskTransform, TaskTransformOutput, Transform},
 };
 
 use super::TransformType;
@@ -86,13 +86,18 @@ impl TransformConfig for NoopTransformConfig {
         _: &TransformContext,
         definitions: &[(OutputId, Definition)],
     ) -> Vec<TransformOutput> {
-        vec![TransformOutput::new(
+        let output = TransformOutput::new(
             DataType::all_bits(),
             definitions
                 .iter()
                 .map(|(output, definition)| (output.clone(), definition.clone()))
                 .collect(),
-        )]
+        );
+        if matches!(self.transform_type, TransformType::MultiOutputTask) {
+            vec![output.clone(), output.with_port("named")]
+        } else {
+            vec![output]
+        }
     }
 
     async fn build(&self, _: &TransformContext) -> crate::Result<Transform> {
@@ -108,6 +113,7 @@ impl TransformConfig for NoopTransformConfig {
                 cpu_burn,
             }))),
             TransformType::Task => Ok(Transform::Task(Box::new(NoopTransform { delay, cpu_burn }))),
+            TransformType::MultiOutputTask => Ok(Transform::Task(Box::new(MultiOutputTask))),
         }
     }
 
@@ -156,6 +162,22 @@ impl FunctionTransform for NoopTransform {
     }
 }
 
+struct MultiOutputTask;
+
+impl TaskTransform<EventArray> for MultiOutputTask {
+    fn transform(
+        self: Box<Self>,
+        task: Pin<Box<dyn futures_util::Stream<Item = EventArray> + Send>>,
+    ) -> Pin<Box<dyn Stream<Item = TaskTransformOutput<EventArray>> + Send>> {
+        Box::pin(task.flat_map(|events| {
+            futures_util::stream::iter([
+                TaskTransformOutput::default(events.clone()),
+                TaskTransformOutput::named("named", events),
+            ])
+        }))
+    }
+}
+
 impl<T> TaskTransform<T> for NoopTransform
 where
     T: EventContainer + Send + 'static,
@@ -163,7 +185,7 @@ where
     fn transform(
         self: Box<Self>,
         task: Pin<Box<dyn futures_util::Stream<Item = T> + Send>>,
-    ) -> Pin<Box<dyn Stream<Item = T> + Send>> {
+    ) -> Pin<Box<dyn Stream<Item = TaskTransformOutput<T>> + Send>> {
         let delay = self.delay;
         let cpu_burn = self.cpu_burn;
         if delay.is_some() || cpu_burn.is_some() {
@@ -174,10 +196,10 @@ where
                 if let Some(delay) = delay {
                     tokio::time::sleep(delay).await;
                 }
-                item
+                TaskTransformOutput::default(item)
             }))
         } else {
-            Box::pin(task)
+            Box::pin(task.map(TaskTransformOutput::default))
         }
     }
 }

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -32,11 +32,10 @@ use vector_lib::{
         },
     },
     enrichment::Table,
-    internal_event::{self, CountByteSize, EventsSent, InternalEventHandle as _, Registered},
+    internal_event::{CountByteSize, InternalEventHandle as _, Registered},
     latency::LatencyRecorder,
     schema::Definition,
     source_sender::{DEFAULT_CHUNK_SIZE_EVENTS, SourceSenderItem},
-    transform::update_runtime_schema_definition,
 };
 use vector_lib::{gauge, internal_event::GaugeName};
 use vector_vrl_metrics::MetricsStorage;
@@ -924,7 +923,7 @@ impl<'a> Builder<'a> {
         } = node;
         let input_type = input_details.data_type();
 
-        let (mut fanout, control) = Fanout::new(key.clone());
+        let (mut outputs, controls) = TransformOutputs::new(outputs, &key);
 
         let sender = self
             .utilization_registry
@@ -941,54 +940,24 @@ impl<'a> Builder<'a> {
                     events.estimated_json_encoded_size_of(),
                 ))
             });
-        let events_sent = register!(EventsSent::from(internal_event::Output(None)));
-        let output_id = Arc::new(OutputId {
-            component: key.clone(),
-            port: None,
-        });
         let latency_recorder = LatencyRecorder::new(self.config.global.latency_ewma_alpha);
-
-        // Task transforms can only write to the default output, so only a single schema def map is needed
-        let schema_definition_map = outputs
-            .iter()
-            .find(|x| x.port.is_none())
-            .expect("output for default port required for task transforms")
-            .log_schema_definitions
-            .clone()
-            .into_iter()
-            .map(|(key, value)| (key, Arc::new(value)))
-            .collect();
-
-        let stream = t
-            .transform(Box::pin(filtered))
-            .map(move |mut events| {
-                for event in events.iter_events_mut() {
-                    update_runtime_schema_definition(event, &output_id, &schema_definition_map);
-                }
-                let now = Instant::now();
-                latency_recorder.on_send(&mut events, now);
-                (events, now)
-            })
-            .inspect(move |(events, _): &(EventArray, Instant)| {
-                events_sent.emit(CountByteSize(
-                    events.len(),
-                    events.estimated_json_encoded_size_of(),
-                ));
-            });
-        let stream = OutputUtilization::new(output_sender, stream);
+        let stream = t.transform(Box::pin(filtered)).map(move |mut output| {
+            latency_recorder.on_send(&mut output.events, Instant::now());
+            output
+        });
+        let mut stream = OutputUtilization::new(output_sender, stream);
         let transform = async move {
             debug!("Task transform starting.");
 
-            match fanout.send_stream(stream).await {
-                Ok(()) => {
-                    debug!("Task transform finished normally.");
-                    Ok(TaskOutput::Transform)
-                }
-                Err(e) => {
-                    debug!("Task transform finished with an error.");
-                    Err(TaskError::wrapped(e))
-                }
+            while let Some(output) = stream.next().await {
+                outputs
+                    .send_event_array(output.port.as_deref(), output.events)
+                    .await
+                    .map_err(TaskError::wrapped)?;
             }
+
+            debug!("Task transform finished normally.");
+            Ok(TaskOutput::Transform)
         };
 
         let transform = if let Some(cpu_ns) = cpu_ns {
@@ -997,12 +966,17 @@ impl<'a> Builder<'a> {
             transform.boxed()
         };
 
-        let mut outputs = HashMap::new();
-        outputs.insert(OutputId::from(&key), control);
+        let mut output_controls = HashMap::new();
+        for (name, control) in controls {
+            let id = name
+                .map(|name| OutputId::from((&key, name)))
+                .unwrap_or_else(|| OutputId::from(&key));
+            output_controls.insert(id, control);
+        }
 
         let task = Task::new(key, typetag, transform);
 
-        (task, outputs)
+        (task, output_controls)
     }
 }
 

--- a/src/topology/test/compliance.rs
+++ b/src/topology/test/compliance.rs
@@ -119,3 +119,57 @@ async fn test_task_transform_single_event() {
     })
     .await;
 }
+
+#[tokio::test]
+async fn test_task_transform_routes_to_default_and_named_outputs() {
+    assert_transform_compliance(async {
+        let event = Event::Log(LogEvent::from("multi-output task transform"));
+        let (default_tx, default_rx) = channel();
+        let (named_tx, named_rx) = channel();
+        let mut builder = ConfigBuilder::default();
+
+        builder.add_source(
+            "in",
+            UnitTestSourceConfig {
+                events: vec![event],
+            },
+        );
+        builder.add_transform(
+            "transform",
+            &["in"],
+            NoopTransformConfig::from(TransformType::MultiOutputTask),
+        );
+        builder.add_sink("default", &["transform"], oneshot_sink(default_tx));
+        builder.add_sink("named", &["transform.named"], oneshot_sink(named_tx));
+
+        let config = builder.build().expect("building config should not fail");
+        let (topology, _) = start_topology(config, false).await;
+        topology.stop().await;
+
+        let default_events = default_rx
+            .await
+            .expect("default output must receive an event")
+            .into_events()
+            .collect::<Vec<_>>();
+        let named_events = named_rx
+            .await
+            .expect("named output must receive an event")
+            .into_events()
+            .collect::<Vec<_>>();
+
+        assert_eq!(default_events.len(), 1);
+        assert_eq!(named_events.len(), 1);
+        assert_eq!(
+            default_events[0].metadata().upstream_id(),
+            Some(&OutputId::from("transform"))
+        );
+        assert_eq!(
+            named_events[0].metadata().upstream_id(),
+            Some(&OutputId::from((
+                "transform".to_owned(),
+                Some("named".to_owned()),
+            )))
+        );
+    })
+    .await;
+}

--- a/src/transforms/aggregate.rs
+++ b/src/transforms/aggregate.rs
@@ -19,7 +19,7 @@ use crate::{
     event::{Event, EventMetadata},
     internal_events::{AggregateEventRecorded, AggregateFlushed, AggregateUpdateFailed},
     schema,
-    transforms::{TaskTransform, Transform},
+    transforms::{TaskTransform, TaskTransformOutput, Transform},
 };
 
 /// Configuration for the `aggregate` transform.
@@ -380,7 +380,7 @@ impl TaskTransform<Event> for Aggregate {
     fn transform(
         mut self: Box<Self>,
         mut input_rx: Pin<Box<dyn Stream<Item = Event> + Send>>,
-    ) -> Pin<Box<dyn Stream<Item = Event> + Send>>
+    ) -> Pin<Box<dyn Stream<Item = TaskTransformOutput<Event>> + Send>>
     where
         Self: 'static,
     {
@@ -409,7 +409,7 @@ impl TaskTransform<Event> for Aggregate {
                     }
                 };
                 for event in output.drain(..) {
-                    yield event;
+                    yield TaskTransformOutput::default(event);
                 }
             }
         })
@@ -1154,7 +1154,7 @@ mod tests {
         // Queue up some events to be consumed & recorded
         let in_stream = Box::pin(stream::iter(inputs));
         // Kick off the transform process which should consume & record them
-        let mut out_stream = agg.transform_events(in_stream);
+        let mut out_stream = agg.transform_events(in_stream).map(|output| output.events);
 
         // B/c the input stream has ended we will have gone through the `input_rx.next() => None`
         // part of the loop and do the shutting down final flush immediately. We'll already be able

--- a/src/transforms/aws_ec2_metadata.rs
+++ b/src/transforms/aws_ec2_metadata.rs
@@ -35,7 +35,7 @@ use crate::{
     http::HttpClient,
     internal_events::{AwsEc2MetadataRefreshError, AwsEc2MetadataRefreshSuccessful},
     schema,
-    transforms::{TaskTransform, Transform},
+    transforms::{TaskTransform, TaskTransformOutput, Transform},
 };
 
 const ACCOUNT_ID_KEY: &str = "account-id";
@@ -312,12 +312,16 @@ impl TaskTransform<Event> for Ec2MetadataTransform {
     fn transform(
         self: Box<Self>,
         task: Pin<Box<dyn Stream<Item = Event> + Send>>,
-    ) -> Pin<Box<dyn Stream<Item = Event> + Send>>
+    ) -> Pin<Box<dyn Stream<Item = TaskTransformOutput<Event>> + Send>>
     where
         Self: 'static,
     {
         let mut inner = self;
-        Box::pin(task.filter_map(move |event| ready(Some(inner.transform_one(event)))))
+        Box::pin(task.filter_map(move |event| {
+            ready(Some(TaskTransformOutput::default(
+                inner.transform_one(event),
+            )))
+        }))
     }
 }
 

--- a/src/transforms/dedupe/timed_transform.rs
+++ b/src/transforms/dedupe/timed_transform.rs
@@ -7,7 +7,11 @@ use super::{
     common::{FieldMatchConfig, TimedCacheConfig},
     transform::{CacheEntry, build_cache_entry},
 };
-use crate::{event::Event, internal_events::DedupeEventsDropped, transforms::TaskTransform};
+use crate::{
+    event::Event,
+    internal_events::DedupeEventsDropped,
+    transforms::{TaskTransform, TaskTransformOutput},
+};
 
 #[derive(Clone)]
 pub struct TimedDedupe {
@@ -58,11 +62,15 @@ impl TaskTransform<Event> for TimedDedupe {
     fn transform(
         self: Box<Self>,
         task: Pin<Box<dyn Stream<Item = Event> + Send>>,
-    ) -> Pin<Box<dyn Stream<Item = Event> + Send>>
+    ) -> Pin<Box<dyn Stream<Item = TaskTransformOutput<Event>> + Send>>
     where
         Self: 'static,
     {
         let mut inner = self;
-        Box::pin(task.filter_map(move |v| ready(inner.transform_one(v))))
+        Box::pin(
+            task.filter_map(move |v| {
+                ready(inner.transform_one(v).map(TaskTransformOutput::default))
+            }),
+        )
     }
 }

--- a/src/transforms/dedupe/transform.rs
+++ b/src/transforms/dedupe/transform.rs
@@ -10,7 +10,7 @@ use super::common::FieldMatchConfig;
 use crate::{
     event::{Event, Value},
     internal_events::DedupeEventsDropped,
-    transforms::TaskTransform,
+    transforms::{TaskTransform, TaskTransformOutput},
 };
 
 #[derive(Clone)]
@@ -124,11 +124,15 @@ impl TaskTransform<Event> for Dedupe {
     fn transform(
         self: Box<Self>,
         task: Pin<Box<dyn Stream<Item = Event> + Send>>,
-    ) -> Pin<Box<dyn Stream<Item = Event> + Send>>
+    ) -> Pin<Box<dyn Stream<Item = TaskTransformOutput<Event>> + Send>>
     where
         Self: 'static,
     {
         let mut inner = self;
-        Box::pin(task.filter_map(move |v| ready(inner.transform_one(v))))
+        Box::pin(
+            task.filter_map(move |v| {
+                ready(inner.transform_one(v).map(TaskTransformOutput::default))
+            }),
+        )
     }
 }

--- a/src/transforms/delay.rs
+++ b/src/transforms/delay.rs
@@ -14,7 +14,7 @@ use crate::{
     config::{DataType, Input, OutputId, TransformConfig, TransformContext, TransformOutput},
     event::Event,
     schema,
-    transforms::{TaskTransform, Transform},
+    transforms::{TaskTransform, TaskTransformOutput, Transform},
 };
 
 /// Configuration for the `delay` transform.
@@ -164,7 +164,7 @@ impl TaskTransform<Event> for Delay {
     fn transform(
         mut self: Box<Self>,
         mut input_rx: Pin<Box<dyn Stream<Item = Event> + Send>>,
-    ) -> Pin<Box<dyn Stream<Item = Event> + Send>>
+    ) -> Pin<Box<dyn Stream<Item = TaskTransformOutput<Event>> + Send>>
     where
         Self: 'static,
     {
@@ -181,7 +181,7 @@ impl TaskTransform<Event> for Delay {
                         let event = res.into_inner();
                         let (result, event) = self.check_condition(event, false);
                         if result {
-                            yield event;
+                            yield TaskTransformOutput::default(event);
                         } else {
                             self.queue.insert(event, self.delay);
                         }
@@ -198,7 +198,7 @@ impl TaskTransform<Event> for Delay {
                             Some(event) => {
                                 let (result, event) = self.check_condition(event, true);
                                 if result {
-                                    yield event
+                                    yield TaskTransformOutput::default(event)
                                 } else {
                                     if self.queue_capacity.get() <= self.queue.len() {
                                         match self.overflow_strategy {
@@ -207,7 +207,7 @@ impl TaskTransform<Event> for Delay {
                                                     let event = next.into_inner();
                                                     let (result, event) = self.check_condition(event, false);
                                                     if result {
-                                                        yield event;
+                                                        yield TaskTransformOutput::default(event);
                                                     } else {
                                                         self.queue.insert(event, self.delay);
                                                     }
@@ -221,7 +221,7 @@ impl TaskTransform<Event> for Delay {
                                                 continue;
                                             }
                                             OverflowStrategy::Forward => {
-                                                yield event;
+                                                yield TaskTransformOutput::default(event);
                                                 continue;
                                             }
                                         }
@@ -316,7 +316,7 @@ mod tests {
         let Poll::Ready(Some(event)) = futures::poll!(out_stream.next()) else {
             panic!("Unexpectedly received None or Pending in output stream");
         };
-        assert!(event.try_into_log().is_some());
+        assert!(event.events.try_into_log().is_some());
 
         // We should be pending, because trace event should have been dropped
         assert_eq!(Poll::Pending, futures::poll!(out_stream.next()));
@@ -346,7 +346,7 @@ mod tests {
         let Poll::Ready(Some(event)) = futures::poll!(out_stream.next()) else {
             panic!("Unexpectedly received None or Pending in output stream");
         };
-        assert!(event.try_into_trace().is_some());
+        assert!(event.events.try_into_trace().is_some());
 
         // We should be pending, because we are now waiting for the delay
         assert_eq!(Poll::Pending, futures::poll!(out_stream.next()));
@@ -357,6 +357,6 @@ mod tests {
         let Poll::Ready(Some(event)) = futures::poll!(out_stream.next()) else {
             panic!("Unexpectedly received None or Pending in output stream");
         };
-        assert!(event.try_into_log().is_some());
+        assert!(event.events.try_into_log().is_some());
     }
 }

--- a/src/transforms/incremental_to_absolute.rs
+++ b/src/transforms/incremental_to_absolute.rs
@@ -8,7 +8,7 @@ use crate::{
     event::Event,
     schema,
     sinks::util::buffer::metrics::{MetricSet, NormalizerConfig, NormalizerSettings},
-    transforms::{TaskTransform, Transform},
+    transforms::{TaskTransform, TaskTransformOutput, Transform},
 };
 
 /// Configuration for the `incremental_to_absolute` transform.
@@ -86,12 +86,16 @@ impl TaskTransform<Event> for IncrementalToAbsolute {
     fn transform(
         self: Box<Self>,
         task: Pin<Box<dyn Stream<Item = Event> + Send>>,
-    ) -> Pin<Box<dyn Stream<Item = Event> + Send>>
+    ) -> Pin<Box<dyn Stream<Item = TaskTransformOutput<Event>> + Send>>
     where
         Self: 'static,
     {
         let mut inner = self;
-        Box::pin(task.filter_map(move |v| ready(inner.transform_one(v))))
+        Box::pin(
+            task.filter_map(move |v| {
+                ready(inner.transform_one(v).map(TaskTransformOutput::default))
+            }),
+        )
     }
 }
 
@@ -147,7 +151,9 @@ mod tests {
             .unwrap();
         let incremental_to_absolute = incremental_to_absolute.into_task();
         let (mut tx, rx) = futures::channel::mpsc::channel(10);
-        let mut out_stream = incremental_to_absolute.transform_events(Box::pin(rx));
+        let mut out_stream = incremental_to_absolute
+            .transform_events(Box::pin(rx))
+            .map(|output| output.events);
 
         let inc_counter_1 = make_metric(
             "incremental_counter",

--- a/src/transforms/lua/v1/mod.rs
+++ b/src/transforms/lua/v1/mod.rs
@@ -16,7 +16,7 @@ use crate::{
     internal_events::{LuaGcTriggered, LuaScriptError},
     schema,
     schema::Definition,
-    transforms::{TaskTransform, Transform},
+    transforms::{TaskTransform, TaskTransformOutput, Transform},
 };
 
 #[derive(Debug, Snafu)]
@@ -196,7 +196,7 @@ impl TaskTransform<Event> for Lua {
     fn transform(
         self: Box<Self>,
         task: Pin<Box<dyn Stream<Item = Event> + Send>>,
-    ) -> Pin<Box<dyn Stream<Item = Event> + Send>>
+    ) -> Pin<Box<dyn Stream<Item = TaskTransformOutput<Event>> + Send>>
     where
         Self: 'static,
     {
@@ -215,7 +215,8 @@ impl TaskTransform<Event> for Lua {
                     }
                 })
             })
-            .flatten(),
+            .flatten()
+            .map(TaskTransformOutput::default),
         )
     }
 }

--- a/src/transforms/mod.rs
+++ b/src/transforms/mod.rs
@@ -39,8 +39,8 @@ pub mod trace_to_log;
 pub mod window;
 
 pub use vector_lib::transform::{
-    FunctionTransform, OutputBuffer, SyncTransform, TaskTransform, Transform, TransformOutputs,
-    TransformOutputsBuf,
+    FunctionTransform, OutputBuffer, SyncTransform, TaskTransform, TaskTransformOutput, Transform,
+    TransformOutputs, TransformOutputsBuf,
 };
 
 #[cfg(test)]

--- a/src/transforms/reduce/transform.rs
+++ b/src/transforms/reduce/transform.rs
@@ -4,7 +4,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use futures::Stream;
+use futures::{Stream, StreamExt};
 use indexmap::IndexMap;
 use vector_lib::stream::expiration_map::{Emitter, map_with_expiration};
 use vector_vrl_metrics::MetricsStorage;
@@ -18,7 +18,7 @@ use crate::{
     event::{Event, EventMetadata, LogEvent, discriminant::Discriminant},
     internal_events::{ReduceAddEventError, ReduceStaleEventFlushed},
     transforms::{
-        TaskTransform,
+        TaskTransform, TaskTransformOutput,
         reduce::{
             config::ReduceConfig,
             merge_strategy::{MergeStrategy, ReduceValueMerger, get_value_merger},
@@ -316,7 +316,7 @@ impl TaskTransform<Event> for Reduce {
     fn transform(
         self: Box<Self>,
         input_rx: Pin<Box<dyn Stream<Item = Event> + Send>>,
-    ) -> Pin<Box<dyn Stream<Item = Event> + Send>>
+    ) -> Pin<Box<dyn Stream<Item = TaskTransformOutput<Event>> + Send>>
     where
         Self: 'static,
     {
@@ -332,25 +332,28 @@ pub fn construct_output_stream(
     reduce: Box<Reduce>,
     input_rx: Pin<Box<dyn Stream<Item = Event> + Send>>,
     mut transform_fn: impl FnMut(&mut Box<Reduce>, Event, &mut Emitter<Event>) + Send + Sync + 'static,
-) -> Pin<Box<dyn Stream<Item = Event> + Send>>
+) -> Pin<Box<dyn Stream<Item = TaskTransformOutput<Event>> + Send>>
 where
     Reduce: 'static,
 {
     let flush_period = reduce.flush_period;
-    Box::pin(map_with_expiration(
-        reduce,
-        input_rx,
-        flush_period,
-        move |me, event, emitter| {
-            transform_fn(me, event, emitter);
-        },
-        |me, emitter| {
-            me.flush_into(emitter);
-        },
-        |me, emitter| {
-            me.flush_all_into(emitter);
-        },
-    ))
+    Box::pin(
+        map_with_expiration(
+            reduce,
+            input_rx,
+            flush_period,
+            move |me, event, emitter| {
+                transform_fn(me, event, emitter);
+            },
+            |me, emitter| {
+                me.flush_into(emitter);
+            },
+            |me, emitter| {
+                me.flush_all_into(emitter);
+            },
+        )
+        .map(TaskTransformOutput::default),
+    )
 }
 
 #[cfg(test)]

--- a/src/transforms/tag_cardinality_limit/mod.rs
+++ b/src/transforms/tag_cardinality_limit/mod.rs
@@ -2,7 +2,10 @@ use std::{future::ready, pin::Pin};
 
 use futures::{Stream, StreamExt};
 use hashbrown::HashMap;
-use vector_lib::{event::Event, transform::TaskTransform};
+use vector_lib::{
+    event::Event,
+    transform::{TaskTransform, TaskTransformOutput},
+};
 
 use crate::internal_events::{
     TagCardinalityLimitRejectingEvent, TagCardinalityLimitRejectingTag,
@@ -414,11 +417,15 @@ impl TaskTransform<Event> for TagCardinalityLimit {
     fn transform(
         self: Box<Self>,
         task: Pin<Box<dyn Stream<Item = Event> + Send>>,
-    ) -> Pin<Box<dyn Stream<Item = Event> + Send>>
+    ) -> Pin<Box<dyn Stream<Item = TaskTransformOutput<Event>> + Send>>
     where
         Self: 'static,
     {
         let mut inner = self;
-        Box::pin(task.filter_map(move |v| ready(inner.transform_one(v))))
+        Box::pin(
+            task.filter_map(move |v| {
+                ready(inner.transform_one(v).map(TaskTransformOutput::default))
+            }),
+        )
     }
 }

--- a/src/transforms/throttle/transform.rs
+++ b/src/transforms/throttle/transform.rs
@@ -16,7 +16,7 @@ use crate::{
     event::Event,
     internal_events::{TemplateRenderingError, ThrottleEventDiscarded},
     template::Template,
-    transforms::TaskTransform,
+    transforms::{TaskTransform, TaskTransformOutput},
 };
 
 #[derive(Clone)]
@@ -94,7 +94,7 @@ where
     fn transform(
         self: Box<Self>,
         mut input_rx: Pin<Box<dyn Stream<Item = Event> + Send>>,
-    ) -> Pin<Box<dyn Stream<Item = Event> + Send>>
+    ) -> Pin<Box<dyn Stream<Item = TaskTransformOutput<Event>> + Send>>
     where
         Self: 'static,
     {
@@ -132,7 +132,7 @@ where
                     Some(event)
                 };
                 if let Some(event) = output {
-                    yield event;
+                    yield TaskTransformOutput::default(event);
                 }
             }
         })

--- a/src/utilization.rs
+++ b/src/utilization.rs
@@ -483,17 +483,17 @@ mod tests {
     }
 
     use crate::event::EventArray;
-    use crate::transforms::TaskTransform;
+    use crate::transforms::{TaskTransform, TaskTransformOutput};
 
     impl TaskTransform<EventArray> for MockTaskTransform {
         fn transform(
             self: Box<Self>,
             task: Pin<Box<dyn Stream<Item = EventArray> + Send>>,
-        ) -> Pin<Box<dyn Stream<Item = EventArray> + Send>> {
+        ) -> Pin<Box<dyn Stream<Item = TaskTransformOutput<EventArray>> + Send>> {
             let processing_time = self.processing_time;
             task.map(move |events| {
                 MockClock::advance(processing_time);
-                events
+                TaskTransformOutput::default(events)
             })
             .boxed()
         }


### PR DESCRIPTION
## Summary

Add named output-port support to task transforms. Task transforms now yield port-tagged batches, while topology continues to own output routing, schema metadata, telemetry, and backpressure. Existing task transforms retain default-output behavior, and a topology test covers default and named task outputs.

## Vector configuration

Not applicable. This adds transform-runtime support without changing an existing user-facing transform configuration.

## How did you test this PR?

- `cargo check -p vector --lib`
- `cargo check -p vector --tests`
- `cargo check -p vector --benches`
- `cargo clippy -p vector --lib --tests -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo test -p vector topology::test::compliance::test_task_transform_routes_to_default_and_named_outputs --lib`

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [x] Yes
- [ ] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Closes: #<issue/PR number or link>
-->
<!--
- Related: #<issue/PR number or link>
-->