### PR TITLE
fix(aws sinks): ensure component_sent_bytes_total carries component and region labels

### DIFF
--- a/changelog.d/20356_aws_component_labels.fix.md
+++ b/changelog.d/20356_aws_component_labels.fix.md
@@ -1,0 +1,3 @@
+AWS sinks (`aws_cloudwatch_logs`, `aws_s3`, `aws_kinesis_firehose`, `aws_kinesis_streams`, `aws_sns`, `aws_sqs`) now emit `component_sent_bytes_total` through the Driver instead of the transport layer, ensuring `component_id`, `component_kind`, `component_type`, and `region` labels are always present.
+
+authors: clee2691

--- a/lib/vector-common/src/internal_event/bytes_sent.rs
+++ b/lib/vector-common/src/internal_event/bytes_sent.rs
@@ -8,8 +8,15 @@ use super::{ByteSize, CounterName, Protocol, SharedString};
 crate::registered_event!(
     BytesSent {
         protocol: SharedString,
+        extra_labels: Vec<(SharedString, SharedString)>,
     } => {
-        bytes_sent: Counter = counter!(CounterName::ComponentSentBytesTotal, "protocol" => self.protocol.clone()),
+        bytes_sent: Counter = {
+            let mut labels: Vec<(String, String)> = vec![("protocol".to_string(), self.protocol.to_string())];
+            for (k, v) in &self.extra_labels {
+                labels.push((k.to_string(), v.to_string()));
+            }
+            counter!(CounterName::ComponentSentBytesTotal, &labels)
+        },
         protocol: SharedString = self.protocol,
     }
 
@@ -23,6 +30,7 @@ impl From<Protocol> for BytesSent {
     fn from(protocol: Protocol) -> Self {
         Self {
             protocol: protocol.0,
+            extra_labels: vec![],
         }
     }
 }

--- a/lib/vector-stream/src/driver.rs
+++ b/lib/vector-stream/src/driver.rs
@@ -44,6 +44,7 @@ pub struct Driver<St, Svc> {
     input: St,
     service: Svc,
     protocol: Option<SharedString>,
+    extra_labels: Vec<(SharedString, SharedString)>,
 }
 
 impl<St, Svc> Driver<St, Svc> {
@@ -52,6 +53,7 @@ impl<St, Svc> Driver<St, Svc> {
             input,
             service,
             protocol: None,
+            extra_labels: vec![],
         }
     }
 
@@ -62,6 +64,13 @@ impl<St, Svc> Driver<St, Svc> {
     #[must_use]
     pub fn protocol(mut self, protocol: impl Into<SharedString>) -> Self {
         self.protocol = Some(protocol.into());
+        self
+    }
+
+    /// Add an extra label to the `BytesSent` metric emitted by this driver.
+    #[must_use]
+    pub fn label(mut self, key: impl Into<SharedString>, value: impl Into<SharedString>) -> Self {
+        self.extra_labels.push((key.into(), value.into()));
         self
     }
 }
@@ -92,12 +101,18 @@ where
             input,
             mut service,
             protocol,
+            extra_labels,
         } = self;
 
         let batched_input = input.ready_chunks(1024);
         pin!(batched_input);
 
