### PR TITLE
chore(transforms): add validate_structure and rename validate_env

### DIFF
--- a/src/config/transform.rs
+++ b/src/config/transform.rs
@@ -255,16 +255,16 @@ pub trait TransformConfig: DynClone + NamedComponent + core::fmt::Debug + Send +
         Ok(())
     }
 
-    /// Validates the transform configuration against environment resources: compiles VRL
-    /// programs, builds conditions, and resolves enrichment table references. Only called
-    /// from `vector validate` (via `validate_transforms`), not during normal startup because
-    /// `build()` performs equivalent checks with real resources.
+    /// Validates the transform configuration against the schema and enrichment context.
+    /// Compiles VRL programs, builds conditions, and resolves enrichment table references.
+    /// Only called from `vector validate` (via `validate_transforms`), not during normal startup
+    /// because `build()` performs equivalent checks with real resources.
     ///
     /// # Errors
     ///
     /// If validation does not succeed, an error variant containing a list of all validation errors
     /// is returned.
-    fn validate_env(&self, _context: &TransformContext) -> Result<(), Vec<String>> {
+    fn validate_with_context(&self, _context: &TransformContext) -> Result<(), Vec<String>> {
         Ok(())
     }
 

--- a/src/config/transform.rs
+++ b/src/config/transform.rs
@@ -241,6 +241,22 @@ pub trait TransformConfig: DynClone + NamedComponent + core::fmt::Debug + Send +
         input_definitions: &[(OutputId, schema::Definition)],
     ) -> Vec<TransformOutput>;
 
