### PR TITLE
fix(vdev): forward CARGO_TERM_COLOR into integration/e2e test containers

### DIFF
--- a/vdev/src/testing/integration.rs
+++ b/vdev/src/testing/integration.rs
@@ -190,6 +190,9 @@ impl ComposeTest {
         }
 
         env_vars.insert("VECTOR_LOG".to_string(), Some("info".into()));
+        if let Ok(val) = std::env::var("CARGO_TERM_COLOR") {
+            env_vars.insert("CARGO_TERM_COLOR".to_string(), Some(val));
+        }
         let mut args = self.config.args.clone().unwrap_or_default();
 
         args.push("--features".to_string());


### PR DESCRIPTION
## Summary

When running integration or e2e tests via `cargo vdev int test` / `cargo vdev e2e test`, the test runner executes inside a Docker container via `docker exec`. Only environment variables explicitly forwarded with `--env` are visible inside the container. `CARGO_TERM_COLOR` was never included in the forwarded set, so cargo output inside the container always fell back to its default color behavior regardless of what the host had set.

## Vector configuration

NA

## How did you test this PR?

`./scripts/run-integration-tests.sh int mqtt` and verified that colors are present when compiling

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

NA