### PR TITLE
fix(topology): consume pending component reloads

### DIFF
--- a/changelog.d/pending_component_reloads.fix.md
+++ b/changelog.d/pending_component_reloads.fix.md
@@ -1,0 +1,3 @@
+Prevent components explicitly reloaded once from being unnecessarily restarted during later configuration reloads.
+
+authors: arunpidugu

--- a/changelog.d/pending_component_reloads.fix.md
+++ b/changelog.d/pending_component_reloads.fix.md
@@ -1,3 +1,3 @@
-Prevent components explicitly reloaded once from being unnecessarily restarted during later configuration reloads.
+Fixes an issue where components selected for an explicit reload remained selected for later configuration reloads. This could unnecessarily restart unchanged components and reset their in-memory state.
 
 authors: arunpidugu

--- a/src/topology/running.rs
+++ b/src/topology/running.rs
@@ -106,7 +106,7 @@ impl RunningTopology {
     /// initializes the pending reload set.
     pub fn extend_reload_set(&mut self, new_set: HashSet<ComponentKey>) {
         match &mut self.pending_reload {
-            None => self.pending_reload = Some(new_set.clone()),
+            None => self.pending_reload = Some(new_set),
             Some(existing) => existing.extend(new_set),
         }
     }
@@ -297,11 +297,8 @@ impl RunningTopology {
         // spawning the new version of the component.
         //
         // We also shutdown any component that is simply being removed entirely.
-        let diff = if let Some(components) = &self.pending_reload {
-            ConfigDiff::new(&self.config, &new_config, components.clone())
-        } else {
-            ConfigDiff::new(&self.config, &new_config, HashSet::new())
-        };
+        let components_to_reload = self.pending_reload.take().unwrap_or_default();
+        let diff = ConfigDiff::new(&self.config, &new_config, components_to_reload);
         let buffers = self.shutdown_diff(&diff, &new_config).await;
 
         // Gives windows some time to make available any port
@@ -1434,4 +1431,51 @@ fn get_changed_outputs(diff: &ConfigDiff, output_ids: Inputs<OutputId>) -> Vec<O
     }
 
     changed_outputs
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use tokio::sync::mpsc;
+    use vector_lib::config::ComponentKey;
+
+    use super::RunningTopology;
+    use crate::{
+        config::Config,
+        test_util::mock::{basic_sink, basic_source},
+    };
+
+    #[tokio::test]
+    async fn pending_component_reloads_are_consumed_after_reload() {
+        let config = || {
+            let mut config = Config::builder();
+            config.add_source("in", basic_source().1);
+            config.add_sink("out", &["in"], basic_sink(1).1);
+            config.build().unwrap()
+        };
+        let (abort_tx, _) = mpsc::unbounded_channel();
+        let mut topology = RunningTopology::new(config(), abort_tx);
+        let component = ComponentKey::from("component");
+
+        topology.extend_reload_set(HashSet::from([component.clone()]));
+        topology
+            .reload_config_and_respawn(config(), Default::default())
+            .await
+            .unwrap();
+        assert!(topology.pending_reload.is_none());
+
+        topology
+            .reload_config_and_respawn(config(), Default::default())
+            .await
+            .unwrap();
+        assert!(topology.pending_reload.is_none());
+
+        topology.extend_reload_set(HashSet::from([component]));
+        topology
+            .reload_config_and_respawn(config(), Default::default())
+            .await
+            .unwrap();
+        assert!(topology.pending_reload.is_none());
+    }
 }


### PR DESCRIPTION
## Summary

Vector can explicitly reload selected components even when their serialized configuration has not changed. This is used, for example, when a file watched by a component changes.

The selected component names currently remain in the pending reload set after the reload finishes. Consider this sequence:

1. A watched file for component `A` changes, so Vector explicitly reloads `A`.
2. Later, an unrelated configuration reload changes only component `B`.
3. Because `A` is still in the pending set, Vector unnecessarily restarts both `A` and `B`.

Repeated restarts can reset task-local in-memory state and cause unnecessary reconnections, health checks, or brief disruption. This change consumes the pending set when calculating the next topology update. An explicit reload therefore applies once, while a later request can still add the component again.

## Vector configuration

Not applicable. This behavior is covered by topology reload tests.

## How did you test this PR?

- Added a regression test that verifies a pending component reload is consumed after the next topology reload and can be requested again.
- `cargo test pending_component_reloads_are_consumed_after_reload --lib --no-default-features`
- `make check-clippy`
- `cargo fmt --all -- --check`
- `./scripts/check_changelog_fragments.sh`

`make check-fmt` could not complete because the environment does not have the YAML formatter executable available.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [x] Yes. A changelog fragment has been added.
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References
