### PR TITLE
fix(disk buffer): retry reads for published writer progress

### DIFF
--- a/changelog.d/disk_v2_reader_wait_bounded.fix.md
+++ b/changelog.d/disk_v2_reader_wait_bounded.fix.md
@@ -1,0 +1,7 @@
+Fixed a rare `disk_v2` disk buffer stall where a reader could wait indefinitely
+after consuming a writer notification but failing to observe the corresponding
+record during a concurrent read/write race. Reader waits for writer progress are
+now bounded so the reader periodically re-checks on-disk state even if no further
+writer notification arrives.
+
+authors: jjh5887

--- a/lib/vector-buffers/src/variants/disk_v2/reader.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/reader.rs
@@ -5,6 +5,7 @@ use std::{
     num::NonZeroU64,
     path::PathBuf,
     sync::Arc,
+    time::Duration,
 };
 
 use crc32fast::Hasher;
@@ -26,6 +27,22 @@ use crate::{
     topology::acks::{EligibleMarker, EligibleMarkerLength, MarkerError, OrderedAcknowledgements},
     variants::disk_v2::{io::AsyncFile, record::try_as_record_archive},
 };
+
+/// Upper bound on how long the reader waits for writer progress before re-checking on-disk state.
+///
+/// Writer notifications are still the normal wake-up path. This interval is only a safety net for
+/// cases where no notification arrives but re-checking file state is harmless.
+const WRITER_WAIT_POLL_INTERVAL: Duration = Duration::from_millis(250);
+const PUBLISHED_RECORD_RETRY_INTERVAL: Duration = Duration::from_millis(1);
+
+async fn wait_for_writer_progress_or_poll<FS>(ledger: &Ledger<FS>)
+where
+    FS: Filesystem,
+{
+    match tokio::time::timeout(WRITER_WAIT_POLL_INTERVAL, ledger.wait_for_writer()).await {
+        Ok(()) | Err(_) => {}
+    }
+}
 
 pub(super) struct ReadToken {
     record_id: u64,
@@ -500,6 +517,12 @@ where
         }
     }
 
+    fn has_unread_published_record(&self) -> bool {
+        let next_reader_record_id = self.last_reader_record_id.saturating_add(1);
+        let next_writer_record_id = self.ledger.state().get_next_writer_record_id();
+        next_reader_record_id < next_writer_record_id
+    }
+
     #[cfg_attr(test, instrument(skip_all, level = "debug"))]
     async fn delete_completed_data_file(
         &mut self,
@@ -795,7 +818,7 @@ where
                                 data_file_path = data_file_path.to_string_lossy().as_ref(),
                                 "Data file does not yet exist. Waiting for writer to create."
                             );
-                            self.ledger.wait_for_writer().await;
+                            wait_for_writer_progress_or_poll(&self.ledger).await;
                         } else {
                             self.ledger.increment_acked_reader_file_id();
                         }
@@ -1117,7 +1140,17 @@ where
                     continue;
                 }
 
-                self.ledger.wait_for_writer().await;
+                if self.has_unread_published_record() {
+                    trace!(
+                        last_reader_record_id = self.last_reader_record_id,
+                        next_writer_record_id = self.ledger.state().get_next_writer_record_id(),
+                        "Published writer progress was not visible to the reader yet."
+                    );
+                    tokio::time::sleep(PUBLISHED_RECORD_RETRY_INTERVAL).await;
+                    continue;
+                }
+
+                wait_for_writer_progress_or_poll(&self.ledger).await;
             } else {
                 debug!(
                     bytes_read = self.bytes_read,

--- a/lib/vector-buffers/src/variants/disk_v2/tests/cold_start.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/tests/cold_start.rs
@@ -1,0 +1,48 @@
+use std::time::Duration;
+
+use tokio::time::sleep;
+use vector_common::finalization::Finalizable;
+
+use super::create_default_buffer_v2;
+use crate::test::{SizedRecord, acknowledge, install_tracing_helpers, with_temp_dir};
+
+#[tokio::test]
+async fn reader_receives_record_after_cold_start_write() {
+    let _assertions = install_tracing_helpers();
+
+    with_temp_dir(|dir| {
+        let data_dir = dir.to_path_buf();
+
+        async move {
+            let (mut writer, mut reader, _ledger) =
+                create_default_buffer_v2::<_, SizedRecord>(data_dir).await;
+
+            let reader_task = tokio::spawn(async move {
+                let mut record = reader
+                    .next()
+                    .await
+                    .expect("read should not fail")
+                    .expect("should get a record, not EOF");
+                acknowledge(record.take_finalizers()).await;
+                record
+            });
+
+            // Leave the buffer genuinely idle before the first write, matching low-volume sources
+            // where the reader is already waiting when the first record arrives.
+            sleep(Duration::from_millis(50)).await;
+
+            writer
+                .write_record(SizedRecord::new(32))
+                .await
+                .expect("write should not fail");
+            writer.flush().await.expect("flush should not fail");
+
+            let record = tokio::time::timeout(Duration::from_secs(2), reader_task)
+                .await
+                .expect("reader should receive the record without another write")
+                .expect("reader task should not panic");
+            assert_eq!(record, SizedRecord::new(32));
+        }
+    })
+    .await;
+}

--- a/lib/vector-buffers/src/variants/disk_v2/tests/mod.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/tests/mod.rs
@@ -24,6 +24,7 @@ type FilesystemUnderTest = ProductionFilesystem;
 
 mod acknowledgements;
 mod basic;
+mod cold_start;
 mod initialization;
 mod invariants;
 mod known_errors;


### PR DESCRIPTION
## Summary

Fix a rare `disk_v2` reader stall by checking published writer progress before waiting for another writer notification.

If the reader reaches EOF on the current writer file but the ledger shows that the writer has already published unread records, the reader now briefly backs off and retries the read instead of waiting indefinitely for another notification. Writer-progress waits are also bounded so periodic re-checks remain a fallback safety net.

## Vector configuration

N/A. This changes internal `disk_v2` buffer reader behavior.

The production shape that motivated this is a low-volume source using a disk buffer, where the writer remains open and a single record may arrive after a long idle period.

## How did you test this PR?

- Added `reader_receives_record_after_cold_start_write`, which starts the reader on an empty disk buffer, keeps the writer open, idles briefly, then writes and flushes one record.
- Ran `cargo fmt --package vector-buffers`.
- Ran `cargo test -p vector-buffers variants::disk_v2::tests::cold_start::reader_receives_record_after_cold_start_write --no-default-features`.
- Ran `cargo test -p vector-buffers --no-default-features -- --test-threads=1`.
- Ran `cargo clippy -p vector-buffers --tests --no-default-features -- -D warnings`.
- Ran `make check-fmt`.
- Ran `make check-markdown`.
- Ran `cargo vdev check changelog-fragments --merge-base upstream/master`.
- Ran `make check-clippy`.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: #23456
- Related: #23605