### PR TITLE
fix(website): render code config examples as code blocks

### DIFF
--- a/src/transforms/lua/v2/mod.rs
+++ b/src/transforms/lua/v2/mod.rs
@@ -60,6 +60,7 @@ pub struct LuaConfig {
     #[configurable(metadata(
         docs::examples = "function init()\n\tcount = 0\nend\n\nfunction process()\n\tcount = count + 1\nend\n\nfunction timer_handler(emit)\n\temit(make_counter(counter))\n\tcounter = 0\nend\n\nfunction shutdown(emit)\n\temit(make_counter(counter))\nend\n\nfunction make_counter(value)\n\treturn metric = {\n\t\tname = \"event_counter\",\n\t\tkind = \"incremental\",\n\t\ttimestamp = os.date(\"!*t\"),\n\t\tcounter = {\n\t\t\tvalue = value\n\t\t}\n \t}\nend",
         docs::examples = "-- external file with hooks and timers defined\nrequire('custom_module')",
+        docs::syntax_override = "lua",
     ))]
     source: Option<String>,
 
@@ -121,6 +122,7 @@ struct HooksConfig {
     #[configurable(metadata(
         docs::examples = "function (emit)\n\t-- Custom Lua code here\nend",
         docs::examples = "init",
+        docs::syntax_override = "lua",
     ))]
     init: Option<String>,
 
@@ -134,6 +136,7 @@ struct HooksConfig {
     #[configurable(metadata(
         docs::examples = "function (event, emit)\n\tevent.log.field = \"value\" -- set value of a field\n\tevent.log.another_field = nil -- remove field\n\tevent.log.first, event.log.second = nil, event.log.first -- rename field\n\t-- Very important! Emit the processed event.\n\temit(event)\nend",
         docs::examples = "process",
+        docs::syntax_override = "lua",
     ))]
     process: String,
 
@@ -146,6 +149,7 @@ struct HooksConfig {
     #[configurable(metadata(
         docs::examples = "function (emit)\n\t-- Custom Lua code here\nend",
         docs::examples = "shutdown",
+        docs::syntax_override = "lua",
     ))]
     shutdown: Option<String>,
 }

--- a/src/transforms/remap.rs
+++ b/src/transforms/remap.rs
@@ -68,7 +68,7 @@ pub struct RemapConfig {
     #[configurable(metadata(
         docs::examples = ". = parse_json!(.message)\n.new_field = \"new value\"\n.status = to_int!(.status)\n.duration = parse_duration!(.duration, \"s\")\n.new_name = del(.old_name)",
         docs::required,
-        docs::syntax_override = "remap_program"
+        docs::syntax_override = "vrl_program"
     ))]
     pub source: Option<String>,
 

--- a/website/cue/reference.cue
+++ b/website/cue/reference.cue
@@ -608,7 +608,7 @@ _values: {
 		]
 	}
 
-	syntax: *"literal" | "file_system_path" | "field_path" | "template" | "regex" | "remap_program" | "strftime"
+	syntax: *"literal" | "file_system_path" | "field_path" | "template" | "regex" | "vrl_program" | "lua" | "yaml" | "toml" | "strftime"
 }
 
 #TypeAsciiChar: {