+    /// Validates structural constraints on the transform configuration that do not require
+    /// environment resources: reserved output names, duplicate route names, invalid sample
+    /// rates, and similar config-level checks.
+    ///
+    /// Called during config compilation so errors are reported on both `vector validate`
+    /// and normal startup/reload. This is the first validation phase, run before any
+    /// context-dependent checks.
+    ///
+    /// # Errors
+    ///
+    /// If validation does not succeed, an error variant containing a list of all validation errors
+    /// is returned.
+    fn validate_structure(&self) -> Result<(), Vec<String>> {
+        Ok(())
+    }
+
     /// Validates that the configuration of the transform is valid.
     /// Validates structural constraints on the transform configuration that do not require
     /// environment resources: reserved output names, duplicate route names, invalid sample

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -234,9 +234,12 @@ pub fn check_outputs(config: &ConfigBuilder) -> Result<(), Vec<String>> {
 
     for (key, transform) in config.transforms.iter() {
         // Structural validation: reserved names, duplicate routes, invalid sample rates.
-        // Uses a default context so transforms that require environment resources (VRL
-        // compilation, condition building) must guard on context.key being None and skip
-        // those checks — they run later in validate.rs with a real context via validate_with_context().
+        // These checks run during config compilation. Transforms that need the schema/enrichment
+        // context must implement validate_with_context(), called later in validate.rs.
+        if let Err(errs) = transform.inner.validate_structure() {
+            errors.extend(errs.into_iter().map(|msg| format!("Transform {key} {msg}")));
+        }
+        // validate() is deprecated. Use validate_structure() for new transforms.
         if let Err(errs) = transform.inner.validate(&TransformContext::default()) {
             errors.extend(errs.into_iter().map(|msg| format!("Transform {key} {msg}")));
         }

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -236,7 +236,7 @@ pub fn check_outputs(config: &ConfigBuilder) -> Result<(), Vec<String>> {
         // Structural validation: reserved names, duplicate routes, invalid sample rates.
         // Uses a default context so transforms that require environment resources (VRL
         // compilation, condition building) must guard on context.key being None and skip
-        // those checks — they run later in validate_transforms() with a real context.
+        // those checks — they run later in validate.rs with a real context via validate_with_context().
         if let Err(errs) = transform.inner.validate(&TransformContext::default()) {
             errors.extend(errs.into_iter().map(|msg| format!("Transform {key} {msg}")));
         }

--- a/src/transforms/delay.rs
+++ b/src/transforms/delay.rs
@@ -115,7 +115,7 @@ impl TransformConfig for DelayConfig {
         }
     }
 
-    fn validate_env(&self, context: &TransformContext) -> Result<(), Vec<String>> {
+    fn validate_with_context(&self, context: &TransformContext) -> Result<(), Vec<String>> {
         self.condition
             .as_ref()
             .map(|c| {

--- a/src/transforms/exclusive_route/config.rs
+++ b/src/transforms/exclusive_route/config.rs
@@ -134,7 +134,7 @@ impl TransformConfig for ExclusiveRouteConfig {
         }
     }
 
-    fn validate_env(&self, context: &TransformContext) -> Result<(), Vec<String>> {
+    fn validate_with_context(&self, context: &TransformContext) -> Result<(), Vec<String>> {
         let errors: Vec<String> = self
             .routes
             .iter()

--- a/src/transforms/filter.rs
+++ b/src/transforms/filter.rs
@@ -50,7 +50,7 @@ impl TransformConfig for FilterConfig {
         )?)))
     }
 
-    fn validate_env(&self, context: &TransformContext) -> Result<(), Vec<String>> {
+    fn validate_with_context(&self, context: &TransformContext) -> Result<(), Vec<String>> {
         self.condition
             .validate(&context.enrichment_tables, &context.metrics_storage)
             .map_err(|e| vec![e.to_string()])

--- a/src/transforms/reduce/config.rs
+++ b/src/transforms/reduce/config.rs
@@ -258,7 +258,7 @@ impl TransformConfig for ReduceConfig {
         }
     }
 
-    fn validate_env(&self, context: &TransformContext) -> Result<(), Vec<String>> {
+    fn validate_with_context(&self, context: &TransformContext) -> Result<(), Vec<String>> {
         let mut errors = Vec::new();
         if let Some(Err(e)) = self
             .ends_when

--- a/src/transforms/remap.rs
+++ b/src/transforms/remap.rs
@@ -279,7 +279,10 @@ impl TransformConfig for RemapConfig {
         Ok(transform)
     }
 
-    fn validate_env(&self, context: &TransformContext) -> std::result::Result<(), Vec<String>> {
+    fn validate_with_context(
+        &self,
+        context: &TransformContext,
+    ) -> std::result::Result<(), Vec<String>> {
         self.compile_vrl_program(
             context.enrichment_tables.clone(),
             context.metrics_storage.clone(),

--- a/src/transforms/route.rs
+++ b/src/transforms/route.rs
@@ -142,7 +142,7 @@ impl TransformConfig for RouteConfig {
         }
     }
 
-    fn validate_env(&self, context: &TransformContext) -> Result<(), Vec<String>> {
+    fn validate_with_context(&self, context: &TransformContext) -> Result<(), Vec<String>> {
         let errors: Vec<String> = self
             .route
             .iter()

--- a/src/transforms/sample/config.rs
+++ b/src/transforms/sample/config.rs
@@ -225,7 +225,7 @@ impl TransformConfig for SampleConfig {
             .map_err(|e| vec![e.to_string()])
     }
 
-    fn validate_env(&self, context: &TransformContext) -> Result<(), Vec<String>> {
+    fn validate_with_context(&self, context: &TransformContext) -> Result<(), Vec<String>> {
         if let Some(Err(e)) = self
             .exclude
             .as_ref()

--- a/src/transforms/throttle/config.rs
+++ b/src/transforms/throttle/config.rs
@@ -97,7 +97,7 @@ impl TransformConfig for ThrottleConfig {
         }
     }
 
-    fn validate_env(&self, context: &TransformContext) -> Result<(), Vec<String>> {
+    fn validate_with_context(&self, context: &TransformContext) -> Result<(), Vec<String>> {
         if let Some(Err(e)) = self
             .exclude
             .as_ref()

--- a/src/transforms/window/config.rs
+++ b/src/transforms/window/config.rs
@@ -92,7 +92,7 @@ impl TransformConfig for WindowConfig {
         )]
     }
 
-    fn validate_env(&self, context: &TransformContext) -> Result<(), Vec<String>> {
+    fn validate_with_context(&self, context: &TransformContext) -> Result<(), Vec<String>> {
         let mut errors = Vec::new();
         if let Some(Err(e)) = self
             .forward_when

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -286,7 +286,7 @@ async fn validate_transforms(config: &Config, fmt: &mut Formatter) -> bool {
             .validate(&context)
             .err()
             .into_iter()
-            .chain(transform.inner.validate_env(&context).err())
+            .chain(transform.inner.validate_with_context(&context).err())
             .flatten()
         {
             errors.push(format!("Transform \"{key}\": {err}"));


### PR DESCRIPTION
## Summary
Implements steps 1 and 2 of the transform migration from RFC 2026-07-15. Adds `validate_structure()` for context-free validation and renames `validate_env()` to `validate_with_context()` for context-dependent validation.

## Vector configuration
NA

## How did you test this PR?
- `make check-clippy` passes
- Unit tests for affected transforms pass

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: #25848