### PR TITLE
chore(dev): migrate GenerateConfig trait to `serde_json::Value`

### DIFF
--- a/lib/vector-config/src/component/description.rs
+++ b/lib/vector-config/src/component/description.rs
@@ -1,7 +1,7 @@
 use std::{cell::RefCell, marker::PhantomData};
 
+use serde_json::Value;
 use snafu::Snafu;
-use toml::Value;
 use vector_config_common::{attributes::CustomAttribute, constants};
 
 use super::{ComponentMarker, GenerateConfig};

--- a/lib/vector-config/src/component/generate.rs
+++ b/lib/vector-config/src/component/generate.rs
@@ -1,14 +1,14 @@
 /// A component that can generate a default configuration for itself.
 pub trait GenerateConfig {
-    fn generate_config() -> toml::Value;
+    fn generate_config() -> serde_json::Value;
 }
 
 #[macro_export]
 macro_rules! impl_generate_config_from_default {
     ($type:ty) => {
         impl $crate::component::GenerateConfig for $type {
-            fn generate_config() -> toml::value::Value {
-                toml::value::Value::try_from(&Self::default()).unwrap()
+            fn generate_config() -> serde_json::Value {
+                serde_json::to_value(&Self::default()).unwrap()
             }
         }
     };

--- a/lib/vector-config/tests/integration/smoke.rs
+++ b/lib/vector-config/tests/integration/smoke.rs
@@ -336,8 +336,8 @@ pub struct SimpleSourceConfig {
 }
 
 impl GenerateConfig for SimpleSourceConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self {
             listen_addr: default_simple_source_listen_addr(),
             timeout: default_simple_source_timeout(),
         })
@@ -382,8 +382,8 @@ pub struct SimpleSinkConfig {
 }
 
 impl GenerateConfig for SimpleSinkConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self {
             endpoint: default_simple_sink_endpoint(),
             batch: default_simple_sink_batch(),
             encoding: default_simple_sink_encoding(),
@@ -464,8 +464,8 @@ pub enum TagConfig {
 }
 
 impl GenerateConfig for AwsBleepBloopSinkConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self {
             auth: AwsAuthentication::default(),
             folder_id: String::from("foo12"),
             batch: default_aws_bleep_bloop_sink_batch(),
@@ -524,8 +524,8 @@ pub mod vector_v2 {
     }
 
     impl GenerateConfig for VectorConfig {
-        fn generate_config() -> toml::Value {
-            toml::Value::try_from(Self {
+        fn generate_config() -> serde_json::Value {
+            serde_json::to_value(Self {
                 address: "0.0.0.0:6000".parse().unwrap(),
                 shutdown_timeout_secs: default_shutdown_timeout_secs(),
             })
@@ -564,12 +564,12 @@ pub enum VectorSourceConfig {
 }
 
 impl GenerateConfig for VectorSourceConfig {
-    fn generate_config() -> toml::Value {
-        let config = toml::Value::try_into::<self::vector_v2::VectorConfig>(
+    fn generate_config() -> serde_json::Value {
+        let config = serde_json::from_value::<self::vector_v2::VectorConfig>(
             self::vector_v2::VectorConfig::generate_config(),
         )
         .unwrap();
-        toml::Value::try_from(VectorConfigV2 {
+        serde_json::to_value(VectorConfigV2 {
             version: Some(V2::V2),
             config,
         })

--- a/src/enrichment_tables/geoip.rs
+++ b/src/enrichment_tables/geoip.rs
@@ -88,8 +88,8 @@ fn default_locale() -> String {
 }
 
 impl GenerateConfig for GeoipConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self {
             path: "/path/to/GeoLite2-City.mmdb".into(),
             locale: default_locale(),
         })

--- a/src/enrichment_tables/mmdb.rs
+++ b/src/enrichment_tables/mmdb.rs
@@ -24,8 +24,8 @@ pub struct MmdbConfig {
 }
 
 impl GenerateConfig for MmdbConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self {
             path: "/path/to/GeoLite2-City.mmdb".into(),
         })
         .unwrap()

--- a/src/enrichment_tables/mod.rs
+++ b/src/enrichment_tables/mod.rs
@@ -84,8 +84,8 @@ impl vector_lib::configurable::NamedComponent for EnrichmentTables {
 }
 
 impl GenerateConfig for EnrichmentTables {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self::File(file::FileConfig {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self::File(file::FileConfig {
             file: file::FileSettings {
                 path: "path/to/file".into(),
                 encoding: file::Encoding::default(),

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -9,7 +9,7 @@ use clap::Parser;
 use colored::*;
 use indexmap::IndexMap;
 use serde::Serialize;
-use toml::{Value, map::Map};
+use serde_json::{Map, Value};
 use vector_lib::{
     buffers::BufferConfig,
     config::GlobalOptions,
@@ -115,6 +115,19 @@ struct FullConfig {
     config: Config,
 }
 
+pub(crate) fn strip_nulls(value: Value) -> Value {
+    match value {
+        Value::Object(map) => Value::Object(
+            map.into_iter()
+                .filter(|(_, v)| !v.is_null())
+                .map(|(k, v)| (k, strip_nulls(v)))
+                .collect(),
+        ),
+        Value::Array(arr) => Value::Array(arr.into_iter().map(strip_nulls).collect()),
+        other => other,
+    }
+}
+
 pub(crate) fn generate_example(
     opts: &Opts,
     transform_inputs_strategy: TransformInputsStrategy,
@@ -157,16 +170,16 @@ pub(crate) fn generate_example(
             source_names.push(name.clone());
 
             let mut example = match SourceDescription::example(&source_type) {
-                Ok(example) => example,
+                Ok(example) => strip_nulls(example),
                 Err(err) => {
                     errs.push(format!("failed to generate source '{source_type}': {err}"));
-                    Value::Table(Map::new())
+                    Value::Object(Map::new())
                 }
             };
             example
-                .as_table_mut()
+                .as_object_mut()
                 .expect("examples are always tables")
-                .insert("type".into(), source_type.to_owned().into());
+                .insert("type".to_string(), Value::String(source_type.to_owned()));
 
             sources.insert(name, example);
         }
@@ -216,18 +229,18 @@ pub(crate) fn generate_example(
             };
 
             let mut example = match TransformDescription::example(&transform_type) {
-                Ok(example) => example,
+                Ok(example) => strip_nulls(example),
                 Err(err) => {
                     errs.push(format!(
                         "failed to generate transform '{transform_type}': {err}"
                     ));
-                    Value::Table(Map::new())
+                    Value::Object(Map::new())
                 }
             };
             example
-                .as_table_mut()
+                .as_object_mut()
                 .expect("examples are always tables")
-                .insert("type".into(), transform_type.to_owned().into());
+                .insert("type".to_string(), Value::String(transform_type.to_owned()));
 
             transforms.insert(
                 name,
@@ -264,16 +277,16 @@ pub(crate) fn generate_example(
             };
 
             let mut example = match SinkDescription::example(&sink_type) {
-                Ok(example) => example,
+                Ok(example) => strip_nulls(example),
                 Err(err) => {
                     errs.push(format!("failed to generate sink '{sink_type}': {err}"));
-                    Value::Table(Map::new())
+                    Value::Object(Map::new())
                 }
             };
             example
-                .as_table_mut()
+                .as_object_mut()
                 .expect("examples are always tables")
-                .insert("type".into(), sink_type.to_owned().into());
+                .insert("type".to_string(), Value::String(sink_type.to_owned()));
 
             sinks.insert(
                 name,

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -482,8 +482,8 @@ mod tests {
 
                 [transforms.transform0]
                 inputs = ["source0"]
-                increase = 0.0
                 suffix = ""
+                increase = 0.0
                 type = "test_basic"
 
                 [sinks.sink0]
@@ -522,8 +522,8 @@ mod tests {
 
                 [transforms.transform0]
                 inputs = ["source0"]
-                increase = 0.0
                 suffix = ""
+                increase = 0.0
                 type = "test_basic"
 
                 [sinks.sink0]
@@ -616,20 +616,20 @@ mod tests {
 
                 [transforms.transform0]
                 inputs = []
-                increase = 0.0
                 suffix = ""
+                increase = 0.0
                 type = "test_basic"
 
                 [transforms.transform1]
                 inputs = ["transform0"]
-                increase = 0.0
                 suffix = ""
+                increase = 0.0
                 type = "test_basic"
 
                 [transforms.transform2]
                 inputs = ["transform1"]
-                increase = 0.0
                 suffix = ""
+                increase = 0.0
                 type = "test_basic"
             "#}
             .to_string())
@@ -642,20 +642,20 @@ mod tests {
             Ok(indoc::indoc! {r#"
                 [transforms.transform0]
                 inputs = []
-                increase = 0.0
                 suffix = ""
+                increase = 0.0
                 type = "test_basic"
 
                 [transforms.transform1]
                 inputs = ["transform0"]
-                increase = 0.0
                 suffix = ""
+                increase = 0.0
                 type = "test_basic"
 
                 [transforms.transform2]
                 inputs = ["transform1"]
-                increase = 0.0
                 suffix = ""
+                increase = 0.0
                 type = "test_basic"
             "#}
             .to_string())
@@ -682,21 +682,21 @@ mod tests {
             data_dir: /var/lib/vector/
             sources:
               source0:
+                interval: 1.0
                 count: 9223372036854775807
-                decoding:
-                  codec: bytes
                 format: json
                 framing:
                   method: bytes
-                interval: 1.0
+                decoding:
+                  codec: bytes
                 type: demo_logs
             transforms:
               transform0:
                 inputs:
                 - source0
-                drop_on_abort: false
-                drop_on_error: false
                 metric_tag_values: single
+                drop_on_error: false
+                drop_on_abort: false
                 reroute_dropped: false
                 runtime: ast
                 type: remap
@@ -704,11 +704,11 @@ mod tests {
               sink0:
                 inputs:
                 - transform0
+                target: stdout
                 encoding:
                   codec: json
                   json:
                     pretty: false
-                target: stdout
                 type: console
                 healthcheck:
                   enabled: true
@@ -742,15 +742,15 @@ mod tests {
               "data_dir": "/var/lib/vector/",
               "sources": {
                 "source0": {
+                  "interval": 1.0,
                   "count": 9223372036854775807,
-                  "decoding": {
-                    "codec": "bytes"
-                  },
                   "format": "json",
                   "framing": {
                     "method": "bytes"
                   },
-                  "interval": 1.0,
+                  "decoding": {
+                    "codec": "bytes"
+                  },
                   "type": "demo_logs"
                 }
               },
@@ -759,9 +759,9 @@ mod tests {
                   "inputs": [
                     "source0"
                   ],
-                  "drop_on_abort": false,
-                  "drop_on_error": false,
                   "metric_tag_values": "single",
+                  "drop_on_error": false,
+                  "drop_on_abort": false,
                   "reroute_dropped": false,
                   "runtime": "ast",
                   "type": "remap"
@@ -772,13 +772,13 @@ mod tests {
                   "inputs": [
                     "transform0"
                   ],
+                  "target": "stdout",
                   "encoding": {
                     "codec": "json",
                     "json": {
                       "pretty": false
                     }
                   },
-                  "target": "stdout",
                   "type": "console",
                   "healthcheck": {
                     "enabled": true,

--- a/src/secrets/aws_secrets_manager.rs
+++ b/src/secrets/aws_secrets_manager.rs
@@ -41,8 +41,8 @@ pub struct AwsSecretsManagerBackend {
 }
 
 impl GenerateConfig for AwsSecretsManagerBackend {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(AwsSecretsManagerBackend {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(AwsSecretsManagerBackend {
             secret_id: String::from("secret-id"),
             region: Default::default(),
             auth: Default::default(),

--- a/src/secrets/directory.rs
+++ b/src/secrets/directory.rs
@@ -20,8 +20,8 @@ pub struct DirectoryBackend {
 }
 
 impl GenerateConfig for DirectoryBackend {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(DirectoryBackend {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(DirectoryBackend {
             path: PathBuf::from("/path/to/secrets"),
             remove_trailing_whitespace: false,
         })

--- a/src/secrets/exec.rs
+++ b/src/secrets/exec.rs
@@ -54,8 +54,8 @@ impl ExecVersion {
 }
 
 impl GenerateConfig for ExecVersion {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(ExecVersion::V1).unwrap()
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(ExecVersion::V1).unwrap()
     }
 }
 
@@ -78,8 +78,8 @@ pub struct ExecBackend {
 }
 
 impl GenerateConfig for ExecBackend {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(ExecBackend {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(ExecBackend {
             command: vec![String::from("/path/to/script")],
             timeout: 5,
             protocol: ExecVersion::V1,

--- a/src/secrets/file.rs
+++ b/src/secrets/file.rs
@@ -16,8 +16,8 @@ pub struct FileBackend {
 }
 
 impl GenerateConfig for FileBackend {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(FileBackend {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(FileBackend {
             path: PathBuf::from("/path/to/secret"),
         })
         .unwrap()

--- a/src/secrets/mod.rs
+++ b/src/secrets/mod.rs
@@ -94,8 +94,8 @@ impl vector_lib::configurable::NamedComponent for SecretBackends {
 }
 
 impl GenerateConfig for SecretBackends {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self::File(file::FileBackend {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self::File(file::FileBackend {
             path: "path/to/file".into(),
         }))
         .unwrap()

--- a/src/sinks/amqp/config.rs
+++ b/src/sinks/amqp/config.rs
@@ -119,7 +119,7 @@ impl Default for AmqpSinkConfig {
 }
 
 impl GenerateConfig for AmqpSinkConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         toml::from_str(
             r#"connection_string = "amqp://localhost:5672/%2f"
             routing_key = "user_id"

--- a/src/sinks/appsignal/tests.rs
+++ b/src/sinks/appsignal/tests.rs
@@ -1,5 +1,4 @@
 use futures::{future::ready, stream};
-use serde::Deserialize;
 use vector_lib::{
     configurable::component::GenerateConfig,
     event::{Event, LogEvent},
@@ -18,11 +17,8 @@ use crate::{
 async fn component_spec_compliance() {
     let mock_endpoint = spawn_blackhole_http_server(always_200_response).await;
 
-    let config = AppsignalConfig::generate_config().to_string();
-    let mut config = AppsignalConfig::deserialize(
-        toml::de::ValueDeserializer::parse(&config).expect("value should deserialize"),
-    )
-    .expect("config should be valid");
+    let mut config: AppsignalConfig =
+        serde_json::from_value(AppsignalConfig::generate_config()).expect("config should be valid");
     config.endpoint = mock_endpoint.to_string();
 
     let context = SinkContext::default();

--- a/src/sinks/aws_cloudwatch_logs/config.rs
+++ b/src/sinks/aws_cloudwatch_logs/config.rs
@@ -261,8 +261,8 @@ impl SinkConfig for CloudwatchLogsSinkConfig {
 }
 
 impl GenerateConfig for CloudwatchLogsSinkConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(default_config(JsonSerializerConfig::default().into())).unwrap()
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(default_config(JsonSerializerConfig::default().into())).unwrap()
     }
 }
 

--- a/src/sinks/aws_kinesis/firehose/config.rs
+++ b/src/sinks/aws_kinesis/firehose/config.rs
@@ -158,7 +158,7 @@ impl SinkConfig for KinesisFirehoseSinkConfig {
 }
 
 impl GenerateConfig for KinesisFirehoseSinkConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         toml::from_str(
             r#"stream_name = "my-stream"
             encoding.codec = "json""#,

--- a/src/sinks/aws_kinesis/streams/config.rs
+++ b/src/sinks/aws_kinesis/streams/config.rs
@@ -157,7 +157,7 @@ impl SinkConfig for KinesisStreamsSinkConfig {
 }
 
 impl GenerateConfig for KinesisStreamsSinkConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         toml::from_str(
             r#"partition_key_field = "foo"
             stream_name = "my-stream"

--- a/src/sinks/aws_s3/config.rs
+++ b/src/sinks/aws_s3/config.rs
@@ -198,8 +198,8 @@ pub(super) fn default_filename_time_format() -> String {
 }
 
 impl GenerateConfig for S3SinkConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self {
             bucket: "".to_owned(),
             key_prefix: default_key_prefix(),
             filename_time_format: default_filename_time_format(),

--- a/src/sinks/aws_s_s/sns/config.rs
+++ b/src/sinks/aws_s_s/sns/config.rs
@@ -34,7 +34,7 @@ pub(super) struct SnsSinkConfig {
 }
 
 impl GenerateConfig for SnsSinkConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         toml::from_str(
             r#"topic_arn = "arn:aws:sns:us-east-2:123456789012:MyTopic"
             region = "us-east-2"

--- a/src/sinks/aws_s_s/sqs/config.rs
+++ b/src/sinks/aws_s_s/sqs/config.rs
@@ -37,7 +37,7 @@ pub(super) struct SqsSinkConfig {
 }
 
 impl GenerateConfig for SqsSinkConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         toml::from_str(
             r#"queue_url = "https://sqs.us-east-2.amazonaws.com/123456789012/MyQueue"
             region = "us-east-2"

--- a/src/sinks/axiom/config.rs
+++ b/src/sinks/axiom/config.rs
@@ -136,7 +136,7 @@ pub struct AxiomConfig {
 }
 
 impl GenerateConfig for AxiomConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         toml::from_str(
             r#"token = "${AXIOM_TOKEN}"
             dataset = "${AXIOM_DATASET}"

--- a/src/sinks/azure_blob/config.rs
+++ b/src/sinks/azure_blob/config.rs
@@ -196,8 +196,8 @@ pub fn default_blob_prefix() -> Template {
 }
 
 impl GenerateConfig for AzureBlobSinkConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self {
             auth: None,
             connection_string: Some(String::from("DefaultEndpointsProtocol=https;AccountName=some-account-name;AccountKey=some-account-key;").into()),
             account_name: None,

--- a/src/sinks/blackhole/config.rs
+++ b/src/sinks/blackhole/config.rs
@@ -68,8 +68,8 @@ impl SinkConfig for BlackholeConfig {
 }
 
 impl GenerateConfig for BlackholeConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self::default()).unwrap()
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self::default()).unwrap()
     }
 }
 

--- a/src/sinks/console/config.rs
+++ b/src/sinks/console/config.rs
@@ -62,8 +62,8 @@ const fn default_target() -> Target {
 }
 
 impl GenerateConfig for ConsoleSinkConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self {
             target: Target::Stdout,
             encoding: (None::<FramingConfig>, JsonSerializerConfig::default()).into(),
             acknowledgements: Default::default(),

--- a/src/sinks/databend/config.rs
+++ b/src/sinks/databend/config.rs
@@ -89,7 +89,7 @@ pub struct DatabendConfig {
 }
 
 impl GenerateConfig for DatabendConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         toml::from_str(
             r#"endpoint = "databend://localhost:8000/default?sslmode=disable"
             table = "default"

--- a/src/sinks/databricks_zerobus/config.rs
+++ b/src/sinks/databricks_zerobus/config.rs
@@ -191,8 +191,8 @@ pub struct ZerobusSinkConfig {
 }
 
 impl GenerateConfig for ZerobusSinkConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self {
             ingestion_endpoint: "https://1234567890123456.zerobus.us-west-2.cloud.databricks.com"
                 .to_string(),
             table_name: "main.default.logs".to_string(),

--- a/src/sinks/datadog/events/config.rs
+++ b/src/sinks/datadog/events/config.rs
@@ -43,7 +43,7 @@ pub struct DatadogEventsConfig {
 }
 
 impl GenerateConfig for DatadogEventsConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         toml::from_str(indoc! {r#"
             default_api_key = "${DATADOG_API_KEY_ENV_VAR}"
         "#})

--- a/src/sinks/datadog/logs/config.rs
+++ b/src/sinks/datadog/logs/config.rs
@@ -82,7 +82,7 @@ const fn default_compression() -> Option<Compression> {
 }
 
 impl GenerateConfig for DatadogLogsConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         toml::from_str(indoc! {r#"
             default_api_key = "${DATADOG_API_KEY_ENV_VAR}"
         "#})

--- a/src/sinks/datadog/traces/config.rs
+++ b/src/sinks/datadog/traces/config.rs
@@ -75,7 +75,7 @@ pub struct DatadogTracesConfig {
 }
 
 impl GenerateConfig for DatadogTracesConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         toml::from_str(indoc! {r#"
             default_api_key = "${DATADOG_API_KEY_ENV_VAR}"
         "#})

--- a/src/sinks/file/mod.rs
+++ b/src/sinks/file/mod.rs
@@ -138,8 +138,8 @@ pub struct FileTruncateConfig {
 }
 
 impl GenerateConfig for FileSinkConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self {
             path: UnconfinedTemplate::try_from("/tmp/vector-%Y-%m-%d.log").unwrap(),
             idle_timeout: default_idle_timeout(),
             encoding: (None::<FramingConfig>, TextSerializerConfig::default()).into(),

--- a/src/sinks/gcp/cloud_storage.rs
+++ b/src/sinks/gcp/cloud_storage.rs
@@ -254,7 +254,7 @@ fn default_config(encoding: EncodingConfigWithFraming) -> GcsSinkConfig {
 }
 
 impl GenerateConfig for GcsSinkConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         toml::from_str(indoc! {r#"
             bucket = "my-bucket"
             credentials_path = "/path/to/credentials.json"

--- a/src/sinks/gcp/pubsub.rs
+++ b/src/sinks/gcp/pubsub.rs
@@ -103,7 +103,7 @@ fn default_endpoint() -> String {
 }
 
 impl GenerateConfig for PubsubConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         toml::from_str(indoc! {r#"
             project = "my-project"
             topic = "my-topic"

--- a/src/sinks/gcp/stackdriver/logs/tests.rs
+++ b/src/sinks/gcp/stackdriver/logs/tests.rs
@@ -7,7 +7,6 @@ use chrono::{TimeZone, Utc};
 use futures::{future::ready, stream};
 use http::Uri;
 use indoc::indoc;
-use serde::Deserialize;
 use vector_lib::lookup::lookup_v2::ConfigValuePath;
 use vrl::{event_path, value};
 
@@ -60,11 +59,9 @@ fn generate_config() {
 async fn component_spec_compliance() {
     let mock_endpoint = spawn_blackhole_http_server(always_200_response).await;
 
-    let config = StackdriverConfig::generate_config().to_string();
-    let mut config = StackdriverConfig::deserialize(
-        toml::de::ValueDeserializer::parse(&config).expect("toml should deserialize"),
-    )
-    .expect("config should be valid");
+    let mut config: StackdriverConfig =
+        serde_json::from_value(StackdriverConfig::generate_config())
+            .expect("config should be valid");
 
     // If we don't override the credentials path/API key, it tries to directly call out to the Google Instance
     // Metadata API, which we clearly don't have in unit tests. :)

--- a/src/sinks/gcp/stackdriver/metrics/tests.rs
+++ b/src/sinks/gcp/stackdriver/metrics/tests.rs
@@ -1,6 +1,5 @@
 use chrono::Utc;
 use futures::{future::ready, stream};
-use serde::Deserialize;
 use vector_lib::event::{Metric, MetricKind, MetricValue};
 
 use super::config::StackdriverConfig;
@@ -24,11 +23,9 @@ fn generate_config() {
 async fn component_spec_compliance() {
     let mock_endpoint = spawn_blackhole_http_server(always_200_response).await;
 
-    let config = StackdriverConfig::generate_config().to_string();
-    let mut config = StackdriverConfig::deserialize(
-        toml::de::ValueDeserializer::parse(&config).expect("toml should deserialize"),
-    )
-    .expect("config should be valid");
+    let mut config: StackdriverConfig =
+        serde_json::from_value(StackdriverConfig::generate_config())
+            .expect("config should be valid");
 
     // If we don't override the credentials path/API key, it tries to directly call out to the Google Instance
     // Metadata API, which we clearly don't have in unit tests. :)

--- a/src/sinks/gcp_chronicle/chronicle_unstructured.rs
+++ b/src/sinks/gcp_chronicle/chronicle_unstructured.rs
@@ -259,7 +259,7 @@ fn chronicle_labels_examples() -> HashMap<String, String> {
 }
 
 impl GenerateConfig for ChronicleUnstructuredConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         toml::from_str(indoc! {r#"
             credentials_path = "/path/to/credentials.json"
             customer_id = "customer_id"

--- a/src/sinks/greptimedb/metrics/config.rs
+++ b/src/sinks/greptimedb/metrics/config.rs
@@ -22,7 +22,7 @@ use crate::sinks::{
 pub struct GreptimeDBConfig(GreptimeDBMetricsConfig);
 
 impl GenerateConfig for GreptimeDBConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         <GreptimeDBMetricsConfig as GenerateConfig>::generate_config()
     }
 }

--- a/src/sinks/honeycomb/config.rs
+++ b/src/sinks/honeycomb/config.rs
@@ -91,7 +91,7 @@ impl SinkBatchSettings for HoneycombDefaultBatchSettings {
 }
 
 impl GenerateConfig for HoneycombConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         toml::from_str(
             r#"api_key = "${HONEYCOMB_API_KEY}"
             dataset = "my-honeycomb-dataset""#,

--- a/src/sinks/honeycomb/tests.rs
+++ b/src/sinks/honeycomb/tests.rs
@@ -1,7 +1,6 @@
 //! Unit tests for the `honeycomb` sink.
 
 use futures::{future::ready, stream};
-use serde::Deserialize;
 
 use super::config::HoneycombConfig;
 use crate::{
@@ -21,11 +20,8 @@ fn generate_config() {
 async fn component_spec_compliance() {
     let mock_endpoint = spawn_blackhole_http_server(always_200_response).await;
 
-    let config = HoneycombConfig::generate_config().to_string();
-    let mut config = HoneycombConfig::deserialize(
-        toml::de::ValueDeserializer::parse(&config).expect("toml should deserialize"),
-    )
-    .expect("config should be valid");
+    let mut config: HoneycombConfig =
+        serde_json::from_value(HoneycombConfig::generate_config()).expect("config should be valid");
     config.endpoint = mock_endpoint.to_string();
 
     let context = SinkContext::default();

--- a/src/sinks/http/config.rs
+++ b/src/sinks/http/config.rs
@@ -176,7 +176,7 @@ impl HttpSinkConfig {
 }
 
 impl GenerateConfig for HttpSinkConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         toml::from_str(
             r#"uri = "https://10.22.212.22:9000/endpoint"
             encoding.codec = "json""#,

--- a/src/sinks/humio/logs.rs
+++ b/src/sinks/humio/logs.rs
@@ -153,8 +153,8 @@ pub fn timestamp_nanos_key() -> Option<String> {
 }
 
 impl GenerateConfig for HumioLogsConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self {
             token: "${HUMIO_TOKEN}".to_owned().into(),
             endpoint: default_endpoint(),
             source: None,

--- a/src/sinks/humio/metrics.rs
+++ b/src/sinks/humio/metrics.rs
@@ -148,7 +148,7 @@ fn default_endpoint() -> String {
 }
 
 impl GenerateConfig for HumioMetricsConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         toml::from_str(indoc! {r#"
                 host_key = "hostname"
                 token = "${HUMIO_TOKEN}"

--- a/src/sinks/influxdb/logs.rs
+++ b/src/sinks/influxdb/logs.rs
@@ -141,7 +141,7 @@ struct InfluxDbLogsSink {
 }
 
 impl GenerateConfig for InfluxDbLogsConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         toml::from_str(indoc! {r#"
             endpoint = "http://localhost:8086/"
             namespace = "my-namespace"

--- a/src/sinks/kafka/config.rs
+++ b/src/sinks/kafka/config.rs
@@ -259,8 +259,8 @@ impl KafkaSinkConfig {
 }
 
 impl GenerateConfig for KafkaSinkConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self {
             bootstrap_servers: "10.14.22.123:9092,10.14.23.332:9092".to_owned(),
             topic: Template::try_from("topic-1234".to_owned()).unwrap(),
             healthcheck_topic: None,

--- a/src/sinks/keep/config.rs
+++ b/src/sinks/keep/config.rs
@@ -79,7 +79,7 @@ impl SinkBatchSettings for KeepDefaultBatchSettings {
 }
 
 impl GenerateConfig for KeepConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         toml::from_str(
             r#"api_key = "${KEEP_API_KEY}"
             "#,

--- a/src/sinks/loki/config.rs
+++ b/src/sinks/loki/config.rs
@@ -196,7 +196,7 @@ pub enum OutOfOrderAction {
 }
 
 impl GenerateConfig for LokiConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         toml::from_str(
             r#"endpoint = "http://localhost:3100"
             encoding.codec = "json"

--- a/src/sinks/mezmo.rs
+++ b/src/sinks/mezmo.rs
@@ -35,7 +35,7 @@ const PATH: &str = "/logs/ingest";
 pub struct LogdnaConfig(MezmoConfig);
 
 impl GenerateConfig for LogdnaConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         <MezmoConfig as GenerateConfig>::generate_config()
     }
 }
@@ -145,7 +145,7 @@ fn default_env() -> String {
 }
 
 impl GenerateConfig for MezmoConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         toml::from_str(
             r#"hostname = "hostname"
             api_key = "${LOGDNA_API_KEY}""#,

--- a/src/sinks/nats/config.rs
+++ b/src/sinks/nats/config.rs
@@ -159,8 +159,8 @@ fn default_name() -> String {
 }
 
 impl GenerateConfig for NatsSinkConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self {
             acknowledgements: Default::default(),
             auth: None,
             connection_name: "vector".into(),

--- a/src/sinks/new_relic/tests.rs
+++ b/src/sinks/new_relic/tests.rs
@@ -2,7 +2,6 @@ use std::{convert::TryFrom, num::NonZeroU32};
 
 use chrono::Utc;
 use futures::{future::ready, stream};
-use serde::Deserialize;
 use serde_json::{json, to_value};
 use vector_lib::config::{Tags, Telemetry, init_telemetry};
 use vrl::value;
@@ -28,11 +27,8 @@ fn generate_config() {
 async fn sink() -> (VectorSink, Event) {
     let mock_endpoint = spawn_blackhole_http_server(always_200_response).await;
 
-    let config = NewRelicConfig::generate_config().to_string();
-    let mut config = NewRelicConfig::deserialize(
-        toml::de::ValueDeserializer::parse(&config).expect("toml should deserialize"),
-    )
-    .expect("config should be valid");
+    let mut config: NewRelicConfig =
+        serde_json::from_value(NewRelicConfig::generate_config()).expect("config should be valid");
     config.override_uri = Some(mock_endpoint);
 
     let context = SinkContext::default();

--- a/src/sinks/opentelemetry/mod.rs
+++ b/src/sinks/opentelemetry/mod.rs
@@ -63,7 +63,7 @@ impl Default for Protocol {
 }
 
 impl GenerateConfig for OpenTelemetryConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         toml::from_str(indoc! {r#"
             [protocol]
             type = "http"

--- a/src/sinks/papertrail.rs
+++ b/src/sinks/papertrail.rs
@@ -55,7 +55,7 @@ fn default_process() -> UnconfinedTemplate {
 }
 
 impl GenerateConfig for PapertrailConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         toml::from_str(
             r#"endpoint = "logs.papertrailapp.com:12345"
             encoding.codec = "json""#,
@@ -184,7 +184,6 @@ impl tokio_util::codec::Encoder<Event> for PapertrailEncoder {
 mod tests {
     use bytes::BytesMut;
     use futures::{future::ready, stream};
-    use serde::Deserialize;
     use tokio_util::codec::Encoder as _;
     use vector_lib::{
         codecs::JsonSerializerConfig,
@@ -207,11 +206,9 @@ mod tests {
     async fn component_spec_compliance() {
         let mock_endpoint = spawn_blackhole_http_server(always_200_response).await;
 
-        let config = PapertrailConfig::generate_config().to_string();
-        let mut config = PapertrailConfig::deserialize(
-            toml::de::ValueDeserializer::parse(&config).expect("toml should deserialize"),
-        )
-        .expect("config should be valid");
+        let mut config: PapertrailConfig =
+            serde_json::from_value(PapertrailConfig::generate_config())
+                .expect("config should be valid");
         config.endpoint = mock_endpoint.into();
         config.tls = Some(TlsEnableableConfig::default());
 

--- a/src/sinks/postgres/config.rs
+++ b/src/sinks/postgres/config.rs
@@ -75,7 +75,7 @@ pub struct PostgresConfig {
 }
 
 impl GenerateConfig for PostgresConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         toml::from_str(
             r#"endpoint = "postgres://user:password@localhost/default"
             table = "table"

--- a/src/sinks/prometheus/exporter.rs
+++ b/src/sinks/prometheus/exporter.rs
@@ -183,8 +183,8 @@ const fn default_suppress_timestamp() -> bool {
 }
 
 impl GenerateConfig for PrometheusExporterConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self::default()).unwrap()
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self::default()).unwrap()
     }
 }
 

--- a/src/sinks/pulsar/config.rs
+++ b/src/sinks/pulsar/config.rs
@@ -385,8 +385,8 @@ impl PulsarSinkConfig {
 }
 
 impl GenerateConfig for PulsarSinkConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self::default()).unwrap()
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self::default()).unwrap()
     }
 }
 

--- a/src/sinks/redis/config.rs
+++ b/src/sinks/redis/config.rs
@@ -182,7 +182,7 @@ pub struct RedisSinkConfig {
 }
 
 impl GenerateConfig for RedisSinkConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         toml::from_str(
             r#"
             url = "redis://127.0.0.1:6379/0"

--- a/src/sinks/sematext/logs.rs
+++ b/src/sinks/sematext/logs.rs
@@ -63,7 +63,7 @@ pub struct SematextLogsConfig {
 }
 
 impl GenerateConfig for SematextLogsConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         toml::from_str(indoc! {r#"
             token = "${SEMATEXT_TOKEN}"
         "#})

--- a/src/sinks/sematext/metrics.rs
+++ b/src/sinks/sematext/metrics.rs
@@ -93,7 +93,7 @@ pub struct SematextMetricsConfig {
 }
 
 impl GenerateConfig for SematextMetricsConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         toml::from_str(indoc! {r#"
             default_namespace = "vector"
             token = "${SEMATEXT_TOKEN}"

--- a/src/sinks/socket.rs
+++ b/src/sinks/socket.rs
@@ -99,7 +99,7 @@ pub struct UnixSinkConfig {
 }
 
 impl GenerateConfig for SocketSinkConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         toml::from_str(
             r#"address = "92.12.333.224:5000"
             mode = "tcp"

--- a/src/sinks/splunk_hec/logs/config.rs
+++ b/src/sinks/splunk_hec/logs/config.rs
@@ -163,8 +163,8 @@ const fn default_endpoint_target() -> EndpointTarget {
 }
 
 impl GenerateConfig for HecLogsSinkConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self {
             default_token: "${VECTOR_SPLUNK_HEC_TOKEN}".to_owned().into(),
             endpoint: "endpoint".to_owned(),
             host_key: None,

--- a/src/sinks/splunk_hec/metrics/config.rs
+++ b/src/sinks/splunk_hec/metrics/config.rs
@@ -127,8 +127,8 @@ pub struct HecMetricsSinkConfig {
 }
 
 impl GenerateConfig for HecMetricsSinkConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self {
             default_namespace: None,
             default_token: "${VECTOR_SPLUNK_HEC_TOKEN}".to_owned().into(),
             endpoint: "http://localhost:8088".to_owned(),

--- a/src/sinks/statsd/config.rs
+++ b/src/sinks/statsd/config.rs
@@ -102,10 +102,10 @@ const fn default_address() -> SocketAddr {
 }
 
 impl GenerateConfig for StatsdSinkConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         let address = default_address();
 
-        toml::Value::try_from(Self {
+        serde_json::to_value(Self {
             default_namespace: None,
             mode: Mode::Udp(UdpConnectorConfig::from_address(
                 address.ip().to_string(),

--- a/src/sinks/vector/config.rs
+++ b/src/sinks/vector/config.rs
@@ -203,8 +203,8 @@ impl VectorConfig {
 }
 
 impl GenerateConfig for VectorConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(default_config("127.0.0.1:6000")).unwrap()
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(default_config("127.0.0.1:6000")).unwrap()
     }
 }
 

--- a/src/sinks/webhdfs/config.rs
+++ b/src/sinks/webhdfs/config.rs
@@ -80,8 +80,8 @@ pub struct WebHdfsConfig {
 }
 
 impl GenerateConfig for WebHdfsConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self {
             root: "/".to_string(),
             prefix: "%F/".to_string(),
             endpoint: "http://127.0.0.1:9870".to_string(),

--- a/src/sinks/websocket/config.rs
+++ b/src/sinks/websocket/config.rs
@@ -32,8 +32,8 @@ pub struct WebSocketSinkConfig {
 }
 
 impl GenerateConfig for WebSocketSinkConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self {
             common: WebSocketCommonConfig {
                 ..Default::default()
             },

--- a/src/sources/apache_metrics/mod.rs
+++ b/src/sources/apache_metrics/mod.rs
@@ -57,8 +57,8 @@ pub fn default_namespace() -> String {
 }
 
 impl GenerateConfig for ApacheMetricsConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self {
             endpoints: vec!["http://localhost:8080/server-status/?auto".to_owned()],
             scrape_interval_secs: default_scrape_interval_secs(),
             namespace: default_namespace(),

--- a/src/sources/aws_ecs_metrics/mod.rs
+++ b/src/sources/aws_ecs_metrics/mod.rs
@@ -139,8 +139,8 @@ impl AwsEcsMetricsSourceConfig {
 }
 
 impl GenerateConfig for AwsEcsMetricsSourceConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self {
             endpoint: default_endpoint(),
             version: default_version(),
             scrape_interval_secs: default_scrape_interval_secs(),

--- a/src/sources/aws_kinesis_firehose/mod.rs
+++ b/src/sources/aws_kinesis_firehose/mod.rs
@@ -283,8 +283,8 @@ impl SourceConfig for AwsKinesisFirehoseConfig {
 }
 
 impl GenerateConfig for AwsKinesisFirehoseConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self {
             address: "0.0.0.0:443".parse().unwrap(),
             access_key: None,
             access_keys: None,

--- a/src/sources/datadog_agent/integration_tests.rs
+++ b/src/sources/datadog_agent/integration_tests.rs
@@ -83,7 +83,8 @@ async fn wait_for_message() {
     ]);
     let context = SourceContext::new_test(sender, Some(schema_definitions));
     tokio::spawn(async move {
-        let config: DatadogAgentConfig = DatadogAgentConfig::generate_config().try_into().unwrap();
+        let config: DatadogAgentConfig =
+            serde_json::from_value(DatadogAgentConfig::generate_config()).unwrap();
         config.build(context).await.unwrap().await.unwrap()
     });
     let events = spawn_collect_n(

--- a/src/sources/datadog_agent/mod.rs
+++ b/src/sources/datadog_agent/mod.rs
@@ -173,8 +173,8 @@ pub struct DatadogAgentConfig {
 }
 
 impl GenerateConfig for DatadogAgentConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self {
             address: "0.0.0.0:8080".parse().unwrap(),
             tls: None,
             store_api_key: true,

--- a/src/sources/file_descriptors/file_descriptor.rs
+++ b/src/sources/file_descriptors/file_descriptor.rs
@@ -71,7 +71,7 @@ impl FileDescriptorConfig for FileDescriptorSourceConfig {
 }
 
 impl GenerateConfig for FileDescriptorSourceConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         let fd = null_fd().unwrap();
         toml::from_str(&format!(
             r#"

--- a/src/sources/fluent/mod.rs
+++ b/src/sources/fluent/mod.rs
@@ -269,8 +269,8 @@ impl FluentUnixConfig {
 }
 
 impl GenerateConfig for FluentConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self {
             mode: FluentMode::Tcp(FluentTcpConfig {
                 address: SocketListenAddr::SocketAddr("0.0.0.0:24224".parse().unwrap()),
                 keepalive: None,

--- a/src/sources/heroku_logs.rs
+++ b/src/sources/heroku_logs.rs
@@ -177,8 +177,8 @@ impl Default for LogplexConfig {
 }
 
 impl GenerateConfig for LogplexConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(LogplexConfig::default()).unwrap()
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(LogplexConfig::default()).unwrap()
     }
 }
 

--- a/src/sources/http_server.rs
+++ b/src/sources/http_server.rs
@@ -43,7 +43,7 @@ use crate::{
 pub struct HttpConfig(SimpleHttpConfig);
 
 impl GenerateConfig for HttpConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         <SimpleHttpConfig as GenerateConfig>::generate_config()
     }
 }

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -285,8 +285,8 @@ const fn default_read_from() -> ReadFromConfig {
 }
 
 impl GenerateConfig for Config {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self {
             self_node_name: default_self_node_name_env_template(),
             auto_partial_merge: true,
             ..Default::default()

--- a/src/sources/logstash.rs
+++ b/src/sources/logstash.rs
@@ -134,8 +134,8 @@ impl Default for LogstashConfig {
 }
 
 impl GenerateConfig for LogstashConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(LogstashConfig::default()).unwrap()
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(LogstashConfig::default()).unwrap()
     }
 }
 

--- a/src/sources/nats/config.rs
+++ b/src/sources/nats/config.rs
@@ -182,7 +182,7 @@ pub const fn default_subscription_capacity() -> usize {
 }
 
 impl GenerateConfig for NatsSourceConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         toml::from_str(
             r#"
             connection_name = "vector"

--- a/src/sources/opentelemetry/config.rs
+++ b/src/sources/opentelemetry/config.rs
@@ -236,8 +236,8 @@ fn example_http_config() -> HttpConfig {
 }
 
 impl GenerateConfig for OpentelemetryConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self {
             grpc: example_grpc_config(),
             http: example_http_config(),
             acknowledgements: Default::default(),

--- a/src/sources/prometheus/pushgateway.rs
+++ b/src/sources/prometheus/pushgateway.rs
@@ -72,8 +72,8 @@ pub struct PrometheusPushgatewayConfig {
 }
 
 impl GenerateConfig for PrometheusPushgatewayConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self {
             address: "127.0.0.1:9091".parse().unwrap(),
             tls: None,
             auth: None,

--- a/src/sources/prometheus/remote_write.rs
+++ b/src/sources/prometheus/remote_write.rs
@@ -106,8 +106,8 @@ fn default_path() -> String {
 }
 
 impl GenerateConfig for PrometheusRemoteWriteConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self {
             address: "127.0.0.1:9090".parse().unwrap(),
             path: default_path(),
             tls: None,

--- a/src/sources/prometheus/scrape.rs
+++ b/src/sources/prometheus/scrape.rs
@@ -113,8 +113,8 @@ fn query_example() -> serde_json::Value {
 }
 
 impl GenerateConfig for PrometheusScrapeConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self {
             endpoints: vec!["http://localhost:9090/metrics".to_string()],
             interval: default_interval(),
             timeout: default_timeout(),

--- a/src/sources/redis/mod.rs
+++ b/src/sources/redis/mod.rs
@@ -134,7 +134,7 @@ pub struct RedisSourceConfig {
 }
 
 impl GenerateConfig for RedisSourceConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         toml::from_str(
             r#"
             url = "redis://127.0.0.1:6379/0"

--- a/src/sources/socket/mod.rs
+++ b/src/sources/socket/mod.rs
@@ -98,7 +98,7 @@ impl From<udp::UdpConfig> for SocketConfig {
 }
 
 impl GenerateConfig for SocketConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         toml::from_str(
             r#"mode = "tcp"
             address = "0.0.0.0:9000""#,

--- a/src/sources/statsd/mod.rs
+++ b/src/sources/statsd/mod.rs
@@ -182,8 +182,8 @@ const fn default_convert_to() -> ConversionUnit {
 }
 
 impl GenerateConfig for StatsdConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self::Udp(UdpConfig::from_address(
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self::Udp(UdpConfig::from_address(
             SocketListenAddr::SocketAddr(SocketAddr::V4(SocketAddrV4::new(
                 Ipv4Addr::LOCALHOST,
                 8125,

--- a/src/sources/syslog.rs
+++ b/src/sources/syslog.rs
@@ -164,8 +164,8 @@ impl Default for SyslogConfig {
 }
 
 impl GenerateConfig for SyslogConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(SyslogConfig::default()).unwrap()
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(SyslogConfig::default()).unwrap()
     }
 }
 

--- a/src/sources/vector/mod.rs
+++ b/src/sources/vector/mod.rs
@@ -175,8 +175,8 @@ impl Default for VectorConfig {
 }
 
 impl GenerateConfig for VectorConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(VectorConfig::default()).unwrap()
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(VectorConfig::default()).unwrap()
     }
 }
 

--- a/src/sources/windows_event_log/config.rs
+++ b/src/sources/windows_event_log/config.rs
@@ -292,8 +292,8 @@ impl Default for WindowsEventLogConfig {
 }
 
 impl GenerateConfig for WindowsEventLogConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(WindowsEventLogConfig::default()).unwrap()
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(WindowsEventLogConfig::default()).unwrap()
     }
 }
 

--- a/src/test_util/mock/sources/backpressure.rs
+++ b/src/test_util/mock/sources/backpressure.rs
@@ -25,11 +25,11 @@ pub struct BackpressureSourceConfig {
 }
 
 impl GenerateConfig for BackpressureSourceConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         let config = Self {
             counter: Arc::new(AtomicUsize::new(0)),
         };
-        toml::Value::try_from(&config).unwrap()
+        serde_json::to_value(&config).unwrap()
     }
 }
 

--- a/src/test_util/mock/sources/tripwire.rs
+++ b/src/test_util/mock/sources/tripwire.rs
@@ -21,11 +21,11 @@ pub struct TripwireSourceConfig {
 }
 
 impl GenerateConfig for TripwireSourceConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         let config = Self {
             tripwire: Arc::new(Mutex::new(None)),
         };
-        toml::Value::try_from(&config).unwrap()
+        serde_json::to_value(&config).unwrap()
     }
 }
 

--- a/src/test_util/mock/transforms/noop.rs
+++ b/src/test_util/mock/transforms/noop.rs
@@ -46,8 +46,8 @@ pub struct NoopTransformConfig {
 }
 
 impl GenerateConfig for NoopTransformConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(&Self {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(&Self {
             transform_type: TransformType::Function,
             delay_ms: None,
             cpu_burn_ms: None,

--- a/src/test_util/mod.rs
+++ b/src/test_util/mod.rs
@@ -99,7 +99,8 @@ where
 {
     let generated = T::generate_config();
 
-    let toml_cfg = toml::to_string(&generated).unwrap();
+    // TOML cannot represent JSON null; strip None-valued fields before serializing.
+    let toml_cfg = toml::to_string(&crate::generate::strip_nulls(generated.clone())).unwrap();
     toml::from_str::<T>(&toml_cfg).unwrap_or_else(|e| {
         panic!("Invalid config generated from TOML string:\n\n{e}\n'{toml_cfg}'")
     });

--- a/src/transforms/dedupe/config.rs
+++ b/src/transforms/dedupe/config.rs
@@ -36,8 +36,8 @@ pub struct DedupeConfig {
 }
 
 impl GenerateConfig for DedupeConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self {
             fields: None,
             cache: default_cache_config(),
             time_settings: None,

--- a/src/transforms/exclusive_route/config.rs
+++ b/src/transforms/exclusive_route/config.rs
@@ -81,8 +81,8 @@ fn routes_example() -> Vec<Route> {
 }
 
 impl GenerateConfig for ExclusiveRouteConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self {
             routes: routes_example(),
         })
         .unwrap()

--- a/src/transforms/filter.rs
+++ b/src/transforms/filter.rs
@@ -35,7 +35,7 @@ impl From<AnyCondition> for FilterConfig {
 }
 
 impl GenerateConfig for FilterConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         toml::from_str(r#"condition = ".message == \"value\"""#).unwrap()
     }
 }

--- a/src/transforms/log_to_metric.rs
+++ b/src/transforms/log_to_metric.rs
@@ -178,8 +178,8 @@ pub struct LogToMetric {
 }
 
 impl GenerateConfig for LogToMetricConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self {
             metrics: Some(vec![MetricConfig {
                 field: "field_name".try_into().expect("Fixed template"),
                 name: None,

--- a/src/transforms/lua/mod.rs
+++ b/src/transforms/lua/mod.rs
@@ -72,7 +72,7 @@ pub enum LuaConfig {
 }
 
 impl GenerateConfig for LuaConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         toml::from_str(
             r#"version = "2"
             hooks.process = """#,

--- a/src/transforms/metric_to_log.rs
+++ b/src/transforms/metric_to_log.rs
@@ -78,8 +78,8 @@ impl MetricToLogConfig {
 }
 
 impl GenerateConfig for MetricToLogConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self {
             host_tag: Some("host-tag".to_string()),
             timezone: None,
             log_namespace: None,

--- a/src/transforms/route.rs
+++ b/src/transforms/route.rs
@@ -111,8 +111,8 @@ fn route_examples() -> IndexMap<String, AnyCondition> {
 }
 
 impl GenerateConfig for RouteConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self {
             reroute_unmatched: true,
             route: route_examples(),
         })

--- a/src/transforms/sample/config.rs
+++ b/src/transforms/sample/config.rs
@@ -163,8 +163,8 @@ impl SampleConfig {
 }
 
 impl GenerateConfig for SampleConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self {
             rate: None,
             ratio: Some(0.1),
             ratio_field: None,

--- a/src/transforms/tag_cardinality_limit/config.rs
+++ b/src/transforms/tag_cardinality_limit/config.rs
@@ -336,8 +336,8 @@ pub(crate) const fn default_cache_size() -> usize {
 // =============================================================================
 
 impl GenerateConfig for Config {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self {
             global: Inner {
                 mode: Mode::Exact,
                 value_limit: default_value_limit(),

--- a/src/transforms/trace_to_log.rs
+++ b/src/transforms/trace_to_log.rs
@@ -25,8 +25,8 @@ pub struct TraceToLogConfig {
 }
 
 impl GenerateConfig for TraceToLogConfig {
-    fn generate_config() -> toml::Value {
-        toml::Value::try_from(Self {
+    fn generate_config() -> serde_json::Value {
+        serde_json::to_value(Self {
             log_namespace: None,
         })
         .unwrap()

--- a/src/transforms/window/config.rs
+++ b/src/transforms/window/config.rs
@@ -42,7 +42,7 @@ pub struct WindowConfig {
 }
 
 impl GenerateConfig for WindowConfig {
-    fn generate_config() -> toml::Value {
+    fn generate_config() -> serde_json::Value {
         toml::from_str(r#"flush_when = ".message == \"value\"""#).unwrap()
     }
 }


### PR DESCRIPTION
## Summary

`GenerateConfig::generate_config()` returned `toml::Value` due to TOML being Vector's original config format. This migrates it to `serde_json::Value`, which is the stated direction in #19963 (drop TOML as an internal value type).

**Note:** `vector generate` output key order now follows struct field declaration order rather than alphabetical order. The old alphabetical ordering was an accidental artifact of `toml::Value` using `BTreeMap` internally -- it was never guaranteed. Generated configs remain valid and correct.

## Vector configuration

N/A

## How did you test this PR?

`make check-clippy` and `make fmt` pass clean. 99 files changed.

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Part of: #19963
- Closes: #21865