--- a/website/cue/reference/components/transforms/generated/lua.cue
+++ b/website/cue/reference/components/transforms/generated/lua.cue
@@ -19,11 +19,14 @@ generated: components: transforms: lua: configuration: {
 					cases, the closure/function takes a single parameter, `emit`, which is a reference to a function for emitting events.
 					"""
 				required: false
-				type: string: examples: ["""
-					function (emit)
-					\t-- Custom Lua code here
-					end
-					""", "init"]
+				type: string: {
+					examples: ["""
+						function (emit)
+						\t-- Custom Lua code here
+						end
+						""", "init"]
+					syntax: "lua"
+				}
 			}
 			process: {
 				description: """
@@ -36,15 +39,18 @@ generated: components: transforms: lua: configuration: {
 					while the second parameter, `emit`, is a reference to a function for emitting events.
 					"""
 				required: true
-				type: string: examples: ["""
-					function (event, emit)
-					\tevent.log.field = "value" -- set value of a field
-					\tevent.log.another_field = nil -- remove field
-					\tevent.log.first, event.log.second = nil, event.log.first -- rename field
-					\t-- Very important! Emit the processed event.
-					\temit(event)
-					end
-					""", "process"]
+				type: string: {
+					examples: ["""
+						function (event, emit)
+						\tevent.log.field = "value" -- set value of a field
+						\tevent.log.another_field = nil -- remove field
+						\tevent.log.first, event.log.second = nil, event.log.first -- rename field
+						\t-- Very important! Emit the processed event.
+						\temit(event)
+						end
+						""", "process"]
+					syntax: "lua"
+				}
 			}
 			shutdown: {
 				description: """
@@ -56,11 +62,14 @@ generated: components: transforms: lua: configuration: {
 					cases, the closure/function takes a single parameter, `emit`, which is a reference to a function for emitting events.
 					"""
 				required: false
-				type: string: examples: ["""
-					function (emit)
-					\t-- Custom Lua code here
-					end
-					""", "shutdown"]
+				type: string: {
+					examples: ["""
+						function (emit)
+						\t-- Custom Lua code here
+						end
+						""", "shutdown"]
+					syntax: "lua"
+				}
 			}
 		}
 	}
@@ -107,38 +116,41 @@ generated: components: transforms: lua: configuration: {
 			hooks can be configured directly with inline Lua source for each respective hook.
 			"""
 		required: false
-		type: string: examples: ["""
-			function init()
-			\tcount = 0
-			end
+		type: string: {
+			examples: ["""
+				function init()
+				\tcount = 0
+				end
 
-			function process()
-			\tcount = count + 1
-			end
+				function process()
+				\tcount = count + 1
+				end
 
-			function timer_handler(emit)
-			\temit(make_counter(counter))
-			\tcounter = 0
-			end
+				function timer_handler(emit)
+				\temit(make_counter(counter))
+				\tcounter = 0
+				end
 
-			function shutdown(emit)
-			\temit(make_counter(counter))
-			end
+				function shutdown(emit)
+				\temit(make_counter(counter))
+				end
 
-			function make_counter(value)
-			\treturn metric = {
-			\t\tname = "event_counter",
-			\t\tkind = "incremental",
-			\t\ttimestamp = os.date("!*t"),
-			\t\tcounter = {
-			\t\t\tvalue = value
-			\t\t}
-			 \t}
-			end
-			""", """
-			-- external file with hooks and timers defined
-			require('custom_module')
-			"""]
+				function make_counter(value)
+				\treturn metric = {
+				\t\tname = "event_counter",
+				\t\tkind = "incremental",
+				\t\ttimestamp = os.date("!*t"),
+				\t\tcounter = {
+				\t\t\tvalue = value
+				\t\t}
+				 \t}
+				end
+				""", """
+				-- external file with hooks and timers defined
+				require('custom_module')
+				"""]
+			syntax: "lua"
+		}
 	}
 	timers: {
 		description: "A list of timers which should be configured and executed periodically."

--- a/website/cue/reference/components/transforms/generated/remap.cue
+++ b/website/cue/reference/components/transforms/generated/remap.cue
@@ -113,7 +113,7 @@ generated: components: transforms: remap: configuration: {
 				.duration = parse_duration!(.duration, "s")
 				.new_name = del(.old_name)
 				"""]
-			syntax: "remap_program"
+			syntax: "vrl_program"
 		}
 	}
 	timezone: {

--- a/website/layouts/partials/data.html
+++ b/website/layouts/partials/data.html
@@ -38,7 +38,7 @@
                   {{ end }}
 
                   {{ with $v.syntax }}
-                    {{ if eq . "remap_program" }}
+                    {{ if eq . "vrl_program" }}
                       {{ partial "badge.html" (dict "word" . "color" "gray" "href" "/docs/reference/vrl#program") }}
                     {{ else if eq . "template" }}
                       {{ partial "badge.html" (dict "word" . "color" "gray" "href" "/docs/reference/configuration/template-syntax/") }}
@@ -179,7 +179,7 @@
                 {{ end }}
 
                 {{ with $v.examples }}
-                  {{ template "config-examples" (dict "examples" .) }}
+                  {{ template "config-examples" (dict "examples" . "syntax" $v.syntax) }}
                 {{ end }}
               {{ end }}
 
@@ -1743,6 +1743,10 @@
 {{ end }}
 
 {{ define "config-examples" }}
+  {{/* Fields whose value is source code (per their declared `syntax`) render their examples as a
+       highlighted code block so multi-line programs keep their newlines; jsonify would escape them
+       to a literal \n. Every other syntax renders inline as JSON. Map: syntax -> Chroma lexer. */}}
+  {{ $codeLexers := dict "vrl_program" "coffee" "lua" "lua" "yaml" "yaml" "toml" "toml" }}
   <div x-data="{ open: false }" class="mt-2.5 border rounded py-2 px-3 dark:border-gray-700">
     <span class="flex justify-between items-center">
       <span class="text-sm"> Examples </span>
@@ -1751,9 +1755,15 @@
     </span>
 
     <div x-show="open" class="mt-3 text-sm flex flex-col space-y-2">
+      {{ $lexer := "" }}
+      {{ with $.syntax }}{{ $lexer = index $codeLexers . }}{{ end }}
       {{ range .examples }}
-        {{ $json := . | jsonify (dict "indent" "  ") }}
-        {{ highlight $json "json" "" }}
+        {{ if $lexer }}
+          {{ highlight . $lexer "" }}
+        {{ else }}
+          {{ $json := . | jsonify (dict "indent" "  ") }}
+          {{ highlight $json "json" "" }}
+        {{ end }}
       {{ end }}
     </div>
   </div>
@@ -2051,7 +2061,7 @@
               {{ end }}
 
               {{ with $v.syntax }}
-                {{ if eq . "remap_program" }}
+                {{ if eq . "vrl_program" }}
                   {{ partial "badge.html" (dict "word" . "color" "gray" "href" "/docs/reference/vrl#program") }}
                 {{ else if eq . "template" }}
                   {{ partial "badge.html" (dict "word" . "color" "gray" "href" "/docs/reference/configuration/template-syntax/") }}
@@ -2141,7 +2151,7 @@
           {{ end }}
 
           {{ with $v.examples }}
-            {{ template "config-examples" (dict "examples" .) }}
+            {{ template "config-examples" (dict "examples" . "syntax" $v.syntax) }}
           {{ end }}
 
           {{ if or $v.default (eq $v.default false) }}


### PR DESCRIPTION
## Summary

Component reference pages render each field's example through `jsonify`, which escapes newlines
to a literal `\n`. Fields whose value is a program — VRL (`remap`'s `source`) or Lua (the `lua`
transform's hooks) — therefore showed their multi-line examples as one run-together escaped
string. This drives example rendering off the field's declared `syntax`: code syntaxes render as
a highlighted code block with newlines intact, everything else stays inline. Doing it declaratively
via `syntax` avoids brittle content-sniffing and extends to any code-valued field with a single
map entry.

## Changes

- `config-examples` renders a field's examples as a highlighted code block when its `syntax` is a
  source-code type, via a `syntax → lexer` map (`vrl_program → coffee`, `lua → lua`, `yaml`,
  `toml`); every other syntax renders inline as JSON.
- Renamed the `remap_program` syntax to `vrl_program` (the language is VRL, not "remap").
- Marked the `lua` transform's program and hook fields with `syntax: lua` so their examples render
  as code too.

## How did you test this PR?

- Built the docs locally and confirmed the `remap` `source` (VRL) and the `lua` hook examples now
  render as multi-line code blocks, while non-code examples — e.g. the `file` source's `\r\n`
  delimiter — stay inline.

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: https://github.com/vectordotdev/vector/pull/25948
