### PR TITLE
chore(codeowners): remove vector-website team from website paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,13 +5,6 @@ regression/config.yaml @vectordotdev/vector @vectordotdev/single-machine-perform
 
 tests/antithesis/ @vectordotdev/vector @vectordotdev/single-machine-performance
 
-website/ @vectordotdev/vector
-website/js @vectordotdev/vector @vectordotdev/vector-website
-website/layouts @vectordotdev/vector @vectordotdev/vector-website
-website/scripts @vectordotdev/vector @vectordotdev/vector-website
-website/data @vectordotdev/vector @vectordotdev/vector-website
-website/* @vectordotdev/vector @vectordotdev/vector-website
-
 # Keep documentation team paths in sync with .github/workflows/add_docs_review_label.yml
 /*.md @vectordotdev/vector @vectordotdev/documentation
 docs/ @vectordotdev/vector @vectordotdev/documentation


### PR DESCRIPTION
## Summary

Removes the `@vectordotdev/vector-website` team.