### PR TITLE
docs(elasticsearch sink): fix invalid version field example

### DIFF
--- a/src/sinks/elasticsearch/config.rs
+++ b/src/sinks/elasticsearch/config.rs
@@ -324,7 +324,8 @@ pub struct BulkConfig {
     pub template_fallback_index: Option<String>,
 
     /// Version field value.
-    #[configurable(metadata(docs::examples = "{{ obj_version }}-%Y-%m-%d"))]
+    #[configurable(metadata(docs::examples = "{{ obj_version }}"))]
+    #[configurable(metadata(docs::examples = "%s"))]
     #[configurable(metadata(docs::examples = "123"))]
     pub version: Option<UnconfinedTemplate>,
 

--- a/website/cue/reference/components/sinks/generated/elasticsearch.cue
+++ b/website/cue/reference/components/sinks/generated/elasticsearch.cue
@@ -300,7 +300,7 @@ generated: components: sinks: elasticsearch: configuration: {
 				description: "Version field value."
 				required:    false
 				type: string: {
-					examples: ["{{ obj_version }}-%Y-%m-%d", "123"]
+					examples: ["{{ obj_version }}", "%s", "123"]
 					syntax: "template"
 				}
 			}


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

The given example is bad because it is invalid for Elasticsearch due to:

> It must be a non-negative long number.

Ref: https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-create#operation-create-version

Better use two examples to show the features of the templating.

## Vector configuration
<!-- Include Vector configuration(s) you used to test and debug your changes. -->

## How did you test this PR?
<!-- Please describe how you tested your changes. Also include any information about your setup. -->

- [x] Tried to create doc with a non-long version on OpenSearch v3.x -> fails with `illegal_argument_exception`
- [x] `./scripts/cue.sh fmt`

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Closes: #<issue/PR number or link>
-->
- Related: #20102

More specifically: https://github.com/vectordotdev/vector/pull/20102/changes#diff-4ddfc8ed62933b9dda997c8f490bfe56e87de0f809eaf318f5f690e2d27e9a57R265