### PR TITLE
chore(dev): add YAML and JSON round-trips to test_generate_config

### DIFF
--- a/src/test_util/mod.rs
+++ b/src/test_util/mod.rs
@@ -97,10 +97,22 @@ pub fn test_generate_config<T>()
 where
     for<'de> T: GenerateConfig + serde::Deserialize<'de>,
 {
-    let cfg = toml::to_string(&T::generate_config()).unwrap();
+    let generated = T::generate_config();
 
-    toml::from_str::<T>(&cfg)
-        .unwrap_or_else(|e| panic!("Invalid config generated from string:\n\n{e}\n'{cfg}'"));
+    let toml_cfg = toml::to_string(&generated).unwrap();
+    toml::from_str::<T>(&toml_cfg).unwrap_or_else(|e| {
+        panic!("Invalid config generated from TOML string:\n\n{e}\n'{toml_cfg}'")
+    });
+
+    let yaml_cfg = serde_yaml::to_string(&generated).unwrap();
+    serde_yaml::from_str::<T>(&yaml_cfg).unwrap_or_else(|e| {
+        panic!("Invalid config generated from YAML string:\n\n{e}\n'{yaml_cfg}'")
+    });
+
+    let json_cfg = serde_json::to_string(&generated).unwrap();
+    serde_json::from_str::<T>(&json_cfg).unwrap_or_else(|e| {
+        panic!("Invalid config generated from JSON string:\n\n{e}\n'{json_cfg}'")
+    });
 }
 
 pub fn open_fixture(path: impl AsRef<Path>) -> crate::Result<serde_json::Value> {


### PR DESCRIPTION
## Summary

`test_generate_config` previously only validated that a component's generated default config round-trips through TOML. Since YAML is now Vector's first-class configuration format, the helper now tests all three supported formats: TOML, YAML, and JSON. This catches format-specific deserialization bugs that would be invisible under a TOML-only test.

## Vector configuration

N/A

## How did you test this PR?

Ran the tests.

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- #21865