### PR TITLE
fix(file source): don't warn about empty files too small to fingerprint

### DIFF
--- a/changelog.d/1065_file_source_empty_file_warning.fix.md
+++ b/changelog.d/1065_file_source_empty_file_warning.fix.md
@@ -1,0 +1,3 @@
+The `file` source no longer logs a "Currently ignoring file too small to fingerprint" warning for empty files when using the `checksum` fingerprinting strategy. Empty files are common and transient (for example freshly-created log files or short-lived Kubernetes pods), so the warning created noise without being actionable. Non-empty files that are still too small to fingerprint continue to warn as before.
+
+authors: gaurav0107

--- a/lib/file-source-common/src/fingerprinter.rs
+++ b/lib/file-source-common/src/fingerprinter.rs
@@ -202,9 +202,18 @@ impl Fingerprinter {
         known_small_files: &mut HashMap<PathBuf, time::Instant>,
         emitter: &impl FileSourceInternalEvents,
     ) -> Option<FileFingerprint> {
+        // Track whether the file is empty so we can suppress the "too small to
+        // fingerprint" warning for empty files. Empty files are common and
+        // transient (freshly-created log files, short-lived Kubernetes pods) and
+        // would otherwise flood logs with non-actionable warnings. Non-empty
+        // files that are still too small to fingerprint continue to warn, since
+        // those can genuinely surprise a user wondering why a file isn't tailed.
+        // See https://github.com/vectordotdev/vector/issues/1065.
+        let mut file_is_empty = false;
         let metadata = match fs::metadata(path).await {
             Ok(metadata) => {
                 if !metadata.is_dir() {
+                    file_is_empty = metadata.len() == 0;
                     self.fingerprint(path).await.map(Some)
                 } else {
                     Ok(None)
@@ -222,7 +231,12 @@ impl Fingerprinter {
                 match error.kind() {
                     ErrorKind::UnexpectedEof => {
                         if !known_small_files.contains_key(path) {
-                            emitter.emit_file_checksum_failed(path);
+                            // Only warn about files that are too small to
+                            // fingerprint when they actually contain data;
+                            // empty files are expected and would just be noise.
+                            if !file_is_empty {
+                                emitter.emit_file_checksum_failed(path);
+                            }
                             known_small_files.insert(path.to_path_buf(), time::Instant::now());
                         }
                         return;
@@ -277,7 +291,17 @@ async fn fingerprinter_read_until(
 
 #[cfg(test)]
 mod test {
-    use std::{collections::HashMap, fs, io::Error, path::Path, time::Duration};
+    use std::{
+        collections::HashMap,
+        fs,
+        io::Error,
+        path::Path,
+        sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        },
+        time::Duration,
+    };
 
     use async_compression::tokio::bufread::GzipEncoder;
     use bytes::BytesMut;
@@ -638,6 +662,64 @@ mod test {
         );
     }
 
+    #[tokio::test]
+    async fn fingerprint_or_emit_only_warns_on_non_empty_small_files() {
+        // Regression test for https://github.com/vectordotdev/vector/issues/1065:
+        // an empty file is too small to fingerprint but must NOT emit the
+        // "too small to fingerprint" warning (it only creates log noise), while
+        // a non-empty file that is still too small SHOULD warn.
+        let mut fingerprinter = Fingerprinter::new(
+            FingerprintStrategy::FirstLinesChecksum {
+                ignored_header_bytes: 0,
+                lines: 1,
+            },
+            1024,
+            false,
+        );
+
+        let target_dir = tempdir().unwrap();
+        let empty_path = target_dir.path().join("empty.log");
+        let too_small_path = target_dir.path().join("too_small.log");
+        // Empty file (0 bytes).
+        fs::write(&empty_path, []).unwrap();
+        // Non-empty but with no newline, so it is too small to fingerprint.
+        fs::write(&too_small_path, vec![b'x'; 8]).unwrap();
+
+        let emitter = RecordingEmitter::default();
+        let mut small_files = HashMap::new();
+
+        // Empty file: returns nothing and emits no checksum-failed warning.
+        assert!(
+            fingerprinter
+                .fingerprint_or_emit(&empty_path, &mut small_files, &emitter)
+                .await
+                .is_none()
+        );
+        assert_eq!(
+            emitter.checksum_failed_count(),
+            0,
+            "empty file must not emit a checksum-failed warning"
+        );
+        // ...but the empty file is still tracked so it is retried once it grows.
+        assert!(
+            small_files.contains_key(&empty_path),
+            "empty file must still be tracked in known_small_files for retry"
+        );
+
+        // Non-empty-but-too-small file: returns nothing but does warn.
+        assert!(
+            fingerprinter
+                .fingerprint_or_emit(&too_small_path, &mut small_files, &emitter)
+                .await
+                .is_none()
+        );
+        assert_eq!(
+            emitter.checksum_failed_count(),
+            1,
+            "non-empty file too small to fingerprint must emit a checksum-failed warning"
+        );
+    }
+
     #[test]
     fn test_monotonic_compression_algorithms() {
         // This test is necessary to handle an edge case where when assessing the magic header
@@ -697,5 +779,49 @@ mod test {
         fn emit_file_line_too_long(&self, _: &BytesMut, _: usize, _: usize) {
             panic!()
         }
+    }
+
+    /// Test emitter that records how many times `emit_file_checksum_failed`
+    /// was called so tests can assert whether the "too small to fingerprint"
+    /// warning was emitted. All other events are treated as no-ops.
+    #[derive(Clone, Default)]
+    struct RecordingEmitter {
+        checksum_failed: Arc<AtomicUsize>,
+    }
+
+    impl RecordingEmitter {
+        fn checksum_failed_count(&self) -> usize {
+            self.checksum_failed.load(Ordering::SeqCst)
+        }
+    }
+
+    impl FileSourceInternalEvents for RecordingEmitter {
+        fn emit_file_added(&self, _: &Path) {}
+
+        fn emit_file_resumed(&self, _: &Path, _: u64) {}
+
+        fn emit_file_watch_error(&self, _: &Path, _: Error) {}
+
+        fn emit_file_unwatched(&self, _: &Path, _: bool) {}
+
+        fn emit_file_deleted(&self, _: &Path) {}
+
+        fn emit_file_delete_error(&self, _: &Path, _: Error) {}
+
+        fn emit_file_fingerprint_read_error(&self, _: &Path, _: Error) {}
+
+        fn emit_file_checkpointed(&self, _: usize, _: Duration) {}
+
+        fn emit_file_checksum_failed(&self, _: &Path) {
+            self.checksum_failed.fetch_add(1, Ordering::SeqCst);
+        }
+
+        fn emit_file_checkpoint_write_error(&self, _: Error) {}
+
+        fn emit_files_open(&self, _: usize) {}
+
+        fn emit_path_globbing_failed(&self, _: &Path, _: &Error) {}
+
+        fn emit_file_line_too_long(&self, _: &BytesMut, _: usize, _: usize) {}
     }
 }


### PR DESCRIPTION
## Summary

When the `file` source uses the `checksum` fingerprinting strategy, files that are too small to be fingerprinted trigger a `Currently ignoring file too small to fingerprint.` warning. In practice this fires constantly for **empty** (0-byte) files, which are common and transient in production — for example freshly-created log files or short-lived Kubernetes pods that start and stop quickly. The result is log noise that isn't actionable, which several users have reported on #1065.

This change suppresses the warning for empty files while keeping it for non-empty files that are still too small to fingerprint (that case can genuinely surprise a user wondering why a file isn't being tailed). The retry/cleanup bookkeeping in `known_small_files` is unchanged, so empty files are still tracked and picked up once they grow.

The fix is confined to `Fingerprinter::fingerprint_or_emit` in `lib/file-source-common/src/fingerprinter.rs`: the file's emptiness is read from the metadata that is already fetched, and `emit_file_checksum_failed` is skipped when the file is empty.

## AI assistance disclosure

Per Vector's [AI policy](https://github.com/vectordotdev/vector/blob/master/AI_POLICY.md): this change was drafted with the assistance of an AI coding agent (model: Claude Opus 4.8). I have read, understood, and locally tested the change, and I own the contribution.

## How did you test this PR?

- Added a unit test `fingerprint_or_emit_only_warns_on_non_empty_small_files` in `fingerprinter.rs` using a recording emitter that counts `emit_file_checksum_failed` calls. It asserts that an empty file emits **no** warning and returns `None`, while a non-empty-but-too-small file **does** emit exactly one warning.
- `cargo test -p file-source-common` — 22 passed, 0 failed.
- `cargo fmt -p file-source-common -- --check` — clean.
- `cargo clippy -p file-source-common --all-targets` — clean.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

The `checksum_errors_total` metric still increments for non-empty files that are too small; only the log warning for empty files changes.

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

A changelog fragment is included: `changelog.d/1065_file_source_empty_file_warning.fix.md`.

## References

- Closes: #1065

---
🤖 Opened with [Superhuman](https://github.com/gaurav0107/superhuman), an open-source contribution agent.