-        let bytes_sent = protocol.map(|protocol| register(BytesSent { protocol }));
+        let bytes_sent = protocol.map(|protocol| {
+            register(BytesSent {
+                protocol,
+                extra_labels,
+            })
+        });
         let events_sent = RegisteredEventCache::new(());
 
         loop {

--- a/src/aws/mod.rs
+++ b/src/aws/mod.rs
@@ -183,9 +183,48 @@ pub async fn create_client<T>(
 where
     T: ClientBuilder,
 {
-    create_client_and_region::<T>(builder, auth, region, endpoint, proxy, tls_options, timeout)
-        .await
-        .map(|(client, _)| client)
+    build_client_inner::<T>(
+        builder,
+        auth,
+        region,
+        endpoint,
+        proxy,
+        tls_options,
+        timeout,
+        true,
+    )
+    .await
+    .map(|(client, _)| client)
+}
+
+/// Like [`create_client`], but suppresses transport-level `AwsBytesSent` emission.
+///
+/// Use this for sinks that report bytes through the Driver to avoid double-counting
+/// `component_sent_bytes_total`.
+pub async fn create_client_without_transport_metrics<T>(
+    builder: &T,
+    auth: &AwsAuthentication,
+    region: Option<Region>,
+    endpoint: Option<String>,
+    proxy: &ProxyConfig,
+    tls_options: Option<&TlsConfig>,
+    timeout: Option<&AwsTimeout>,
+) -> crate::Result<T::Client>
+where
+    T: ClientBuilder,
+{
+    build_client_inner::<T>(
+        builder,
+        auth,
+        region,
+        endpoint,
+        proxy,
+        tls_options,
+        timeout,
+        false,
+    )
+    .await
+    .map(|(client, _)| client)
 }
 
 /// Create the SDK client and resolve the region using the provided settings.
@@ -197,6 +236,33 @@ pub async fn create_client_and_region<T>(
     proxy: &ProxyConfig,
     tls_options: Option<&TlsConfig>,
     timeout: Option<&AwsTimeout>,
+) -> crate::Result<(T::Client, Region)>
+where
+    T: ClientBuilder,
+{
+    build_client_inner::<T>(
+        builder,
+        auth,
+        region,
+        endpoint,
+        proxy,
+        tls_options,
+        timeout,
+        true,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn build_client_inner<T>(
+    builder: &T,
+    auth: &AwsAuthentication,
+    region: Option<Region>,
+    endpoint: Option<String>,
+    proxy: &ProxyConfig,
+    tls_options: Option<&TlsConfig>,
+    timeout: Option<&AwsTimeout>,
+    emit_bytes_sent: bool,
 ) -> crate::Result<(T::Client, Region)>
 where
     T: ClientBuilder,
@@ -484,11 +550,10 @@ where
 {
     fn call(&self, req: HttpRequest) -> HttpConnectorFuture {
         if !self.emit_bytes_sent {
-            return HttpConnectorFuture::new(self.call_inner(req));
+            return self.http.call(req);
         }
 
-        let bytes_sent = Arc::new(AtomicUsize::new(0));
-
+        let bytes_sent = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let req = req.map(|body| {
             let bytes_sent = Arc::clone(&bytes_sent);
             body.map_preserve_contents(move |body| {

--- a/src/aws/mod.rs
+++ b/src/aws/mod.rs
@@ -281,7 +281,7 @@ where
     let connector = AwsHttpClient {
         http: connector,
         region: region.clone(),
-        emit_bytes_sent: true,
+        emit_bytes_sent,
     };
 
     // Build the configuration first.

--- a/src/aws/mod.rs
+++ b/src/aws/mod.rs
@@ -209,7 +209,7 @@ pub async fn create_client_without_transport_metrics<T>(
     proxy: &ProxyConfig,
     tls_options: Option<&TlsConfig>,
     timeout: Option<&AwsTimeout>,
-) -> crate::Result<T::Client>
+) -> crate::Result<(T::Client, Region)>
 where
     T: ClientBuilder,
 {
@@ -224,7 +224,6 @@ where
         false,
     )
     .await
-    .map(|(client, _)| client)
 }
 
 /// Create the SDK client and resolve the region using the provided settings.

--- a/src/aws/mod.rs
+++ b/src/aws/mod.rs
@@ -549,7 +549,7 @@ where
 {
     fn call(&self, req: HttpRequest) -> HttpConnectorFuture {
         if !self.emit_bytes_sent {
-            return self.http.call(req);
+            return HttpConnectorFuture::new(self.call_inner(req));
         }
 
         let bytes_sent = Arc::new(std::sync::atomic::AtomicUsize::new(0));

--- a/src/sinks/aws_cloudwatch_logs/config.rs
+++ b/src/sinks/aws_cloudwatch_logs/config.rs
@@ -7,6 +7,8 @@ use tower::ServiceBuilder;
 use vector_lib::{codecs::JsonSerializerConfig, configurable::configurable_component, schema};
 use vrl::value::Kind;
 
+use aws_config::Region;
+
 use crate::{
     aws::{
         AwsAuthentication, ClientBuilder, RegionOrEndpoint, create_client_without_transport_metrics,
@@ -191,7 +193,10 @@ pub struct CloudwatchLogsSinkConfig {
 }
 
 impl CloudwatchLogsSinkConfig {
-    pub async fn create_client(&self, proxy: &ProxyConfig) -> crate::Result<CloudwatchLogsClient> {
+    pub async fn create_client(
+        &self,
+        proxy: &ProxyConfig,
+    ) -> crate::Result<(CloudwatchLogsClient, Region)> {
         create_client_without_transport_metrics::<CloudwatchLogsClientBuilder>(
             &CloudwatchLogsClientBuilder {},
             &self.auth,
@@ -220,7 +225,7 @@ impl SinkConfig for CloudwatchLogsSinkConfig {
 
         let batcher_settings = self.batch.into_batcher_settings()?;
         let request_settings = self.request.tower.into_settings();
-        let client = self.create_client(cx.proxy()).await?;
+        let (client, resolved_region) = self.create_client(cx.proxy()).await?;
         let svc = ServiceBuilder::new()
             .settings(request_settings, CloudwatchRetryLogic::new())
             .service(CloudwatchLogsPartitionSvc::new(
@@ -239,10 +244,7 @@ impl SinkConfig for CloudwatchLogsSinkConfig {
                 transformer,
                 encoder,
             },
-            region: self
-                .region
-                .region()
-                .map_or_else(String::new, |r| r.to_string()),
+            region: resolved_region.to_string(),
             service: svc,
         };
         Ok((VectorSink::from_event_streamsink(sink), healthcheck))

--- a/src/sinks/aws_cloudwatch_logs/config.rs
+++ b/src/sinks/aws_cloudwatch_logs/config.rs
@@ -8,7 +8,9 @@ use vector_lib::{codecs::JsonSerializerConfig, configurable::configurable_compon
 use vrl::value::Kind;
 
 use crate::{
-    aws::{AwsAuthentication, ClientBuilder, RegionOrEndpoint, create_client},
+    aws::{
+        AwsAuthentication, ClientBuilder, RegionOrEndpoint, create_client_without_transport_metrics,
+    },
     codecs::{Encoder, EncodingConfig},
     config::{
         AcknowledgementsConfig, DataType, GenerateConfig, Input, ProxyConfig, SinkConfig,
@@ -190,7 +192,7 @@ pub struct CloudwatchLogsSinkConfig {
 
 impl CloudwatchLogsSinkConfig {
     pub async fn create_client(&self, proxy: &ProxyConfig) -> crate::Result<CloudwatchLogsClient> {
-        create_client::<CloudwatchLogsClientBuilder>(
+        create_client_without_transport_metrics::<CloudwatchLogsClientBuilder>(
             &CloudwatchLogsClientBuilder {},
             &self.auth,
             self.region.region(),
@@ -237,7 +239,10 @@ impl SinkConfig for CloudwatchLogsSinkConfig {
                 transformer,
                 encoder,
             },
-
+            region: self
+                .region
+                .region()
+                .map_or_else(String::new, |r| r.to_string()),
             service: svc,
         };
         Ok((VectorSink::from_event_streamsink(sink), healthcheck))

--- a/src/sinks/aws_cloudwatch_logs/config.rs
+++ b/src/sinks/aws_cloudwatch_logs/config.rs
@@ -231,6 +231,7 @@ impl SinkConfig for CloudwatchLogsSinkConfig {
             .service(CloudwatchLogsPartitionSvc::new(
                 self.clone(),
                 client.clone(),
+                resolved_region.to_string(),
             )?);
         let transformer = self.encoding.transformer();
         let serializer = self.encoding.build()?;

--- a/src/sinks/aws_cloudwatch_logs/integration_tests.rs
+++ b/src/sinks/aws_cloudwatch_logs/integration_tests.rs
@@ -576,7 +576,7 @@ async fn cloudwatch_healthcheck() {
         confinement: Default::default(),
     };
 
-    let client = config.create_client(&ProxyConfig::default()).await.unwrap();
+    let (client, _resolved_region) = config.create_client(&ProxyConfig::default()).await.unwrap();
     healthcheck(config, client).await.unwrap();
 }
 

--- a/src/sinks/aws_cloudwatch_logs/request.rs
+++ b/src/sinks/aws_cloudwatch_logs/request.rs
@@ -32,6 +32,8 @@ pub struct CloudwatchFuture {
     retention_enabled: bool,
     events: Vec<Vec<InputLogEvent>>,
     token_tx: Option<oneshot::Sender<Option<String>>>,
+    current_batch_bytes: usize,
+    accumulated_bytes_sent: usize,
 }
 
 struct Client {
@@ -55,6 +57,10 @@ enum State {
 }
 
 impl CloudwatchFuture {
+    fn batch_message_bytes(batch: &[InputLogEvent]) -> usize {
+        batch.iter().map(|e| e.message.len()).sum()
+    }
+
     /// Panics if events.is_empty()
     #[allow(clippy::too_many_arguments)]
     pub(super) fn new(
@@ -82,10 +88,12 @@ impl CloudwatchFuture {
             tags,
         };
 
-        let state = if let Some(token) = token {
-            State::Put(client.put_logs(Some(token), events.pop().expect("No Events to send")))
+        let (state, current_batch_bytes) = if let Some(token) = token {
+            let batch = events.pop().expect("No Events to send");
+            let bytes = Self::batch_message_bytes(&batch);
+            (State::Put(client.put_logs(Some(token), batch)), bytes)
         } else {
-            State::DescribeStream(client.describe_stream())
+            (State::DescribeStream(client.describe_stream()), 0)
         };
 
         let retention_enabled = retention.enabled;
@@ -98,6 +106,8 @@ impl CloudwatchFuture {
             create_missing_group,
             create_missing_stream,
             retention_enabled,
+            current_batch_bytes,
+            accumulated_bytes_sent: 0,
         }
     }
 }
@@ -145,6 +155,7 @@ impl Future for CloudwatchFuture {
 
                         let token = stream.upload_sequence_token;
 
+                        self.current_batch_bytes = Self::batch_message_bytes(&events);
                         info!(message = "Putting logs.", token = ?token);
                         self.state = State::Put(self.client.put_logs(token, events));
                     } else if self.create_missing_stream {
@@ -210,10 +221,21 @@ impl Future for CloudwatchFuture {
                 State::Put(fut) => {
                     let next_token = match ready!(fut.poll_unpin(cx)) {
                         Ok(resp) => resp.next_sequence_token,
-                        Err(err) => return Poll::Ready(Err(CloudwatchError::Put(err))),
+                        Err(err) => {
+                            if self.accumulated_bytes_sent > 0 {
+                                return Poll::Ready(Err(CloudwatchError::PutPartial {
+                                    error: err,
+                                    bytes_sent: self.accumulated_bytes_sent,
+                                }));
+                            }
+                            return Poll::Ready(Err(CloudwatchError::Put(err)));
+                        }
                     };
 
+                    self.accumulated_bytes_sent += self.current_batch_bytes;
+
                     if let Some(events) = self.events.pop() {
+                        self.current_batch_bytes = Self::batch_message_bytes(&events);
                         debug!(message = "Putting logs.", next_token = ?next_token);
                         self.state = State::Put(self.client.put_logs(next_token, events));
                     } else {

--- a/src/sinks/aws_cloudwatch_logs/request.rs
+++ b/src/sinks/aws_cloudwatch_logs/request.rs
@@ -22,7 +22,10 @@ use http::{HeaderValue, header::HeaderName};
 use indexmap::IndexMap;
 use tokio::sync::oneshot;
 
-use crate::sinks::aws_cloudwatch_logs::{config::Retention, service::CloudwatchError};
+use crate::sinks::{
+    aws_cloudwatch_logs::{config::Retention, service::CloudwatchError},
+    util::EncodedLength,
+};
 
 pub struct CloudwatchFuture {
     client: Client,
@@ -58,7 +61,7 @@ enum State {
 
 impl CloudwatchFuture {
     fn batch_message_bytes(batch: &[InputLogEvent]) -> usize {
-        batch.iter().map(|e| e.message.len()).sum()
+        batch.iter().map(|e| e.encoded_length()).sum()
     }
 
     /// Panics if events.is_empty()

--- a/src/sinks/aws_cloudwatch_logs/request_builder.rs
+++ b/src/sinks/aws_cloudwatch_logs/request_builder.rs
@@ -109,8 +109,8 @@ impl CloudwatchRequestBuilder {
             return None;
         }
 
-        let bytes_len =
-            NonZeroUsize::new(message_bytes.len()).expect("payload should never be zero length");
+        let bytes_len = NonZeroUsize::new(message_bytes.len() + BATCH_SIZE_OVERHEAD)
+            .expect("payload should never be zero length");
         let metadata = builder.with_request_size(bytes_len);
 
         Some(CloudwatchRequest {

--- a/src/sinks/aws_cloudwatch_logs/retry.rs
+++ b/src/sinks/aws_cloudwatch_logs/retry.rs
@@ -45,7 +45,7 @@ impl<Request: Send + Sync + 'static, Response: Send + Sync + 'static> RetryLogic
     #[allow(clippy::cognitive_complexity)] // long, but just a hair over our limit
     fn is_retriable_error(&self, error: &Self::Error) -> bool {
         match error {
-            CloudwatchError::Put(err) => {
+            CloudwatchError::Put(err) | CloudwatchError::PutPartial { error: err, .. } => {
                 if let SdkError::ServiceError(inner) = err {
                     let err = inner.err();
                     if matches!(err, PutLogEventsError::ServiceUnavailableException(_)) {
@@ -54,10 +54,6 @@ impl<Request: Send + Sync + 'static, Response: Send + Sync + 'static> RetryLogic
                 }
                 is_retriable_error(err)
             }
-            // PutPartial means some sub-batches were already acknowledged by
-            // CloudWatch. Retrying would re-send those sub-batches, causing
-            // duplicate log delivery and double-counted bytes metrics.
-            CloudwatchError::PutPartial { .. } => false,
             CloudwatchError::DescribeLogStreams(err) => {
                 if let SdkError::ServiceError(inner) = err {
                     let err = inner.err();

--- a/src/sinks/aws_cloudwatch_logs/retry.rs
+++ b/src/sinks/aws_cloudwatch_logs/retry.rs
@@ -45,7 +45,7 @@ impl<Request: Send + Sync + 'static, Response: Send + Sync + 'static> RetryLogic
     #[allow(clippy::cognitive_complexity)] // long, but just a hair over our limit
     fn is_retriable_error(&self, error: &Self::Error) -> bool {
         match error {
-            CloudwatchError::Put(err) => {
+            CloudwatchError::Put(err) | CloudwatchError::PutPartial { error: err, .. } => {
                 if let SdkError::ServiceError(inner) = err {
                     let err = inner.err();
                     if matches!(err, PutLogEventsError::ServiceUnavailableException(_)) {

--- a/src/sinks/aws_cloudwatch_logs/retry.rs
+++ b/src/sinks/aws_cloudwatch_logs/retry.rs
@@ -45,7 +45,7 @@ impl<Request: Send + Sync + 'static, Response: Send + Sync + 'static> RetryLogic
     #[allow(clippy::cognitive_complexity)] // long, but just a hair over our limit
     fn is_retriable_error(&self, error: &Self::Error) -> bool {
         match error {
-            CloudwatchError::Put(err) | CloudwatchError::PutPartial { error: err, .. } => {
+            CloudwatchError::Put(err) => {
                 if let SdkError::ServiceError(inner) = err {
                     let err = inner.err();
                     if matches!(err, PutLogEventsError::ServiceUnavailableException(_)) {
@@ -54,6 +54,10 @@ impl<Request: Send + Sync + 'static, Response: Send + Sync + 'static> RetryLogic
                 }
                 is_retriable_error(err)
             }
+            // PutPartial means some sub-batches were already acknowledged by
+            // CloudWatch. Retrying would re-send those sub-batches, causing
+            // duplicate log delivery and double-counted bytes metrics.
+            CloudwatchError::PutPartial { .. } => false,
             CloudwatchError::DescribeLogStreams(err) => {
                 if let SdkError::ServiceError(inner) = err {
                     let err = inner.err();

--- a/src/sinks/aws_cloudwatch_logs/service.rs
+++ b/src/sinks/aws_cloudwatch_logs/service.rs
@@ -16,7 +16,6 @@ use aws_sdk_cloudwatchlogs::{
 use aws_smithy_runtime_api::client::{orchestrator::HttpResponse, result::SdkError};
 use chrono::Duration;
 use futures::{FutureExt, future::BoxFuture};
-use futures_util::TryFutureExt;
 use http::{
     HeaderValue,
     header::{HeaderName, InvalidHeaderName, InvalidHeaderValue},
@@ -33,6 +32,7 @@ use tower::{
 };
 use vector_lib::{
     finalization::EventStatus,
+    internal_event::{ByteSize, BytesSent, InternalEventHandle as _, Registered, register},
     request_metadata::{GroupedCountByteSize, MetaDescriptive},
     stream::DriverResponse,
 };
@@ -66,6 +66,10 @@ type Svc = Buffer<
 #[derive(Debug)]
 pub enum CloudwatchError {
     Put(SdkError<PutLogEventsError, HttpResponse>),
+    PutPartial {
+        error: SdkError<PutLogEventsError, HttpResponse>,
+        bytes_sent: usize,
+    },
     DescribeLogStreams(SdkError<DescribeLogStreamsError, HttpResponse>),
     CreateStream(SdkError<CreateLogStreamError, HttpResponse>),
     CreateGroup(SdkError<CreateLogGroupError, HttpResponse>),
@@ -77,6 +81,12 @@ impl fmt::Display for CloudwatchError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             CloudwatchError::Put(error) => write!(f, "CloudwatchError::Put: {error}"),
+            CloudwatchError::PutPartial { error, bytes_sent } => {
+                write!(
+                    f,
+                    "CloudwatchError::PutPartial({bytes_sent} bytes sent): {error}"
+                )
+            }
             CloudwatchError::DescribeLogStreams(error) => {
                 write!(f, "CloudwatchError::DescribeLogStreams: {error}")
             }
@@ -150,6 +160,7 @@ impl CloudwatchLogsPartitionSvc {
     pub fn new(
         config: CloudwatchLogsSinkConfig,
         client: CloudwatchLogsClient,
+        region: String,
     ) -> crate::Result<Self> {
         let request_settings = config.request.tower.into_settings();
 
@@ -165,12 +176,18 @@ impl CloudwatchLogsPartitionSvc {
             })
             .collect::<Result<IndexMap<_, _>, HeaderError>>()?;
 
+        let bytes_sent = register(BytesSent {
+            protocol: "https".into(),
+            extra_labels: vec![("region".into(), region.into())],
+        });
+
         Ok(Self {
             config,
             clients: HashMap::new(),
             request_settings,
             client,
             headers,
+            bytes_sent,
         })
     }
 }
@@ -230,12 +247,23 @@ impl Service<BatchCloudwatchRequest> for CloudwatchLogsPartitionSvc {
             svc
         };
 
+        let bytes_sent_handle = self.bytes_sent.clone();
+
         svc.oneshot(events)
-            .map_ok(move |_x| CloudwatchResponse {
-                events_byte_size,
-                byte_size,
+            .map(move |result| match result {
+                Ok(()) => Ok(CloudwatchResponse {
+                    events_byte_size,
+                    byte_size,
+                }),
+                Err(box_err) => {
+                    if let Some(CloudwatchError::PutPartial { bytes_sent, .. }) =
+                        box_err.downcast_ref::<CloudwatchError>()
+                    {
+                        bytes_sent_handle.emit(ByteSize(*bytes_sent));
+                    }
+                    Err(box_err)
+                }
             })
-            .map_err(Into::into)
             .boxed()
     }
 }
@@ -381,4 +409,5 @@ pub struct CloudwatchLogsPartitionSvc {
     clients: HashMap<CloudwatchKey, Svc>,
     request_settings: TowerRequestSettings,
     client: CloudwatchLogsClient,
+    bytes_sent: Registered<BytesSent>,
 }

--- a/src/sinks/aws_cloudwatch_logs/service.rs
+++ b/src/sinks/aws_cloudwatch_logs/service.rs
@@ -111,6 +111,7 @@ impl From<SdkError<DescribeLogStreamsError, HttpResponse>> for CloudwatchError {
 #[derive(Debug)]
 pub struct CloudwatchResponse {
     events_byte_size: GroupedCountByteSize,
+    byte_size: usize,
 }
 
 impl crate::sinks::util::sink::Response for CloudwatchResponse {
@@ -130,6 +131,10 @@ impl DriverResponse for CloudwatchResponse {
 
     fn events_sent(&self) -> &GroupedCountByteSize {
         &self.events_byte_size
+    }
+
+    fn bytes_sent(&self) -> Option<usize> {
+        Some(self.byte_size)
     }
 }
 
@@ -181,6 +186,7 @@ impl Service<BatchCloudwatchRequest> for CloudwatchLogsPartitionSvc {
 
     fn call(&mut self, mut req: BatchCloudwatchRequest) -> Self::Future {
         let metadata = std::mem::take(req.metadata_mut());
+        let byte_size = metadata.request_encoded_size();
         let events_byte_size = metadata.into_events_estimated_json_encoded_byte_size();
 
         let key = req.key;
@@ -225,7 +231,10 @@ impl Service<BatchCloudwatchRequest> for CloudwatchLogsPartitionSvc {
         };
 
         svc.oneshot(events)
-            .map_ok(move |_x| CloudwatchResponse { events_byte_size })
+            .map_ok(move |_x| CloudwatchResponse {
+                events_byte_size,
+                byte_size,
+            })
             .map_err(Into::into)
             .boxed()
     }

--- a/src/sinks/aws_cloudwatch_logs/sink.rs
+++ b/src/sinks/aws_cloudwatch_logs/sink.rs
@@ -25,6 +25,8 @@ use crate::{
 pub struct CloudwatchSink<S> {
     pub batcher_settings: BatcherSettings,
     pub(super) request_builder: CloudwatchRequestBuilder,
+    /// The AWS region string for metric labels.
+    pub region: String,
     pub service: S,
 }
 
@@ -64,6 +66,8 @@ where
                 }
             })
             .into_driver(service)
+            .protocol("https")
+            .label("region", self.region)
             .run()
             .await
     }

--- a/src/sinks/aws_kinesis/config.rs
+++ b/src/sinks/aws_kinesis/config.rs
@@ -88,6 +88,7 @@ pub fn build_sink<C, R, RR, E, RT>(
     batch_settings: BatcherSettings,
     client: C,
     retry_logic: RT,
+    region: String,
 ) -> crate::Result<VectorSink>
 where
     C: SendRecord + Clone + Send + Sync + 'static,
@@ -101,13 +102,13 @@ where
 {
     let request_limits = config.request.into_settings();
 
-    let region = config.region.region();
+    let sdk_region = config.region.region();
     let service = ServiceBuilder::new()
         .settings::<RT, BatchKinesisRequest<RR>>(request_limits, retry_logic)
         .service(KinesisService::<C, R, E> {
             client,
             stream_name: config.stream_name.clone(),
-            region,
+            region: sdk_region,
             _phantom_t: PhantomData,
             _phantom_e: PhantomData,
         });
@@ -127,6 +128,7 @@ where
         service,
         request_builder,
         partition_key_field,
+        region,
         _phantom: PhantomData,
     };
     Ok(VectorSink::from_event_streamsink(sink))

--- a/src/sinks/aws_kinesis/firehose/config.rs
+++ b/src/sinks/aws_kinesis/firehose/config.rs
@@ -11,6 +11,8 @@ use super::{
     record::{KinesisFirehoseClient, KinesisFirehoseRecord},
     sink::BatchKinesisRequest,
 };
+use aws_config::Region;
+
 use crate::{
     aws::{ClientBuilder, create_client_without_transport_metrics, is_retriable_error},
     config::{AcknowledgementsConfig, GenerateConfig, Input, ProxyConfig, SinkConfig, SinkContext},
@@ -101,7 +103,10 @@ impl KinesisFirehoseSinkConfig {
         }
     }
 
-    pub async fn create_client(&self, proxy: &ProxyConfig) -> crate::Result<KinesisClient> {
+    pub async fn create_client(
+        &self,
+        proxy: &ProxyConfig,
+    ) -> crate::Result<(KinesisClient, Region)> {
         create_client_without_transport_metrics::<KinesisFirehoseClientBuilder>(
             &KinesisFirehoseClientBuilder {},
             &self.base.auth,
@@ -119,7 +124,7 @@ impl KinesisFirehoseSinkConfig {
 #[typetag::serde(name = "aws_kinesis_firehose")]
 impl SinkConfig for KinesisFirehoseSinkConfig {
     async fn build(&self, cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
-        let client = self.create_client(&cx.proxy).await?;
+        let (client, resolved_region) = self.create_client(&cx.proxy).await?;
         let healthcheck = self.clone().healthcheck(client.clone()).boxed();
 
         let batch_settings = self
@@ -129,11 +134,7 @@ impl SinkConfig for KinesisFirehoseSinkConfig {
             .limit_max_events(MAX_PAYLOAD_EVENTS)?
             .into_batcher_settings()?;
 
-        let region = self
-            .base
-            .region
-            .region()
-            .map_or_else(String::new, |r| r.to_string());
+        let region = resolved_region.to_string();
         let sink = build_sink::<
             KinesisFirehoseClient,
             KinesisRecord,

--- a/src/sinks/aws_kinesis/firehose/config.rs
+++ b/src/sinks/aws_kinesis/firehose/config.rs
@@ -12,7 +12,7 @@ use super::{
     sink::BatchKinesisRequest,
 };
 use crate::{
-    aws::{ClientBuilder, create_client, is_retriable_error},
+    aws::{ClientBuilder, create_client_without_transport_metrics, is_retriable_error},
     config::{AcknowledgementsConfig, GenerateConfig, Input, ProxyConfig, SinkConfig, SinkContext},
     sinks::{
         Healthcheck, VectorSink,
@@ -102,7 +102,7 @@ impl KinesisFirehoseSinkConfig {
     }
 
     pub async fn create_client(&self, proxy: &ProxyConfig) -> crate::Result<KinesisClient> {
-        create_client::<KinesisFirehoseClientBuilder>(
+        create_client_without_transport_metrics::<KinesisFirehoseClientBuilder>(
             &KinesisFirehoseClientBuilder {},
             &self.base.auth,
             self.base.region.region(),
@@ -129,6 +129,11 @@ impl SinkConfig for KinesisFirehoseSinkConfig {
             .limit_max_events(MAX_PAYLOAD_EVENTS)?
             .into_batcher_settings()?;
 
+        let region = self
+            .base
+            .region
+            .region()
+            .map_or_else(String::new, |r| r.to_string());
         let sink = build_sink::<
             KinesisFirehoseClient,
             KinesisRecord,
@@ -143,6 +148,7 @@ impl SinkConfig for KinesisFirehoseSinkConfig {
             KinesisRetryLogic {
                 retry_partial: self.base.request_retry_partial,
             },
+            region,
         )?;
 
         Ok((sink, healthcheck))

--- a/src/sinks/aws_kinesis/firehose/record.rs
+++ b/src/sinks/aws_kinesis/firehose/record.rs
@@ -66,6 +66,7 @@ impl SendRecord for KinesisFirehoseClient {
             .map(|output: PutRecordBatchOutput| KinesisResponse {
                 failure_count: output.failed_put_count() as usize,
                 events_byte_size: CountByteSize(rec_count, JsonSize::new(total_size)).into(),
+                byte_size: 0,
                 #[cfg(feature = "sinks-aws_kinesis_streams")]
                 failed_records: vec![], // Firehose doesn't support partial failure retry
             })

--- a/src/sinks/aws_kinesis/service.rs
+++ b/src/sinks/aws_kinesis/service.rs
@@ -84,8 +84,12 @@ where
 
     // Emission of internal events for errors and dropped events is handled upstream by the caller.
     fn call(&mut self, mut requests: BatchKinesisRequest<R>) -> Self::Future {
+        let byte_size: usize = requests
+            .events
+            .iter()
+            .map(|req| req.record.encoded_length())
+            .sum();
         let metadata = std::mem::take(requests.metadata_mut());
-        let byte_size = metadata.request_encoded_size();
         let events_byte_size = metadata.into_events_estimated_json_encoded_byte_size();
 
         let records = requests

--- a/src/sinks/aws_kinesis/service.rs
+++ b/src/sinks/aws_kinesis/service.rs
@@ -38,6 +38,7 @@ where
 pub struct KinesisResponse {
     pub(crate) failure_count: usize,
     pub(crate) events_byte_size: GroupedCountByteSize,
+    pub(crate) byte_size: usize,
     #[cfg(feature = "sinks-aws_kinesis_streams")]
     /// Track individual failed records for retry logic (Streams only)
     pub(crate) failed_records: Vec<RecordResult>,
@@ -58,6 +59,10 @@ impl DriverResponse for KinesisResponse {
 
     fn events_sent(&self) -> &GroupedCountByteSize {
         &self.events_byte_size
+    }
+
+    fn bytes_sent(&self) -> Option<usize> {
+        Some(self.byte_size)
     }
 }
 
@@ -80,6 +85,7 @@ where
     // Emission of internal events for errors and dropped events is handled upstream by the caller.
     fn call(&mut self, mut requests: BatchKinesisRequest<R>) -> Self::Future {
         let metadata = std::mem::take(requests.metadata_mut());
+        let byte_size = metadata.request_encoded_size();
         let events_byte_size = metadata.into_events_estimated_json_encoded_byte_size();
 
         let records = requests
@@ -95,6 +101,7 @@ where
             client.send(records, stream_name).await.map(|mut r| {
                 // augment the response
                 r.events_byte_size = events_byte_size;
+                r.byte_size = byte_size;
                 r
             })
         })

--- a/src/sinks/aws_kinesis/sink.rs
+++ b/src/sinks/aws_kinesis/sink.rs
@@ -29,6 +29,8 @@ pub struct KinesisSink<S, R> {
     pub service: S,
     pub request_builder: KinesisRequestBuilder<R>,
     pub partition_key_field: Option<ConfigValuePath>,
+    /// The AWS region string for metric labels.
+    pub region: String,
     pub _phantom: PhantomData<R>,
 }
 
@@ -72,6 +74,8 @@ where
                 BatchKinesisRequest { events, metadata }
             })
             .into_driver(self.service)
+            .protocol("https")
+            .label("region", self.region)
             .run()
             .await
     }

--- a/src/sinks/aws_kinesis/streams/config.rs
+++ b/src/sinks/aws_kinesis/streams/config.rs
@@ -12,7 +12,7 @@ use super::{
     sink::BatchKinesisRequest,
 };
 use crate::{
-    aws::{ClientBuilder, create_client, is_retriable_error},
+    aws::{ClientBuilder, create_client_without_transport_metrics, is_retriable_error},
     config::{AcknowledgementsConfig, Input, ProxyConfig, SinkConfig, SinkContext},
     sinks::{
         Healthcheck, VectorSink,
@@ -101,7 +101,7 @@ impl KinesisStreamsSinkConfig {
     }
 
     pub async fn create_client(&self, proxy: &ProxyConfig) -> crate::Result<KinesisClient> {
-        create_client::<KinesisClientBuilder>(
+        create_client_without_transport_metrics::<KinesisClientBuilder>(
             &KinesisClientBuilder {},
             &self.base.auth,
             self.base.region.region(),
@@ -128,6 +128,11 @@ impl SinkConfig for KinesisStreamsSinkConfig {
             .limit_max_events(MAX_PAYLOAD_EVENTS)?
             .into_batcher_settings()?;
 
+        let region = self
+            .base
+            .region
+            .region()
+            .map_or_else(String::new, |r| r.to_string());
         let sink = build_sink::<
             KinesisStreamClient,
             KinesisRecord,
@@ -142,6 +147,7 @@ impl SinkConfig for KinesisStreamsSinkConfig {
             KinesisRetryLogic {
                 retry_partial: self.base.request_retry_partial,
             },
+            region,
         )?;
 
         Ok((sink, healthcheck))

--- a/src/sinks/aws_kinesis/streams/config.rs
+++ b/src/sinks/aws_kinesis/streams/config.rs
@@ -11,6 +11,8 @@ use super::{
     record::{KinesisStreamClient, KinesisStreamRecord},
     sink::BatchKinesisRequest,
 };
+use aws_config::Region;
+
 use crate::{
     aws::{ClientBuilder, create_client_without_transport_metrics, is_retriable_error},
     config::{AcknowledgementsConfig, Input, ProxyConfig, SinkConfig, SinkContext},
@@ -100,7 +102,10 @@ impl KinesisStreamsSinkConfig {
         }
     }
 
-    pub async fn create_client(&self, proxy: &ProxyConfig) -> crate::Result<KinesisClient> {
+    pub async fn create_client(
+        &self,
+        proxy: &ProxyConfig,
+    ) -> crate::Result<(KinesisClient, Region)> {
         create_client_without_transport_metrics::<KinesisClientBuilder>(
             &KinesisClientBuilder {},
             &self.base.auth,
@@ -118,7 +123,7 @@ impl KinesisStreamsSinkConfig {
 #[typetag::serde(name = "aws_kinesis_streams")]
 impl SinkConfig for KinesisStreamsSinkConfig {
     async fn build(&self, cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
-        let client = self.create_client(&cx.proxy).await?;
+        let (client, resolved_region) = self.create_client(&cx.proxy).await?;
         let healthcheck = self.clone().healthcheck(client.clone()).boxed();
 
         let batch_settings = self
@@ -128,11 +133,7 @@ impl SinkConfig for KinesisStreamsSinkConfig {
             .limit_max_events(MAX_PAYLOAD_EVENTS)?
             .into_batcher_settings()?;
 
-        let region = self
-            .base
-            .region
-            .region()
-            .map_or_else(String::new, |r| r.to_string());
+        let region = resolved_region.to_string();
         let sink = build_sink::<
             KinesisStreamClient,
             KinesisRecord,

--- a/src/sinks/aws_kinesis/streams/record.rs
+++ b/src/sinks/aws_kinesis/streams/record.rs
@@ -78,6 +78,7 @@ impl SendRecord for KinesisStreamClient {
                 failed_records: extract_failed_records(&output),
                 failure_count: output.failed_record_count().unwrap_or(0) as usize,
                 events_byte_size: CountByteSize(rec_count, JsonSize::new(total_size)).into(),
+                byte_size: 0,
             })
     }
 }

--- a/src/sinks/aws_s3/config.rs
+++ b/src/sinks/aws_s3/config.rs
@@ -229,9 +229,10 @@ impl GenerateConfig for S3SinkConfig {
 #[typetag::serde(name = "aws_s3")]
 impl SinkConfig for S3SinkConfig {
     async fn build(&self, cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
-        let service = self.create_service(&cx.proxy).await?;
+        let (service, region) = self.create_service(&cx.proxy).await?;
         let healthcheck = self.build_healthcheck(service.client())?;
-        let sink = self.build_processor(service, cx)?;
+        let sink = self.build_processor(service, cx, region)?;
+        self.confinement.set_confinement_gauge("sink", Self::NAME);
         Ok((sink, healthcheck))
     }
 
@@ -259,6 +260,7 @@ impl S3SinkConfig {
         &self,
         service: S3Service,
         cx: SinkContext,
+        region: String,
     ) -> crate::Result<VectorSink> {
         // Build our S3 client/service, which is what we'll ultimately feed
         // requests into in order to ship files to S3.  We build this here in
@@ -339,7 +341,13 @@ impl S3SinkConfig {
                 filename_tz_offset: offset,
             };
 
-            let sink = S3Sink::new(service, request_options, partitioner, batch_settings);
+            let sink = S3Sink::new(
+                service,
+                request_options,
+                partitioner,
+                batch_settings,
+                region,
+            );
             return Ok(VectorSink::from_event_streamsink(sink));
         }
 
@@ -357,7 +365,13 @@ impl S3SinkConfig {
             filename_tz_offset: offset,
         };
 
-        let sink = S3Sink::new(service, request_options, partitioner, batch_settings);
+        let sink = S3Sink::new(
+            service,
+            request_options,
+            partitioner,
+            batch_settings,
+            region,
+        );
 
         Ok(VectorSink::from_event_streamsink(sink))
     }
@@ -366,7 +380,7 @@ impl S3SinkConfig {
         s3_common::config::build_healthcheck(self.bucket.clone(), client)
     }
 
-    pub async fn create_service(&self, proxy: &ProxyConfig) -> crate::Result<S3Service> {
+    pub async fn create_service(&self, proxy: &ProxyConfig) -> crate::Result<(S3Service, String)> {
         s3_common::config::create_service(
             &self.region,
             &self.auth,

--- a/src/sinks/aws_s3/config.rs
+++ b/src/sinks/aws_s3/config.rs
@@ -232,7 +232,6 @@ impl SinkConfig for S3SinkConfig {
         let (service, region) = self.create_service(&cx.proxy).await?;
         let healthcheck = self.build_healthcheck(service.client())?;
         let sink = self.build_processor(service, cx, region)?;
-        self.confinement.set_confinement_gauge("sink", Self::NAME);
         Ok((sink, healthcheck))
     }
 

--- a/src/sinks/aws_s3/integration_tests.rs
+++ b/src/sinks/aws_s3/integration_tests.rs
@@ -68,8 +68,8 @@ async fn s3_insert_message_into_with_flat_key_prefix() {
         ..config(&bucket, 1000000, 5.0)
     };
     let prefix = config.key_prefix.clone();
-    let service = config.create_service(&cx.globals.proxy).await.unwrap();
-    let sink = config.build_processor(service, cx).unwrap();
+    let (service, region) = config.create_service(&cx.globals.proxy).await.unwrap();
+    let sink = config.build_processor(service, cx, region).unwrap();
 
     let (lines, events, receiver) = make_events_batch(100, 10);
     run_and_assert_sink_compliance(sink, events, &AWS_SINK_TAGS).await;
@@ -104,8 +104,8 @@ async fn s3_insert_message_into_with_folder_key_prefix() {
         ..config(&bucket, 1000000, 5.0)
     };
     let prefix = config.key_prefix.clone();
-    let service = config.create_service(&cx.globals.proxy).await.unwrap();
-    let sink = config.build_processor(service, cx).unwrap();
+    let (service, region) = config.create_service(&cx.globals.proxy).await.unwrap();
+    let sink = config.build_processor(service, cx, region).unwrap();
 
     let (lines, events, receiver) = make_events_batch(100, 10);
     run_and_assert_sink_compliance(sink, events, &AWS_SINK_TAGS).await;
@@ -146,8 +146,8 @@ async fn s3_insert_message_into_with_ssekms_key_id() {
     };
     let prefix = config.key_prefix.clone();
 
-    let service = config.create_service(&cx.globals.proxy).await.unwrap();
-    let sink = config.build_processor(service, cx).unwrap();
+    let (service, region) = config.create_service(&cx.globals.proxy).await.unwrap();
+    let sink = config.build_processor(service, cx, region).unwrap();
 
     let (lines, events, receiver) = make_events_batch(100, 10);
     run_and_assert_sink_compliance(sink, events, &AWS_SINK_TAGS).await;
@@ -184,8 +184,8 @@ async fn s3_rotate_files_after_the_buffer_size_is_reached() {
         ..config(&bucket, 10, 5.0)
     };
     let prefix = config.key_prefix.clone();
-    let service = config.create_service(&cx.globals.proxy).await.unwrap();
-    let sink = config.build_processor(service, cx).unwrap();
+    let (service, region) = config.create_service(&cx.globals.proxy).await.unwrap();
+    let sink = config.build_processor(service, cx, region).unwrap();
 
     let (lines, _events) = random_lines_with_stream(100, 30, None);
 
@@ -243,8 +243,8 @@ async fn s3_gzip() {
     };
 
     let prefix = config.key_prefix.clone();
-    let service = config.create_service(&cx.globals.proxy).await.unwrap();
-    let sink = config.build_processor(service, cx).unwrap();
+    let (service, region) = config.create_service(&cx.globals.proxy).await.unwrap();
+    let sink = config.build_processor(service, cx, region).unwrap();
 
     let (lines, events, receiver) = make_events_batch(100, batch_size * batch_multiplier);
     run_and_assert_sink_compliance(sink, events, &AWS_SINK_TAGS).await;
@@ -288,8 +288,8 @@ async fn s3_zstd() {
     };
 
     let prefix = config.key_prefix.clone();
-    let service = config.create_service(&cx.globals.proxy).await.unwrap();
-    let sink = config.build_processor(service, cx).unwrap();
+    let (service, region) = config.create_service(&cx.globals.proxy).await.unwrap();
+    let sink = config.build_processor(service, cx, region).unwrap();
 
     let (lines, events, receiver) = make_events_batch(100, batch_size * batch_multiplier);
     run_and_assert_sink_compliance(sink, events, &AWS_SINK_TAGS).await;
@@ -350,8 +350,8 @@ async fn s3_insert_message_into_object_lock() {
 
     let config = config(&bucket, 1000000, 5.0);
     let prefix = config.key_prefix.clone();
-    let service = config.create_service(&cx.globals.proxy).await.unwrap();
-    let sink = config.build_processor(service, cx).unwrap();
+    let (service, region) = config.create_service(&cx.globals.proxy).await.unwrap();
+    let sink = config.build_processor(service, cx, region).unwrap();
 
     let (lines, events, receiver) = make_events_batch(100, 10);
     run_and_assert_sink_compliance(sink, events, &AWS_SINK_TAGS).await;
@@ -383,8 +383,8 @@ async fn acknowledges_failures() {
         ..config(&bucket, 1, 5.0)
     };
     let prefix = config.key_prefix.clone();
-    let service = config.create_service(&cx.globals.proxy).await.unwrap();
-    let sink = config.build_processor(service, cx).unwrap();
+    let (service, region) = config.create_service(&cx.globals.proxy).await.unwrap();
+    let sink = config.build_processor(service, cx, region).unwrap();
 
     let (_lines, events, receiver) = make_events_batch(1, 1);
     run_and_assert_sink_error(sink, events, &COMPONENT_ERROR_TAGS).await;
@@ -401,7 +401,7 @@ async fn s3_healthchecks() {
     create_bucket(&bucket, false).await;
 
     let config = config(&bucket, 1, 5.0);
-    let service = config
+    let (service, _region) = config
         .create_service(&ProxyConfig::from_env())
         .await
         .unwrap();
@@ -415,7 +415,7 @@ async fn s3_healthchecks() {
 #[tokio::test]
 async fn s3_healthchecks_invalid_bucket() {
     let config = config("s3_healthchecks_invalid_bucket", 1, 5.0);
-    let service = config
+    let (service, _region) = config
         .create_service(&ProxyConfig::from_env())
         .await
         .unwrap();
@@ -438,8 +438,8 @@ async fn s3_flush_on_exhaustion() {
     // batch size of ten events, timeout of ten seconds
     let config = config(&bucket, 10, 10.0);
     let prefix = config.key_prefix.clone();
-    let service = config.create_service(&cx.globals.proxy).await.unwrap();
-    let sink = config.build_processor(service, cx).unwrap();
+    let (service, region) = config.create_service(&cx.globals.proxy).await.unwrap();
+    let sink = config.build_processor(service, cx, region).unwrap();
 
     let (lines, _events) = random_lines_with_stream(100, 2, None); // only generate two events (less than batch size)
 
@@ -507,8 +507,8 @@ async fn s3_parquet_insert_message() {
     };
 
     let prefix = config.key_prefix.clone();
-    let service = config.create_service(&cx.globals.proxy).await.unwrap();
-    let sink = config.build_processor(service, cx).unwrap();
+    let (service, region) = config.create_service(&cx.globals.proxy).await.unwrap();
+    let sink = config.build_processor(service, cx, region).unwrap();
 
     let (batch_notifier, receiver) = BatchNotifier::new_with_receiver();
     let events: Vec<Event> = (0..10)

--- a/src/sinks/aws_s_s/service.rs
+++ b/src/sinks/aws_s_s/service.rs
@@ -7,7 +7,7 @@ use aws_smithy_runtime_api::client::{orchestrator::HttpResponse, result::SdkErro
 use futures::future::BoxFuture;
 use tower::Service;
 use vector_lib::{
-    ByteSizeOf, event::EventStatus, request_metadata::GroupedCountByteSize, stream::DriverResponse,
+    event::EventStatus, request_metadata::GroupedCountByteSize, stream::DriverResponse,
 };
 
 use super::{client::Client, request_builder::SendMessageEntry};
@@ -63,7 +63,7 @@ where
 
     // Emission of internal events for errors and dropped events is handled upstream by the caller.
     fn call(&mut self, entry: SendMessageEntry) -> Self::Future {
-        let byte_size = entry.size_of();
+        let byte_size = entry.metadata.request_encoded_size();
         let client = self.client.clone();
 
         Box::pin(async move { client.send_message(entry, byte_size).await })

--- a/src/sinks/aws_s_s/sink.rs
+++ b/src/sinks/aws_s_s/sink.rs
@@ -10,6 +10,8 @@ where
     request_builder: SSRequestBuilder,
     service: SSService<C, E>,
     request: TowerRequestConfig,
+    /// The AWS region string for metric labels.
+    region: String,
 }
 
 impl<C, E> SSSink<C, E>
@@ -21,11 +23,13 @@ where
         request_builder: SSRequestBuilder,
         request: TowerRequestConfig,
         publisher: C,
+        region: String,
     ) -> crate::Result<Self> {
         Ok(SSSink {
             request_builder,
             service: SSService::new(publisher),
             request,
+            region,
         })
     }
 
@@ -48,6 +52,8 @@ where
                 .ok()
             })
             .into_driver(service)
+            .protocol("https")
+            .label("region", self.region)
             .run()
             .await
     }

--- a/src/sinks/aws_s_s/sns/config.rs
+++ b/src/sinks/aws_s_s/sns/config.rs
@@ -5,6 +5,8 @@ use super::{
     BaseSSSinkConfig, SSRequestBuilder, SSSink, client::SnsMessagePublisher,
     message_deduplication_id, message_group_id,
 };
+use aws_config::Region;
+
 use crate::{
     aws::{ClientBuilder, RegionOrEndpoint, create_client_without_transport_metrics},
     config::{
@@ -45,7 +47,10 @@ impl GenerateConfig for SnsSinkConfig {
 }
 
 impl SnsSinkConfig {
-    pub(super) async fn create_client(&self, proxy: &ProxyConfig) -> crate::Result<SnsClient> {
+    pub(super) async fn create_client(
+        &self,
+        proxy: &ProxyConfig,
+    ) -> crate::Result<(SnsClient, Region)> {
         create_client_without_transport_metrics::<SnsClientBuilder>(
             &SnsClientBuilder {},
             &self.base_config.auth,
@@ -66,7 +71,7 @@ impl SinkConfig for SnsSinkConfig {
         &self,
         cx: SinkContext,
     ) -> crate::Result<(crate::sinks::VectorSink, crate::sinks::Healthcheck)> {
-        let client = self.create_client(&cx.proxy).await?;
+        let (client, resolved_region) = self.create_client(&cx.proxy).await?;
 
         let publisher = SnsMessagePublisher::new(client.clone(), self.topic_arn.clone());
 
@@ -79,10 +84,7 @@ impl SinkConfig for SnsSinkConfig {
         let message_deduplication_id =
             message_deduplication_id(self.base_config.message_deduplication_id.clone());
 
-        let region = self
-            .region
-            .region()
-            .map_or_else(String::new, |r| r.to_string());
+        let region = resolved_region.to_string();
         let sink = SSSink::new(
             SSRequestBuilder::new(
                 message_group_id?,

--- a/src/sinks/aws_s_s/sns/config.rs
+++ b/src/sinks/aws_s_s/sns/config.rs
@@ -6,7 +6,7 @@ use super::{
     message_deduplication_id, message_group_id,
 };
 use crate::{
-    aws::{ClientBuilder, RegionOrEndpoint, create_client},
+    aws::{ClientBuilder, RegionOrEndpoint, create_client_without_transport_metrics},
     config::{
         AcknowledgementsConfig, DataType, GenerateConfig, Input, ProxyConfig, SinkConfig,
         SinkContext,
@@ -46,7 +46,7 @@ impl GenerateConfig for SnsSinkConfig {
 
 impl SnsSinkConfig {
     pub(super) async fn create_client(&self, proxy: &ProxyConfig) -> crate::Result<SnsClient> {
-        create_client::<SnsClientBuilder>(
+        create_client_without_transport_metrics::<SnsClientBuilder>(
             &SnsClientBuilder {},
             &self.base_config.auth,
             self.region.region(),
@@ -79,6 +79,10 @@ impl SinkConfig for SnsSinkConfig {
         let message_deduplication_id =
             message_deduplication_id(self.base_config.message_deduplication_id.clone());
 
+        let region = self
+            .region
+            .region()
+            .map_or_else(String::new, |r| r.to_string());
         let sink = SSSink::new(
             SSRequestBuilder::new(
                 message_group_id?,
@@ -87,6 +91,7 @@ impl SinkConfig for SnsSinkConfig {
             )?,
             self.base_config.request,
             publisher,
+            region,
         )?;
         Ok((
             crate::sinks::VectorSink::from_event_streamsink(sink),

--- a/src/sinks/aws_s_s/sqs/config.rs
+++ b/src/sinks/aws_s_s/sqs/config.rs
@@ -5,6 +5,8 @@ use super::{
     BaseSSSinkConfig, SSRequestBuilder, SSSink, client::SqsMessagePublisher,
     message_deduplication_id, message_group_id,
 };
+use aws_config::Region;
+
 use crate::{
     aws::{RegionOrEndpoint, create_client_without_transport_metrics},
     common::sqs::SqsClientBuilder,
@@ -48,7 +50,10 @@ impl GenerateConfig for SqsSinkConfig {
 }
 
 impl SqsSinkConfig {
-    pub(super) async fn create_client(&self, proxy: &ProxyConfig) -> crate::Result<SqsClient> {
+    pub(super) async fn create_client(
+        &self,
+        proxy: &ProxyConfig,
+    ) -> crate::Result<(SqsClient, Region)> {
         create_client_without_transport_metrics::<SqsClientBuilder>(
             &SqsClientBuilder {},
             &self.base_config.auth,
@@ -69,7 +74,7 @@ impl SinkConfig for SqsSinkConfig {
         &self,
         cx: SinkContext,
     ) -> crate::Result<(crate::sinks::VectorSink, crate::sinks::Healthcheck)> {
-        let client = self.create_client(&cx.proxy).await?;
+        let (client, resolved_region) = self.create_client(&cx.proxy).await?;
 
         let publisher = SqsMessagePublisher::new(client.clone(), self.queue_url.clone());
 
@@ -81,10 +86,7 @@ impl SinkConfig for SqsSinkConfig {
         let message_deduplication_id =
             message_deduplication_id(self.base_config.message_deduplication_id.clone());
 
-        let region = self
-            .region
-            .region()
-            .map_or_else(String::new, |r| r.to_string());
+        let region = resolved_region.to_string();
         let sink = SSSink::new(
             SSRequestBuilder::new(
                 message_group_id?,

--- a/src/sinks/aws_s_s/sqs/config.rs
+++ b/src/sinks/aws_s_s/sqs/config.rs
@@ -6,7 +6,7 @@ use super::{
     message_deduplication_id, message_group_id,
 };
 use crate::{
-    aws::{RegionOrEndpoint, create_client},
+    aws::{RegionOrEndpoint, create_client_without_transport_metrics},
     common::sqs::SqsClientBuilder,
     config::{
         AcknowledgementsConfig, DataType, GenerateConfig, Input, ProxyConfig, SinkConfig,
@@ -49,7 +49,7 @@ impl GenerateConfig for SqsSinkConfig {
 
 impl SqsSinkConfig {
     pub(super) async fn create_client(&self, proxy: &ProxyConfig) -> crate::Result<SqsClient> {
-        create_client::<SqsClientBuilder>(
+        create_client_without_transport_metrics::<SqsClientBuilder>(
             &SqsClientBuilder {},
             &self.base_config.auth,
             self.region.region(),
@@ -81,6 +81,10 @@ impl SinkConfig for SqsSinkConfig {
         let message_deduplication_id =
             message_deduplication_id(self.base_config.message_deduplication_id.clone());
 
+        let region = self
+            .region
+            .region()
+            .map_or_else(String::new, |r| r.to_string());
         let sink = SSSink::new(
             SSRequestBuilder::new(
                 message_group_id?,
@@ -89,6 +93,7 @@ impl SinkConfig for SqsSinkConfig {
             )?,
             self.base_config.request,
             publisher,
+            region,
         )?;
         Ok((
             crate::sinks::VectorSink::from_event_streamsink(sink),

--- a/src/sinks/s3_common/config.rs
+++ b/src/sinks/s3_common/config.rs
@@ -15,7 +15,10 @@ use vector_lib::configurable::configurable_component;
 
 use super::service::{S3Request, S3Response, S3Service};
 use crate::{
-    aws::{AwsAuthentication, RegionOrEndpoint, create_client, is_retriable_error},
+    aws::{
+        AwsAuthentication, RegionOrEndpoint, create_client_without_transport_metrics,
+        is_retriable_error,
+    },
     common::s3::S3ClientBuilder,
     config::ProxyConfig,
     http::status,
@@ -431,11 +434,15 @@ pub async fn create_service(
     proxy: &ProxyConfig,
     tls_options: Option<&TlsConfig>,
     force_path_style: impl Into<bool>,
-) -> crate::Result<S3Service> {
+) -> crate::Result<(S3Service, String)> {
     let endpoint = region.endpoint();
+    let region_string = region
+        .region()
+        .as_ref()
+        .map_or_else(String::new, |r| r.to_string());
     let region = region.region();
     let force_path_style_value: bool = force_path_style.into();
-    let client = create_client::<S3ClientBuilder>(
+    let client = create_client_without_transport_metrics::<S3ClientBuilder>(
         &S3ClientBuilder {
             force_path_style: Some(force_path_style_value),
         },
@@ -447,7 +454,7 @@ pub async fn create_service(
         None,
     )
     .await?;
-    Ok(S3Service::new(client))
+    Ok((S3Service::new(client), region_string))
 }
 
 #[cfg(test)]

--- a/src/sinks/s3_common/config.rs
+++ b/src/sinks/s3_common/config.rs
@@ -436,13 +436,9 @@ pub async fn create_service(
     force_path_style: impl Into<bool>,
 ) -> crate::Result<(S3Service, String)> {
     let endpoint = region.endpoint();
-    let region_string = region
-        .region()
-        .as_ref()
-        .map_or_else(String::new, |r| r.to_string());
     let region = region.region();
     let force_path_style_value: bool = force_path_style.into();
-    let client = create_client_without_transport_metrics::<S3ClientBuilder>(
+    let (client, resolved_region) = create_client_without_transport_metrics::<S3ClientBuilder>(
         &S3ClientBuilder {
             force_path_style: Some(force_path_style_value),
         },
@@ -454,7 +450,7 @@ pub async fn create_service(
         None,
     )
     .await?;
-    Ok((S3Service::new(client), region_string))
+    Ok((S3Service::new(client), resolved_region.to_string()))
 }
 
 #[cfg(test)]

--- a/src/sinks/s3_common/service.rs
+++ b/src/sinks/s3_common/service.rs
@@ -53,6 +53,7 @@ pub struct S3Metadata {
 #[derive(Debug)]
 pub struct S3Response {
     events_byte_size: GroupedCountByteSize,
+    byte_size: usize,
 }
 
 impl DriverResponse for S3Response {
@@ -62,6 +63,10 @@ impl DriverResponse for S3Response {
 
     fn events_sent(&self) -> &GroupedCountByteSize {
         &self.events_byte_size
+    }
+
+    fn bytes_sent(&self) -> Option<usize> {
+        Some(self.byte_size)
     }
 }
 
@@ -118,6 +123,7 @@ impl Service<S3Request> for S3Service {
             tagging.finish()
         });
 
+        let byte_size = request.request_metadata.request_encoded_size();
         let events_byte_size = request
             .request_metadata
             .into_events_estimated_json_encoded_byte_size();
@@ -153,7 +159,10 @@ impl Service<S3Request> for S3Service {
                     key = request.metadata.s3_key
                 );
 
-                S3Response { events_byte_size }
+                S3Response {
+                    events_byte_size,
+                    byte_size,
+                }
             })
         })
     }

--- a/src/sinks/s3_common/sink.rs
+++ b/src/sinks/s3_common/sink.rs
@@ -10,20 +10,25 @@ pub struct S3Sink<Svc, RB, P> {
     request_builder: RB,
     partitioner: P,
     batcher_settings: BatcherSettings,
+    /// The AWS region string for metric labels.
+    region: String,
 }
 
 impl<Svc, RB, P> S3Sink<Svc, RB, P> {
+    /// Create a new S3 sink.
     pub const fn new(
         service: Svc,
         request_builder: RB,
         partitioner: P,
         batcher_settings: BatcherSettings,
+        region: String,
     ) -> Self {
         Self {
             partitioner,
             service,
             request_builder,
             batcher_settings,
+            region,
         }
     }
 }
@@ -62,6 +67,8 @@ where
                 }
             })
             .into_driver(self.service)
+            .protocol("https")
+            .label("region", self.region)
             .run()
             .await
     }


### PR DESCRIPTION
## Summary
- Suppress transport-level `AwsBytesSent` for all Driver-based AWS sinks to eliminate duplicate `component_sent_bytes_total` metrics missing component labels
- Route byte reporting through the Driver, which runs within the component tracing span
- Add generic `.label(key, value)` builder on `Driver`; each AWS sink uses it to add a `region` label

## Vector configuration
Any AWS sink config

## How did you test this PR?
- Added integration tests for all changed AWS sinks
- See [functional tests](https://github.com/openshift/cluster-logging-operator/pull/3348) for the ClusterLogging Operator (for Cloudwatch & S3 only)

## Change Type

- [X] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [X] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [X] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References
- Fixes: https://github.com/vectordotdev/vector/issues/20356

## Notes

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details on the [dd-rust-license-tool](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert, perf
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional but appreciated; letters, digits, spaces, hyphens, underscores (e.g. `kafka source`, `amazon-linux`)
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
