### PR TITLE
chore(vdev): auto-generate versions.cue and release stub in generate-cue

### DIFF
--- a/vdev/src/commands/release/generate_cue.rs
+++ b/vdev/src/commands/release/generate_cue.rs
@@ -1457,11 +1457,8 @@ releases: "0.55.0": {
 
         refresh_versions_cue(tmp.path()).unwrap();
 
-        let out = fs::read_to_string(
-            tmp.path()
-                .join("website/cue/reference/versions.cue"),
-        )
-        .unwrap();
+        let out =
+            fs::read_to_string(tmp.path().join("website/cue/reference/versions.cue")).unwrap();
 
         let expected = indoc::indoc! {r#"
             package metadata

--- a/vdev/src/commands/release/generate_cue.rs
+++ b/vdev/src/commands/release/generate_cue.rs
@@ -84,6 +84,18 @@ pub(super) fn run(new_version: &Version) -> Result<PathBuf> {
             cue_path.display()
         );
     }
+    let stub_path = repo_root
+        .join("website")
+        .join("content")
+        .join("en")
+        .join("releases")
+        .join(format!("{new_version}.md"));
+    if stub_path.exists() {
+        bail!(
+            "{} already exists. Delete it (or move it aside) and re-run.",
+            stub_path.display()
+        );
+    }
     // Note: the highlights collision is checked later, only if we're actually going to
     // write it — so a manually-authored upgrade guide doesn't block a release with no
     // breaking fragments.
@@ -167,11 +179,12 @@ pub(super) fn run(new_version: &Version) -> Result<PathBuf> {
 }
 
 /// Regenerate `website/cue/reference/versions.cue` from the filenames in the `releases/`
-/// directory. Replaces the hand-maintained list and fixes the gap where `release generate-cue`
-/// previously left `versions.cue` stale (so the new version was invisible in local Hugo previews).
+/// directory, preserving any versions already listed there that have no backing `.cue` file
+/// (legacy releases predating the automated tooling). Fixes the gap where `release generate-cue`
+/// previously left `versions.cue` stale so the new version was invisible in local Hugo previews.
 pub(super) fn refresh_versions_cue(repo_root: &Path) -> Result<()> {
     let releases_dir = repo_root.join(RELEASES_DIR);
-    let mut versions: Vec<Version> = fs::read_dir(&releases_dir)
+    let mut versions: std::collections::HashSet<Version> = fs::read_dir(&releases_dir)
         .with_context(|| format!("Failed to read {}", releases_dir.display()))?
         .filter_map(std::result::Result::ok)
         .filter_map(|e| {
@@ -183,6 +196,24 @@ pub(super) fn refresh_versions_cue(repo_root: &Path) -> Result<()> {
             }
         })
         .collect();
+
+    // Preserve versions already in versions.cue that have no backing CUE file — these are
+    // legacy releases that predate the per-release CUE files and must not be silently dropped.
+    let versions_cue_path = repo_root
+        .join("website")
+        .join("cue")
+        .join("reference")
+        .join("versions.cue");
+    if let Ok(text) = fs::read_to_string(&versions_cue_path) {
+        for line in text.lines() {
+            let trimmed = line.trim().trim_end_matches(',').trim_matches('"');
+            if let Ok(v) = trimmed.parse::<Version>() {
+                versions.insert(v);
+            }
+        }
+    }
+
+    let mut versions: Vec<Version> = versions.into_iter().collect();
     versions.sort_by(|a, b| b.cmp(a));
 
     let list = versions
@@ -1514,5 +1545,36 @@ releases: "0.55.0": {
         let version = Version::parse("0.58.0").unwrap();
         let err = write_release_stub(tmp.path(), &version).unwrap_err();
         assert!(err.to_string().contains("already exists"), "{err}");
+    }
+
+    #[test]
+    fn refresh_versions_cue_preserves_legacy_versions_without_cue_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let releases_dir = tmp.path().join("website/cue/reference/releases");
+        fs::create_dir_all(&releases_dir).unwrap();
+        fs::write(releases_dir.join("0.15.0.cue"), "").unwrap();
+
+        // Simulate an existing versions.cue that lists a legacy version with no CUE file.
+        let versions_cue_dir = tmp.path().join("website/cue/reference");
+        let existing = indoc::indoc! {r#"
+            package metadata
+
+            versions: [string, ...string] & [
+            	"0.15.0",
+            	"0.14.1",
+            ]
+        "#};
+        fs::write(versions_cue_dir.join("versions.cue"), existing).unwrap();
+
+        refresh_versions_cue(tmp.path()).unwrap();
+
+        let out = fs::read_to_string(versions_cue_dir.join("versions.cue")).unwrap();
+        assert!(out.contains("\"0.15.0\""), "CUE-backed version missing");
+        assert!(out.contains("\"0.14.1\""), "legacy version was dropped");
+        // 0.15.0 must sort above 0.14.1
+        assert!(
+            out.find("\"0.15.0\"") < out.find("\"0.14.1\""),
+            "wrong sort order"
+        );
     }
 }

--- a/vdev/src/commands/release/generate_cue.rs
+++ b/vdev/src/commands/release/generate_cue.rs
@@ -159,8 +159,96 @@ pub(super) fn run(new_version: &Version) -> Result<PathBuf> {
         warn!("cue fmt failed (skipping format): {e}");
     }
 
+    refresh_versions_cue(&repo_root)?;
+    write_release_stub(&repo_root, &new_version)?;
+
     success!("Wrote {}", cue_path.display());
     Ok(cue_path)
+}
+
+/// Regenerate `website/cue/reference/versions.cue` from the filenames in the `releases/`
+/// directory. Replaces the hand-maintained list and fixes the gap where `release generate-cue`
+/// previously left `versions.cue` stale (so the new version was invisible in local Hugo previews).
+pub(super) fn refresh_versions_cue(repo_root: &Path) -> Result<()> {
+    let releases_dir = repo_root.join(RELEASES_DIR);
+    let mut versions: Vec<Version> = fs::read_dir(&releases_dir)
+        .with_context(|| format!("Failed to read {}", releases_dir.display()))?
+        .filter_map(std::result::Result::ok)
+        .filter_map(|e| {
+            let p = e.path();
+            if p.extension().is_some_and(|ext| ext == "cue") {
+                p.file_stem()?.to_str()?.parse::<Version>().ok()
+            } else {
+                None
+            }
+        })
+        .collect();
+    versions.sort_by(|a, b| b.cmp(a));
+
+    let list = versions
+        .iter()
+        .map(|v| format!("\t\"{v}\","))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let content = format!("package metadata\n\nversions: [string, ...string] & [\n{list}\n]\n");
+
+    let versions_cue = repo_root
+        .join("website")
+        .join("cue")
+        .join("reference")
+        .join("versions.cue");
+    atomic_write(&versions_cue, &content)?;
+    Ok(())
+}
+
+/// Write `website/content/en/releases/<version>.md` — the Hugo stub Hugo needs to route
+/// `/releases/<version>/`. Weight is derived from the highest weight found among existing
+/// stubs so the new release naturally sorts last (newest).
+pub(super) fn write_release_stub(repo_root: &Path, version: &Version) -> Result<()> {
+    let releases_dir = repo_root
+        .join("website")
+        .join("content")
+        .join("en")
+        .join("releases");
+
+    let stub_path = releases_dir.join(format!("{version}.md"));
+    if stub_path.exists() {
+        bail!(
+            "{} already exists. Delete it (or move it aside) and re-run.",
+            stub_path.display()
+        );
+    }
+
+    let max_weight: u32 = fs::read_dir(&releases_dir)
+        .with_context(|| format!("Failed to read {}", releases_dir.display()))?
+        .filter_map(std::result::Result::ok)
+        .filter(|e| {
+            let p = e.path();
+            p.extension().is_some_and(|x| x == "md")
+                && p.file_name()
+                    .and_then(|n| n.to_str())
+                    .is_some_and(|n| n != "_index.md")
+        })
+        .filter_map(|e| {
+            let text = fs::read_to_string(e.path()).ok()?;
+            text.lines()
+                .find(|l| l.trim_start().starts_with("weight:"))?
+                .split_once(':')?
+                .1
+                .trim()
+                .parse::<u32>()
+                .ok()
+        })
+        .max()
+        .unwrap_or(0);
+
+    let content = format!(
+        "---\ntitle: Vector v{version} release notes\nweight: {}\n---\n",
+        max_weight + 1
+    );
+    atomic_write(&stub_path, &content)?;
+    Ok(())
 }
 
 // ---------- Tag / version discovery ----------
