### PR TITLE
chore(dev): set ZERO_AR_DATE and SOURCE_DATE_EPOCH for reproducible vendored C builds

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -7,6 +7,13 @@ vdev = "run --quiet --package vdev --"
 # coarsens jemalloc's allocation granularity; no regression was measured in
 # https://github.com/vectordotdev/vector/pull/18481.
 JEMALLOC_SYS_WITH_LG_PAGE = "16"
+# Zero out timestamps in macOS static archives so vendored C libraries (openssl,
+# curl, librdkafka) produce deterministic artifacts. Ignored on Linux.
+ZERO_AR_DATE = "1"
+# OpenSSL embeds the exact compile time ("built on: ...") in libcrypto.a.
+# Setting SOURCE_DATE_EPOCH to a fixed epoch makes OpenSSL 3.x use a
+# reproducible timestamp instead, producing identical artifacts across builds.
+SOURCE_DATE_EPOCH = "0"
 
 [target.'cfg(all())']
 rustflags = [


### PR DESCRIPTION
## Summary

Vendored C libraries (openssl, curl, librdkafka) were producing non-deterministic static archives, causing the build cache to miss on every clean build. Two independent sources of variance:

1. `ar` archive member timestamps (macOS-specific) — fixed by `ZERO_AR_DATE=1`
2. OpenSSL embedding the exact wall-clock compile time in `libcrypto.a` via its `built on:` string — fixed by `SOURCE_DATE_EPOCH=0`, which causes OpenSSL 3.x to substitute a fixed epoch for `localtime()`

Only 3 bytes differed between builds of `libcrypto.a` (the seconds field of the timestamp), but that was enough to bust kache on every clean. The cascade: `openssl_sys` → `curl_sys` → `rdkafka_sys` → `rdkafka`.

`ZERO_AR_DATE` is a no-op on Linux. `SOURCE_DATE_EPOCH` applies on all platforms.

## Vector configuration

NA

## How did you test this PR?

Built `rdkafka` twice from a clean state and confirmed `libcrypto.a` is byte-for-byte identical between builds (`cmp` reports 0 differing bytes, versus 3 before the fix). Subsequent kache restores complete in ~0.5s versus ~40s for a full C recompile.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Dependencies
- [x] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

NA