### PR TITLE
chore(dev): move component maturity skill out of .claude/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,10 +73,11 @@ local/
 # vscode
 .vscode/
 
-# Claude skill-generated reports (published to Confluence, not tracked)
-.claude/skill-reports/
-# Local Claude Code settings (machine-specific permissions)
-.claude/settings.local.json
+# Claude Code project directory (local tooling, not tracked)
+.claude/
+
+# agent skill-generated reports (published to Confluence, not tracked)
+agents/reports/
 
 # antithesis scratchbook (private knowledge store)
 /tests/antithesis/scratchbook/

--- a/agents/skills/vector-components-maturity-eval/SKILL.md
+++ b/agents/skills/vector-components-maturity-eval/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vector-components-maturity-eval
-description: Evaluates all Vector component maturity levels and writes a monthly markdown report to .claude/skill-reports/maturity-YYYY-MM.md. Use when asked to evaluate component maturity or generate the monthly maturity report.
+description: Evaluates all Vector component maturity levels and writes a monthly markdown report to agents/reports/maturity-YYYY-MM.md. Use when asked to evaluate component maturity or generate the monthly maturity report.
 ---
 
 You are the Vector Component Maturity Evaluator. Work through the phases below to collect signals for all components, evaluate them, and write the report.
@@ -246,10 +246,10 @@ Use judgment for borderline cases. A component with 2 bugs but a long stable his
 Create the output directory and write the report:
 
 ```bash
-mkdir -p .claude/skill-reports
+mkdir -p agents/reports
 ```
 
-Write to `.claude/skill-reports/maturity-YYYY-MM.md` using the actual current year and month.
+Write to `agents/reports/maturity-YYYY-MM.md` using the actual current year and month.
 
 ---
 


### PR DESCRIPTION
## Summary

`.claude/` previously had only two specific paths ignored (`.claude/skill-reports/`, `.claude/settings.local.json`), leaving one file tracked: the `vector-components-maturity-eval` skill. This PR ignores `.claude/` entirely and relocates that skill to `agents/skills/`, a tool-agnostic location, with its generated reports now written to `agents/reports/` (also gitignored, same as before).

## Vector configuration

N/A — no runtime config changes.

## How did you test this PR?

Verified the skill's internal path references were updated consistently and that `agents/reports/` is ignored while `agents/skills/` is tracked.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

## Notes