### PR TITLE
chore: remove redundant Change Type checklist from PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,14 +8,6 @@ This should help the reviewers give feedback faster and with higher quality. -->
 ## How did you test this PR?
 <!-- Please describe how you tested your changes. Also include any information about your setup. -->
 
-## Change Type
-
-- [ ] Bug fix
-- [ ] New feature
-- [ ] Dependencies
-- [ ] Non-functional (chore, refactoring, docs)
-- [ ] Performance
-
 ## Is this a breaking change?
 
 - [ ] Yes


### PR DESCRIPTION
## Summary

The PR title already encodes the change type via conventional commits (enforced by CI's semantic check), making the "Change Type" redundant. Removes it to reduce contributor friction.

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.