### PR TITLE
fix(ci): vdev_autotag should use the  vectordotdev-bot app

### DIFF
--- a/.github/workflows/vdev_autotag.yml
+++ b/.github/workflows/vdev_autotag.yml
@@ -18,8 +18,8 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
         with:
-          app-id: ${{ secrets.GH_APP_DATADOG_VECTOR_CI_APP_ID }}
-          private-key: ${{ secrets.GH_APP_DATADOG_VECTOR_CI_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.GH_APP_VECTORDOTDEV_BOT_APP_ID }}
+          private-key: ${{ secrets.GH_APP_VECTORDOTDEV_BOT_APP_PRIVATE_KEY }}
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
## Summary

`vdev_autotag.yml` authenticates as the `datadog-vector-ci` GitHub App, which doesn't have `contents` permission on this repo, so every push has failed since v0.3.4: see [this failed run](https://github.com/vectordotdev/vector/actions/runs/29527551731). This switches the workflow to `vectordotdev-bot`, which has `contents: write`.

## Vector configuration

N/A — CI workflow only.

## How did you test this PR?

Confirmed via the GitHub API that `datadog-vector-ci`'s installation lacks `contents` permission and that `vectordotdev-bot` has it. Org secrets for the new app are now scoped to this repo.

## Change Type

- [x] Bug fix

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes.
- [x] No. A maintainer will apply the `no-changelog` label to this PR.