### PR TITLE
chore(ci): warm check-mode artifacts so clippy jobs hit the cache

### DIFF
--- a/.github/workflows/warm-cache.yml
+++ b/.github/workflows/warm-cache.yml
@@ -26,7 +26,7 @@ jobs:
   warm:
     name: Warm shared workspace cache
     runs-on: ubuntu-24.04-8core
-    timeout-minutes: 60
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -35,11 +35,22 @@ jobs:
           rust: true
           protoc: true
           libsasl2: true
+          vdev: true
           cargo-cache: true
           cache-save: true
 
-      # cargo build (not check) so cached deps include .rlib for cargo test consumers.
-      # --all-features to match `vdev check rust` used by check-clippy, so
-      # optional deps (rdkafka, ...) are in the cache.
-      - name: Seed build
+      # Warm BOTH cargo profiles. cargo's fingerprint differs between build-mode
+      # (.rlib, emitted by `cargo build`/`cargo test`) and check-mode (.rmeta,
+      # emitted by `cargo clippy`/`cargo check`), so a build-only cache does not
+      # accelerate clippy at all: it re-checks the whole dep graph. We therefore
+      # seed both so every consumer gets a real cache hit.
+
+      # build-mode: serves `test` (cargo nextest) consumers.
+      - name: Seed build-mode (.rlib)
         run: cargo build --workspace --tests --all-features --locked
+
+      # check-mode: serves check-clippy / check-generated-docs / check-rust-docs.
+      # Runs the exact command those jobs use (`vdev check rust` ->
+      # `cargo clippy --workspace --all-targets --all-features`) so fingerprints match.
+      - name: Seed check-mode (.rmeta)
+        run: make check-clippy


### PR DESCRIPTION
## Summary

The shared Rust build cache (`Swatinem/rust-cache`, added in #25478) never
sped up `check-clippy` (it actually came out slightly slower). Root cause is a
**build-vs-check profile mismatch**: `warm-cache.yml` warms the cache with
`cargo build` (build-mode, `.rlib`), but `check-clippy` / `check-generated-docs`
/ `check-rust-docs` run in check-mode (`.rmeta`), which carries a different cargo
fingerprint. A build-only cache therefore contains none of the artifacts those
jobs need, so clippy re-checks the entire dependency graph on every run while
still paying the ~30s restore cost. The `test` job (build-mode) was the only
real beneficiary.

This PR warms **both** profiles in `warm-cache.yml`: it adds a `make check-clippy`
step (which is exactly `cargo clippy --workspace --all-targets --all-features`,
the same command the consumer jobs run) alongside the existing `cargo build --tests`
step, so the cache carries both `.rlib` and `.rmeta` artifacts.

External-dep artifacts stay valid until `Cargo.lock` changes, which is precisely
what already triggers the warmer and rotates the cache key, so consumers get a
real hit for the expensive dependency graph. The warm job timeout is bumped to
90m to cover the added clippy pass; the warmer runs asynchronously on `master`
pushes, off the CI critical path.

## How did you test this PR?

Reproduced both the problem and the fix on `vectordotdev/ci-sandbox` using real
Vector code (the `prometheus-parser` crate and its full dependency tree), with a
`main`-only seeder and consumer jobs on a branch, all confirmed as full cache hits:

| Consumer | Cache contents | crate units rebuilt | wall time |
| --- | --- | --- | --- |
| clippy (check-mode) | build-only (before) | 322 | 186s |
| clippy (check-mode) | build + clippy (after) | 6 | 73s |
| test (build-mode) | build + clippy | 6 | 74s |
| clippy cold baseline | none | 351 | 176s |

Warming check-mode drops the clippy consumer from 322 rebuilt units to 6, and
186s to 73s (2.5x, and now faster than a cold run instead of slower). The `test`
consumer is unaffected.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: #25478
