### PR TITLE
fix(sources): default ALPN to h2 for gRPC-based sources when TLS is enabled

### DIFF
--- a/changelog.d/grpc_sources_default_alpn_h2.fix.md
+++ b/changelog.d/grpc_sources_default_alpn_h2.fix.md
@@ -1,0 +1,7 @@
+gRPC-based sources (e.g. `opentelemetry`) now default to advertising `h2` via ALPN when TLS is
+enabled, unless `tls.alpn_protocols` is already set. Previously, gRPC clients that require the
+server to confirm `h2` via ALPN (RFC 7540 Section 3.3) could fail the TLS handshake with
+`Cannot check peer: missing selected ALPN property.`, since none of these sources expose an
+`alpn_protocols` config option for users to set it themselves.
+
+authors: vladimir-dd

--- a/lib/vector-core/src/tls/incoming.rs
+++ b/lib/vector-core/src/tls/incoming.rs
@@ -71,7 +71,12 @@ impl MaybeTlsSettings {
 
         let acceptor = match (self, reloader) {
             (Self::Raw(()), _) => None,
-            (Self::Tls(_), Some(reloader)) => Some(reloader.shared()),
+            (Self::Tls(tls), Some(reloader)) => {
+                // `reloader`'s acceptor may have been built from settings that predate any
+                // defaults applied to `self` (e.g. the `h2` ALPN default), so refresh it here.
+                reloader.reload(tls)?;
+                Some(reloader.shared())
+            }
             (Self::Tls(tls), None) => Some(Arc::new(ArcSwap::from_pointee(tls.acceptor()?))),
         };
 

--- a/lib/vector-core/src/tls/reload.rs
+++ b/lib/vector-core/src/tls/reload.rs
@@ -21,13 +21,20 @@ use super::{MaybeTlsSettings, TlsSettings};
 #[derive(Clone)]
 pub struct TlsAcceptorReloader {
     acceptor: Arc<ArcSwap<SslAcceptor>>,
+    /// ALPN protocol names to apply to every acceptor this reloader builds, unless the settings
+    /// passed to [`reload`](Self::reload) already configure their own. Set by
+    /// [`MaybeTlsSettings::reloadable_acceptor_for_grpc`], since `reload`'s caller (e.g. a
+    /// certificate-rotation watcher) rebuilds `TlsSettings` from scratch and has no reason to know
+    /// this reloader serves a gRPC listener.
+    default_alpn_protocols: Option<Vec<String>>,
 }
 
 impl TlsAcceptorReloader {
     /// Wrap an initial acceptor in a swappable cell.
-    pub(super) fn new(acceptor: SslAcceptor) -> Self {
+    pub(super) fn new(acceptor: SslAcceptor, default_alpn_protocols: Option<Vec<String>>) -> Self {
         Self {
             acceptor: Arc::new(ArcSwap::from_pointee(acceptor)),
+            default_alpn_protocols,
         }
     }
 
@@ -36,9 +43,16 @@ impl TlsAcceptorReloader {
         Arc::clone(&self.acceptor)
     }
 
-    /// Swap in a freshly built acceptor from `settings`. New connections pick it up
-    /// immediately; the previous acceptor is dropped once its last in-flight handshake completes.
+    /// Swap in a freshly built acceptor from `settings`, applying this reloader's ALPN default
+    /// (see [`MaybeTlsSettings::reloadable_acceptor_for_grpc`]) if `settings` doesn't already
+    /// configure `alpn_protocols` itself. New connections pick up the swapped acceptor
+    /// immediately; the previous one is dropped once its last in-flight handshake completes.
     pub fn reload(&self, settings: &TlsSettings) -> crate::tls::Result<()> {
+        let mut settings = settings.clone();
+        if let Some(default) = &self.default_alpn_protocols {
+            let protocols: Vec<&str> = default.iter().map(String::as_str).collect();
+            settings.set_default_alpn_protocols(&protocols)?;
+        }
         self.acceptor.store(Arc::new(settings.acceptor()?));
         Ok(())
     }
@@ -47,6 +61,7 @@ impl TlsAcceptorReloader {
     pub fn downgrade(&self) -> WeakTlsAcceptorReloader {
         WeakTlsAcceptorReloader {
             acceptor: Arc::downgrade(&self.acceptor),
+            default_alpn_protocols: self.default_alpn_protocols.clone(),
         }
     }
 }
@@ -55,14 +70,16 @@ impl TlsAcceptorReloader {
 #[derive(Clone)]
 pub struct WeakTlsAcceptorReloader {
     acceptor: Weak<ArcSwap<SslAcceptor>>,
+    default_alpn_protocols: Option<Vec<String>>,
 }
 
 impl WeakTlsAcceptorReloader {
     /// Return the live [`TlsAcceptorReloader`], or `None` once the bound listener has been dropped.
     pub fn upgrade(&self) -> Option<TlsAcceptorReloader> {
-        self.acceptor
-            .upgrade()
-            .map(|acceptor| TlsAcceptorReloader { acceptor })
+        self.acceptor.upgrade().map(|acceptor| TlsAcceptorReloader {
+            acceptor,
+            default_alpn_protocols: self.default_alpn_protocols.clone(),
+        })
     }
 }
 
@@ -74,7 +91,27 @@ impl MaybeTlsSettings {
     /// certificate material rotates.
     pub fn reloadable_acceptor(&self) -> crate::tls::Result<Option<TlsAcceptorReloader>> {
         match self {
-            Self::Tls(tls) => Ok(Some(TlsAcceptorReloader::new(tls.acceptor()?))),
+            Self::Tls(tls) => Ok(Some(TlsAcceptorReloader::new(tls.acceptor()?, None))),
+            Self::Raw(()) => Ok(None),
+        }
+    }
+
+    /// Like [`reloadable_acceptor`](Self::reloadable_acceptor), but for a gRPC listener: the
+    /// returned reloader defaults every acceptor it builds, including on future
+    /// [`reload`](TlsAcceptorReloader::reload) calls, to advertise `h2` via ALPN unless the
+    /// settings passed to `reload` already configure `alpn_protocols` themselves. gRPC always runs
+    /// over HTTP/2, and strict gRPC clients fail the handshake without a confirmed ALPN protocol
+    /// (RFC 7540 Section 3.3).
+    pub fn reloadable_acceptor_for_grpc(&self) -> crate::tls::Result<Option<TlsAcceptorReloader>> {
+        match self {
+            Self::Tls(tls) => {
+                let mut tls = tls.clone();
+                tls.set_default_alpn_protocols(&["h2"])?;
+                Ok(Some(TlsAcceptorReloader::new(
+                    tls.acceptor()?,
+                    Some(vec!["h2".to_owned()]),
+                )))
+            }
             Self::Raw(()) => Ok(None),
         }
     }
@@ -252,6 +289,57 @@ mod test {
             Some(b"h2".to_vec()),
             "acceptor served through the reloader must reflect the ALPN default applied after the \
              reloader was built"
+        );
+
+        server.abort();
+    }
+
+    /// `reloadable_acceptor_for_grpc`'s `h2` default must survive a later certificate rotation, even
+    /// when whoever triggers the rotation (e.g. a generic file-watcher, unaware this reloader serves
+    /// a gRPC listener) reloads with settings that never went through `set_default_alpn_protocols`.
+    #[tokio::test]
+    async fn reloadable_acceptor_for_grpc_applies_default_across_reload() {
+        let (crt_a, key_a) = self_signed("alpn.example");
+        let (crt_b, key_b) = self_signed("alpn.example");
+        let settings = server_settings(&crt_a, &key_a);
+
+        let reloader = settings
+            .reloadable_acceptor_for_grpc()
+            .unwrap()
+            .expect("tls enabled, so an acceptor should exist");
+
+        let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+        let mut listener = settings
+            .bind_reloadable(&addr, Some(reloader.clone()))
+            .await
+            .unwrap();
+        let local_addr = listener.local_addr().unwrap();
+
+        let server = tokio::spawn(async move {
+            while let Ok(mut stream) = listener.accept().await {
+                stream.handshake().await.ok();
+            }
+        });
+
+        assert_eq!(
+            negotiated_alpn_protocol(local_addr).await,
+            Some(b"h2".to_vec()),
+            "h2 must be negotiated before any reload"
+        );
+
+        // Rotate the certificate with settings that don't know about the `h2` default, mirroring a
+        // generic reload path (e.g. a certificate-file watcher shared with non-gRPC listeners).
+        let settings_b = server_settings(&crt_b, &key_b);
+        let tls_b = match &settings_b {
+            MaybeTls::Tls(tls) => tls.clone(),
+            MaybeTls::Raw(()) => unreachable!(),
+        };
+        reloader.reload(&tls_b).unwrap();
+
+        assert_eq!(
+            negotiated_alpn_protocol(local_addr).await,
+            Some(b"h2".to_vec()),
+            "h2 must still be negotiated after a reload that didn't itself request it"
         );
 
         server.abort();

--- a/lib/vector-core/src/tls/reload.rs
+++ b/lib/vector-core/src/tls/reload.rs
@@ -215,6 +215,65 @@ mod test {
             .unwrap()
     }
 
+    /// A reloader built before ALPN defaults are applied to its settings (mirroring
+    /// `run_grpc_server`, which receives an already-built reloader and only then calls
+    /// `set_default_alpn_protocols`) must still serve those defaults once bound: `bind_reloadable`
+    /// has to refresh the reloader's acceptor from the settings passed into that call, not just
+    /// reuse whatever acceptor the reloader already held.
+    #[tokio::test]
+    async fn bind_reloadable_applies_alpn_default_set_after_reloader_is_built() {
+        let (crt, key) = self_signed("alpn.example");
+        let mut settings = server_settings(&crt, &key);
+
+        // Build the reloader from settings that don't have the `h2` default applied yet.
+        let reloader = settings
+            .reloadable_acceptor()
+            .unwrap()
+            .expect("tls enabled, so an acceptor should exist");
+
+        // Only now apply the default, as `run_grpc_server` does, right before binding.
+        settings.set_default_alpn_protocols(&["h2"]).unwrap();
+
+        let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+        let mut listener = settings
+            .bind_reloadable(&addr, Some(reloader))
+            .await
+            .unwrap();
+        let local_addr = listener.local_addr().unwrap();
+
+        let server = tokio::spawn(async move {
+            while let Ok(mut stream) = listener.accept().await {
+                stream.handshake().await.ok();
+            }
+        });
+
+        assert_eq!(
+            negotiated_alpn_protocol(local_addr).await,
+            Some(b"h2".to_vec()),
+            "acceptor served through the reloader must reflect the ALPN default applied after the \
+             reloader was built"
+        );
+
+        server.abort();
+    }
+
+    /// Connect as a TLS client offering `h2` via ALPN and return the protocol the server selected.
+    async fn negotiated_alpn_protocol(addr: SocketAddr) -> Option<Vec<u8>> {
+        let tcp = tokio::net::TcpStream::connect(addr).await.unwrap();
+
+        let mut builder = SslConnector::builder(SslMethod::tls()).unwrap();
+        builder.set_verify(SslVerifyMode::NONE);
+        builder.set_alpn_protos(&[2, b'h', b'2']).unwrap();
+        let mut config = builder.build().configure().unwrap();
+        config.set_verify_hostname(false);
+        let ssl = config.into_ssl("localhost").unwrap();
+
+        let mut stream = tokio_openssl::SslStream::new(ssl, tcp).unwrap();
+        Pin::new(&mut stream).connect().await.unwrap();
+
+        stream.ssl().selected_alpn_protocol().map(<[u8]>::to_vec)
+    }
+
     fn server_settings(crt_pem: &str, key_pem: &str) -> MaybeTlsSettings {
         // `crt_file`/`key_file` accept inline PEM (detected by the `-----BEGIN ` marker), so no
         // temp files are needed.

--- a/lib/vector-core/src/tls/settings.rs
+++ b/lib/vector-core/src/tls/settings.rs
@@ -786,7 +786,7 @@ mod test {
         settings.set_default_alpn_protocols(&["h2"]).unwrap();
         assert_eq!(
             settings.alpn_protocols,
-            Some(vec![8, 104, 116, 116, 112, 47, 49, 46, 49])
+            Some(vec![8, 104, 116, 116, 112, 47, 49, 46, 49]) // ALPN-encoded "http/1.1"
         );
     }
 

--- a/lib/vector-core/src/tls/settings.rs
+++ b/lib/vector-core/src/tls/settings.rs
@@ -225,6 +225,17 @@ impl TlsSettings {
         })
     }
 
+    /// Forces the given protocols to be advertised via ALPN, unless the user already set
+    /// `alpn_protocols` explicitly. Used by protocols like gRPC that require a specific ALPN
+    /// value (`h2`) to be negotiated by the underlying HTTP/2 stack, but whose source config
+    /// doesn't expose an `alpn_protocols` option for users to set it themselves.
+    pub fn set_default_alpn_protocols(&mut self, protocols: &[&str]) -> Result<()> {
+        if self.alpn_protocols.is_none() {
+            self.alpn_protocols = Some(encode_alpn_protocols(protocols)?);
+        }
+        Ok(())
+    }
+
     /// The configured SNI server name override, if any.
     pub fn server_name(&self) -> Option<&str> {
         self.server_name.as_deref()
@@ -423,6 +434,23 @@ fn intern_alpn_protocols(protocols: &[u8]) -> &'static [u8] {
     leaked
 }
 
+/// Encodes a list of protocol names into ALPN "wire format": each protocol name prefixed by
+/// its byte length.
+fn encode_alpn_protocols<S: AsRef<str>>(protocols: &[S]) -> Result<Vec<u8>> {
+    let mut data: Vec<u8> = Vec::new();
+    for protocol in protocols {
+        let protocol = protocol.as_ref();
+        data.push(
+            protocol
+                .len()
+                .try_into()
+                .context(EncodeAlpnProtocolsSnafu)?,
+        );
+        data.extend_from_slice(protocol.as_bytes());
+    }
+    Ok(data)
+}
+
 impl TlsConfig {
     fn load_authorities(&self) -> Result<Vec<X509>> {
         match &self.ca_file {
@@ -458,21 +486,14 @@ impl TlsConfig {
         }
     }
 
-    /// The input must be in ALPN "wire format".
+    /// The result is in ALPN "wire format".
     ///
     /// It consists of a sequence of supported protocol names prefixed by their byte length.
     fn parse_alpn_protocols(&self) -> Result<Option<Vec<u8>>> {
-        match &self.alpn_protocols {
-            None => Ok(None),
-            Some(protocols) => {
-                let mut data: Vec<u8> = Vec::new();
-                for str in protocols {
-                    data.push(str.len().try_into().context(EncodeAlpnProtocolsSnafu)?);
-                    data.append(&mut str.clone().into_bytes());
-                }
-                Ok(Some(data))
-            }
-        }
+        self.alpn_protocols
+            .as_deref()
+            .map(encode_alpn_protocols)
+            .transpose()
     }
 
     /// Parse identity from a PEM encoded certificate + key pair of files
@@ -657,6 +678,14 @@ impl MaybeTlsSettings {
             MaybeTls::Tls(_) => "https",
         }
     }
+
+    /// See [`TlsSettings::set_default_alpn_protocols`]. A no-op when TLS is not enabled.
+    pub fn set_default_alpn_protocols(&mut self, protocols: &[&str]) -> Result<()> {
+        if let MaybeTls::Tls(tls) = self {
+            tls.set_default_alpn_protocols(protocols)?;
+        }
+        Ok(())
+    }
 }
 
 impl From<TlsSettings> for MaybeTlsSettings {
@@ -738,6 +767,34 @@ mod test {
         let settings =
             TlsSettings::from_options(Some(&options)).expect("Failed to parse alpn_protocols");
         assert_eq!(settings.alpn_protocols, Some(vec![2, 104, 50]));
+    }
+
+    #[test]
+    fn set_default_alpn_protocols_applies_when_unset() {
+        let mut settings = TlsSettings::from_options(None).unwrap();
+        settings.set_default_alpn_protocols(&["h2"]).unwrap();
+        assert_eq!(settings.alpn_protocols, Some(vec![2, 104, 50]));
+    }
+
+    #[test]
+    fn set_default_alpn_protocols_preserves_explicit_config() {
+        let options = TlsConfig {
+            alpn_protocols: Some(vec![String::from("http/1.1")]),
+            ..Default::default()
+        };
+        let mut settings = TlsSettings::from_options(Some(&options)).unwrap();
+        settings.set_default_alpn_protocols(&["h2"]).unwrap();
+        assert_eq!(
+            settings.alpn_protocols,
+            Some(vec![8, 104, 116, 116, 112, 47, 49, 46, 49])
+        );
+    }
+
+    #[test]
+    fn maybe_tls_settings_set_default_alpn_protocols_is_noop_without_tls() {
+        let mut settings = MaybeTlsSettings::Raw(());
+        settings.set_default_alpn_protocols(&["h2"]).unwrap();
+        assert!(matches!(settings, MaybeTlsSettings::Raw(())));
     }
 
     #[test]

--- a/src/sources/util/grpc/mod.rs
+++ b/src/sources/util/grpc/mod.rs
@@ -371,9 +371,7 @@ where
 {
     let span = Span::current();
     let (tx, rx) = tokio::sync::oneshot::channel::<ShutdownSignalToken>();
-    // gRPC always runs over HTTP/2, and gRPC clients require the server to confirm `h2` via ALPN
-    // post-handshake (RFC 7540 Section 3.3). None of this function's callers expose an
-    // `alpn_protocols` config option, so the default has to be forced here.
+    // gRPC clients require the server to confirm `h2` via ALPN.
     tls_settings.set_default_alpn_protocols(&["h2"])?;
     let listener = tls_settings.bind_reloadable(&address, tls_reloader).await?;
     let max_connection_lifetime = keepalive.max_connection_lifetime();
@@ -417,8 +415,7 @@ pub async fn run_grpc_server_with_routes(
 ) -> crate::Result<()> {
     let span = Span::current();
     let (tx, rx) = tokio::sync::oneshot::channel::<ShutdownSignalToken>();
-    // See the comment in `run_grpc_server` above: gRPC requires `h2` confirmed via ALPN, and
-    // this function's callers don't expose an `alpn_protocols` config option.
+    // See the comment in `run_grpc_server` above.
     tls_settings.set_default_alpn_protocols(&["h2"])?;
     let listener = tls_settings.bind_reloadable(&address, tls_reloader).await?;
     let max_connection_lifetime = keepalive.max_connection_lifetime();

--- a/src/sources/util/grpc/mod.rs
+++ b/src/sources/util/grpc/mod.rs
@@ -355,7 +355,7 @@ where
 
 pub async fn run_grpc_server<S>(
     address: SocketAddr,
-    tls_settings: MaybeTlsSettings,
+    mut tls_settings: MaybeTlsSettings,
     tls_reloader: Option<TlsAcceptorReloader>,
     service: S,
     keepalive: GrpcKeepaliveConfig,
@@ -371,6 +371,10 @@ where
 {
     let span = Span::current();
     let (tx, rx) = tokio::sync::oneshot::channel::<ShutdownSignalToken>();
+    // gRPC always runs over HTTP/2, and gRPC clients require the server to confirm `h2` via ALPN
+    // post-handshake (RFC 7540 Section 3.3). None of this function's callers expose an
+    // `alpn_protocols` config option, so the default has to be forced here.
+    tls_settings.set_default_alpn_protocols(&["h2"])?;
     let listener = tls_settings.bind_reloadable(&address, tls_reloader).await?;
     let max_connection_lifetime = keepalive.max_connection_lifetime();
     let stream = listener
@@ -405,7 +409,7 @@ where
 // I just don't know how to convert the generic type with associated types into a Vec<Box<trait object>>.
 pub async fn run_grpc_server_with_routes(
     address: SocketAddr,
-    tls_settings: MaybeTlsSettings,
+    mut tls_settings: MaybeTlsSettings,
     tls_reloader: Option<TlsAcceptorReloader>,
     routes: Routes,
     keepalive: GrpcKeepaliveConfig,
@@ -413,6 +417,9 @@ pub async fn run_grpc_server_with_routes(
 ) -> crate::Result<()> {
     let span = Span::current();
     let (tx, rx) = tokio::sync::oneshot::channel::<ShutdownSignalToken>();
+    // See the comment in `run_grpc_server` above: gRPC requires `h2` confirmed via ALPN, and
+    // this function's callers don't expose an `alpn_protocols` config option.
+    tls_settings.set_default_alpn_protocols(&["h2"])?;
     let listener = tls_settings.bind_reloadable(&address, tls_reloader).await?;
     let max_connection_lifetime = keepalive.max_connection_lifetime();
     let stream = listener


### PR DESCRIPTION
## Summary

gRPC always runs over HTTP/2, and HTTP/2 clients require the server to confirm `h2` via ALPN post-handshake (RFC 7540 Section 3.3). None of Vector's gRPC-based sources (e.g. `opentelemetry`) expose an `alpn_protocols` config option, so when TLS is enabled without one, strict gRPC clients fail the handshake with:

```
rpc error: code = Unavailable desc = connection error: desc = "transport: authentication handshake failed: credentials: cannot check peer: missing selected ALPN property."
```

This adds `TlsSettings::set_default_alpn_protocols` / `MaybeTlsSettings::set_default_alpn_protocols`, which set a default ALPN protocol list only if the user hasn't already configured `tls.alpn_protocols` explicitly, and calls it with `["h2"]` from the shared `run_grpc_server`/`run_grpc_server_with_routes` helpers in `src/sources/util/grpc/mod.rs`. Fixing it at that shared layer means every current and future gRPC-based source gets the correct default without needing per-source config plumbing.

This is narrowly scoped to TLS: plaintext gRPC (h2c) has no ALPN step at all (ALPN is a TLS-handshake-only extension per RFC 7301), so it's unaffected and continues to work as before.


## Vector configuration

```yaml
sources:
  otel:
    type: opentelemetry
    grpc:
      address: 0.0.0.0:4317
      tls:
        enabled: true
        crt_file: server.crt
        key_file: server.key
    http:
      address: 0.0.0.0:4318
```

## How did you test this PR?

- Added unit tests in `lib/vector-core/src/tls/settings.rs` covering: default ALPN applies when unset, explicit `alpn_protocols` config is preserved (not overridden), and `MaybeTlsSettings::set_default_alpn_protocols` is a no-op when TLS is disabled.
- Reproduced the reported handshake failure end-to-end using [`telemetrygen`](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/cmd/telemetrygen) against a TLS-enabled `opentelemetry` source, on both the commit prior to this fix and this branch:

  **Setup:**

  ```bash
  # 1. Generate a self-signed cert with SANs covering how the client will dial it
  openssl req -x509 -newkey rsa:2048 -keyout otel-repro.key.pem -out otel-repro.cert.pem -days 2 -nodes \
    -subj "/CN=vector-repro" \
    -addext "subjectAltName=IP:127.0.0.1,DNS:host.docker.internal,DNS:localhost"
  ```

  ```yaml
  # 2. otel-tls-repro.yaml
  sources:
    otel:
      type: opentelemetry
      grpc:
        address: 0.0.0.0:4317
        tls:
          enabled: true
          crt_file: otel-repro.cert.pem
          key_file: otel-repro.key.pem
      http:
        address: 127.0.0.1:4318
  sinks:
    console:
      type: console
      inputs: [otel.logs]
      encoding:
        codec: json
  ```

  ```bash
  # 3. Run Vector, then generate real OTLP traffic against its gRPC listener
  vector -c otel-tls-repro.yaml &

  docker run --rm --add-host=host.docker.internal:host-gateway \
    -v "$(pwd)/otel-repro.cert.pem:/certs/ca.pem:ro" \
    --entrypoint /telemetrygen \
    ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.137.0 \
    logs --otlp-endpoint=host.docker.internal:4317 --ca-cert=/certs/ca.pem --logs=1 --rate=0
  ```

  **Results:**

  - On the commit prior to this fix, `telemetrygen` fails exactly as reported:
    ```
    FATAL   logs/worker.go:97      exporter failed {"worker": 0, "error": "exporter export timeout: rpc error: code = Unavailable desc = connection error: desc = \"transport: authentication handshake failed: credentials: cannot check peer: missing selected ALPN property. If you upgraded from a grpc-go version earlier than 1.67, your TLS connections may have stopped working due to ALPN enforcement...\""}
    ```
  - On this branch, `telemetrygen` exits `0` and Vector's console sink prints the received log:
    ```json
    {"message":"the message","resources":{"service.name":"telemetrygen"},"severity_text":"Info","source_type":"opentelemetry",...}
    ```

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [x] Yes. Changelog fragment added at `changelog.d/grpc_sources_default_alpn_h2.fix.md`.
- [ ] No.

## References

## Notes

Generated with Claude Sonnet 5 as a coding assistant; I've read, tested, and take ownership of these changes per the [AI Policy](https://github.com/vectordotdev/vector/blob/master/AI_POLICY.md). 
