### PR TITLE
docs: link GitHub Container Registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
     <a href="https://vector.dev/components/">Integrations</a>&nbsp;&nbsp;&bull;&nbsp;&nbsp;
     <a href="https://chat.vector.dev">Chat</a>&nbsp;&nbsp;&bull;&nbsp;&nbsp;
     <a href="https://vector.dev/releases/latest/download/">Download</a>&nbsp;&nbsp;&bull;&nbsp;&nbsp;
+    <a href="https://github.com/vectordotdev/vector/pkgs/container/vector">Container Images</a>&nbsp;&nbsp;&bull;&nbsp;&nbsp;
     <a href="https://rust-doc.vector.dev/">Rust Crate Docs</a>
   </strong>
 </p>

--- a/website/content/en/docs/setup/installation/platforms/docker.md
+++ b/website/content/en/docs/setup/installation/platforms/docker.md
@@ -15,6 +15,12 @@ Pull the Vector image:
 docker pull timberio/vector:{{< version >}}-debian
 ```
 
+Vector images are also available from the [GitHub Container Registry]:
+
+```shell
+docker pull ghcr.io/vectordotdev/vector:{{< version >}}-debian
+```
+
 {{< success >}}
 Other available distributions (beyond `debian`):
 
@@ -108,3 +114,4 @@ docker rm vector
 ```
 
 [docker]: https://docker.com
+[GitHub Container Registry]: https://github.com/vectordotdev/vector/pkgs/container/vector


### PR DESCRIPTION
## Summary

- add the GitHub Container Registry package to the README navigation
- document the equivalent `ghcr.io` image pull command on the Docker installation page

## Motivation

Vector publishes images to GitHub Container Registry, but the package page is not readily discoverable from the repository homepage or Docker installation documentation. This addresses the feedback in [discussion #25534](https://github.com/vectordotdev/vector/discussions/25534).

## Validation

- `make check-markdown`
