### PR TITLE
feat(http sources): allow auth enrichment in all http server sources

### DIFF
--- a/changelog.d/allow_auth_enrichment_all_http_sources.enhancement.md
+++ b/changelog.d/allow_auth_enrichment_all_http_sources.enhancement.md
@@ -1,0 +1,7 @@
+Custom auth VRL enrichment (`%field` writes) is now supported by all HTTP-based sources
+(`http_server`, `heroku_logs`, `prometheus_pushgateway`, `prometheus_remote_write`), not just
+a subset. Enrichment fields are inserted into event metadata under `http_server.<field>` in the
+Vector namespace, or into the event body in the legacy namespace, without overwriting existing
+fields.
+
+authors: petere-datadog

--- a/src/sources/heroku_logs.rs
+++ b/src/sources/heroku_logs.rs
@@ -284,6 +284,14 @@ impl LogplexSource {
 }
 
 impl HttpSource for LogplexSource {
+    fn log_namespace(&self) -> LogNamespace {
+        self.log_namespace
+    }
+
+    fn name() -> &'static str {
+        LogplexConfig::NAME
+    }
+
     fn build_events(
         &self,
         body: Bytes,

--- a/src/sources/heroku_logs.rs
+++ b/src/sources/heroku_logs.rs
@@ -146,7 +146,14 @@ impl LogplexConfig {
 
         // for metadata that is added to the events dynamically from config options
         if log_namespace == LogNamespace::Legacy {
-            schema_definition = schema_definition.unknown_fields(Kind::bytes());
+            // Custom auth programs can inject any VRL value, not just bytes; widen the unknown
+            // field kind accordingly so schema-aware downstream components don't reject events.
+            let unknown_kind = if matches!(self.auth, Some(HttpServerAuthConfig::Custom { .. })) {
+                Kind::any()
+            } else {
+                Kind::bytes()
+            };
+            schema_definition = schema_definition.unknown_fields(unknown_kind);
         }
 
         schema_definition

--- a/src/sources/http_server.rs
+++ b/src/sources/http_server.rs
@@ -13,13 +13,10 @@ use vector_lib::{
     },
     config::{DataType, LegacyKey, LogNamespace},
     configurable::configurable_component,
-    lookup::{PathPrefix, lookup_v2::OptionalValuePath, owned_value_path, path},
+    lookup::{lookup_v2::OptionalValuePath, owned_value_path, path},
     schema::Definition,
 };
-use vrl::{
-    path::ValuePath as _,
-    value::{Kind, ObjectMap, kind::Collection},
-};
+use vrl::value::{Kind, kind::Collection};
 use warp::http::HeaderMap;
 
 use crate::{
@@ -442,6 +439,14 @@ struct SimpleHttpSource {
 }
 
 impl HttpSource for SimpleHttpSource {
+    fn log_namespace(&self) -> LogNamespace {
+        self.log_namespace
+    }
+
+    fn name() -> &'static str {
+        SimpleHttpConfig::NAME
+    }
+
     /// Enriches the log events with metadata for the `request_path` and for each of the headers.
     /// Non-log events are skipped.
     fn enrich_events(
@@ -538,42 +543,6 @@ impl HttpSource for SimpleHttpSource {
 
     fn enable_source_ip(&self) -> bool {
         self.host_key.path.is_some()
-    }
-
-    /// Injects `%field` enrichment from a `custom` auth VRL program into events.
-    /// Both namespaces use insert-if-empty semantics so auth enrichment never
-    /// overwrites built-in source metadata (`path`, `host`, `headers`, …) that
-    /// `enrich_events` already populated.
-    /// Vector namespace: inserted into event metadata under `http_server.<field>` for
-    ///   all event types (Log, Metric, Trace).
-    /// Legacy namespace: inserted into the Log event body only (Metric/Trace are skipped).
-    fn inject_auth_enrichment(&self, events: &mut [Event], enrichment: ObjectMap) {
-        for event in events.iter_mut() {
-            match self.log_namespace {
-                LogNamespace::Vector => {
-                    // metadata_mut() dispatches to Log, Metric, and Trace so every
-                    // decoded event type receives the auth enrichment fields.
-                    let meta = event.metadata_mut().value_mut();
-                    for (key, value) in &enrichment {
-                        let key_str = key.as_str();
-                        let name_part = path!(SimpleHttpConfig::NAME);
-                        let key_part = path!(key_str);
-                        let full_path = name_part.concat(key_part);
-                        if meta.get(full_path.clone()).is_none() {
-                            meta.insert(full_path, value.clone());
-                        }
-                    }
-                }
-                LogNamespace::Legacy => {
-                    // Legacy enrichment targets the event body; only Log events have one.
-                    if let Event::Log(log) = event {
-                        for (key, value) in &enrichment {
-                            log.try_insert((PathPrefix::Event, path!(key.as_str())), value.clone());
-                        }
-                    }
-                }
-            }
-        }
     }
 }
 

--- a/src/sources/prometheus/pushgateway.rs
+++ b/src/sources/prometheus/pushgateway.rs
@@ -91,6 +91,7 @@ impl SourceConfig for PrometheusPushgatewayConfig {
     async fn build(&self, cx: SourceContext) -> crate::Result<sources::Source> {
         let source = PushgatewaySource {
             aggregate_metrics: self.aggregate_metrics,
+            log_namespace: cx.log_namespace(None),
         };
         source.run(
             self.address,
@@ -118,6 +119,7 @@ impl SourceConfig for PrometheusPushgatewayConfig {
 #[derive(Clone)]
 struct PushgatewaySource {
     aggregate_metrics: bool,
+    log_namespace: LogNamespace,
 }
 
 impl PushgatewaySource {
@@ -127,6 +129,14 @@ impl PushgatewaySource {
 }
 
 impl HttpSource for PushgatewaySource {
+    fn name() -> &'static str {
+        PrometheusPushgatewayConfig::NAME
+    }
+
+    fn log_namespace(&self) -> LogNamespace {
+        self.log_namespace
+    }
+
     fn build_events(
         &self,
         body: Bytes,

--- a/src/sources/prometheus/remote_write.rs
+++ b/src/sources/prometheus/remote_write.rs
@@ -128,6 +128,7 @@ impl SourceConfig for PrometheusRemoteWriteConfig {
         let source = RemoteWriteSource {
             metadata_conflict_strategy: self.metadata_conflict_strategy,
             skip_nan_values: self.skip_nan_values,
+            log_namespace: cx.log_namespace(None),
         };
         source.run(
             self.address,
@@ -156,6 +157,7 @@ impl SourceConfig for PrometheusRemoteWriteConfig {
 struct RemoteWriteSource {
     metadata_conflict_strategy: MetadataConflictStrategy,
     skip_nan_values: bool,
+    log_namespace: LogNamespace,
 }
 
 impl RemoteWriteSource {
@@ -184,6 +186,14 @@ impl RemoteWriteSource {
 }
 
 impl HttpSource for RemoteWriteSource {
+    fn log_namespace(&self) -> LogNamespace {
+        self.log_namespace
+    }
+
+    fn name() -> &'static str {
+        PrometheusRemoteWriteConfig::NAME
+    }
+
     fn decode(&self, encoding_header: Option<&str>, body: Bytes) -> Result<Bytes, ErrorMessage> {
         // Default to snappy decoding the request body.
         decompress_body(encoding_header.or(Some("snappy")), body)

--- a/src/sources/util/http/prelude.rs
+++ b/src/sources/util/http/prelude.rs
@@ -95,6 +95,12 @@ pub trait HttpSource: Clone + Send + Sync + 'static {
                                 value.clone(),
                             );
                         }
+                    } else if !enrichment.is_empty() {
+                        warn!(
+                            message = "Auth metadata enrichment is not supported for trace/metric events in the legacy namespace and will be dropped. \
+                                       Switch this source to the Vector namespace (`log_namespace: true`) to enable it for all event types.",
+                            fields = ?enrichment.keys().collect::<Vec<_>>(),
+                        );
                     }
                 }
             }

--- a/src/sources/util/http/prelude.rs
+++ b/src/sources/util/http/prelude.rs
@@ -8,10 +8,10 @@ use tower::ServiceBuilder;
 use tracing::Span;
 use vector_lib::{
     EstimatedJsonEncodedSizeOf,
-    config::SourceAcknowledgementsConfig,
+    config::{LogNamespace, SourceAcknowledgementsConfig},
     event::{BatchNotifier, BatchStatus, BatchStatusReceiver, Event},
 };
-use vrl::value::ObjectMap;
+use vrl::{path::PathPrefix, path::ValuePath as _, value::ObjectMap};
 use warp::{
     Filter,
     filters::{
@@ -49,6 +49,10 @@ pub trait HttpSource: Clone + Send + Sync + 'static {
     ) {
     }
 
+    fn log_namespace(&self) -> LogNamespace;
+
+    fn name() -> &'static str;
+
     fn build_events(
         &self,
         body: Bytes,
@@ -57,15 +61,43 @@ pub trait HttpSource: Clone + Send + Sync + 'static {
         path: &str,
     ) -> Result<Vec<Event>, ErrorMessage>;
 
-    /// Called after `enrich_events` when `custom` auth returned metadata enrichment fields.
-    /// Sources that do not override this will emit a warning and drop the enrichment.
-    fn inject_auth_enrichment(&self, _events: &mut [Event], enrichment: ObjectMap) {
-        if !enrichment.is_empty() {
-            warn!(
-                message = "Auth metadata enrichment is not supported by this source and will be dropped. \
-                           Remove %field writes from the custom auth VRL program or switch to a source that supports enrichment.",
-                fields = ?enrichment.keys().collect::<Vec<_>>(),
-            );
+    /// Injects `%field` enrichment from a `custom` auth VRL program into events.
+    /// Both namespaces use insert-if-empty semantics so auth enrichment never
+    /// overwrites built-in source metadata (`path`, `host`, `headers`, …) that
+    /// `enrich_events` already populated.
+    /// Vector namespace: inserted into event metadata under `http_server.<field>` for
+    ///   all event types (Log, Metric, Trace).
+    /// Legacy namespace: inserted into the Log event body only (Metric/Trace are skipped).
+    fn inject_auth_enrichment(&self, events: &mut [Event], enrichment: ObjectMap) {
+        for event in events.iter_mut() {
+            match self.log_namespace() {
+                LogNamespace::Vector => {
+                    // metadata_mut() dispatches to Log, Metric, and Trace so every
+                    // decoded event type receives the auth enrichment fields.
+                    let meta = event.metadata_mut().value_mut();
+                    let source_name = Self::name();
+                    for (key, value) in &enrichment {
+                        let key_str = key.as_str();
+                        let name_part = vrl::path!(source_name);
+                        let key_part = vrl::path!(key_str);
+                        let full_path = name_part.concat(key_part);
+                        if meta.get(full_path.clone()).is_none() {
+                            meta.insert(full_path, value.clone());
+                        }
+                    }
+                }
+                LogNamespace::Legacy => {
+                    // Legacy enrichment targets the event body; only Log events have one.
+                    if let Event::Log(log) = event {
+                        for (key, value) in &enrichment {
+                            log.try_insert(
+                                (PathPrefix::Event, vrl::path!(key.as_str())),
+                                value.clone(),
+                            );
+                        }
+                    }
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Expand custom auth enrichment to other http server sources i.e. prometheus pushgateway, heroku etc. This will allow us to use %field in the custom VRL script to enrich events after authentication.

<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

## Vector configuration
<!-- Include Vector configuration(s) you used to test and debug your changes. -->

## How did you test this PR?
<!-- Please describe how you tested your changes. Also include any information about your setup. -->

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Closes: #<issue/PR number or link>
-->
<!--
- Related: #<issue/PR number or link>
-->

## Notes

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details on the [dd-rust-license-tool](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert, perf
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional but appreciated; letters, digits, spaces, hyphens, underscores (e.g. `kafka source`, `amazon-linux`)
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
