### PR TITLE
chore(docs): quiet component docs generation

### DIFF
--- a/vdev/src/commands/build/component_docs/runner.rs
+++ b/vdev/src/commands/build/component_docs/runner.rs
@@ -117,14 +117,14 @@ fn render_and_import_schema(
     let final_json = serde_json::to_string_pretty(&data)?;
     let json_output_file = write_to_temp_file(&prefix, ".json", &final_json)?;
 
-    info!(
+    debug!(
         "[✓]   Wrote {} schema to '{}'. ({} bytes)",
         friendly_name,
         json_output_file.display(),
         final_json.len()
     );
 
-    info!("[*] Importing {} schema as Cue file...", friendly_name);
+    debug!("[*] Importing {} schema as Cue file...", friendly_name);
     let cue_output_file = PathBuf::from("website/cue/reference").join(cue_relative_path);
 
     if let Some(parent) = cue_output_file.parent() {
@@ -150,7 +150,7 @@ fn render_and_import_schema(
         );
     }
 
-    info!(
+    debug!(
         "[✓]   Imported {} schema to '{}'.",
         friendly_name,
         cue_output_file.display()
@@ -313,14 +313,14 @@ fn render_and_import_generated_top_level_config_schema(
     let final_json = serde_json::to_string_pretty(&data)?;
     let json_output_file = write_to_temp_file(prefix, ".json", &final_json)?;
 
-    info!(
+    debug!(
         "[✓]   Wrote {} schema to '{}'. ({} bytes)",
         friendly_name,
         json_output_file.display(),
         final_json.len()
     );
 
-    info!("[*] Importing {} schema as Cue file...", friendly_name);
+    debug!("[*] Importing {} schema as Cue file...", friendly_name);
     let cue_output_file =
         PathBuf::from("website/cue/reference").join("generated/configuration.cue");
 
@@ -347,7 +347,7 @@ fn render_and_import_generated_top_level_config_schema(
         );
     }
 
-    info!(
+    debug!(
         "[✓]   Imported {} schema to '{}'.",
         friendly_name,
         cue_output_file.display()

--- a/vdev/src/commands/build/component_docs/schema_utils.rs
+++ b/vdev/src/commands/build/component_docs/schema_utils.rs
@@ -35,7 +35,7 @@ impl SchemaContext {
         schema_name: &str,
         friendly_name: &str,
     ) -> Result<Map<String, Value>> {
-        info!("[*] Resolving schema definition for {}...", friendly_name);
+        debug!("[*] Resolving schema definition for {}...", friendly_name);
 
         let resolved_schema = self.resolve_schema_by_name(schema_name)?;
 


### PR DESCRIPTION
## Summary

- move per-schema component-doc generation progress logs to debug level
- keep normal successful runs silent while preserving errors
- expose the detailed trace through `cargo vdev -v build component-docs …`

## Why

Generating component documentation emits a line for every schema resolution and CUE import. That output is not useful during a successful normal run, but remains valuable while diagnosing a failure.

## Validation

- `cargo clippy --manifest-path vdev/Cargo.toml -- -D warnings`
- `cargo run --manifest-path vdev/Cargo.toml -- build component-docs /tmp/vector-config-schema.json` (0 lines of component-doc output)