### PR TITLE
chore(transforms): migrate validate() to validate_structure()

### DIFF
--- a/src/config/transform.rs
+++ b/src/config/transform.rs
@@ -257,20 +257,6 @@ pub trait TransformConfig: DynClone + NamedComponent + core::fmt::Debug + Send +
         Ok(())
     }
 
-    /// Validates that the configuration of the transform is valid.
-    /// Validates structural constraints on the transform configuration that do not require
-    /// environment resources: reserved output names, duplicate route names, invalid sample
-    /// rates, and similar config-level checks. Called during config compilation so errors
-    /// are reported on both `vector validate` and normal startup/reload.
-    ///
-    /// # Errors
-    ///
-    /// If validation does not succeed, an error variant containing a list of all validation errors
-    /// is returned.
-    fn validate(&self, _context: &TransformContext) -> Result<(), Vec<String>> {
-        Ok(())
-    }
-
     /// Validates the transform configuration against the schema and enrichment context.
     /// Compiles VRL programs, builds conditions, and resolves enrichment table references.
     /// Only called from `vector validate` (via `validate_transforms`), not during normal startup

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -6,7 +6,7 @@ use indexmap::IndexMap;
 use vector_lib::{buffers::config::DiskUsage, internal_event::DEFAULT_OUTPUT};
 
 use super::{
-    ComponentKey, Config, OutputId, Resource, TransformContext, builder::ConfigBuilder,
+    ComponentKey, Config, OutputId, Resource, builder::ConfigBuilder,
     transform::get_transform_output_ids,
 };
 
@@ -237,10 +237,6 @@ pub fn check_outputs(config: &ConfigBuilder) -> Result<(), Vec<String>> {
         // These checks run during config compilation. Transforms that need the schema/enrichment
         // context must implement validate_with_context(), called later in validate.rs.
         if let Err(errs) = transform.inner.validate_structure() {
-            errors.extend(errs.into_iter().map(|msg| format!("Transform {key} {msg}")));
-        }
-        // validate() is deprecated. Use validate_structure() for new transforms.
-        if let Err(errs) = transform.inner.validate(&TransformContext::default()) {
             errors.extend(errs.into_iter().map(|msg| format!("Transform {key} {msg}")));
         }
 

--- a/src/transforms/delay.rs
+++ b/src/transforms/delay.rs
@@ -107,7 +107,7 @@ impl TransformConfig for DelayConfig {
         )]
     }
 
