### PR TITLE
chore(core): remove redundant vrl feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -232,7 +232,7 @@ vector-config = { path = "lib/vector-config" }
 vector-config-common = { path = "lib/vector-config-common" }
 vector-config-macros = { path = "lib/vector-config-macros" }
 vector-common-macros = { path = "lib/vector-common-macros" }
-vector-lib = { path = "lib/vector-lib", default-features = false, features = ["vrl"] }
+vector-lib = { path = "lib/vector-lib", default-features = false }
 vector-vrl-category = { path = "lib/vector-vrl/category" }
 vector-vrl-functions = { path = "lib/vector-vrl/functions", default-features = false }
 vrl = { git = "https://github.com/vectordotdev/vrl.git", branch = "main", default-features = false, features = ["arbitrary", "cli", "test", "test_framework", "stdlib-base"] }

--- a/lib/codecs/Cargo.toml
+++ b/lib/codecs/Cargo.toml
@@ -60,7 +60,7 @@ vector-common = { path = "../vector-common", default-features = false }
 vector-common-macros.workspace = true
 vector-config = { path = "../vector-config", default-features = false }
 vector-config-macros = { path = "../vector-config-macros", default-features = false }
-vector-core = { path = "../vector-core", default-features = false, features = ["vrl"] }
+vector-core = { path = "../vector-core", default-features = false }
 vector-vrl-functions.workspace = true
 toml = { version = "0.9.8", optional = true }
 
@@ -71,7 +71,7 @@ indoc.workspace = true
 tokio = { workspace = true, features = ["test-util"] }
 toml.workspace = true
 similar-asserts = "1.7.0"
-vector-core = { path = "../vector-core", default-features = false, features = ["vrl", "test"] }
+vector-core = { path = "../vector-core", default-features = false, features = ["test"] }
 rstest = "0.26.1"
 tracing-test = "0.2.6"
 uuid.workspace = true