@@ -1355,5 +1443,79 @@ releases: "0.55.0": {
 
         "#};
         assert_eq!(md, expected);
+    }
+
+    #[test]
+    fn refresh_versions_cue_sorts_descending_and_writes_correct_format() {
+        let tmp = tempfile::tempdir().unwrap();
+        let releases_dir = tmp.path().join("website/cue/reference/releases");
+        fs::create_dir_all(&releases_dir).unwrap();
+        for v in ["0.9.0", "0.10.0", "0.9.1", "0.8.2"] {
+            fs::write(releases_dir.join(format!("{v}.cue")), "").unwrap();
+        }
+        fs::write(releases_dir.join("README.md"), "not a version").unwrap();
+
+        refresh_versions_cue(tmp.path()).unwrap();
+
+        let out = fs::read_to_string(
+            tmp.path()
+                .join("website/cue/reference/versions.cue"),
+        )
+        .unwrap();
+
+        let expected = indoc::indoc! {r#"
+            package metadata
+
+            versions: [string, ...string] & [
+            	"0.10.0",
+            	"0.9.1",
+            	"0.9.0",
+            	"0.8.2",
+            ]
+        "#};
+        assert_eq!(out, expected);
+    }
+
+    #[test]
+    fn write_release_stub_picks_max_weight_and_writes_correct_format() {
+        let tmp = tempfile::tempdir().unwrap();
+        let stubs_dir = tmp.path().join("website/content/en/releases");
+        fs::create_dir_all(&stubs_dir).unwrap();
+        fs::write(stubs_dir.join("_index.md"), "---\n---\n").unwrap();
+        fs::write(
+            stubs_dir.join("0.56.0.md"),
+            "---\ntitle: Vector v0.56.0 release notes\nweight: 35\n---\n",
+        )
+        .unwrap();
+        fs::write(
+            stubs_dir.join("0.57.0.md"),
+            "---\ntitle: Vector v0.57.0 release notes\nweight: 36\n---\n",
+        )
+        .unwrap();
+
+        let version = Version::parse("0.58.0").unwrap();
+        write_release_stub(tmp.path(), &version).unwrap();
+
+        let out = fs::read_to_string(stubs_dir.join("0.58.0.md")).unwrap();
+        assert_eq!(
+            out,
+            "---\ntitle: Vector v0.58.0 release notes\nweight: 37\n---\n"
+        );
+    }
+
+    #[test]
+    fn write_release_stub_rejects_existing_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let stubs_dir = tmp.path().join("website/content/en/releases");
+        fs::create_dir_all(&stubs_dir).unwrap();
+        fs::write(
+            stubs_dir.join("0.58.0.md"),
+            "---\ntitle: Vector v0.58.0 release notes\nweight: 37\n---\n",
+        )
+        .unwrap();
+
+        let version = Version::parse("0.58.0").unwrap();
+        let err = write_release_stub(tmp.path(), &version).unwrap_err();
+        assert!(err.to_string().contains("already exists"), "{err}");
     }
 }

