### PR TITLE
docs(website): release page security improvements

### DIFF
--- a/website/cue/reference/releases/0.57.0.cue
+++ b/website/cue/reference/releases/0.57.0.cue
@@ -18,6 +18,14 @@ releases: "0.57.0": {
 		  table or stream names): sinks now enforce a confinement boundary and reject templates with no
 		  literal prefix at startup. Set a static prefix in the template, or use
 		  `dangerously_allow_unconfined_template_resolution: true` to opt out.
+
+		Confinement was applied uniformly across most templated fields rather than tailoring it
+		field by field. The intent is to over-restrict now and relax later as specific cases are
+		analyzed. The `dangerously_allow_*` flags fully restore pre-0.57 behavior. The name is intentionally loud,
+		but it is not a verdict that every use is reckless, but rather a motivation to assess the risk for your deployments.
+
+		If you believe confinement is unwarranted for a specific field, please open an issue with a detailed rationale.
+		Proposals are always welcome.
 		"""
 
 	known_issues: [

--- a/website/layouts/releases/single.html
+++ b/website/layouts/releases/single.html
@@ -6,7 +6,7 @@
 {{ $version := .File.BaseFileName }}
 {{ $release := index site.Data.docs.releases $version }}
 {{ $highlights := where (where site.RegularPages "Section" "highlights") ".Params.release" "eq" $version }}
-{{ $groups := dict "enhancement" "enhancements" "feat" "new features" "fix" "bug fixes" "security" "security fixes" "deprecation" "deprecations" "chore" "chore"}}
+{{ $groups := dict "enhancement" "enhancements" "feat" "new features" "fix" "bug fixes" "security" "security changes" "deprecation" "deprecations" "chore" "chore"}}
 {{ $orderedGroups := slice "security" "feat" "enhancement" "fix" "deprecation" "chore" }}
 
 <div class="relative max-w-3xl lg:max-w-5xl mx-auto px-6 lg:px-8 lg:grid lg:grid-cols-5 lg:gap-8 mt-16">


### PR DESCRIPTION
## Summary

- Adds a rationale paragraph to the 0.57.0 release description explaining why template confinement was applied uniformly and how to request field-specific relaxations.
- Renames the release changelog group label from "security fixes" to "security changes" (more generic to catch all).

## Change Type

- [x] Non-functional (chore, refactoring, docs)

## Is this a breaking change?

- [x] No

## Does this PR include user facing changes?

- [x] No. A maintainer will apply the `no-changelog` label to this PR.