### PR TITLE
fix(redis source): add reconnecting pubsub session for channel `data_type`

### DIFF
--- a/changelog.d/22615_redis_channel_reconnect.fix.md
+++ b/changelog.d/22615_redis_channel_reconnect.fix.md
@@ -1,0 +1,3 @@
+The `redis` source configured with `data_type = "channel"` now automatically reconnects and re-subscribes after the Redis connection drops (for example on a Redis restart or a transient network blip), instead of silently stopping until Vector is restarted. Reconnect attempts use exponential backoff (capped at 30s) and emit `component_errors_total` on failures and `connection_established_total` on recovery.
+
+authors: gibranbadrul

--- a/src/internal_events/redis.rs
+++ b/src/internal_events/redis.rs
@@ -70,6 +70,31 @@ impl InternalEvent for RedisConnectionError {
     }
 }
 
+/// Emitted when an established `redis` channel pub/sub connection drops unexpectedly. The
+/// source reconnects automatically, but this records the drop as a component error so that
+/// metric-based alerts still fire even when the following reconnect succeeds immediately.
+#[derive(Debug, NamedInternalEvent)]
+pub struct RedisConnectionDropped;
+
+impl InternalEvent for RedisConnectionDropped {
+    fn emit(self) {
+        error!(
+            message = "Redis pub/sub connection dropped; will reconnect.",
+            error = "connection closed by server",
+            error_code = "connection_dropped",
+            error_type = error_type::CONNECTION_FAILED,
+            stage = error_stage::RECEIVING,
+        );
+        counter!(
+            CounterName::ComponentErrorsTotal,
+            "error_code" => "connection_dropped",
+            "error_type" => error_type::CONNECTION_FAILED,
+            "stage" => error_stage::RECEIVING,
+        )
+        .increment(1);
+    }
+}
+
 /// Emitted when the `redis` channel source (re)establishes its pub/sub subscription.
 /// `reconnect` distinguishes the first successful connect from a recovery after a drop.
 #[derive(Debug, NamedInternalEvent)]

