### PR TITLE
fix(ci): ensure otelcol output dir exists and pin collector to 0.157.0

### DIFF
--- a/tests/e2e/opentelemetry-logs/config/compose.yaml
+++ b/tests/e2e/opentelemetry-logs/config/compose.yaml
@@ -49,7 +49,15 @@ services:
         CONFIG_COLLECTOR_VERSION: ${CONFIG_COLLECTOR_VERSION}
     init: true
     user: "0:0" # test only, override special user with root
-    command: ["--config", "/etc/otelcol-contrib/config.yaml"]
+    # Wipe stale output before starting: the file exporter appends and the
+    # vector_target volume is external, so it survives `compose down --volumes`.
+    # Also ensures the directory exists before otelcol scans it on startup (v0.157.0+).
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        rm -rf /output/opentelemetry-logs
+        mkdir -p /output/opentelemetry-logs
+        exec /otelcol-contrib --config /etc/otelcol-contrib/config.yaml
     volumes:
       - type: bind
         source: ../data/collector-sink.yaml

--- a/tests/e2e/opentelemetry-logs/config/test.yaml
+++ b/tests/e2e/opentelemetry-logs/config/test.yaml
@@ -14,7 +14,7 @@ runner:
 
 matrix:
   # Determines which `otel/opentelemetry-collector-contrib` version to use
-  collector_version: ["latest"]
+  collector_version: ["0.157.0"]
   vector_config: ["vector_default.yaml", "vector_otlp.yaml"]
 
 # Only trigger this integration test if relevant OTEL source/sink files change

--- a/tests/e2e/opentelemetry-metrics-native/config/test.yaml
+++ b/tests/e2e/opentelemetry-metrics-native/config/test.yaml
@@ -13,7 +13,7 @@ runner:
     OTEL_COLLECTOR_SINK_HTTP_PORT: "5318"
 
 matrix:
-  collector_version: ["latest"]
+  collector_version: ["0.157.0"]
 
 # Only trigger this integration test if relevant OTEL source/sink files change
 paths:

--- a/tests/e2e/opentelemetry-metrics/config/compose.yaml
+++ b/tests/e2e/opentelemetry-metrics/config/compose.yaml
@@ -86,7 +86,15 @@ services:
         CONFIG_COLLECTOR_VERSION: ${CONFIG_COLLECTOR_VERSION}
     init: true
     user: "0:0" # test only, override special user with root
-    command: ["--config", "/etc/otelcol-contrib/config.yaml"]
+    # Wipe stale output before starting: the file exporter appends and the
+    # vector_target volume is external, so it survives `compose down --volumes`.
+    # Also ensures the directory exists before otelcol scans it on startup (v0.157.0+).
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        rm -rf /output/opentelemetry-metrics
+        mkdir -p /output/opentelemetry-metrics
+        exec /otelcol-contrib --config /etc/otelcol-contrib/config.yaml
     volumes:
       - type: bind
         source: ../data/collector-sink.yaml

--- a/tests/e2e/opentelemetry-metrics/config/test.yaml
+++ b/tests/e2e/opentelemetry-metrics/config/test.yaml
@@ -14,7 +14,7 @@ runner:
 
 matrix:
   # Determines which `otel/opentelemetry-collector-contrib` version to use
-  collector_version: ["latest"]
+  collector_version: ["0.157.0"]
 
 # Only trigger this integration test if relevant OTEL source/sink files change
 paths:


### PR DESCRIPTION
## Summary

`otelcol-contrib` v0.157.0 introduced a startup migration scan in the file exporter ([#47674](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/47674)) that reads the output directory to rename legacy lumberjack backup files to the timberjack naming convention. If the directory does not exist, the exporter fails to start and the entire collector exits.

The `opentelemetry-logs` e2e test was failing because the second test environment (`vector_otlp.yaml`) lost the race between Vector creating the output directory and otelcol scanning it. The `opentelemetry-metrics-native` compose already had the fix; apply the same pattern to `opentelemetry-logs` and `opentelemetry-metrics`.

Also pins `collector_version` to `0.157.0` across all three OTEL e2e test configs to prevent future `latest` bumps from silently breaking tests.

## Vector configuration

NA

## How did you test this PR?

Ran both affected suites locally:

```
./scripts/run-integration-test.sh e2e opentelemetry-logs
./scripts/run-integration-test.sh e2e opentelemetry-metrics
```

- https://github.com/vectordotdev/vector/actions/runs/29944253392/job/89005556491?pr=25925

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- #25793