### PR TITLE
chore(ci): bump create-github-app-token to v3.2.0 (node24)

### DIFF
--- a/.github/workflows/vdev_autotag.yml
+++ b/.github/workflows/vdev_autotag.yml
@@ -16,9 +16,9 @@ jobs:
     steps:
       - name: Generate token via GitHub App
         id: generate_token
-        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.GH_APP_VECTORDOTDEV_BOT_APP_ID }}
+          client-id: ${{ secrets.GH_APP_VECTORDOTDEV_BOT_CLIENT_ID }}
           private-key: ${{ secrets.GH_APP_VECTORDOTDEV_BOT_APP_PRIVATE_KEY }}
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
Bumps `create-github-app-token` v1.12.0 (deprecated Node 20) to v3.2.0 (node24), and switches the deprecated `app-id` input to `client-id`. No behavior change: private-key, token output, repo scoping, and inherited contents:write are unchanged.