--- a/vdev/src/commands/release/prepare.rs
+++ b/vdev/src/commands/release/prepare.rs
@@ -7,8 +7,6 @@ use anyhow::{Context, Result, anyhow, bail};
 use semver::Version;
 use std::{
     env, fs,
-    fs::File,
-    io::{BufRead, BufReader, Write},
     path::{Path, PathBuf},
     process::Command,
 };
@@ -104,10 +102,6 @@ impl Prepare {
 
         self.update_vector_version(&self.repo_root.join(KUBECLT_CUE_FILE))?;
         self.update_vector_version(&self.repo_root.join(INSTALL_SCRIPT))?;
-
-        self.add_new_version_to_versions_cue()?;
-
-        self.create_new_release_md()?;
 
         if !self.dry_run {
             self.open_release_pr()?;
@@ -265,95 +259,6 @@ impl Prepare {
             file_path.strip_prefix(&self.repo_root).unwrap().display(),
         ))?;
 
-        Ok(())
-    }
-
-    /// Step 9: Add new version to `versions.cue`
-    fn add_new_version_to_versions_cue(&self) -> Result<()> {
-        debug!("add_new_version_to_versions_cue");
-        let cure_reference_path = &self.repo_root.join("website").join("cue").join("reference");
-        let versions_cue_path = cure_reference_path.join("versions.cue");
-        if !versions_cue_path.is_file() {
-            return Err(anyhow!("{} not found", versions_cue_path.display()));
-        }
-
-        let vector_version = &self.new_vector_version;
-        let temp_file_path = cure_reference_path.join(format!("{vector_version}.cue.tmp"));
-        let input_file = File::open(&versions_cue_path)?;
-        let reader = BufReader::new(input_file);
-        let mut output_file = File::create(&temp_file_path)?;
-
-        for line in reader.lines() {
-            let line = line?;
-            writeln!(output_file, "{line}")?;
-            if line.contains("versions:") {
-                writeln!(output_file, "\t\"{vector_version}\",")?;
-            }
-        }
-
-        fs::rename(&temp_file_path, &versions_cue_path)?;
-
-        git::commit(&format!(
-            "chore(releasing): Add {vector_version} to versions.cue"
-        ))?;
-        Ok(())
-    }
-
-    /// Step 10: Create a new release md file
-    fn create_new_release_md(&self) -> Result<()> {
-        debug!("create_new_release_md");
-        let releases_dir = self
-            .repo_root
-            .join("website")
-            .join("content")
-            .join("en")
-            .join("releases");
-
-        let old_version = &self.latest_vector_version;
-        let new_version = &self.new_vector_version;
-        let old_file_path = releases_dir.join(format!("{old_version}.md"));
-        if !old_file_path.exists() {
-            return Err(anyhow!(
-                "Source file not found: {}",
-                old_file_path.display()
-            ));
-        }
-
-        let content = fs::read_to_string(&old_file_path)?;
-        let updated_content = content.replace(&old_version.to_string(), &new_version.to_string());
-        let lines: Vec<&str> = updated_content.lines().collect();
-        let mut updated_lines = Vec::new();
-        let mut weight_updated = false;
-
-        for line in lines {
-            if line.trim().starts_with("weight: ") && !weight_updated {
-                // Extract the current weight value
-                let weight_str = line
-                    .trim()
-                    .strip_prefix("weight: ")
-                    .ok_or_else(|| anyhow!("Invalid weight format"))?;
-                let weight: i32 = weight_str
-                    .parse()
-                    .map_err(|e| anyhow!("Failed to parse weight: {e}"))?;
-                // Increase by 1
-                let new_weight = weight + 1;
-                updated_lines.push(format!("weight: {new_weight}"));
-                weight_updated = true;
-            } else {
-                updated_lines.push(line.to_string());
-            }
-        }
-
-        if !weight_updated {
-            error!("Couldn't update 'weight' line from {old_file_path:?}");
-        }
-
-        let new_file_path = releases_dir.join(format!("{new_version}.md"));
-        updated_lines.push(String::new()); // File should end with a newline.
-        let updated_content = updated_lines.join("\n");
-        fs::write(&new_file_path, updated_content)?;
-        git::add_files_in_current_dir()?;
-        git::commit("chore(releasing): Created release md file")?;
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

`vdev release generate-cue` is the standalone command for previewing a release locally without running the full `release prepare` flow. The motivation is to run `generate-cue` and then `make serve` to see the release page in Hugo — but the command was leaving two Hugo-required artifacts stale:

- `website/cue/reference/versions.cue` — the version selector list; without a refresh, the new version was absent from the local site
- `website/content/en/releases/<version>.md` — the Hugo stub that routes `/releases/<version>/`; without it, Hugo 404s on the release page

This PR folds both writes into `generate_cue::run()`. As a side effect, `release prepare` drops its separate `add_new_version_to_versions_cue` and `create_new_release_md` steps — the files are now produced inside `generate_cue::run()` and picked up by the existing `git::add_files_in_current_dir()` commit.

## Vector configuration

N/A

## How did you test this PR?

Unit tests cover:
- `refresh_versions_cue`: correct descending semver sort and output format
- `write_release_stub`: max-weight derivation, correct frontmatter, rejection of existing files

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.