### PR TITLE
fix(topology): prevent security_confinement_disabled gauge from expiring

### DIFF
--- a/changelog.d/security_confinement_gauge_expiry.fix.md
+++ b/changelog.d/security_confinement_gauge_expiry.fix.md
@@ -1,0 +1,3 @@
+Fixed the `vector_security_confinement_disabled` internal metric disappearing after the metric idle timeout (300 seconds by default) while a sink was still running with `dangerously_allow_unconfined_template_resolution` enabled. The gauge is now owned by the topology and held for the lifetime of each sink, and refreshed on configuration reload, so alerts watching this metric no longer silently stop firing.
+
+authors: thomasqueirozb

--- a/src/config/sink.rs
+++ b/src/config/sink.rs
@@ -266,6 +266,15 @@ pub trait SinkConfig: DynClone + NamedComponent + core::fmt::Debug + Send + Sync
         Vec::new()
     }
 
+    /// Returns this sink's template-confinement config, if it supports confinement.
+    ///
+    /// The topology uses this to own the `vector_security_confinement_disabled`
+    /// gauge for the sink's lifetime. `None` (the default) means the sink does
+    /// not participate in template confinement and emits no gauge.
+    fn confinement_config(&self) -> Option<&crate::template::ConfinementConfig> {
+        None
+    }
+
     /// Gets the acknowledgements configuration for this sink.
     fn acknowledgements(&self) -> &AcknowledgementsConfig;
 }