--- a/lib/vector-core/Cargo.toml
+++ b/lib/vector-core/Cargo.toml
@@ -101,7 +101,6 @@ vector-common = { path = "../vector-common", default-features = false, features 
 [features]
 default = []
 lua = ["dep:mlua", "dep:tokio-stream", "vrl/lua"]
-vrl = []
 test = ["vector-common/test", "proptest"]
 generate-fixtures = ["vrl/generate-fixtures", "dep:quickcheck"]
 

--- a/lib/vector-core/src/event/metric/mod.rs
+++ b/lib/vector-core/src/event/metric/mod.rs
@@ -1,4 +1,3 @@
-#[cfg(feature = "vrl")]
 use std::convert::TryFrom;
 use std::{
     convert::AsRef,
@@ -15,7 +14,6 @@ use vector_common::{
     request_metadata::GetEventCountTags,
 };
 use vector_config::configurable_component;
-#[cfg(feature = "vrl")]
 use vrl::compiler::value::VrlValueConvert;
 
 use super::{
@@ -526,7 +524,6 @@ pub enum MetricKind {
     Absolute,
 }
 
-#[cfg(feature = "vrl")]
 impl TryFrom<vrl::value::Value> for MetricKind {
     type Error = String;
 
@@ -542,7 +539,6 @@ impl TryFrom<vrl::value::Value> for MetricKind {
     }
 }
 
-#[cfg(feature = "vrl")]
 impl From<MetricKind> for vrl::value::Value {
     fn from(kind: MetricKind) -> Self {
         match kind {

--- a/lib/vector-core/src/event/metric/value.rs
+++ b/lib/vector-core/src/event/metric/value.rs
@@ -513,7 +513,6 @@ impl From<AgentDDSketch> for MetricValue {
 }
 
 // Currently, VRL can only read the type of the value and doesn't consider any actual metric values.
-#[cfg(feature = "vrl")]
 impl From<MetricValue> for vrl::value::Value {
     fn from(value: MetricValue) -> Self {
         value.as_name().into()
@@ -575,7 +574,6 @@ impl ByteSizeOf for MetricSketch {
 }
 
 // Currently, VRL can only read the type of the value and doesn't consider ny actual metric values.
-#[cfg(feature = "vrl")]
 impl From<MetricSketch> for vrl::value::Value {
     fn from(value: MetricSketch) -> Self {
         value.as_name().into()

--- a/lib/vector-core/src/event/mod.rs
+++ b/lib/vector-core/src/event/mod.rs
@@ -18,7 +18,6 @@ use vector_common::{
     internal_event::TaggedEventsSent, json_size::JsonSize, request_metadata::GetEventCountTags,
 };
 pub use vrl::value::{KeyString, ObjectMap, Value};
-#[cfg(feature = "vrl")]
 pub use vrl_target::{TargetEvents, VrlTarget};
 
 use crate::config::{LogNamespace, OutputId};
@@ -42,7 +41,6 @@ mod ser;
 mod test;
 mod trace;
 pub mod util;
-#[cfg(feature = "vrl")]
 mod vrl_target;
 
 pub const PARTIAL: &str = "_partial";

--- a/lib/vector-core/src/lib.rs
+++ b/lib/vector-core/src/lib.rs
@@ -44,7 +44,6 @@ mod test_util;
 pub mod time;
 pub mod tls;
 pub mod transform;
-#[cfg(feature = "vrl")]
 pub mod vrl;
 
 use std::path::PathBuf;
@@ -52,7 +51,6 @@ use std::path::PathBuf;
 pub use event::EstimatedJsonEncodedSizeOf;
 use float_eq::FloatEq;
 
-#[cfg(feature = "vrl")]
 pub use crate::vrl::compile_vrl;
 
 #[macro_use]

--- a/lib/vector-lib/Cargo.toml
+++ b/lib/vector-lib/Cargo.toml
@@ -24,7 +24,7 @@ vector-lookup = { path = "../vector-lookup", features = ["test"] }
 vector-stream = { path = "../vector-stream" }
 vector-tap = { path = "../vector-tap" }
 vector-top = { path = "../vector-top", optional = true }
-vrl = { workspace = true, optional = true }
+vrl.workspace = true
 
 [features]
 antithesis-disk-asserts = ["vector-buffers/antithesis-disk-asserts"]
@@ -39,4 +39,3 @@ prometheus = ["dep:prometheus-parser"]
 proptest = ["vector-lookup/proptest", "vrl/proptest"]
 syslog = ["codecs/syslog"]
 test = ["codecs/test", "vector-core/test"]
-vrl = ["vector-core/vrl", "dep:vrl"]

--- a/lib/vector-lib/src/lib.rs
+++ b/lib/vector-lib/src/lib.rs
@@ -18,7 +18,6 @@ pub use vector_common::{
 };
 pub use vector_config as configurable;
 pub use vector_config::impl_generate_config_from_default;
-#[cfg(feature = "vrl")]
 pub use vector_core::compile_vrl;
 pub use vector_core::{
     EstimatedJsonEncodedSizeOf, SpanField, buckets, default_data_dir, emit, event, fanout,
@@ -31,7 +30,6 @@ pub use vector_stream as stream;
 pub use vector_tap as tap;
 #[cfg(feature = "vector-top")]
 pub use vector_top as top;
-#[cfg(feature = "vrl")]
 pub use vrl;
 
 pub mod config {

--- a/lib/vector-vrl/metrics/Cargo.toml
+++ b/lib/vector-vrl/metrics/Cargo.toml
@@ -13,7 +13,7 @@ workspace = true
 arc-swap.workspace = true
 const-str.workspace = true
 vrl.workspace = true
-vector-core = { path = "../../vector-core", default-features = false, features = ["vrl"] }
+vector-core = { path = "../../vector-core", default-features = false }
 vector-common = { path = "../../vector-common", default-features = false }
 tokio.workspace = true
 tokio-stream.workspace = true

--- a/lib/vector-vrl/tests/Cargo.toml
+++ b/lib/vector-vrl/tests/Cargo.toml
@@ -13,7 +13,7 @@ chrono-tz.workspace = true
 vector-vrl-functions = { workspace = true, features = ["dnstap", "vrl-metrics"] }
 enrichment = { path = "../enrichment" }
 vector-vrl-metrics = { path = "../metrics" }
-vector-core = { path = "../../vector-core", default-features = false, features = ["vrl"] }
+vector-core = { path = "../../vector-core", default-features = false }
 vrl = { workspace = true, features = ["stdlib"] }
 
 clap.workspace = true


### PR DESCRIPTION
## Summary

Remove the redundant `vrl` feature gates from `vector-core` and `vector-lib`.

VRL is already an unconditional core dependency (that we own).

## Changes

- Compile the VRL integration in `vector-core` unconditionally.
- Make the VRL re-exports in `vector-lib` unconditional.
- Remove `vector-core/vrl` and `vector-lib/vrl` feature wiring.
- Remove redundant feature activation from `codecs` and Vector's VRL helper crates.

## References

https://github.com/vectordotdev/vector/pull/25376