### PR TITLE
docs(website): advertise product resources in footer

### DIFF
--- a/website/config.toml
+++ b/website/config.toml
@@ -276,7 +276,7 @@ parent = "community"
 weight = 3
 
 [[languages.en.menus.footer]]
-name = "Download"
+name = "Product"
 url = "/download"
 identifier = "download"
 weight = 5
@@ -285,6 +285,18 @@ weight = 5
 name = "Releases"
 url = "/releases"
 weight = 1
+parent = "download"
+
+[[languages.en.menus.footer]]
+name = "Deprecations"
+url = "/deprecations"
+weight = 2
+parent = "download"
+
+[[languages.en.menus.footer]]
+name = "Highlights"
+url = "/highlights"
+weight = 3
 parent = "download"
 
 # Extra links under the "Meta" section in the docs


### PR DESCRIPTION
## Summary

Renames the footer's Download section to Product and adds links to the Deprecations and Highlights pages.

## Vector configuration

Not applicable.

## How did you test this PR?

- Ran `hugo config --format json` and verified the Product, Deprecations, and Highlights footer entries.
- Ran `make serve` and verified the links in the local footer.

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.
