### PR TITLE
fix(config): allow hyphens in SECRET[] backend name

### DIFF
--- a/changelog.d/25849_secret_backend_hyphen.fix.md
+++ b/changelog.d/25849_secret_backend_hyphen.fix.md
@@ -1,0 +1,3 @@
+Allows hyphens in the `<backend name>` portion of the `SECRET[<backend name>.<secret name>]` collector regex. Before, a backend name containing a hyphen (e.g. `my-backend`) would fail to match, leaving the literal `SECRET[...]` string in the resolved config instead of the secret value.
+
+authors: maklean

--- a/src/config/loading/secret.rs
+++ b/src/config/loading/secret.rs
@@ -23,13 +23,14 @@ use crate::{
 // The following regex aims to extract a pair of strings, the first being the secret backend name
 // and the second being the secret key. Here are some matching & non-matching examples:
 // - "SECRET[backend.secret_name]" will match and capture "backend" and "secret_name"
+// - "SECRET[my-backend.secret_name]" will match and capture "my-backend" and "secret_name"
 // - "SECRET[backend.secret.name]" will match and capture "backend" and "secret.name"
 // - "SECRET[backend..secret.name]" will match and capture "backend" and ".secret.name"
 // - "SECRET[backend.path/to/secret]" will match and capture "backend" and "path/to/secret"
 // - "SECRET[secret_name]" will not match
 // - "SECRET[.secret.name]" will not match
 pub static COLLECTOR: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"SECRET\[([[:word:]]+)\.([[:word:].\-/]+)\]").unwrap());
+    LazyLock::new(|| Regex::new(r"SECRET\[([[:word:]\-]+)\.([[:word:].\-/]+)\]").unwrap());
 
 /// Helper type for specifically deserializing secrets backends.
 #[derive(Debug, Default, Deserialize, Serialize)]
@@ -183,6 +184,7 @@ mod tests {
             ("a...key".into(), "a...value".into()),
             ("backend.path/to/secret".into(), "secret_value".into()),
             ("backend.nested/dir/file".into(), "nested_value".into()),
+            ("my-backend.secret.key".into(), "hyphenated_value".into()),
         ]
         .into_iter()
         .collect();
@@ -213,6 +215,10 @@ mod tests {
             interpolate("SECRET[backend.nested/dir/file]", &secrets)
         );
         assert_eq!(
+            Ok("hyphenated_value".into()),
+            interpolate("SECRET[my-backend.secret.key]", &secrets)
+        );
+        assert_eq!(
             Ok("xxxSECRET[non_matching_syntax]yyy".into()),
             interpolate("xxxSECRET[non_matching_syntax]yyy", &secrets)
         );
@@ -236,16 +242,19 @@ mod tests {
             SECRET[second_backend.secret.key]
             SECRET[first_backend.a_third.secret_key]
             SECRET[first_backend...an_extra_secret_key]
+            SECRET[third-backend.secret_key]
             SECRET[first_backend.path/to/secret]
             SECRET[second_backend.nested/dir/secret]
+            SECRET[third-backend.another-secret]
             SECRET[non_matching_syntax]
             SECRET[.non.matching.syntax]
         "},
             &mut keys,
         );
-        assert_eq!(keys.len(), 2);
+        assert_eq!(keys.len(), 3);
         assert!(keys.contains_key("first_backend"));
         assert!(keys.contains_key("second_backend"));
+        assert!(keys.contains_key("third-backend"));
 
         let first_backend_keys = keys.get("first_backend").unwrap();
         assert_eq!(first_backend_keys.len(), 6);
@@ -261,6 +270,11 @@ mod tests {
         assert!(second_backend_keys.contains("secret_key"));
         assert!(second_backend_keys.contains("secret.key"));
         assert!(second_backend_keys.contains("nested/dir/secret"));
+
+        let third_backend_keys = keys.get("third-backend").unwrap();
+        assert_eq!(third_backend_keys.len(), 2);
+        assert!(third_backend_keys.contains("secret_key"));
+        assert!(third_backend_keys.contains("another-secret"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Allows hyphens in the `<backend name>` portion of the `SECRET[<backend name>.<secret name>]` collector regex.

## How did you test this PR?
Extended the existing `replacement` and `collection` unit tests in `src/config/loading/secret.rs` with hyphenated backend name cases.

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?
- [ ] Yes
- [x] No

## Does this PR include user facing changes?
- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References
- Closes #25849 