--- a/src/sinks/amqp/config.rs
+++ b/src/sinks/amqp/config.rs
@@ -145,8 +145,11 @@ impl SinkConfig for AmqpSinkConfig {
             .transpose()?;
         let sink = AmqpSink::new(config).await?;
         let hc = healthcheck(sink.channels.clone()).boxed();
-        self.confinement.set_confinement_gauge("sink", Self::NAME);
         Ok((VectorSink::from_event_streamsink(sink), hc))
+    }
+
+    fn confinement_config(&self) -> Option<&crate::template::ConfinementConfig> {
+        Some(&self.confinement)
     }
 
     fn input(&self) -> Input {

--- a/src/sinks/aws_cloudwatch_logs/config.rs
+++ b/src/sinks/aws_cloudwatch_logs/config.rs
@@ -240,9 +240,11 @@ impl SinkConfig for CloudwatchLogsSinkConfig {
 
             service: svc,
         };
-
-        self.confinement.set_confinement_gauge("sink", Self::NAME);
         Ok((VectorSink::from_event_streamsink(sink), healthcheck))
+    }
+
+    fn confinement_config(&self) -> Option<&crate::template::ConfinementConfig> {
+        Some(&self.confinement)
     }
 
     fn input(&self) -> Input {

--- a/src/sinks/aws_s3/config.rs
+++ b/src/sinks/aws_s3/config.rs
@@ -232,8 +232,11 @@ impl SinkConfig for S3SinkConfig {
         let service = self.create_service(&cx.proxy).await?;
         let healthcheck = self.build_healthcheck(service.client())?;
         let sink = self.build_processor(service, cx)?;
-        self.confinement.set_confinement_gauge("sink", Self::NAME);
         Ok((sink, healthcheck))
+    }
+
+    fn confinement_config(&self) -> Option<&crate::template::ConfinementConfig> {
+        Some(&self.confinement)
     }
 
     fn input(&self) -> Input {

--- a/src/sinks/axiom/config.rs
+++ b/src/sinks/axiom/config.rs
@@ -193,14 +193,16 @@ impl SinkConfig for AxiomConfig {
             confinement: self.confinement.clone(),
         };
 
-        // Route through the HTTP builder that doesn't emit the gauge, so
-        // per-template warnings and the sink-level gauge both carry
-        // `component_type=axiom` — not `http`.
-        let result = http_sink_config
-            .build_without_confinement_gauge(cx, Self::NAME)
-            .await?;
-        self.confinement.set_confinement_gauge("sink", Self::NAME);
-        Ok(result)
+        // Route through the HTTP builder threaded with our own component type,
+        // so per-template security warnings carry `component_type=axiom` rather
+        // than `http`.
+        http_sink_config
+            .build_with_component_type(cx, Self::NAME)
+            .await
+    }
+
+    fn confinement_config(&self) -> Option<&crate::template::ConfinementConfig> {
+        Some(&self.confinement)
     }
 
     fn input(&self) -> Input {

--- a/src/sinks/azure_blob/config.rs
+++ b/src/sinks/azure_blob/config.rs
@@ -275,8 +275,11 @@ impl SinkConfig for AzureBlobSinkConfig {
 
         let healthcheck = build_healthcheck(self.container_name.clone(), Arc::clone(&client))?;
         let sink = self.build_processor(client)?;
-        self.confinement.set_confinement_gauge("sink", Self::NAME);
         Ok((sink, healthcheck))
+    }
+
+    fn confinement_config(&self) -> Option<&crate::template::ConfinementConfig> {
+        Some(&self.confinement)
     }
 
     fn input(&self) -> Input {

--- a/src/sinks/clickhouse/config.rs
+++ b/src/sinks/clickhouse/config.rs
@@ -280,9 +280,11 @@ impl SinkConfig for ClickhouseConfig {
         );
 
         let healthcheck = Box::pin(healthcheck(client, endpoint, auth));
-
-        self.confinement.set_confinement_gauge("sink", Self::NAME);
         Ok((VectorSink::from_event_streamsink(sink), healthcheck))
+    }
+
+    fn confinement_config(&self) -> Option<&crate::template::ConfinementConfig> {
+        Some(&self.confinement)
     }
 
     fn input(&self) -> Input {

--- a/src/sinks/doris/config.rs
+++ b/src/sinks/doris/config.rs
@@ -241,9 +241,11 @@ impl SinkConfig for DorisConfig {
         }))
         .map_ok(|((), _)| ())
         .boxed();
-
-        self.confinement.set_confinement_gauge("sink", Self::NAME);
         Ok((sink, healthcheck))
+    }
+
+    fn confinement_config(&self) -> Option<&crate::template::ConfinementConfig> {
+        Some(&self.confinement)
     }
 
     fn input(&self) -> Input {

--- a/src/sinks/elasticsearch/config.rs
+++ b/src/sinks/elasticsearch/config.rs
@@ -753,8 +753,11 @@ impl SinkConfig for ElasticsearchConfig {
         )
         .map_ok(|((), _)| ())
         .boxed();
-        self.confinement.set_confinement_gauge("sink", Self::NAME);
         Ok((stream, healthcheck))
+    }
+
+    fn confinement_config(&self) -> Option<&crate::template::ConfinementConfig> {
+        Some(&self.confinement)
     }
 
     fn input(&self) -> Input {

--- a/src/sinks/file/mod.rs
+++ b/src/sinks/file/mod.rs
@@ -248,11 +248,14 @@ impl SinkConfig for FileSinkConfig {
         cx: SinkContext,
     ) -> crate::Result<(super::VectorSink, super::Healthcheck)> {
         let sink = FileSink::new(self, cx)?;
-        self.confinement.set_confinement_gauge("sink", Self::NAME);
         Ok((
             super::VectorSink::from_event_streamsink(sink),
             future::ok(()).boxed(),
         ))
+    }
+
+    fn confinement_config(&self) -> Option<&crate::template::ConfinementConfig> {
+        Some(&self.confinement)
     }
 
     fn input(&self) -> Input {

--- a/src/sinks/gcp/cloud_storage.rs
+++ b/src/sinks/gcp/cloud_storage.rs
@@ -281,9 +281,11 @@ impl SinkConfig for GcsSinkConfig {
         )?;
         auth.spawn_regenerate_token();
         let sink = self.build_sink(client, base_url, auth, cx)?;
-
-        self.confinement.set_confinement_gauge("sink", Self::NAME);
         Ok((sink, healthcheck))
+    }
+
+    fn confinement_config(&self) -> Option<&crate::template::ConfinementConfig> {
+        Some(&self.confinement)
     }
 
     fn input(&self) -> Input {

--- a/src/sinks/gcp/stackdriver/logs/config.rs
+++ b/src/sinks/gcp/stackdriver/logs/config.rs
@@ -319,9 +319,11 @@ impl SinkConfig for StackdriverConfig {
         let healthcheck = healthcheck(client, auth.clone(), uri).boxed();
 
         auth.spawn_regenerate_token();
-
-        self.confinement.set_confinement_gauge("sink", Self::NAME);
         Ok((VectorSink::from_event_streamsink(sink), healthcheck))
+    }
+
+    fn confinement_config(&self) -> Option<&crate::template::ConfinementConfig> {
+        Some(&self.confinement)
     }
 
     fn input(&self) -> Input {

--- a/src/sinks/greptimedb/logs/config.rs
+++ b/src/sinks/greptimedb/logs/config.rs
@@ -207,8 +207,11 @@ impl SinkConfig for GreptimeDBLogsConfig {
             this.endpoint.clone(),
             auth.clone(),
         ));
-        self.confinement.set_confinement_gauge("sink", Self::NAME);
         Ok((VectorSink::from_event_streamsink(sink), healthcheck))
+    }
+
+    fn confinement_config(&self) -> Option<&crate::template::ConfinementConfig> {
+        Some(&self.confinement)
     }
 
     fn input(&self) -> Input {

--- a/src/sinks/http/config.rs
+++ b/src/sinks/http/config.rs
@@ -241,9 +241,11 @@ pub(super) fn validate_payload_wrapper(
 #[typetag::serde(name = "http")]
 impl SinkConfig for HttpSinkConfig {
     async fn build(&self, cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
-        let result = self.build_without_confinement_gauge(cx, Self::NAME).await?;
-        self.confinement.set_confinement_gauge("sink", Self::NAME);
-        Ok(result)
+        self.build_with_component_type(cx, Self::NAME).await
+    }
+
+    fn confinement_config(&self) -> Option<&crate::template::ConfinementConfig> {
+        Some(&self.confinement)
     }
 
     fn input(&self) -> Input {
@@ -269,12 +271,11 @@ impl SinkConfig for HttpSinkConfig {
 }
 
 impl HttpSinkConfig {
-    /// Confinement + sink construction without emitting the per-sink
-    /// confinement gauge. `component_name` is threaded through so both the
-    /// gauge (emitted by the caller) and per-template security warnings
-    /// carry the outer sink type — `http` when this is the top-level sink,
-    /// `opentelemetry` when [`OpenTelemetryConfig::build`] delegates here.
-    pub(crate) async fn build_without_confinement_gauge(
+    /// Confinement + sink construction. `component_name` is threaded through so
+    /// per-template security warnings carry the outer sink type — `http` when
+    /// this is the top-level sink, `opentelemetry` when
+    /// [`OpenTelemetryConfig::build`] delegates here.
+    pub(crate) async fn build_with_component_type(
         &self,
         cx: SinkContext,
         component_name: &'static str,

--- a/src/sinks/humio/logs.rs
+++ b/src/sinks/humio/logs.rs
@@ -180,9 +180,11 @@ impl GenerateConfig for HumioLogsConfig {
 #[typetag::serde(name = "humio_logs")]
 impl SinkConfig for HumioLogsConfig {
     async fn build(&self, cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
-        let result = self.build_without_confinement_gauge(cx, Self::NAME)?;
-        self.confinement.set_confinement_gauge("sink", Self::NAME);
-        Ok(result)
+        self.build_with_component_type(cx, Self::NAME)
+    }
+
+    fn confinement_config(&self) -> Option<&crate::template::ConfinementConfig> {
+        Some(&self.confinement)
     }
 
     fn input(&self) -> Input {
@@ -195,19 +197,17 @@ impl SinkConfig for HumioLogsConfig {
 }
 
 impl HumioLogsConfig {
-    /// Confinement + sink construction without emitting the per-sink
-    /// confinement gauge. `component_name` is threaded through so both the
-    /// gauge (emitted by the caller) and per-template security warnings
-    /// carry the outer sink type — `humio_logs` when this is the top-level
-    /// sink, `humio_metrics` when [`HumioMetricsConfig::build`] delegates
-    /// here.
-    pub(super) fn build_without_confinement_gauge(
+    /// Confinement + sink construction. `component_name` is threaded through so
+    /// per-template security warnings carry the outer sink type — `humio_logs`
+    /// when this is the top-level sink, `humio_metrics` when
+    /// [`HumioMetricsConfig::build`] delegates here.
+    pub(super) fn build_with_component_type(
         &self,
         cx: SinkContext,
         component_name: &'static str,
     ) -> crate::Result<(VectorSink, Healthcheck)> {
         self.build_hec_config()
-            .build_without_confinement_gauge(cx, component_name)
+            .build_with_component_type(cx, component_name)
     }
 
     fn build_hec_config(&self) -> HecLogsSinkConfig {

--- a/src/sinks/humio/metrics.rs
+++ b/src/sinks/humio/metrics.rs
@@ -191,19 +191,20 @@ impl SinkConfig for HumioMetricsConfig {
             confinement: self.confinement.clone(),
         };
 
-        // Route through the inner Humio helper so the wrapped
-        // `humio_logs` sink's gauge isn't emitted alongside our own —
-        // operators watching `security_confinement_disabled` for a
-        // `humio_metrics` sink should only see one series.
-        let (sink, healthcheck) = sink.build_without_confinement_gauge(cx, Self::NAME)?;
+        // Route through the inner Humio helper threaded with our own component
+        // type, so per-template security warnings carry `humio_metrics` rather
+        // than the delegated `humio_logs`/`splunk_hec_logs`.
+        let (sink, healthcheck) = sink.build_with_component_type(cx, Self::NAME)?;
 
         let sink = HumioMetricsSink {
             inner: sink,
             transform,
         };
-
-        self.confinement.set_confinement_gauge("sink", Self::NAME);
         Ok((VectorSink::Stream(Box::new(sink)), healthcheck))
+    }
+
+    fn confinement_config(&self) -> Option<&crate::template::ConfinementConfig> {
+        Some(&self.confinement)
     }
 
     fn input(&self) -> Input {

--- a/src/sinks/kafka/config.rs
+++ b/src/sinks/kafka/config.rs
@@ -292,8 +292,11 @@ impl SinkConfig for KafkaSinkConfig {
             .confine(&self.confinement, Self::NAME, "topic")?;
         let sink = KafkaSink::new(config.clone())?;
         let hc = healthcheck(config, cx.healthcheck.clone()).boxed();
-        self.confinement.set_confinement_gauge("sink", Self::NAME);
         Ok((VectorSink::from_event_streamsink(sink), hc))
+    }
+
+    fn confinement_config(&self) -> Option<&crate::template::ConfinementConfig> {
+        Some(&self.confinement)
     }
 
     fn input(&self) -> Input {

--- a/src/sinks/loki/config.rs
+++ b/src/sinks/loki/config.rs
@@ -240,9 +240,11 @@ impl SinkConfig for LokiConfig {
         let sink = LokiSink::new(config.clone(), client.clone())?;
 
         let healthcheck = healthcheck(config, client).boxed();
-
-        self.confinement.set_confinement_gauge("sink", Self::NAME);
         Ok((VectorSink::from_event_streamsink(sink), healthcheck))
+    }
+
+    fn confinement_config(&self) -> Option<&crate::template::ConfinementConfig> {
+        Some(&self.confinement)
     }
 
     fn input(&self) -> Input {

--- a/src/sinks/mqtt/config.rs
+++ b/src/sinks/mqtt/config.rs
@@ -122,12 +122,14 @@ impl SinkConfig for MqttSinkConfig {
             .confine(&self.confinement, Self::NAME, "topic")?;
         let connector = config.build_connector()?;
         let sink = MqttSink::new(&config, connector.clone())?;
-
-        self.confinement.set_confinement_gauge("sink", Self::NAME);
         Ok((
             VectorSink::from_event_streamsink(sink),
             Box::pin(async move { connector.healthcheck().await }),
         ))
+    }
+
+    fn confinement_config(&self) -> Option<&crate::template::ConfinementConfig> {
+        Some(&self.confinement)
     }
 
     fn input(&self) -> Input {

--- a/src/sinks/nats/config.rs
+++ b/src/sinks/nats/config.rs
@@ -191,8 +191,11 @@ impl SinkConfig for NatsSinkConfig {
             .confine(&self.confinement, Self::NAME, "subject")?;
         let sink = NatsSink::new(config.clone()).await?;
         let healthcheck = healthcheck(config).boxed();
-        self.confinement.set_confinement_gauge("sink", Self::NAME);
         Ok((VectorSink::from_event_streamsink(sink), healthcheck))
+    }
+
+    fn confinement_config(&self) -> Option<&crate::template::ConfinementConfig> {
+        Some(&self.confinement)
     }
 
     fn input(&self) -> Input {

--- a/src/sinks/opentelemetry/mod.rs
+++ b/src/sinks/opentelemetry/mod.rs
@@ -81,12 +81,17 @@ impl SinkConfig for OpenTelemetryConfig {
         match &self.protocol {
             Protocol::Http(config) => {
                 warn_on_invalid_otlp_batching(config);
-                let result = config
-                    .build_without_confinement_gauge(cx, Self::NAME)
-                    .await?;
-                config.confinement.set_confinement_gauge("sink", Self::NAME);
-                Ok(result)
+                // Delegate to the HTTP sink, but thread through `opentelemetry`
+                // as the component type so security warnings carry the outer
+                // sink type rather than `http`.
+                config.build_with_component_type(cx, Self::NAME).await
             }
+        }
+    }
+
+    fn confinement_config(&self) -> Option<&crate::template::ConfinementConfig> {
+        match &self.protocol {
+            Protocol::Http(config) => Some(&config.confinement),
         }
     }
 

--- a/src/sinks/prometheus/remote_write/config.rs
+++ b/src/sinks/prometheus/remote_write/config.rs
@@ -289,9 +289,11 @@ impl SinkConfig for RemoteWriteConfig {
             expire_metrics_secs: self.expire_metrics_secs,
             service,
         };
-
-        self.confinement.set_confinement_gauge("sink", Self::NAME);
         Ok((VectorSink::from_event_streamsink(sink), healthcheck))
+    }
+
+    fn confinement_config(&self) -> Option<&crate::template::ConfinementConfig> {
+        Some(&self.confinement)
     }
 
     fn input(&self) -> Input {

--- a/src/sinks/pulsar/config.rs
+++ b/src/sinks/pulsar/config.rs
@@ -406,9 +406,11 @@ impl SinkConfig for PulsarSinkConfig {
 
         let sink = PulsarSink::new(client, config.clone())?;
         let hc = healthcheck(config).boxed();
-
-        self.confinement.set_confinement_gauge("sink", Self::NAME);
         Ok((VectorSink::from_event_streamsink(sink), hc))
+    }
+
+    fn confinement_config(&self) -> Option<&crate::template::ConfinementConfig> {
+        Some(&self.confinement)
     }
 
     fn input(&self) -> Input {

--- a/src/sinks/redis/config.rs
+++ b/src/sinks/redis/config.rs
@@ -209,8 +209,11 @@ impl SinkConfig for RedisSinkConfig {
         let conn = config.build_connection().await?;
         let healthcheck = RedisSinkConfig::healthcheck(conn.clone()).boxed();
         let sink = RedisSink::new(&config, conn)?;
-        self.confinement.set_confinement_gauge("sink", Self::NAME);
         Ok((super::VectorSink::from_event_streamsink(sink), healthcheck))
+    }
+
+    fn confinement_config(&self) -> Option<&crate::template::ConfinementConfig> {
+        Some(&self.confinement)
     }
 
     fn input(&self) -> Input {

--- a/src/sinks/splunk_hec/logs/config.rs
+++ b/src/sinks/splunk_hec/logs/config.rs
@@ -189,12 +189,11 @@ impl GenerateConfig for HecLogsSinkConfig {
 }
 
 impl HecLogsSinkConfig {
-    /// Confinement + sink construction without emitting the per-sink
-    /// confinement gauge. `component_name` is used for both the gauge label
-    /// (by the caller) and the per-template security warnings emitted from
-    /// `Template::confine`, so wrapping sinks (Humio) see their own type in
-    /// logs and metrics rather than the delegated `splunk_hec_logs`.
-    pub(crate) fn build_without_confinement_gauge(
+    /// Confinement + sink construction. `component_name` is threaded into the
+    /// per-template security warnings emitted from `Template::confine`, so
+    /// wrapping sinks (Humio) see their own type in logs rather than the
+    /// delegated `splunk_hec_logs`.
+    pub(crate) fn build_with_component_type(
         &self,
         cx: SinkContext,
         component_name: &'static str,
@@ -234,9 +233,11 @@ impl HecLogsSinkConfig {
 #[typetag::serde(name = "splunk_hec_logs")]
 impl SinkConfig for HecLogsSinkConfig {
     async fn build(&self, cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
-        let result = self.build_without_confinement_gauge(cx, Self::NAME)?;
-        self.confinement.set_confinement_gauge("sink", Self::NAME);
-        Ok(result)
+        self.build_with_component_type(cx, Self::NAME)
+    }
+
+    fn confinement_config(&self) -> Option<&crate::template::ConfinementConfig> {
+        Some(&self.confinement)
     }
 
     fn input(&self) -> Input {

--- a/src/sinks/splunk_hec/metrics/config.rs
+++ b/src/sinks/splunk_hec/metrics/config.rs
@@ -172,8 +172,11 @@ impl SinkConfig for HecMetricsSinkConfig {
         )
         .boxed();
         let sink = config.build_processor(client, cx)?;
-        self.confinement.set_confinement_gauge("sink", Self::NAME);
         Ok((sink, healthcheck))
+    }
+
+    fn confinement_config(&self) -> Option<&crate::template::ConfinementConfig> {
+        Some(&self.confinement)
     }
 
     fn input(&self) -> Input {

--- a/src/sinks/webhdfs/config.rs
+++ b/src/sinks/webhdfs/config.rs
@@ -111,8 +111,11 @@ impl SinkConfig for WebHdfsConfig {
         let healthcheck = Box::pin(async move { Ok(check_op.check().await?) });
 
         let sink = self.build_processor(op)?;
-        self.confinement.set_confinement_gauge("sink", Self::NAME);
         Ok((sink, healthcheck))
+    }
+
+    fn confinement_config(&self) -> Option<&crate::template::ConfinementConfig> {
+        Some(&self.confinement)
     }
 
     fn input(&self) -> Input {

--- a/src/template.rs
+++ b/src/template.rs
@@ -12,8 +12,6 @@ use snafu::Snafu;
 use tracing::warn;
 use vector_lib::{
     configurable::{ConfigurableNumber, ConfigurableString, NumberClass, configurable_component},
-    gauge,
-    internal_event::GaugeName,
     lookup::lookup_v2::parse_target_path,
 };
 
@@ -263,9 +261,8 @@ impl Template {
         field_name: &'static str,
     ) -> crate::Result<Self> {
         // Full opt-out: bypass all confinement for this template (startup AND
-        // runtime). The per-sink gauge is emitted by each sink's build() on
-        // the success path — not here — so a failed reload cannot clobber the
-        // still-active sink's gauge.
+        // runtime). The `vector_security_confinement_disabled` gauge is owned by
+        // the topology, not emitted here.
         if config.dangerously_allow_unconfined_template_resolution {
             ConfinementConfig::warn_unconfined_template("sink", component_name, field_name);
             return Ok(self);
@@ -1231,9 +1228,12 @@ pub struct ConfinementConfig {
 }
 
 impl ConfinementConfig {
-    /// Logs a per-template SECURITY warning on the opt-out path. Does NOT
-    /// touch the gauge — the gauge is emitted once per sink build by
-    /// [`Self::set_confinement_gauge`].
+    /// Logs a per-template SECURITY warning on the opt-out path.
+    ///
+    /// The `vector_security_confinement_disabled` gauge is owned by the topology
+    /// (see `RunningTopology::refresh_confinement_gauges`), which holds a handle
+    /// for the sink's lifetime so the metric matches the active topology and
+    /// never expires while the sink runs.
     pub fn warn_unconfined_template(
         component_kind: &'static str,
         component_type: &'static str,
@@ -1245,36 +1245,6 @@ impl ConfinementConfig {
                        field used in the template can write to arbitrary keys.",
             component_kind, component_type, field,
         );
-    }
-
-    /// Emit `vector_security_confinement_disabled{component_kind,component_type}`
-    /// reflecting whether this sink has the confinement policy disabled.
-    ///
-    /// Must be called at the END of `SinkConfig::build`, on the success
-    /// path only. Value = `1` when the flag is set (operator explicitly
-    /// disabled confinement policy for this sink), `0` otherwise.
-    ///
-    /// Emitting earlier means a build that later errors would still leave
-    /// its gauge write behind. On a reload where the new config fails to
-    /// build, the topology manager keeps the old sink active but the
-    /// failed replacement's write would silently misreport the live
-    /// sink's confinement state.
-    pub fn set_confinement_gauge(
-        &self,
-        component_kind: &'static str,
-        component_type: &'static str,
-    ) {
-        let value = if self.dangerously_allow_unconfined_template_resolution {
-            1.0
-        } else {
-            0.0
-        };
-        gauge!(
-            GaugeName::SecurityConfinementDisabled,
-            "component_kind" => component_kind,
-            "component_type" => component_type,
-        )
-        .set(value);
     }
 }
 

--- a/src/test_util/mock/sinks/basic.rs
+++ b/src/test_util/mock/sinks/basic.rs
@@ -26,6 +26,11 @@ pub struct BasicSinkConfig {
     #[serde(skip)]
     healthy: bool,
 
+    /// Optional template-confinement config, so tests can exercise the
+    /// topology-owned `security_confinement_disabled` gauge.
+    #[serde(skip)]
+    confinement: Option<crate::template::ConfinementConfig>,
+
     /// Dummy field used for generating unique configurations to trigger reloads.
     data: Option<String>,
 }
@@ -45,6 +50,7 @@ impl BasicSinkConfig {
         Self {
             sink: Mode::Normal(sink),
             healthy,
+            confinement: None,
             data: None,
         }
     }
@@ -53,8 +59,20 @@ impl BasicSinkConfig {
         Self {
             sink: Mode::Normal(sink),
             healthy,
+            confinement: None,
             data: Some(data.into()),
         }
+    }
+
+    /// Attach a template-confinement config, marking this sink as
+    /// confinement-aware so the topology emits its
+    /// `security_confinement_disabled` gauge. `disabled` sets
+    /// `dangerously_allow_unconfined_template_resolution`.
+    pub fn with_confinement(mut self, disabled: bool) -> Self {
+        self.confinement = Some(crate::template::ConfinementConfig {
+            dangerously_allow_unconfined_template_resolution: disabled,
+        });
+        self
     }
 }
 
@@ -92,6 +110,10 @@ impl SinkConfig for BasicSinkConfig {
 
     fn input(&self) -> Input {
         Input::all()
+    }
+
+    fn confinement_config(&self) -> Option<&crate::template::ConfinementConfig> {
+        self.confinement.as_ref()
     }
 
     fn acknowledgements(&self) -> &AcknowledgementsConfig {

--- a/src/test_util/mock/sinks/basic.rs
+++ b/src/test_util/mock/sinks/basic.rs
@@ -66,11 +66,11 @@ impl BasicSinkConfig {
 
     /// Attach a template-confinement config, marking this sink as
     /// confinement-aware so the topology emits its
-    /// `security_confinement_disabled` gauge. `disabled` sets
+    /// `security_confinement_disabled` gauge. `allowed` sets
     /// `dangerously_allow_unconfined_template_resolution`.
-    pub fn with_confinement(mut self, disabled: bool) -> Self {
+    pub fn with_confinement(mut self, allowed: bool) -> Self {
         self.confinement = Some(crate::template::ConfinementConfig {
-            dangerously_allow_unconfined_template_resolution: disabled,
+            dangerously_allow_unconfined_template_resolution: allowed,
         });
         self
     }

--- a/src/topology/running.rs
+++ b/src/topology/running.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use futures::{Future, FutureExt, future};
+use metrics::Gauge;
 use snafu::Snafu;
 use stream_cancel::Trigger;
 use tokio::{
@@ -13,6 +14,8 @@ use tokio::{
 use tracing::Instrument;
 use vector_lib::{
     buffers::topology::channel::BufferSender,
+    gauge,
+    internal_event::GaugeName,
     shutdown::ShutdownSignal,
     tap::topology::{TapOutput, TapResource, WatchRx, WatchTx},
     trigger::DisabledTrigger,
@@ -70,6 +73,7 @@ pub struct RunningTopology {
     metrics_task: Option<TaskHandle>,
     metrics_task_shutdown_trigger: Option<Trigger>,
     pending_reload: Option<HashSet<ComponentKey>>,
+    sink_confinement_gauges: HashMap<ComponentKey, Gauge>,
 }
 
 impl RunningTopology {
@@ -94,6 +98,7 @@ impl RunningTopology {
             metrics_task: None,
             metrics_task_shutdown_trigger: None,
             pending_reload: None,
+            sink_confinement_gauges: HashMap::new(),
         }
     }
 
@@ -332,6 +337,7 @@ impl RunningTopology {
                 self.connect_diff(&diff, &mut new_pieces).await;
                 self.spawn_diff(&diff, new_pieces);
                 self.config = new_config;
+                self.refresh_confinement_gauges();
 
                 info!("New configuration loaded successfully.");
 
@@ -357,6 +363,9 @@ impl RunningTopology {
         {
             self.connect_diff(&diff, &mut new_pieces).await;
             self.spawn_diff(&diff, new_pieces);
+            // `self.config` still holds the old config on the rollback path, so
+            // this restores the gauges for the re-spawned old sinks.
+            self.refresh_confinement_gauges();
 
             info!("Old configuration restored successfully.");
 
@@ -1074,6 +1083,47 @@ impl RunningTopology {
         }
     }
 
+    /// Reconcile the `vector_security_confinement_disabled` gauges with the
+    /// currently active topology.
+    ///
+    /// The topology is the single owner of this gauge: it holds a handle for
+    /// every confinement-aware sink for the sink's whole lifetime, which keeps
+    /// the metric from expiring out of the registry (a dropped handle would let
+    /// it age out after the idle timeout even while the sink runs). The value
+    /// is `1` when the sink opted out of confinement, `0` otherwise.
+    ///
+    /// This rebuilds from `self.config`, so it must be called *after* `self.config`
+    /// reflects the active topology (updated to the new config on a successful
+    /// reload, or left as the old config on a rollback). Handles for sinks no
+    /// longer present are dropped, allowing their series to expire naturally.
+    fn refresh_confinement_gauges(&mut self) {
+        // Rebuild the handle set from the active config on every call. Reusing a
+        // handle keyed only by `ComponentKey` would be wrong: a reloaded sink
+        // can keep its id but change `type`, and a cached handle carries the old
+        // `component_type` label. Recreating is cheap — `gauge!` returns a
+        // handle to the same registry entry for a given label set.
+        let mut gauges = HashMap::with_capacity(self.sink_confinement_gauges.len());
+        for (key, outer) in self.config.sinks() {
+            let Some(confinement) = outer.inner.confinement_config() else {
+                continue;
+            };
+            let value = f64::from(confinement.dangerously_allow_unconfined_template_resolution);
+            let handle = gauge!(
+                GaugeName::SecurityConfinementDisabled,
+                "component_kind" => "sink",
+                "component_id" => key.id().to_string(),
+                "component_type" => outer.inner.get_component_name(),
+            );
+            handle.set(value);
+            gauges.insert(key.clone(), handle);
+        }
+
+        // Replacing the map drops handles for sinks that are gone (or changed
+        // type), letting their now-stale series expire instead of reporting a
+        // stale value forever.
+        self.sink_confinement_gauges = gauges;
+    }
+
     /// Starts any new or changed components in the given configuration diff.
     pub(crate) fn spawn_diff(&mut self, diff: &ConfigDiff, mut new_pieces: TopologyPieces) {
         for key in &diff.sources.to_change {
@@ -1382,6 +1432,8 @@ impl RunningTopology {
         }
         running_topology.connect_diff(&diff, &mut pieces).await;
         running_topology.spawn_diff(&diff, pieces);
+        // `running_topology.config` was set from the initial config in `new()`.
+        running_topology.refresh_confinement_gauges();
 
         let (utilization_task_shutdown_trigger, utilization_shutdown_signal, _) =
             ShutdownSignal::new_wired();

--- a/src/topology/test/confinement_gauge.rs
+++ b/src/topology/test/confinement_gauge.rs
@@ -1,0 +1,165 @@
+//! Tests for the topology-owned `security_confinement_disabled` gauge.
+//!
+//! The gauge reports whether a sink has opted out of template confinement
+//! (`dangerously_allow_unconfined_template_resolution`). The topology owns it
+//! for each sink's lifetime so it does not expire while the sink runs, and
+//! reconciles it on every (re)load. These tests exercise the observable parts:
+//! per-sink identity (no cross-sink clobbering) and value updates on reload.
+
+use vector_lib::metrics::Controller;
+
+use crate::{
+    config::Config,
+    event::{Metric, MetricValue},
+    test_util::{
+        mock::{basic_sink, basic_sink_with_data, basic_source},
+        start_topology, trace_init,
+    },
+};
+
+const GAUGE: &str = "security_confinement_disabled";
+
+/// Find the confinement gauge for a specific sink `component_id` in a captured
+/// metrics snapshot. Filtering by `component_id` keeps the assertion isolated
+/// from other tests sharing the process-wide metrics registry.
+fn confinement_gauge<'a>(metrics: &'a [Metric], component_id: &str) -> Option<&'a Metric> {
+    metrics.iter().find(|m| {
+        m.name() == GAUGE
+            && m.tags().and_then(|tags| tags.get("component_id")) == Some(component_id)
+    })
+}
+
+#[track_caller]
+fn assert_gauge(metrics: &[Metric], component_id: &str, expected: f64) {
+    let metric = confinement_gauge(metrics, component_id).unwrap_or_else(|| {
+        panic!(
+            "{GAUGE} not found for sink '{component_id}'; present series: {:?}",
+            metrics
+                .iter()
+                .filter(|m| m.name() == GAUGE)
+                .filter_map(|m| m
+                    .tags()
+                    .and_then(|t| t.get("component_id").map(String::from)))
+                .collect::<Vec<_>>(),
+        )
+    });
+
+    let tags = metric.tags().expect("gauge must carry component tags");
+    assert_eq!(tags.get("component_kind"), Some("sink"));
+    assert_eq!(tags.get("component_type"), Some("test_basic"));
+
+    match metric.value() {
+        MetricValue::Gauge { value } => assert_eq!(
+            *value, expected,
+            "unexpected {GAUGE} value for '{component_id}'"
+        ),
+        other => panic!("expected Gauge, got {other:?}"),
+    }
+}
+
+/// At startup the gauge is emitted per sink, keyed by `component_id`, so two
+/// sinks of the same type with different confinement settings produce two
+/// distinct series rather than clobbering a single type-keyed series.
+#[tokio::test]
+async fn per_sink_series_at_startup() {
+    trace_init();
+    let controller = Controller::get().expect("metrics controller");
+
+    let source_id = "conf_gauge_startup_source";
+    let disabled_id = "conf_gauge_startup_disabled";
+    let enabled_id = "conf_gauge_startup_enabled";
+
+    let (_src_tx, source_config) = basic_source();
+    let (_rx_disabled, disabled_sink) = basic_sink(1);
+    let (_rx_enabled, enabled_sink) = basic_sink(1);
+
+    let mut config = Config::builder();
+    config.add_source(source_id, source_config);
+    config.add_sink(
+        disabled_id,
+        &[source_id],
+        disabled_sink.with_confinement(true),
+    );
+    config.add_sink(
+        enabled_id,
+        &[source_id],
+        enabled_sink.with_confinement(false),
+    );
+
+    let (topology, _shutdown) = start_topology(config.build().unwrap(), false).await;
+
+    let metrics = controller.capture_metrics();
+    assert_gauge(&metrics, disabled_id, 1.0);
+    assert_gauge(&metrics, enabled_id, 0.0);
+
+    topology.stop().await;
+}
+
+/// A sink that does not participate in confinement (the default mock) emits no
+/// gauge — matching the pre-existing behavior where only confinement-aware
+/// sinks reported.
+#[tokio::test]
+async fn no_gauge_for_non_confinement_sink() {
+    trace_init();
+    let controller = Controller::get().expect("metrics controller");
+
+    let source_id = "conf_gauge_absent_source";
+    let sink_id = "conf_gauge_absent_sink";
+
+    let (_src_tx, source_config) = basic_source();
+    let (_rx, sink) = basic_sink(1);
+
+    let mut config = Config::builder();
+    config.add_source(source_id, source_config);
+    config.add_sink(sink_id, &[source_id], sink);
+
+    let (topology, _shutdown) = start_topology(config.build().unwrap(), false).await;
+
+    let metrics = controller.capture_metrics();
+    assert!(
+        confinement_gauge(&metrics, sink_id).is_none(),
+        "sink without confinement config should emit no {GAUGE} gauge"
+    );
+
+    topology.stop().await;
+}
+
+/// On reload the gauge value is updated to reflect the sink's current
+/// confinement setting.
+#[tokio::test]
+async fn value_updated_on_reload() {
+    trace_init();
+    let controller = Controller::get().expect("metrics controller");
+
+    let source_id = "conf_gauge_reload_source";
+    let sink_id = "conf_gauge_reload_sink";
+
+    let (_src_tx, source_config) = basic_source();
+    // `data` differs across the two revisions so the reload detects the sink as
+    // changed and re-spawns it, mirroring a real config edit.
+    let (_rx1, sink_v1) = basic_sink_with_data(1, "v1");
+
+    let mut config = Config::builder();
+    config.add_source(source_id, source_config);
+    config.add_sink(sink_id, &[source_id], sink_v1.with_confinement(true));
+
+    let (mut topology, _shutdown) = start_topology(config.build().unwrap(), false).await;
+
+    assert_gauge(&controller.capture_metrics(), sink_id, 1.0);
+
+    // Reload with confinement disabled flipped off.
+    let (_src_tx2, source_config2) = basic_source();
+    let (_rx2, sink_v2) = basic_sink_with_data(1, "v2");
+    let mut new_config = Config::builder();
+    new_config.add_source(source_id, source_config2);
+    new_config.add_sink(sink_id, &[source_id], sink_v2.with_confinement(false));
+
+    topology
+        .reload_config_and_respawn(new_config.build().unwrap(), Default::default())
+        .await
+        .expect("reload should succeed");
+
+    assert_gauge(&controller.capture_metrics(), sink_id, 0.0);
+
+    topology.stop().await;
+}

--- a/src/topology/test/mod.rs
+++ b/src/topology/test/mod.rs
@@ -34,6 +34,7 @@ use crate::{
 
 mod backpressure;
 mod compliance;
+mod confinement_gauge;
 #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
 mod cpu_metrics;
 #[cfg(all(feature = "sinks-socket", feature = "sources-socket"))]


### PR DESCRIPTION
## Summary

The `vector_security_confinement_disabled` gauge was emitted once per sink at build time and its handle dropped immediately, so the metric aged out of the registry after the idle timeout (300s by default) while the sink was still running with confinement disabled. Ownership of the gauge is moved to the topology, which holds a handle for each confinement-aware sink's lifetime and reconciles the gauges on every (re)load.

Without this fix, any dashboard or alert watching `vector_security_confinement_disabled` silently loses signal ~5 minutes after startup, making it impossible to detect sinks running with confinement disabled for the rest of their lifetime. An absent gauge was also indistinguishable from a sink that had been removed or renamed.

## Vector configuration

```yaml
sources:
  dummy:
    type: demo_logs
    format: json
    interval: 30

  internal:
    type: internal_metrics
    scrape_interval_secs: 15

transforms:
  only_confinement:
    type: filter
    inputs: [internal]
    condition: .name == "security_confinement_disabled"

sinks:
  confinement_sink:
    type: file
    inputs: [dummy]
    path: /tmp/vector-confinement-test.log
    encoding:
      codec: text

  watch:
    type: console
    inputs: [only_confinement]
    encoding:
      codec: json
```


## How did you test this PR?

Before it stopped outputting to the console after 300s (20 logs) and now it continues.

`make check-clippy`, `make check-fmt`, and `make check-changelog-fragments` all pass. Added `src/topology/test/confinement_gauge.rs` covering per-sink series at startup, absence for non-confinement sinks, and value updates on reload; the topology test suite passes (`cargo nextest run --lib topology::test::`).

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

NA
