### PR TITLE
fix(ci): narrow vdev path filter to Cargo.toml in changes.yml

### DIFF
--- a/.github/workflows/changes.yml
+++ b/.github/workflows/changes.yml
@@ -211,7 +211,7 @@ jobs:
               - "Cargo.toml"
               - "Makefile"
               - "rust-toolchain.toml"
-              - "vdev/Cargo.toml"
+              - "vdev/**"
               - ".github/workflows/changes.yml"
             dependencies:
               - ".cargo/**"

--- a/.github/workflows/changes.yml
+++ b/.github/workflows/changes.yml
@@ -211,7 +211,7 @@ jobs:
               - "Cargo.toml"
               - "Makefile"
               - "rust-toolchain.toml"
-              - "vdev/**"
+              - "vdev/Cargo.toml"
               - ".github/workflows/changes.yml"
             dependencies:
               - ".cargo/**"
@@ -220,7 +220,7 @@ jobs:
               - 'rust-toolchain.toml'
               - 'Makefile'
               - 'scripts/cross/**'
-              - "vdev/**"
+              - "vdev/Cargo.toml"
               - ".github/workflows/changes.yml"
             deny:
               - '**/Cargo.toml'
@@ -229,15 +229,15 @@ jobs:
             deprecations:
               - 'deprecation.d/**'
               - 'website/data/deprecations.json'
-              - "vdev/**"
+              - "vdev/Cargo.toml"
               - ".github/workflows/deprecation.yaml"
               - ".github/workflows/changes.yml"
             cue:
               - 'website/cue/**'
-              - "vdev/**"
+              - "vdev/Cargo.toml"
               - ".github/workflows/changes.yml"
             component_docs:
-              - "vdev/**"
+              - "vdev/Cargo.toml"
               - 'website/cue/**/*.cue'
               - 'docs/generated/**'
               # If changes to the VRL sha is made the combined generated cue file will change which
@@ -246,18 +246,18 @@ jobs:
               - ".github/workflows/changes.yml"
             markdown:
               - '**/**.md'
-              - "vdev/**"
+              - "vdev/Cargo.toml"
               - ".github/workflows/changes.yml"
             scripts:
               - '**/**.sh'
               - ".github/workflows/changes.yml"
             internal_events:
               - 'src/internal_events/**'
-              - "vdev/**"
+              - "vdev/Cargo.toml"
               - ".github/workflows/changes.yml"
             docker:
               - 'distribution/docker/**'
-              - "vdev/**"
+              - "vdev/Cargo.toml"
               - ".github/workflows/changes.yml"
             install:
               - ".github/workflows/install-sh.yml"


### PR DESCRIPTION
## Summary

The `vdev/**` glob in `changes.yml` path filters was too broad now that we're installing released vdev versions. Narrowed to `vdev/Cargo.toml` to only trigger when vdev's dependency manifest changes. CI effectively only updates the running vdev version once `version = ` is bumped in `vdev/Cargo.toml`.

## Vector configuration

NA

## How did you test this PR?

NA

## Change Type

- [ ] Bug fix
- [x] Non-functional (chore, refactoring, docs)
- [ ] New feature
- [ ] Dependencies
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

NA