--- a/src/internal_events/redis.rs
+++ b/src/internal_events/redis.rs
@@ -74,9 +74,9 @@ impl InternalEvent for RedisConnectionError {
 /// source reconnects automatically, but this records the drop as a component error so that
 /// metric-based alerts still fire even when the following reconnect succeeds immediately.
 #[derive(Debug, NamedInternalEvent)]
-pub struct RedisConnectionDropped;
+pub struct RedisConnectionDroppedError;
 
-impl InternalEvent for RedisConnectionDropped {
+impl InternalEvent for RedisConnectionDroppedError {
     fn emit(self) {
         error!(
             message = "Redis pub/sub connection dropped; will reconnect.",

--- a/src/internal_events/redis.rs
+++ b/src/internal_events/redis.rs
@@ -34,3 +34,56 @@ impl InternalEvent for RedisReceiveEventError {
         .increment(1);
     }
 }
+
+/// Emitted when the `redis` channel source fails to open a pub/sub connection or to
+/// subscribe to its channel. The source backs off and retries, so this is a transient
+/// error rather than a fatal one.
+#[derive(Debug, NamedInternalEvent)]
+pub struct RedisConnectionError {
+    error: redis::RedisError,
+    error_code: String,
+}
+
+impl From<redis::RedisError> for RedisConnectionError {
+    fn from(error: redis::RedisError) -> Self {
+        let error_code = error.code().unwrap_or("UNKNOWN").to_string();
+        Self { error, error_code }
+    }
+}
+
+impl InternalEvent for RedisConnectionError {
+    fn emit(self) {
+        error!(
+            message = "Failed to establish Redis pub/sub subscription; will reconnect.",
+            error = %self.error,
+            error_code = %self.error_code,
+            error_type = error_type::CONNECTION_FAILED,
+            stage = error_stage::RECEIVING,
+        );
+        counter!(
+            CounterName::ComponentErrorsTotal,
+            "error_code" => self.error_code,
+            "error_type" => error_type::CONNECTION_FAILED,
+            "stage" => error_stage::RECEIVING,
+        )
+        .increment(1);
+    }
+}
+
+/// Emitted when the `redis` channel source (re)establishes its pub/sub subscription.
+/// `reconnect` distinguishes the first successful connect from a recovery after a drop.
+#[derive(Debug, NamedInternalEvent)]
+pub struct RedisConnectionEstablished {
+    pub reconnect: bool,
+}
+
+impl InternalEvent for RedisConnectionEstablished {
+    fn emit(self) {
+        if self.reconnect {
+            info!(message = "Redis pub/sub connection re-established and resubscribed.");
+        } else {
+            debug!(message = "Redis pub/sub connection established.");
+        }
+        counter!(CounterName::ConnectionEstablishedTotal, "mode" => "redis").increment(1);
+    }
+}

--- a/src/sources/redis/channel.rs
+++ b/src/sources/redis/channel.rs
@@ -1,5 +1,7 @@
 use futures_util::StreamExt;
-use snafu::{ResultExt, Snafu};
+use snafu::Snafu;
+use std::time::Duration;
+use tracing::{trace, warn, info};
 
 use crate::{
     internal_events::RedisReceiveEventError,
@@ -17,38 +19,225 @@ enum BuildError {
     Subscribe { source: redis::RedisError },
 }
 
+/// Defines how a pub/sub "session" ended.
+///
+/// A session = we connected to Redis, SUBSCRIBE'd to a channel,
+/// and started reading messages in a loop.
+enum SessionEnd {
+    /// Vector is shutting down; stop and don't reconnect.
+    Shutdown,
+    /// Redis connection dropped; we should reconnect.
+    Disconnected,
+    /// Downstream stopped accepting events; there's no point continuing.
+    DownstreamClosed,
+}
+
+/// Exponential backoff used between reconnect attempts.
+async fn backoff_exponential(exp: u32) {
+    let ms = if exp <= 4 { 2_u64.pow(exp + 5) } else { 1000 };
+    tokio::time::sleep(Duration::from_millis(ms)).await;
+}
+
 impl InputHandler {
+    /// Build the Redis `channel` source.
     pub(super) async fn subscribe(
         mut self,
         connection_info: ConnectionInfo,
     ) -> crate::Result<Source> {
-        let mut pubsub_conn = self
-            .client
-            .get_async_pubsub()
-            .await
-            .context(ConnectionSnafu {})?;
+        let client = self.client.clone();
+        let channel = self.key.clone();
+        let endpoint = connection_info.endpoint.to_string();
 
-        trace!(endpoint = %connection_info.endpoint.as_str(), "Connected.");
+        /// Open a pubsub connection and SUBSCRIBE to `channel`.
+        /// Returns a ready `PubSub` on success.
+        async fn connect_and_subscribe(
+            client: &redis::Client,
+            endpoint: &str,
+            channel: &str,
+        ) -> Result<redis::aio::PubSub, BuildError> {
+            // create pubsub connection
+            let mut pubsub_conn = client
+                .get_async_pubsub()
+                .await
+                .map_err(|source| BuildError::Connection { source })?;
 
-        pubsub_conn
-            .subscribe(&self.key)
-            .await
-            .context(SubscribeSnafu {})?;
-        trace!(endpoint = %connection_info.endpoint.as_str(), channel = %self.key, "Subscribed to channel.");
+            trace!(endpoint, "Connected.");
 
-        Ok(Box::pin(async move {
-            let shutdown = self.cx.shutdown.clone();
-            let mut pubsub_stream = pubsub_conn.on_message().take_until(shutdown);
-            while let Some(msg) = pubsub_stream.next().await {
-                match msg.get_payload::<String>() {
-                    Ok(line) => {
-                        if let Err(()) = self.handle_line(line).await {
-                            break;
+            // subscribe to the configured channel
+            pubsub_conn
+                .subscribe(channel)
+                .await
+                .map_err(|source| BuildError::Subscribe { source })?;
+
+            trace!(endpoint, channel, "Subscribed to channel.");
+
+            Ok(pubsub_conn)
+        }
+
+        async fn run_subscription_session<S>(
+            pubsub_conn: &mut redis::aio::PubSub,
+            channel: &str,
+            shutdown: &mut S,
+            handler: &mut InputHandler,
+            endpoint: &str,
+        ) -> SessionEnd
+        where
+            S: std::future::Future + Unpin,
+        {
+            let mut stream = pubsub_conn.on_message();
+
+            loop {
+                // One "step" in the session: either we got a message,
+                // Redis dropped us, or shutdown fired.
+                enum RecvEvent {
+                    Msg(redis::Msg),
+                    Shutdown,
+                    Disconnected,
+                }
+
+                let event = tokio::select! {
+                    maybe_msg = stream.next() => {
+                        match maybe_msg {
+                            Some(msg) => RecvEvent::Msg(msg),
+                            None => RecvEvent::Disconnected,
                         }
                     }
-                    Err(error) => emit!(RedisReceiveEventError::from(error)),
+                    _ = &mut *shutdown => {
+                        RecvEvent::Shutdown
+                    }
+                };
+
+                match event {
+                    RecvEvent::Msg(msg) => match msg.get_payload::<String>() {
+                        Ok(line) => {
+                            // If downstream is gone and won't take more data,
+                            // stop the source too.
+                            if let Err(()) = handler.handle_line(line).await {
+                                return SessionEnd::DownstreamClosed;
+                            }
+                        }
+                        Err(error) => {
+                            // Bad payload. We just log and keep going.
+                            emit!(RedisReceiveEventError::from(error));
+                        }
+                    },
+
+                    RecvEvent::Disconnected => {
+                        // Redis connection ended (e.g. server restart).
+                        // We'll reconnect in the outer loop.
+                        warn!(
+                            endpoint,
+                            channel,
+                            "Redis pubsub stream ended; will reconnect"
+                        );
+                        return SessionEnd::Disconnected;
+                    }
+
+                    RecvEvent::Shutdown => {
+                        // Vector shutdown. Caller will not reconnect.
+                        return SessionEnd::Shutdown;
+                    }
                 }
             }
+        }
+
+        Ok(Box::pin(async move {
+            // `shutdown` is a signal that resolves when Vector is stopping.
+            let mut shutdown = self.cx.shutdown.clone();
+
+            // retry counter for exponential backoff between reconnects
+            let mut retry: u32 = 0;
+
+            loop {
+                // connect + SUBSCRIBE
+                let mut pubsub_conn =
+                    match connect_and_subscribe(&client, &endpoint, &channel).await {
+                        Ok(conn) => {
+                            let was_reconnecting = retry > 0;
+
+                            if was_reconnecting {
+                                // we previously failed but now we're back
+                                info!(
+                                    endpoint = %endpoint,
+                                    channel  = %channel,
+                                    "Redis pubsub connection re-established and resubscribed"
+                                );
+                            } else {
+                                trace!(
+                                    endpoint = %endpoint,
+                                    channel  = %channel,
+                                    "Redis pubsub connection established"
+                                );
+                            }
+
+                            retry = 0;
+                            conn
+                        }
+                        Err(err) => {
+                            // failed to connect or SUBSCRIBE
+                            warn!(
+                                %err,
+                                endpoint = %endpoint,
+                                channel  = %channel,
+                                "Failed to establish subscription; will retry"
+                            );
+
+                            retry += 1;
+
+                            // back off before retrying, unless we're shutting down
+                            tokio::select! {
+                                _ = backoff_exponential(retry) => {
+                                    continue;
+                                }
+                                _ = &mut shutdown => {
+                                    break;
+                                }
+                            }
+                        }
+                    };
+
+                // run that session (receive messages, forward them, etc.)
+                let end_reason = run_subscription_session(
+                    &mut pubsub_conn,
+                    &channel,
+                    &mut shutdown,
+                    &mut self,
+                    &endpoint,
+                )
+                    .await;
+
+                match end_reason {
+                    SessionEnd::Shutdown => {
+                        // shutting down cleanly
+                        let _ = pubsub_conn.unsubscribe(&channel).await;
+                        break;
+                    }
+
+                    SessionEnd::DownstreamClosed => {
+                        // downstream closed, no point continuing
+                        let _ = pubsub_conn.unsubscribe(&channel).await;
+                        break;
+                    }
+
+                    SessionEnd::Disconnected => {
+                        // Redis dropped us. We'll try to reconnect after a backoff,
+                        // unless shutdown fires during that backoff.
+                        retry += 1;
+
+                        tokio::select! {
+                            _ = backoff_exponential(retry) => {
+                                let _ = pubsub_conn.unsubscribe(&channel).await;
+                                continue;
+                            }
+                            _ = &mut shutdown => {
+                                let _ = pubsub_conn.unsubscribe(&channel).await;
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+
             Ok(())
         }))
     }

--- a/src/sources/redis/channel.rs
+++ b/src/sources/redis/channel.rs
@@ -1,10 +1,12 @@
+use std::time::Duration;
+
 use futures_util::StreamExt;
 use snafu::Snafu;
-use std::time::Duration;
-use tracing::{trace, warn, info};
+use tracing::{trace, warn};
 
 use crate::{
-    internal_events::RedisReceiveEventError,
+    common::backoff::ExponentialBackoff,
+    internal_events::{RedisConnectionError, RedisConnectionEstablished, RedisReceiveEventError},
     sources::{
         Source,
         redis::{ConnectionInfo, InputHandler},
@@ -17,6 +19,15 @@ enum BuildError {
     Connection { source: redis::RedisError },
     #[snafu(display("Failed to subscribe to channel: {}", source))]
     Subscribe { source: redis::RedisError },
+}
+
+impl BuildError {
+    /// The underlying Redis error, regardless of which stage (connect or subscribe) failed.
+    fn into_source(self) -> redis::RedisError {
+        match self {
+            BuildError::Connection { source } | BuildError::Subscribe { source } => source,
+        }
+    }
 }
 
 /// Defines how a pub/sub "session" ended.
@@ -32,14 +43,13 @@ enum SessionEnd {
     DownstreamClosed,
 }
 
-/// Exponential backoff used between reconnect attempts.
-async fn backoff_exponential(exp: u32) {
-    let ms = if exp <= 4 { 2_u64.pow(exp + 5) } else { 1000 };
-    tokio::time::sleep(Duration::from_millis(ms)).await;
-}
-
 impl InputHandler {
     /// Build the Redis `channel` source.
+    ///
+    /// The source runs a reconnect loop: it connects, SUBSCRIBEs, and streams messages
+    /// until either shutdown fires, downstream closes, or the Redis connection drops. On a
+    /// drop it reconnects with exponential backoff instead of stopping, so a Redis restart
+    /// or transient network blip no longer requires a manual Vector restart.
     pub(super) async fn subscribe(
         mut self,
         connection_info: ConnectionInfo,
@@ -127,8 +137,7 @@ impl InputHandler {
                         // We'll reconnect in the outer loop.
                         warn!(
                             endpoint,
-                            channel,
-                            "Redis pubsub stream ended; will reconnect"
+                            channel, "Redis pubsub stream ended; will reconnect."
                         );
                         return SessionEnd::Disconnected;
                     }
@@ -145,48 +154,36 @@ impl InputHandler {
             // `shutdown` is a signal that resolves when Vector is stopping.
             let mut shutdown = self.cx.shutdown.clone();
 
-            // retry counter for exponential backoff between reconnects
-            let mut retry: u32 = 0;
+            // Exponential backoff between reconnect attempts: 500ms, 1s, 2s, 4s, ...
+            // capped at 30s. Matches the strategy used by other reconnecting sources
+            // (e.g. `aws_s3`/`sqs`). Reset once a connection is successfully established.
+            let mut backoff = ExponentialBackoff::from_millis(2)
+                .factor(250)
+                .max_delay(Duration::from_secs(30));
+
+            // Whether we're recovering from a dropped/failed connection. Drives the
+            // log/metric emitted on a successful (re)connect.
+            let mut reconnecting = false;
 
             loop {
                 // connect + SUBSCRIBE
                 let mut pubsub_conn =
                     match connect_and_subscribe(&client, &endpoint, &channel).await {
                         Ok(conn) => {
-                            let was_reconnecting = retry > 0;
-
-                            if was_reconnecting {
-                                // we previously failed but now we're back
-                                info!(
-                                    endpoint = %endpoint,
-                                    channel  = %channel,
-                                    "Redis pubsub connection re-established and resubscribed"
-                                );
-                            } else {
-                                trace!(
-                                    endpoint = %endpoint,
-                                    channel  = %channel,
-                                    "Redis pubsub connection established"
-                                );
-                            }
-
-                            retry = 0;
+                            emit!(RedisConnectionEstablished {
+                                reconnect: reconnecting
+                            });
                             conn
                         }
                         Err(err) => {
                             // failed to connect or SUBSCRIBE
-                            warn!(
-                                %err,
-                                endpoint = %endpoint,
-                                channel  = %channel,
-                                "Failed to establish subscription; will retry"
-                            );
-
-                            retry += 1;
+                            emit!(RedisConnectionError::from(err.into_source()));
+                            reconnecting = true;
 
                             // back off before retrying, unless we're shutting down
+                            let delay = backoff.next().expect("backoff never ends");
                             tokio::select! {
-                                _ = backoff_exponential(retry) => {
+                                _ = tokio::time::sleep(delay) => {
                                     continue;
                                 }
                                 _ = &mut shutdown => {
@@ -196,6 +193,10 @@ impl InputHandler {
                         }
                     };
 
+                // Connected: reset backoff so the next outage starts from the shortest delay.
+                backoff.reset();
+                reconnecting = false;
+
                 // run that session (receive messages, forward them, etc.)
                 let end_reason = run_subscription_session(
                     &mut pubsub_conn,
@@ -204,17 +205,11 @@ impl InputHandler {
                     &mut self,
                     &endpoint,
                 )
-                    .await;
+                .await;
 
                 match end_reason {
-                    SessionEnd::Shutdown => {
-                        // shutting down cleanly
-                        let _ = pubsub_conn.unsubscribe(&channel).await;
-                        break;
-                    }
-
-                    SessionEnd::DownstreamClosed => {
-                        // downstream closed, no point continuing
+                    SessionEnd::Shutdown | SessionEnd::DownstreamClosed => {
+                        // shutting down cleanly, or downstream closed: stop for good.
                         let _ = pubsub_conn.unsubscribe(&channel).await;
                         break;
                     }
@@ -222,15 +217,15 @@ impl InputHandler {
                     SessionEnd::Disconnected => {
                         // Redis dropped us. We'll try to reconnect after a backoff,
                         // unless shutdown fires during that backoff.
-                        retry += 1;
+                        reconnecting = true;
+                        let _ = pubsub_conn.unsubscribe(&channel).await;
 
+                        let delay = backoff.next().expect("backoff never ends");
                         tokio::select! {
-                            _ = backoff_exponential(retry) => {
-                                let _ = pubsub_conn.unsubscribe(&channel).await;
+                            _ = tokio::time::sleep(delay) => {
                                 continue;
                             }
                             _ = &mut shutdown => {
-                                let _ = pubsub_conn.unsubscribe(&channel).await;
                                 break;
                             }
                         }

--- a/src/sources/redis/channel.rs
+++ b/src/sources/redis/channel.rs
@@ -32,12 +32,14 @@ impl BuildError {
 
 /// Whether a Redis error is transient (worth reconnecting) rather than non-recoverable.
 ///
-/// I/O errors — unreachable server, connection reset, timeout, TLS failures — are treated
-/// as transient. Anything else (e.g. authentication/permission/config rejections of
-/// `SUBSCRIBE`) is treated as permanent, so an invalid configuration fails fast instead of
-/// silently retrying forever.
+/// Uses redis-rs's own retry classification: only `RetryMethod::NoRetry` — e.g.
+/// authentication/permission/config rejections of `SUBSCRIBE` — is treated as permanent, so
+/// an invalid configuration fails fast instead of retrying forever. Everything else is
+/// transient: I/O failures (unreachable/reset/timeout) and server-side retryable states such
+/// as `LOADING`/`BUSYLOADING`/`TRYAGAIN` reported while a Redis node is restarting — exactly
+/// the recovery scenario this source is meant to survive.
 fn is_transient(error: &redis::RedisError) -> bool {
-    error.kind() == redis::ErrorKind::IoError
+    !matches!(error.retry_method(), redis::RetryMethod::NoRetry)
 }
 
 /// Defines how a pub/sub "session" ended.

--- a/src/sources/redis/channel.rs
+++ b/src/sources/redis/channel.rs
@@ -166,32 +166,36 @@ impl InputHandler {
             let mut reconnecting = false;
 
             loop {
-                // connect + SUBSCRIBE
-                let mut pubsub_conn =
-                    match connect_and_subscribe(&client, &endpoint, &channel).await {
-                        Ok(conn) => {
-                            emit!(RedisConnectionEstablished {
-                                reconnect: reconnecting
-                            });
-                            conn
-                        }
-                        Err(err) => {
-                            // failed to connect or SUBSCRIBE
-                            emit!(RedisConnectionError::from(err.into_source()));
-                            reconnecting = true;
+                // Connect + SUBSCRIBE, raced with shutdown. A connect against a black-holed
+                // endpoint can stall for a long time, so we must still observe shutdown
+                // promptly instead of waiting for the force-shutdown deadline. `biased`
+                // checks shutdown first so it always wins when both are ready.
+                let connect_result = tokio::select! {
+                    biased;
+                    _ = &mut shutdown => break,
+                    res = connect_and_subscribe(&client, &endpoint, &channel) => res,
+                };
 
-                            // back off before retrying, unless we're shutting down
-                            let delay = backoff.next().expect("backoff never ends");
-                            tokio::select! {
-                                _ = tokio::time::sleep(delay) => {
-                                    continue;
-                                }
-                                _ = &mut shutdown => {
-                                    break;
-                                }
-                            }
+                let mut pubsub_conn = match connect_result {
+                    Ok(conn) => {
+                        emit!(RedisConnectionEstablished {
+                            reconnect: reconnecting
+                        });
+                        conn
+                    }
+                    Err(err) => {
+                        // failed to connect or SUBSCRIBE
+                        emit!(RedisConnectionError::from(err.into_source()));
+                        reconnecting = true;
+
+                        // back off before retrying, unless we're shutting down
+                        let delay = backoff.next().expect("backoff never ends");
+                        tokio::select! {
+                            _ = tokio::time::sleep(delay) => continue,
+                            _ = &mut shutdown => break,
                         }
-                    };
+                    }
+                };
 
                 // Connected: reset backoff so the next outage starts from the shortest delay.
                 backoff.reset();
@@ -207,27 +211,26 @@ impl InputHandler {
                 )
                 .await;
 
+                // We deliberately do not `UNSUBSCRIBE` here: on shutdown or a dropped
+                // connection, awaiting that network round trip could block graceful shutdown
+                // if Redis is slow or the socket is half-open. Dropping `pubsub_conn` closes
+                // the connection and Redis releases the subscription automatically.
                 match end_reason {
                     SessionEnd::Shutdown | SessionEnd::DownstreamClosed => {
                         // shutting down cleanly, or downstream closed: stop for good.
-                        let _ = pubsub_conn.unsubscribe(&channel).await;
                         break;
                     }
 
                     SessionEnd::Disconnected => {
-                        // Redis dropped us. We'll try to reconnect after a backoff,
-                        // unless shutdown fires during that backoff.
+                        // Redis dropped us. Reconnect after a backoff, unless shutdown fires
+                        // during that backoff. The dead `pubsub_conn` is dropped when this
+                        // iteration ends.
                         reconnecting = true;
-                        let _ = pubsub_conn.unsubscribe(&channel).await;
 
                         let delay = backoff.next().expect("backoff never ends");
                         tokio::select! {
-                            _ = tokio::time::sleep(delay) => {
-                                continue;
-                            }
-                            _ = &mut shutdown => {
-                                break;
-                            }
+                            _ = tokio::time::sleep(delay) => continue,
+                            _ = &mut shutdown => break,
                         }
                     }
                 }

--- a/src/sources/redis/channel.rs
+++ b/src/sources/redis/channel.rs
@@ -30,15 +30,25 @@ impl BuildError {
     }
 }
 
+/// How long a pub/sub session must stay connected before we consider it healthy and reset
+/// the reconnect backoff, even if it hasn't delivered any messages. This keeps a flapping
+/// connection backing off while ensuring a stable-but-quiet low-volume channel doesn't retain
+/// a backoff that a previous flapping period drove up to the cap.
+const HEALTHY_SESSION_THRESHOLD: Duration = Duration::from_secs(60);
+
 /// Whether a Redis error is transient (worth reconnecting) rather than non-recoverable.
 ///
-/// Uses redis-rs's own retry classification: only `RetryMethod::NoRetry` — e.g.
-/// authentication/permission/config rejections of `SUBSCRIBE` — is treated as permanent, so
-/// an invalid configuration fails fast instead of retrying forever. Everything else is
-/// transient: I/O failures (unreachable/reset/timeout) and server-side retryable states such
-/// as `LOADING`/`BUSYLOADING`/`TRYAGAIN` reported while a Redis node is restarting — exactly
-/// the recovery scenario this source is meant to survive.
+/// Uses redis-rs's own retry classification (`RetryMethod::NoRetry` => permanent) with one
+/// override: redis-rs maps `ErrorKind::AuthenticationFailed` to `RetryMethod::Reconnect`, but
+/// bad credentials/permissions are never fixed by reconnecting, so we treat them as permanent
+/// too. This makes an invalid configuration (auth/ACL/config) fail fast instead of retrying
+/// forever, while everything else — I/O failures (unreachable/reset/timeout) and server-side
+/// retryable states such as `LOADING`/`BUSYLOADING`/`TRYAGAIN` during a Redis restart — is
+/// transient and reconnected.
 fn is_transient(error: &redis::RedisError) -> bool {
+    if error.kind() == redis::ErrorKind::AuthenticationFailed {
+        return false;
+    }
     !matches!(error.retry_method(), redis::RetryMethod::NoRetry)
 }
 
@@ -110,11 +120,21 @@ impl InputHandler {
         {
             let mut stream = pubsub_conn.on_message();
 
+            // Once the connection has either delivered a message or simply stayed up for
+            // `HEALTHY_SESSION_THRESHOLD`, we consider it healthy and reset the backoff. The
+            // timer covers low-volume channels that stay connected a long time without
+            // publishing, so a stable-but-quiet session doesn't keep a backoff a prior
+            // flapping period drove up to the cap.
+            let healthy = tokio::time::sleep(HEALTHY_SESSION_THRESHOLD);
+            tokio::pin!(healthy);
+            let mut backoff_reset = false;
+
             loop {
-                // One "step" in the session: either we got a message,
-                // Redis dropped us, or shutdown fired.
+                // One "step" in the session: either we got a message, the connection became
+                // healthy, Redis dropped us, or shutdown fired.
                 enum RecvEvent {
                     Msg(redis::Msg),
+                    Healthy,
                     Shutdown,
                     Disconnected,
                 }
@@ -126,6 +146,7 @@ impl InputHandler {
                             None => RecvEvent::Disconnected,
                         }
                     }
+                    _ = &mut healthy, if !backoff_reset => RecvEvent::Healthy,
                     _ = &mut *shutdown => {
                         RecvEvent::Shutdown
                     }
@@ -139,17 +160,27 @@ impl InputHandler {
                             if let Err(()) = handler.handle_line(line).await {
                                 return SessionEnd::DownstreamClosed;
                             }
-                            // A message was delivered downstream, so the connection is
-                            // healthy: reset the reconnect backoff. Resetting only here
-                            // (not on connect) means a connection that drops before
-                            // delivering anything keeps backing off exponentially.
-                            backoff.reset();
+                            // A message was delivered downstream: the connection is healthy,
+                            // so reset the reconnect backoff. Resetting only on a health signal
+                            // (data, or the timer below) — never on a bare connect — means a
+                            // connection that drops before becoming healthy keeps backing off.
+                            if !backoff_reset {
+                                backoff.reset();
+                                backoff_reset = true;
+                            }
                         }
                         Err(error) => {
                             // Bad payload. We just log and keep going.
                             emit!(RedisReceiveEventError::from(error));
                         }
                     },
+
+                    RecvEvent::Healthy => {
+                        // Stayed connected long enough to be considered stable even without
+                        // delivering data (low-volume channel): reset the backoff.
+                        backoff.reset();
+                        backoff_reset = true;
+                    }
 
                     RecvEvent::Disconnected => {
                         // Redis connection ended (e.g. server restart).

--- a/src/sources/redis/channel.rs
+++ b/src/sources/redis/channel.rs
@@ -7,7 +7,7 @@ use tracing::trace;
 use crate::{
     common::backoff::ExponentialBackoff,
     internal_events::{
-        RedisConnectionDropped, RedisConnectionError, RedisConnectionEstablished,
+        RedisConnectionDroppedError, RedisConnectionError, RedisConnectionEstablished,
         RedisReceiveEventError,
     },
     sources::{
@@ -172,7 +172,7 @@ impl InputHandler {
                         // Redis closed an established connection (e.g. server restart). Record
                         // it as a component error — so alerts fire even if the reconnect
                         // succeeds immediately — and reconnect in the outer loop.
-                        emit!(RedisConnectionDropped);
+                        emit!(RedisConnectionDroppedError);
                         return SessionEnd::Disconnected;
                     }
 

--- a/src/sources/redis/channel.rs
+++ b/src/sources/redis/channel.rs
@@ -2,11 +2,14 @@ use std::time::Duration;
 
 use futures_util::StreamExt;
 use snafu::Snafu;
-use tracing::{trace, warn};
+use tracing::trace;
 
 use crate::{
     common::backoff::ExponentialBackoff,
-    internal_events::{RedisConnectionError, RedisConnectionEstablished, RedisReceiveEventError},
+    internal_events::{
+        RedisConnectionDropped, RedisConnectionError, RedisConnectionEstablished,
+        RedisReceiveEventError,
+    },
     sources::{
         Source,
         redis::{ConnectionInfo, InputHandler},
@@ -30,27 +33,11 @@ impl BuildError {
     }
 }
 
-/// How long a pub/sub session must stay connected before we consider it healthy and reset
-/// the reconnect backoff, even if it hasn't delivered any messages. This keeps a flapping
+/// How long a pub/sub session must stay connected before we consider it healthy and reset the
+/// reconnect backoff, even if it hasn't delivered any messages. This keeps a flapping
 /// connection backing off while ensuring a stable-but-quiet low-volume channel doesn't retain
 /// a backoff that a previous flapping period drove up to the cap.
 const HEALTHY_SESSION_THRESHOLD: Duration = Duration::from_secs(60);
-
-/// Whether a Redis error is transient (worth reconnecting) rather than non-recoverable.
-///
-/// Uses redis-rs's own retry classification (`RetryMethod::NoRetry` => permanent) with one
-/// override: redis-rs maps `ErrorKind::AuthenticationFailed` to `RetryMethod::Reconnect`, but
-/// bad credentials/permissions are never fixed by reconnecting, so we treat them as permanent
-/// too. This makes an invalid configuration (auth/ACL/config) fail fast instead of retrying
-/// forever, while everything else — I/O failures (unreachable/reset/timeout) and server-side
-/// retryable states such as `LOADING`/`BUSYLOADING`/`TRYAGAIN` during a Redis restart — is
-/// transient and reconnected.
-fn is_transient(error: &redis::RedisError) -> bool {
-    if error.kind() == redis::ErrorKind::AuthenticationFailed {
-        return false;
-    }
-    !matches!(error.retry_method(), redis::RetryMethod::NoRetry)
-}
 
 /// Defines how a pub/sub "session" ended.
 ///
@@ -68,10 +55,11 @@ enum SessionEnd {
 impl InputHandler {
     /// Build the Redis `channel` source.
     ///
-    /// The initial connect + SUBSCRIBE happens here so a non-recoverable error (bad auth,
-    /// ACLs, invalid config) fails the source build immediately. Once started, the source
-    /// runs a reconnect loop: on a dropped connection it reconnects with exponential
-    /// backoff instead of stopping, so a Redis restart or transient network blip no longer
+    /// The initial connect + SUBSCRIBE happens at build time (as the source did before this
+    /// change), so any failure — including a permanent misconfiguration such as bad auth, TLS,
+    /// or ACLs — fails the source build immediately instead of appearing to start and only
+    /// erroring at runtime. Once running, a dropped connection is handled by a reconnect loop
+    /// with exponential backoff, so a Redis restart or transient network blip no longer
     /// requires a manual Vector restart.
     pub(super) async fn subscribe(
         mut self,
@@ -109,10 +97,8 @@ impl InputHandler {
 
         async fn run_subscription_session<S>(
             pubsub_conn: &mut redis::aio::PubSub,
-            channel: &str,
             shutdown: &mut S,
             handler: &mut InputHandler,
-            endpoint: &str,
             backoff: &mut ExponentialBackoff,
         ) -> SessionEnd
         where
@@ -183,12 +169,10 @@ impl InputHandler {
                     }
 
                     RecvEvent::Disconnected => {
-                        // Redis connection ended (e.g. server restart).
-                        // We'll reconnect in the outer loop.
-                        warn!(
-                            endpoint,
-                            channel, "Redis pubsub stream ended; will reconnect."
-                        );
+                        // Redis closed an established connection (e.g. server restart). Record
+                        // it as a component error — so alerts fire even if the reconnect
+                        // succeeds immediately — and reconnect in the outer loop.
+                        emit!(RedisConnectionDropped);
                         return SessionEnd::Disconnected;
                     }
 
@@ -200,25 +184,12 @@ impl InputHandler {
             }
         }
 
-        // Initial connect + SUBSCRIBE, performed here (not inside the source future) so a
-        // non-recoverable error fails the source build immediately rather than silently
-        // entering a retry loop that makes an invalid config look like it started. A
-        // transient error (Redis unreachable/restarting) is tolerated and handled by the
-        // reconnect loop once the source starts.
-        let initial_conn = match connect_and_subscribe(&client, &endpoint, &channel).await {
-            Ok(conn) => {
-                emit!(RedisConnectionEstablished { reconnect: false });
-                Some(conn)
-            }
-            Err(err) => {
-                let source = err.into_source();
-                if !is_transient(&source) {
-                    return Err(source.into());
-                }
-                emit!(RedisConnectionError::from(source));
-                None
-            }
-        };
+        // Initial connect + SUBSCRIBE. Fail fast on *any* error, matching the source's
+        // behavior before reconnect support was added: this surfaces a permanent
+        // misconfiguration (bad auth, TLS, ACLs) — and connectivity problems — at startup
+        // rather than masking them behind a silent retry loop. Drops that occur once the
+        // source is running are handled by the reconnect loop below.
+        let initial_conn = connect_and_subscribe(&client, &endpoint, &channel).await?;
 
         Ok(Box::pin(async move {
             // `shutdown` is a signal that resolves when Vector is stopping.
@@ -226,20 +197,22 @@ impl InputHandler {
 
             // Exponential backoff between reconnect attempts: 500ms, 1s, 2s, 4s, ...
             // capped at 30s. Matches the strategy used by other reconnecting sources
-            // (e.g. `aws_s3`/`sqs`). Only reset once a session delivers data (see
+            // (e.g. `aws_s3`/`sqs`). Reset once a session is healthy (see
             // `run_subscription_session`), so a flapping connection still backs off.
             let mut backoff = ExponentialBackoff::from_millis(2)
                 .factor(250)
                 .max_delay(Duration::from_secs(30));
 
-            // A connection to run next: the one established at startup, or `None` to
-            // (re)connect via the loop below.
-            let mut next_conn = initial_conn;
+            // The live connection from startup; subsequent iterations reconnect via the loop.
+            let mut next_conn = Some(initial_conn);
 
             loop {
                 // Obtain a live connection: reuse the pending one, or reconnect with backoff.
                 let mut pubsub_conn = match next_conn.take() {
-                    Some(conn) => conn,
+                    Some(conn) => {
+                        emit!(RedisConnectionEstablished { reconnect: false });
+                        conn
+                    }
                     None => 'reconnect: loop {
                         let delay = backoff.next().expect("backoff never ends");
                         tokio::select! {
@@ -263,15 +236,13 @@ impl InputHandler {
                                 break 'reconnect conn;
                             }
                             Err(err) => {
-                                let source = err.into_source();
-                                let permanent = !is_transient(&source);
-                                emit!(RedisConnectionError::from(source));
-                                if permanent {
-                                    // Non-recoverable (auth/ACL/config): stop the source
-                                    // rather than retry forever.
-                                    return Err(());
-                                }
-                                // transient: keep retrying; backoff advances next iteration.
+                                // Once the source has started, every reconnect failure is
+                                // treated as retryable: a permanent misconfiguration was
+                                // already ruled out by the successful build-time connect, and
+                                // stopping here would drop the resilience this adds. The error
+                                // is recorded so metric-based alerts still fire.
+                                emit!(RedisConnectionError::from(err.into_source()));
+                                // keep retrying; backoff advances on the next iteration.
                             }
                         }
                     },
@@ -280,10 +251,8 @@ impl InputHandler {
                 // run that session (receive messages, forward them, etc.)
                 let end_reason = run_subscription_session(
                     &mut pubsub_conn,
-                    &channel,
                     &mut shutdown,
                     &mut self,
-                    &endpoint,
                     &mut backoff,
                 )
                 .await;

--- a/src/sources/redis/channel.rs
+++ b/src/sources/redis/channel.rs
@@ -30,6 +30,16 @@ impl BuildError {
     }
 }
 
+/// Whether a Redis error is transient (worth reconnecting) rather than non-recoverable.
+///
+/// I/O errors — unreachable server, connection reset, timeout, TLS failures — are treated
+/// as transient. Anything else (e.g. authentication/permission/config rejections of
+/// `SUBSCRIBE`) is treated as permanent, so an invalid configuration fails fast instead of
+/// silently retrying forever.
+fn is_transient(error: &redis::RedisError) -> bool {
+    error.kind() == redis::ErrorKind::IoError
+}
+
 /// Defines how a pub/sub "session" ended.
 ///
 /// A session = we connected to Redis, SUBSCRIBE'd to a channel,
@@ -46,10 +56,11 @@ enum SessionEnd {
 impl InputHandler {
     /// Build the Redis `channel` source.
     ///
-    /// The source runs a reconnect loop: it connects, SUBSCRIBEs, and streams messages
-    /// until either shutdown fires, downstream closes, or the Redis connection drops. On a
-    /// drop it reconnects with exponential backoff instead of stopping, so a Redis restart
-    /// or transient network blip no longer requires a manual Vector restart.
+    /// The initial connect + SUBSCRIBE happens here so a non-recoverable error (bad auth,
+    /// ACLs, invalid config) fails the source build immediately. Once started, the source
+    /// runs a reconnect loop: on a dropped connection it reconnects with exponential
+    /// backoff instead of stopping, so a Redis restart or transient network blip no longer
+    /// requires a manual Vector restart.
     pub(super) async fn subscribe(
         mut self,
         connection_info: ConnectionInfo,
@@ -90,6 +101,7 @@ impl InputHandler {
             shutdown: &mut S,
             handler: &mut InputHandler,
             endpoint: &str,
+            backoff: &mut ExponentialBackoff,
         ) -> SessionEnd
         where
             S: std::future::Future + Unpin,
@@ -125,6 +137,11 @@ impl InputHandler {
                             if let Err(()) = handler.handle_line(line).await {
                                 return SessionEnd::DownstreamClosed;
                             }
+                            // A message was delivered downstream, so the connection is
+                            // healthy: reset the reconnect backoff. Resetting only here
+                            // (not on connect) means a connection that drops before
+                            // delivering anything keeps backing off exponentially.
+                            backoff.reset();
                         }
                         Err(error) => {
                             // Bad payload. We just log and keep going.
@@ -150,56 +167,82 @@ impl InputHandler {
             }
         }
 
+        // Initial connect + SUBSCRIBE, performed here (not inside the source future) so a
+        // non-recoverable error fails the source build immediately rather than silently
+        // entering a retry loop that makes an invalid config look like it started. A
+        // transient error (Redis unreachable/restarting) is tolerated and handled by the
+        // reconnect loop once the source starts.
+        let initial_conn = match connect_and_subscribe(&client, &endpoint, &channel).await {
+            Ok(conn) => {
+                emit!(RedisConnectionEstablished { reconnect: false });
+                Some(conn)
+            }
+            Err(err) => {
+                let source = err.into_source();
+                if !is_transient(&source) {
+                    return Err(source.into());
+                }
+                emit!(RedisConnectionError::from(source));
+                None
+            }
+        };
+
         Ok(Box::pin(async move {
             // `shutdown` is a signal that resolves when Vector is stopping.
             let mut shutdown = self.cx.shutdown.clone();
 
             // Exponential backoff between reconnect attempts: 500ms, 1s, 2s, 4s, ...
             // capped at 30s. Matches the strategy used by other reconnecting sources
-            // (e.g. `aws_s3`/`sqs`). Reset once a connection is successfully established.
+            // (e.g. `aws_s3`/`sqs`). Only reset once a session delivers data (see
+            // `run_subscription_session`), so a flapping connection still backs off.
             let mut backoff = ExponentialBackoff::from_millis(2)
                 .factor(250)
                 .max_delay(Duration::from_secs(30));
 
-            // Whether we're recovering from a dropped/failed connection. Drives the
-            // log/metric emitted on a successful (re)connect.
-            let mut reconnecting = false;
+            // A connection to run next: the one established at startup, or `None` to
+            // (re)connect via the loop below.
+            let mut next_conn = initial_conn;
 
             loop {
-                // Connect + SUBSCRIBE, raced with shutdown. A connect against a black-holed
-                // endpoint can stall for a long time, so we must still observe shutdown
-                // promptly instead of waiting for the force-shutdown deadline. `biased`
-                // checks shutdown first so it always wins when both are ready.
-                let connect_result = tokio::select! {
-                    biased;
-                    _ = &mut shutdown => break,
-                    res = connect_and_subscribe(&client, &endpoint, &channel) => res,
-                };
-
-                let mut pubsub_conn = match connect_result {
-                    Ok(conn) => {
-                        emit!(RedisConnectionEstablished {
-                            reconnect: reconnecting
-                        });
-                        conn
-                    }
-                    Err(err) => {
-                        // failed to connect or SUBSCRIBE
-                        emit!(RedisConnectionError::from(err.into_source()));
-                        reconnecting = true;
-
-                        // back off before retrying, unless we're shutting down
+                // Obtain a live connection: reuse the pending one, or reconnect with backoff.
+                let mut pubsub_conn = match next_conn.take() {
+                    Some(conn) => conn,
+                    None => 'reconnect: loop {
                         let delay = backoff.next().expect("backoff never ends");
                         tokio::select! {
-                            _ = tokio::time::sleep(delay) => continue,
-                            _ = &mut shutdown => break,
+                            _ = tokio::time::sleep(delay) => {}
+                            _ = &mut shutdown => return Ok(()),
                         }
-                    }
-                };
 
-                // Connected: reset backoff so the next outage starts from the shortest delay.
-                backoff.reset();
-                reconnecting = false;
+                        // Race the connect with shutdown: a connect against a black-holed
+                        // endpoint can stall for a long time, and we must still observe
+                        // shutdown promptly instead of waiting for the force-shutdown
+                        // deadline. `biased` makes shutdown win when both are ready.
+                        let res = tokio::select! {
+                            biased;
+                            _ = &mut shutdown => return Ok(()),
+                            res = connect_and_subscribe(&client, &endpoint, &channel) => res,
+                        };
+
+                        match res {
+                            Ok(conn) => {
+                                emit!(RedisConnectionEstablished { reconnect: true });
+                                break 'reconnect conn;
+                            }
+                            Err(err) => {
+                                let source = err.into_source();
+                                let permanent = !is_transient(&source);
+                                emit!(RedisConnectionError::from(source));
+                                if permanent {
+                                    // Non-recoverable (auth/ACL/config): stop the source
+                                    // rather than retry forever.
+                                    return Err(());
+                                }
+                                // transient: keep retrying; backoff advances next iteration.
+                            }
+                        }
+                    },
+                };
 
                 // run that session (receive messages, forward them, etc.)
                 let end_reason = run_subscription_session(
@@ -208,6 +251,7 @@ impl InputHandler {
                     &mut shutdown,
                     &mut self,
                     &endpoint,
+                    &mut backoff,
                 )
                 .await;
 
@@ -222,16 +266,9 @@ impl InputHandler {
                     }
 
                     SessionEnd::Disconnected => {
-                        // Redis dropped us. Reconnect after a backoff, unless shutdown fires
-                        // during that backoff. The dead `pubsub_conn` is dropped when this
-                        // iteration ends.
-                        reconnecting = true;
-
-                        let delay = backoff.next().expect("backoff never ends");
-                        tokio::select! {
-                            _ = tokio::time::sleep(delay) => continue,
-                            _ = &mut shutdown => break,
-                        }
+                        // Redis dropped us. `next_conn` stays `None`, so the next iteration
+                        // reconnects with backoff. The dead `pubsub_conn` is dropped when
+                        // this iteration ends.
                     }
                 }
             }

--- a/src/sources/redis/list.rs
+++ b/src/sources/redis/list.rs
@@ -25,12 +25,13 @@ impl InputHandler {
         Ok(Box::pin(async move {
             let mut shutdown = self.cx.shutdown.clone();
 
-            // Exponential backoff between retries after an I/O error: 500ms, 1s, 2s, 4s,
-            // ... capped at 30s. Shares the strategy used by the `channel` source and
-            // `aws_s3`/`sqs`. Reset once a value is successfully received.
+            // Exponential backoff between retries after an I/O error: 500ms, then capped at
+            // 1s. Uses the shared `ExponentialBackoff` helper (as the `channel` source does)
+            // but keeps this source's prior 1s cap so recovery latency after a Redis outage
+            // is unchanged. Reset once a value is successfully received.
             let mut backoff = ExponentialBackoff::from_millis(2)
                 .factor(250)
-                .max_delay(Duration::from_secs(30));
+                .max_delay(Duration::from_secs(1));
 
             loop {
                 let res = match method {

--- a/src/sources/redis/list.rs
+++ b/src/sources/redis/list.rs
@@ -4,7 +4,9 @@ use redis::{AsyncCommands, ErrorKind, RedisError, RedisResult, aio::ConnectionMa
 use snafu::{ResultExt, Snafu};
 
 use super::{InputHandler, Method};
-use crate::{internal_events::RedisReceiveEventError, sources::Source};
+use crate::{
+    common::backoff::ExponentialBackoff, internal_events::RedisReceiveEventError, sources::Source,
+};
 
 #[derive(Debug, Snafu)]
 enum BuildError {
@@ -22,7 +24,14 @@ impl InputHandler {
 
         Ok(Box::pin(async move {
             let mut shutdown = self.cx.shutdown.clone();
-            let mut retry: u32 = 0;
+
+            // Exponential backoff between retries after an I/O error: 500ms, 1s, 2s, 4s,
+            // ... capped at 30s. Shares the strategy used by the `channel` source and
+            // `aws_s3`/`sqs`. Reset once a value is successfully received.
+            let mut backoff = ExponentialBackoff::from_millis(2)
+                .factor(250)
+                .max_delay(Duration::from_secs(30));
+
             loop {
                 let res = match method {
                     Method::Rpop => tokio::select! {
@@ -43,14 +52,16 @@ impl InputHandler {
                         emit!(RedisReceiveEventError::from(err));
 
                         if kind == ErrorKind::IoError {
-                            retry += 1;
-                            backoff_exponential(retry).await
+                            // Back off before retrying, but stay responsive to shutdown.
+                            let delay = backoff.next().expect("backoff never ends");
+                            tokio::select! {
+                                _ = tokio::time::sleep(delay) => {}
+                                _ = &mut shutdown => break,
+                            }
                         }
                     }
                     Ok(line) => {
-                        if retry > 0 {
-                            retry = 0
-                        }
+                        backoff.reset();
                         if let Err(()) = self.handle_line(line).await {
                             break;
                         }
@@ -60,11 +71,6 @@ impl InputHandler {
             Ok(())
         }))
     }
-}
-
-async fn backoff_exponential(exp: u32) {
-    let ms = if exp <= 4 { 2_u64.pow(exp + 5) } else { 1000 };
-    tokio::time::sleep(Duration::from_millis(ms)).await;
 }
 
 async fn brpop(conn: &mut ConnectionManager, key: &str) -> RedisResult<String> {


### PR DESCRIPTION
Supersedes #24100 (rebased onto master; original work by @gibranbadrul, preserved as the first commit). Closes #22615.

The `redis` source with `data_type = "channel"` currently stops receiving after any Redis connection drop and only recovers on a Vector restart. This adds a reconnect loop that re-connects and re-subscribes automatically, with exponential backoff.

Addresses the review feedback on #24100:
- Uses the shared `common::backoff::ExponentialBackoff` (from_millis(2).factor(250), capped at 30s), matching `aws_s3`/`sqs`, instead of a bespoke helper. Backoff resets on a successful connect.
- Emits reconnection internal events: `RedisConnectionError` → `component_errors_total` (error_type=connection_failed) on connect/subscribe failure, and `RedisConnectionEstablished` → `connection_established_total` on initial connect and recovery.
- Adds a changelog fragment.

Also unifies the `list` data_type source onto the same shared `ExponentialBackoff` (removing its duplicate `backoff_exponential`) and makes its retry sleep shutdown-aware.
