### PR TITLE
feat(grpc connection management): add jitter controls to grpc max age

### DIFF
--- a/changelog.d/grpc_connection_age_jitter.enhancement.md
+++ b/changelog.d/grpc_connection_age_jitter.enhancement.md
@@ -1,0 +1,4 @@
+Added the `max_connection_age_jitter_factor` gRPC keepalive option to vary the maximum
+connection age for each connection and avoid synchronized reconnects.
+
+authors: hiporox

--- a/src/sources/util/grpc/mod.rs
+++ b/src/sources/util/grpc/mod.rs
@@ -14,6 +14,7 @@ use futures::{FutureExt, StreamExt, future::BoxFuture};
 use http::{HeaderMap, Request, Response};
 use hyper::{Body, body::HttpBody};
 use pin_project::pin_project;
+use rand::Rng;
 use tokio::{
     io::{AsyncRead, AsyncWrite, ReadBuf},
     net::TcpStream,
@@ -68,7 +69,7 @@ pub(crate) mod test_support {
 
 /// Configuration of gRPC server keepalive parameters.
 #[configurable_component]
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct GrpcKeepaliveConfig {
     /// The maximum amount of time a connection may exist before the server closes it.
@@ -79,6 +80,14 @@ pub struct GrpcKeepaliveConfig {
     #[configurable(metadata(docs::type_unit = "seconds"))]
     #[configurable(metadata(docs::human_name = "Maximum Connection Age"))]
     pub max_connection_age_secs: Option<u64>,
+
+    /// The factor by which to jitter `max_connection_age_secs` for each connection.
+    ///
+    /// A value of 0.1 gives each connection an age between 90% and 110% of the configured
+    /// maximum. The default of zero preserves the configured age exactly.
+    #[serde(default)]
+    #[configurable(validation(range(min = 0.0, max = 1.0)))]
+    pub max_connection_age_jitter_factor: f64,
 
     /// The grace period added to `max_connection_age_secs` before the server closes the connection.
     ///
@@ -93,7 +102,11 @@ pub struct GrpcKeepaliveConfig {
 impl GrpcKeepaliveConfig {
     fn max_connection_lifetime(&self) -> Option<Duration> {
         self.max_connection_age_secs.map(|max_connection_age_secs| {
-            let age = Duration::from_secs(max_connection_age_secs);
+            let age = jittered_duration(
+                Duration::from_secs(max_connection_age_secs),
+                self.max_connection_age_jitter_factor,
+                rand::rng().random_range(-1.0..=1.0),
+            );
             let grace = self
                 .max_connection_age_grace_secs
                 .map(Duration::from_secs)
@@ -102,6 +115,10 @@ impl GrpcKeepaliveConfig {
             age.checked_add(grace).unwrap_or(Duration::MAX)
         })
     }
+}
+
+fn jittered_duration(duration: Duration, jitter_factor: f64, jitter: f64) -> Duration {
+    duration.mul_f64(1.0 + jitter_factor.clamp(0.0, 1.0) * jitter.clamp(-1.0, 1.0))
 }
 
 struct MaxConnectionAgeIo {
@@ -372,10 +389,9 @@ where
     let span = Span::current();
     let (tx, rx) = tokio::sync::oneshot::channel::<ShutdownSignalToken>();
     let listener = tls_settings.bind_reloadable(&address, tls_reloader).await?;
-    let max_connection_lifetime = keepalive.max_connection_lifetime();
-    let stream = listener
-        .accept_stream()
-        .map(move |stream| stream.map(|io| MaxConnectionAgeIo::new(io, max_connection_lifetime)));
+    let stream = listener.accept_stream().map(move |stream| {
+        stream.map(|io| MaxConnectionAgeIo::new(io, keepalive.max_connection_lifetime()))
+    });
 
     info!(%address, "Building gRPC server.");
 
@@ -414,10 +430,9 @@ pub async fn run_grpc_server_with_routes(
     let span = Span::current();
     let (tx, rx) = tokio::sync::oneshot::channel::<ShutdownSignalToken>();
     let listener = tls_settings.bind_reloadable(&address, tls_reloader).await?;
-    let max_connection_lifetime = keepalive.max_connection_lifetime();
-    let stream = listener
-        .accept_stream()
-        .map(move |stream| stream.map(|io| MaxConnectionAgeIo::new(io, max_connection_lifetime)));
+    let stream = listener.accept_stream().map(move |stream| {
+        stream.map(|io| MaxConnectionAgeIo::new(io, keepalive.max_connection_lifetime()))
+    });
 
     info!(%address, "Building gRPC server.");
 
@@ -497,6 +512,21 @@ mod tests {
         fn call(&mut self, _req: Request<Body>) -> Self::Future {
             ready(Ok(Response::new(Body::empty())))
         }
+    }
+
+    #[test]
+    fn connection_age_jitter_is_bounded() {
+        let duration = Duration::from_secs(100);
+
+        assert_eq!(jittered_duration(duration, 0.0, 1.0), duration);
+        assert_eq!(
+            jittered_duration(duration, 0.2, -1.0),
+            Duration::from_secs(80)
+        );
+        assert_eq!(
+            jittered_duration(duration, 0.2, 1.0),
+            Duration::from_secs(120)
+        );
     }
 
     #[tokio::test]

--- a/src/sources/util/grpc/mod.rs
+++ b/src/sources/util/grpc/mod.rs
@@ -118,7 +118,11 @@ impl GrpcKeepaliveConfig {
 }
 
 fn jittered_duration(duration: Duration, jitter_factor: f64, jitter: f64) -> Duration {
-    duration.mul_f64(1.0 + jitter_factor.clamp(0.0, 1.0) * jitter.clamp(-1.0, 1.0))
+    let multiplier = 1.0 + jitter_factor.clamp(0.0, 1.0) * jitter.clamp(-1.0, 1.0);
+
+    Duration::try_from_secs_f64(duration.as_secs_f64() * multiplier)
+        .unwrap_or(Duration::MAX)
+        .max(Duration::from_secs(1))
 }
 
 struct MaxConnectionAgeIo {
@@ -526,6 +530,26 @@ mod tests {
         assert_eq!(
             jittered_duration(duration, 0.2, 1.0),
             Duration::from_secs(120)
+        );
+    }
+
+    #[test]
+    fn connection_age_jitter_saturates_on_overflow() {
+        assert_eq!(
+            jittered_duration(Duration::from_secs(u64::MAX), 1.0, 1.0),
+            Duration::MAX
+        );
+    }
+
+    #[test]
+    fn connection_age_jitter_has_one_second_minimum() {
+        assert_eq!(
+            jittered_duration(Duration::from_secs(1), 1.0, -1.0),
+            Duration::from_secs(1)
+        );
+        assert_eq!(
+            jittered_duration(Duration::ZERO, 0.0, 0.0),
+            Duration::from_secs(1)
         );
     }
 

--- a/src/sources/vector/mod.rs
+++ b/src/sources/vector/mod.rs
@@ -279,12 +279,14 @@ mod test {
 
                 [keepalive]
                 max_connection_age_secs = 300
+                max_connection_age_jitter_factor = 0.2
                 max_connection_age_grace_secs = 30
             "#,
         )
         .unwrap();
 
         assert_eq!(config.keepalive.max_connection_age_secs, Some(300));
+        assert_eq!(config.keepalive.max_connection_age_jitter_factor, 0.2);
         assert_eq!(config.keepalive.max_connection_age_grace_secs, Some(30));
     }
 

--- a/website/cue/reference/components/sources/generated/opentelemetry.cue
+++ b/website/cue/reference/components/sources/generated/opentelemetry.cue
@@ -29,8 +29,9 @@ generated: components: sources: opentelemetry: configuration: {
 			examples: [{
 				address: "0.0.0.0:4317"
 				keepalive: {
-					max_connection_age_grace_secs: null
-					max_connection_age_secs:       null
+					max_connection_age_grace_secs:    null
+					max_connection_age_jitter_factor: 0.0
+					max_connection_age_secs:          null
 				}
 			}]
 			options: {
@@ -58,6 +59,16 @@ generated: components: sources: opentelemetry: configuration: {
 								examples: [30]
 								unit: "seconds"
 							}
+						}
+						max_connection_age_jitter_factor: {
+							description: """
+																The factor by which to jitter `max_connection_age_secs` for each connection.
+
+																A value of 0.1 gives each connection an age between 90% and 110% of the configured
+																maximum. The default of zero preserves the configured age exactly.
+																"""
+							required: false
+							type: float: default: 0.0
 						}
 						max_connection_age_secs: {
 							description: """

--- a/website/cue/reference/components/sources/generated/vector.cue
+++ b/website/cue/reference/components/sources/generated/vector.cue
@@ -47,6 +47,16 @@ generated: components: sources: vector: configuration: {
 					unit: "seconds"
 				}
 			}
+			max_connection_age_jitter_factor: {
+				description: """
+					The factor by which to jitter `max_connection_age_secs` for each connection.
+
+					A value of 0.1 gives each connection an age between 90% and 110% of the configured
+					maximum. The default of zero preserves the configured age exactly.
+					"""
+				required: false
+				type: float: default: 0.0
+			}
 			max_connection_age_secs: {
 				description: """
 					The maximum amount of time a connection may exist before the server closes it.


### PR DESCRIPTION
## Summary
PR https://github.com/vectordotdev/vector/issues/19457 added max connection age. This adds the ability to add jitter to those connections to stagger the connection resets better. Jitter is provided as a percentage, modifying the max connection age +/- that percentage.

## How did you test this PR?
Added tests to the parser and to make sure we process the bounds correctly. We also can see that existing max connection age tests still pass

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

https://github.com/vectordotdev/vector/issues/19457

## Notes

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details on the [dd-rust-license-tool](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert, perf
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional but appreciated; letters, digits, spaces, hyphens, underscores (e.g. `kafka source`, `amazon-linux`)
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