-    fn validate(&self, _: &TransformContext) -> Result<(), Vec<String>> {
+    fn validate_structure(&self) -> Result<(), Vec<String>> {
         if self.delay_ms.as_millis() == 0 {
             Err(vec!["delay must not be zero".to_string()])
         } else {

--- a/src/transforms/exclusive_route/config.rs
+++ b/src/transforms/exclusive_route/config.rs
@@ -101,7 +101,7 @@ impl TransformConfig for ExclusiveRouteConfig {
         Input::all()
     }
 
-    fn validate(&self, _: &TransformContext) -> Result<(), Vec<String>> {
+    fn validate_structure(&self) -> Result<(), Vec<String>> {
         let mut errors = Vec::new();
 
         let mut counts = std::collections::HashMap::new();

--- a/src/transforms/reduce/config.rs
+++ b/src/transforms/reduce/config.rs
@@ -232,7 +232,7 @@ impl TransformConfig for ReduceConfig {
         vec![TransformOutput::new(DataType::Log, output_definitions)]
     }
 
-    fn validate(&self, _: &TransformContext) -> Result<(), Vec<String>> {
+    fn validate_structure(&self) -> Result<(), Vec<String>> {
         let mut errors = Vec::new();
 
         if self.ends_when.is_some() && self.starts_when.is_some() {

--- a/src/transforms/route.rs
+++ b/src/transforms/route.rs
@@ -132,7 +132,7 @@ impl TransformConfig for RouteConfig {
         Input::all()
     }
 
-    fn validate(&self, _: &TransformContext) -> Result<(), Vec<String>> {
+    fn validate_structure(&self) -> Result<(), Vec<String>> {
         if self.route.contains_key(UNMATCHED_ROUTE) {
             Err(vec![format!(
                 "cannot have a named output with reserved name: `{UNMATCHED_ROUTE}`"

--- a/src/transforms/sample/config.rs
+++ b/src/transforms/sample/config.rs
@@ -219,7 +219,7 @@ impl TransformConfig for SampleConfig {
         Input::new(DataType::Log | DataType::Trace)
     }
 
-    fn validate(&self, _: &TransformContext) -> Result<(), Vec<String>> {
+    fn validate_structure(&self) -> Result<(), Vec<String>> {
         self.sample_rate()
             .map(|_| ())
             .map_err(|e| vec![e.to_string()])
@@ -326,11 +326,7 @@ mod tests {
             exclude: None,
         };
 
-        assert!(
-            config
-                .validate(&crate::config::TransformContext::default())
-                .is_ok()
-        );
+        assert!(config.validate_structure().is_ok());
     }
 
     #[test]

--- a/src/transforms/tag_cardinality_limit/config.rs
+++ b/src/transforms/tag_cardinality_limit/config.rs
@@ -362,45 +362,6 @@ pub enum BuildError {
     CacheSizeRequiresProbabilistic { tag_key: String },
 }
 
-impl Config {
-    fn validate_structure_impl(&self) -> crate::Result<()> {
-        // Global per_tag_limits: cache_size_per_key only applies in probabilistic mode.
-        if !matches!(self.global.mode, Mode::Probabilistic(_)) {
-            for (tag_key, tag_cfg) in &self.per_tag_limits {
-                if let PerTagMode::LimitOverride {
-                    cache_size_per_key: Some(_),
-                    ..
-                } = tag_cfg.mode
-                {
-                    return Err(Box::new(BuildError::CacheSizeRequiresProbabilistic {
-                        tag_key: tag_key.clone(),
-                    }));
-                }
-            }
-        }
-
-        // Per-metric per_tag_limits: cache_size_per_key only applies when the per-metric
-        // mode is probabilistic.
-        for per_metric in self.per_metric_limits.values() {
-            if !matches!(per_metric.config.mode, OverrideMode::Probabilistic(_)) {
-                for (tag_key, tag_cfg) in &per_metric.per_tag_limits {
-                    if let PerTagMode::LimitOverride {
-                        cache_size_per_key: Some(_),
-                        ..
-                    } = tag_cfg.mode
-                    {
-                        return Err(Box::new(BuildError::CacheSizeRequiresProbabilistic {
-                            tag_key: tag_key.clone(),
-                        }));
-                    }
-                }
-            }
-        }
-
-        Ok(())
-    }
-}
-
 #[async_trait::async_trait]
 #[typetag::serde(name = "tag_cardinality_limit")]
 impl TransformConfig for Config {
@@ -423,6 +384,51 @@ impl TransformConfig for Config {
     }
 
     fn validate_structure(&self) -> Result<(), Vec<String>> {
-        self.validate_structure_impl().map_err(|e| vec![e.to_string()])
+        let mut errors = Vec::new();
+
+        // Global per_tag_limits: cache_size_per_key only applies in probabilistic mode.
+        if !matches!(self.global.mode, Mode::Probabilistic(_)) {
+            for (tag_key, tag_cfg) in &self.per_tag_limits {
+                if let PerTagMode::LimitOverride {
+                    cache_size_per_key: Some(_),
+                    ..
+                } = tag_cfg.mode
+                {
+                    errors.push(
+                        BuildError::CacheSizeRequiresProbabilistic {
+                            tag_key: tag_key.clone(),
+                        }
+                        .to_string(),
+                    );
+                }
+            }
+        }
+
+        // Per-metric per_tag_limits: cache_size_per_key only applies when the per-metric
+        // mode is probabilistic.
+        for per_metric in self.per_metric_limits.values() {
+            if !matches!(per_metric.config.mode, OverrideMode::Probabilistic(_)) {
+                for (tag_key, tag_cfg) in &per_metric.per_tag_limits {
+                    if let PerTagMode::LimitOverride {
+                        cache_size_per_key: Some(_),
+                        ..
+                    } = tag_cfg.mode
+                    {
+                        errors.push(
+                            BuildError::CacheSizeRequiresProbabilistic {
+                                tag_key: tag_key.clone(),
+                            }
+                            .to_string(),
+                        );
+                    }
+                }
+            }
+        }
+
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(errors)
+        }
     }
 }

--- a/src/transforms/tag_cardinality_limit/config.rs
+++ b/src/transforms/tag_cardinality_limit/config.rs
@@ -363,7 +363,7 @@ pub enum BuildError {
 }
 
 impl Config {
-    fn validate(&self) -> crate::Result<()> {
+    fn validate_structure_impl(&self) -> crate::Result<()> {
         // Global per_tag_limits: cache_size_per_key only applies in probabilistic mode.
         if !matches!(self.global.mode, Mode::Probabilistic(_)) {
             for (tag_key, tag_cfg) in &self.per_tag_limits {
@@ -405,7 +405,6 @@ impl Config {
 #[typetag::serde(name = "tag_cardinality_limit")]
 impl TransformConfig for Config {
     async fn build(&self, _context: &TransformContext) -> crate::Result<Transform> {
-        self.validate()?;
         Ok(Transform::event_task(TagCardinalityLimit::new(
             self.clone(),
         )))
@@ -421,5 +420,9 @@ impl TransformConfig for Config {
         _: &[(OutputId, schema::Definition)],
     ) -> Vec<TransformOutput> {
         vec![TransformOutput::new(DataType::Metric, HashMap::new())]
+    }
+
+    fn validate_structure(&self) -> Result<(), Vec<String>> {
+        self.validate_structure_impl().map_err(|e| vec![e.to_string()])
     }
 }

--- a/src/transforms/tag_cardinality_limit/tests.rs
+++ b/src/transforms/tag_cardinality_limit/tests.rs
@@ -1711,8 +1711,8 @@ per_tag_limits:
 // ============================================================================
 
 /// cache_size_per_key on a global per-tag entry in exact mode is a build error.
-#[tokio::test]
-async fn validation_rejects_cache_size_in_global_exact_mode() {
+#[test]
+fn validation_rejects_cache_size_in_global_exact_mode() {
     let config = make_transform_with_global_per_tag_limits(
         500,
         LimitExceededAction::DropTag,
@@ -1727,12 +1727,12 @@ async fn validation_rejects_cache_size_in_global_exact_mode() {
             },
         )]),
     );
-    assert!(config.build(&TransformContext::default()).await.is_err());
+    assert!(config.validate_structure().is_err());
 }
 
 /// cache_size_per_key on a per-metric per-tag entry in exact mode is a build error.
-#[tokio::test]
-async fn validation_rejects_cache_size_in_per_metric_exact_mode() {
+#[test]
+fn validation_rejects_cache_size_in_per_metric_exact_mode() {
     let config = make_transform_hashset_with_per_metric_limits(
         500,
         LimitExceededAction::DropTag,
@@ -1753,12 +1753,12 @@ async fn validation_rejects_cache_size_in_per_metric_exact_mode() {
             ),
         )]),
     );
-    assert!(config.build(&TransformContext::default()).await.is_err());
+    assert!(config.validate_structure().is_err());
 }
 
 /// cache_size_per_key on a per-metric per-tag entry in excluded mode is a build error.
-#[tokio::test]
-async fn validation_rejects_cache_size_in_per_metric_excluded_mode() {
+#[test]
+fn validation_rejects_cache_size_in_per_metric_excluded_mode() {
     let config = make_transform_hashset_with_per_metric_limits(
         500,
         LimitExceededAction::DropTag,
@@ -1775,7 +1775,7 @@ async fn validation_rejects_cache_size_in_per_metric_excluded_mode() {
             )])),
         )]),
     );
-    assert!(config.build(&TransformContext::default()).await.is_err());
+    assert!(config.validate_structure().is_err());
 }
 
 /// cache_size_per_key in probabilistic mode is valid.

--- a/src/transforms/throttle/config.rs
+++ b/src/transforms/throttle/config.rs
@@ -87,7 +87,7 @@ impl TransformConfig for ThrottleConfig {
         )]
     }
 
-    fn validate(&self, _: &TransformContext) -> Result<(), Vec<String>> {
+    fn validate_structure(&self) -> Result<(), Vec<String>> {
         if self.threshold == 0 || self.window_secs.as_secs_f64() == 0.0 {
             Err(vec![
                 "`threshold` and `window_secs` must be non-zero".to_string(),

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -283,10 +283,9 @@ async fn validate_transforms(config: &Config, fmt: &mut Formatter) -> bool {
 
         for err in transform
             .inner
-            .validate(&context)
+            .validate_with_context(&context)
             .err()
             .into_iter()
-            .chain(transform.inner.validate_with_context(&context).err())
             .flatten()
         {
             errors.push(format!("Transform \"{key}\": {err}"));


### PR DESCRIPTION
## Summary

Completes the transform migration for RFC 2026-07-15-split-component-build-lifecycle by removing the deprecated `validate()` method from the `TransformConfig` trait and migrating all implementations to `validate_structure()`.

## Vector configuration

NA

## How did you test this PR?

- `cargo check` passes
- `cargo clippy` passes  
- `cargo nextest run` for all affected transforms (route, sample, throttle, reduce, exclusive_route, delay, tag_cardinality_limit)

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: #25953