### PR TITLE
docs(website): fix option example rendering

### DIFF
--- a/website/cue/reference.cue
+++ b/website/cue/reference.cue
@@ -596,17 +596,9 @@ _values: {
 	//      }
 	enum?: #Enum
 
+	// `examples` demonstrates example values. Enum values are not repeated here;
+	// they are rendered from `enum` as their own table.
 	examples?: [...string]
-
-	if Args.required && enum != _|_ {
-		// `examples` demonstrates example values. This should be used when
-		// examples cannot be derived from the `default` or `enum` options.
-		examples: [string, ...string] | *[
-			for k, v in enum {
-				k
-			},
-		]
-	}
 
 	syntax: *"literal" | "file_system_path" | "field_path" | "template" | "regex" | "vrl_program" | "lua" | "yaml" | "toml" | "strftime"
 }

--- a/website/layouts/partials/data.html
+++ b/website/layouts/partials/data.html
@@ -2150,6 +2150,15 @@
             </div>
           {{ end }}
 
+          {{ if eq $k "array" }}
+            {{/* Array examples live on the item type, not the array itself */}}
+            {{ range $k, $v := $v.items.type }}
+              {{ with $v.examples }}
+                {{ template "config-array-examples" (dict "examples" .) }}
+              {{ end }}
+            {{ end }}
+          {{ end }}
+
           {{ with $v.examples }}
             {{ template "config-examples" (dict "examples" . "syntax" $v.syntax) }}
           {{ end }}


### PR DESCRIPTION
## Summary

Two independent option-rendering fixes on the component docs pages.

**1. Nested array options never rendered their examples.** The `config-object` partial reads
`examples` off the option's type definition, but for an array the examples live on the item type
(`type.array.items.type.<t>.examples`). The top-level option renderer already descends into
`items`; object sub-options did not, so the examples were silently dropped. Affects every nested
array option, for example `tls.alpn_protocols` (`examples: ["h2"]`) on every sink and source with
TLS support.

**2. Required enum options duplicated their enum values as examples.** `#TypeString` defaulted
`examples` to the enum keys whenever the option was required, so the page rendered an "Examples"
list immediately above the "Enum options" table listing the exact same values with descriptions.
Removing the default drops the redundant list; explicitly authored examples still render.

No Rust or generated CUE changes.

## Vector configuration

N/A, docs rendering only.

## How did you test this PR?

Local Hugo server, before/after on the same pages.

- `tls.alpn_protocols` on `/docs/reference/configuration/sinks/http/`: no Examples block before,
  now renders `["h2"]`. Same for the nested array options on the `remap` page.
- `encoding.codec` on the same page: 13 synthesized examples before (confirmed via
  `./scripts/cue.sh export`, output identical to the enum keys), none after, with the Enum options
  table unchanged. `retry_strategy.type` is unaffected, since it is optional and never had them.
- `./scripts/cue.sh vet` passes and `./scripts/cue.sh fmt` is clean.
- Generated config examples are byte-identical before and after: snapshotted every component's
  `example_configs` from `data/docs.json` across both states and diffed. This is expected, since
  `create-config-examples.js` picks `default || examples[0] || Object.keys(enum)[0]` and the
  synthesized `examples[0]` was always the first enum key.

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

N/A
