### PR TITLE
fix(azure_blob sink): Fix Shared Key auth for multipart uploads

### DIFF
--- a/changelog.d/azure_blob_shared_key_multipart.fix.md
+++ b/changelog.d/azure_blob_shared_key_multipart.fix.md
@@ -1,0 +1,3 @@
+Fix Azure Blob Storage uploads larger than 4 MiB when using an account-key connection string. Vector now signs the final multipart request with its serialized body length.
+
+authors: ArunPiduguDD

--- a/changelog.d/azure_blob_shared_key_multipart.fix.md
+++ b/changelog.d/azure_blob_shared_key_multipart.fix.md
@@ -1,3 +1,3 @@
-Fix Azure Blob Storage uploads larger than 4 MiB when using an account-key connection string. Vector now signs the final multipart request with its serialized body length.
+Fix Azure Blob Storage uploads larger than 4 MiB when using an account-key connection string. These uploads could send all data blocks successfully but fail with a 403 while completing the upload because the final request's body length was missing during Shared Key signing. Vector now sets the body length before signing that request.
 
 authors: ArunPiduguDD

--- a/src/sinks/azure_blob/config.rs
+++ b/src/sinks/azure_blob/config.rs
@@ -542,7 +542,7 @@ pub async fn build_client(
             .map_err(|e| format!("Failed to create SharedKey policy: {e}"))?;
             options
                 .client_options
-                .per_call_policies
+                .per_try_policies
                 .push(Arc::new(policy));
         }
         (Auth::None, Some(AzureAuthentication::Specific(..))) => {

--- a/src/sinks/azure_blob/config.rs
+++ b/src/sinks/azure_blob/config.rs
@@ -542,7 +542,7 @@ pub async fn build_client(
             .map_err(|e| format!("Failed to create SharedKey policy: {e}"))?;
             options
                 .client_options
-                .per_try_policies
+                .per_call_policies
                 .push(Arc::new(policy));
         }
         (Auth::None, Some(AzureAuthentication::Specific(..))) => {

--- a/src/sinks/azure_blob/integration_tests.rs
+++ b/src/sinks/azure_blob/integration_tests.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use vrl::event_path;
 
-use azure_core::http::StatusCode;
+use azure_core::http::{RequestContent, StatusCode};
 use azure_storage_blob::BlobContainerClient;
 
 use bytes::{Buf, BytesMut};
@@ -30,6 +30,34 @@ use crate::{
     },
     tls,
 };
+
+#[tokio::test]
+async fn azure_blob_uploads_one_shot_with_shared_key() {
+    let config = AzureBlobSinkConfig::new_emulator().await;
+    let client = config.build_test_client().await;
+    let blob_name = format!("one-shot/{}.blob", random_string(10));
+    let payload = vec![b'x'; 3 * 1024 * 1024];
+
+    client
+        .blob_client(&blob_name)
+        .upload(RequestContent::from(payload), None)
+        .await
+        .expect("one-shot upload should succeed");
+}
+
+#[tokio::test]
+async fn azure_blob_uploads_multipart_with_shared_key() {
+    let config = AzureBlobSinkConfig::new_emulator().await;
+    let client = config.build_test_client().await;
+    let blob_name = format!("multipart/{}.blob", random_string(10));
+    let payload = vec![b'x'; 5 * 1024 * 1024];
+
+    client
+        .blob_client(&blob_name)
+        .upload(RequestContent::from(payload), None)
+        .await
+        .expect("multipart upload should commit the block list");
+}
 
 #[tokio::test]
 async fn azure_blob_healthcheck_passed() {

--- a/src/sinks/azure_common/shared_key_policy.rs
+++ b/src/sinks/azure_common/shared_key_policy.rs
@@ -13,7 +13,7 @@ use openssl::{hash::MessageDigest, pkey::PKey, sign::Signer};
 
 /// Shared Key authorization policy for Azure Blob Storage requests.
 ///
-/// This policy injects the required headers (x-ms-date, x-ms-version, and a known
+/// This policy injects the required headers (x-ms-date, x-ms-version, and
 /// Content-Length) if missing and adds the `Authorization: SharedKey {account}:{signature}` header. The signature
 /// is computed according to the "Authorize with Shared Key" rules for the Blob service:
 ///

--- a/src/sinks/azure_common/shared_key_policy.rs
+++ b/src/sinks/azure_common/shared_key_policy.rs
@@ -270,6 +270,38 @@ impl Policy for SharedKeyAuthorizationPolicy {
 
 // ---------- Helpers ----------
 
+fn append_canonicalized_resource(s: &mut String, account: &str, url: &Url) -> AzureResult<()> {
+    // "/{account_name}{path}\n"
+    s.push('/');
+    s.push_str(account);
+    // Append the URL path exactly as-is (per spec).
+    s.push_str(url.path());
+
+    // Canonicalized query: lowercase names, sort by name, join multi-values by comma, each line "name:value\n"
+    // https://learn.microsoft.com/en-us/rest/api/storageservices/authorize-with-shared-key#shared-key-format-for-2009-09-19-and-later
+    if url.query().is_some() {
+        let mut qp_map: BTreeMap<String, Vec<String>> = BTreeMap::new();
+        for (name, value) in url.query_pairs() {
+            let key_l = name.to_ascii_lowercase();
+            let v = value.to_string();
+            if v.is_empty() {
+                continue;
+            }
+            qp_map.entry(key_l).or_default().push(v);
+        }
+        for (k, mut vals) in qp_map {
+            vals.sort();
+            let mut line = String::new();
+            write!(&mut line, "\n{}:", k).ok();
+            let joined = vals.join(",");
+            line.push_str(&joined);
+            s.push_str(&line);
+        }
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use azure_core::http::Method;
@@ -346,36 +378,4 @@ mod tests {
         assert_eq!(content_length_field(&mut request), "");
         assert_eq!(content_length_header(&request), Some("0"));
     }
-}
-
-fn append_canonicalized_resource(s: &mut String, account: &str, url: &Url) -> AzureResult<()> {
-    // "/{account_name}{path}\n"
-    s.push('/');
-    s.push_str(account);
-    // Append the URL path exactly as-is (per spec).
-    s.push_str(url.path());
-
-    // Canonicalized query: lowercase names, sort by name, join multi-values by comma, each line "name:value\n"
-    // https://learn.microsoft.com/en-us/rest/api/storageservices/authorize-with-shared-key#shared-key-format-for-2009-09-19-and-later
-    if url.query().is_some() {
-        let mut qp_map: BTreeMap<String, Vec<String>> = BTreeMap::new();
-        for (name, value) in url.query_pairs() {
-            let key_l = name.to_ascii_lowercase();
-            let v = value.to_string();
-            if v.is_empty() {
-                continue;
-            }
-            qp_map.entry(key_l).or_default().push(v);
-        }
-        for (k, mut vals) in qp_map {
-            vals.sort();
-            let mut line = String::new();
-            write!(&mut line, "\n{}:", k).ok();
-            let joined = vals.join(",");
-            line.push_str(&joined);
-            s.push_str(&line);
-        }
-    }
-
-    Ok(())
 }

--- a/src/sinks/azure_common/shared_key_policy.rs
+++ b/src/sinks/azure_common/shared_key_policy.rs
@@ -118,9 +118,19 @@ impl SharedKeyAuthorizationPolicy {
         }
         s.push('\n');
 
-        // Content-Length (include value if present; keep "0")
-        if let Some(v) = header("Content-Length") {
-            s.push_str(v);
+        // Azure's Shared Key format represents zero length as an empty field. When the SDK
+        // has not set the header yet, use the known body length that the transport will send.
+        let content_length = header("Content-Length")
+            .filter(|value| *value != "0")
+            .map(str::to_owned)
+            .or_else(|| {
+                req.body()
+                    .len()
+                    .filter(|length| *length != 0)
+                    .map(|length| length.to_string())
+            });
+        if let Some(content_length) = content_length {
+            s.push_str(&content_length);
         }
         s.push('\n');
 
@@ -257,6 +267,69 @@ impl Policy for SharedKeyAuthorizationPolicy {
 }
 
 // ---------- Helpers ----------
+
+#[cfg(test)]
+mod tests {
+    use azure_core::http::Method;
+
+    use super::*;
+
+    fn policy() -> SharedKeyAuthorizationPolicy {
+        SharedKeyAuthorizationPolicy::new(
+            "account".to_owned(),
+            "ZmFrZS10ZXN0LWFjY291bnQta2V5".to_owned(),
+            "2025-11-05".to_owned(),
+        )
+        .expect("test key should be valid base64")
+    }
+
+    fn content_length_field(request: &Request) -> String {
+        policy()
+            .build_string_to_sign(request, "Thu, 30 Jul 2026 16:02:25 GMT", "2025-11-05")
+            .expect("request should be signed")
+            .lines()
+            .nth(3)
+            .expect("string to sign should contain content length")
+            .to_owned()
+    }
+
+    #[test]
+    fn uses_the_body_length_when_content_length_is_missing() {
+        let mut request = Request::new(
+            Url::parse("https://account.blob.core.windows.net/container/blob?comp=blocklist")
+                .expect("test URL should be valid"),
+            Method::Put,
+        );
+        request.set_body(vec![0_u8; 123]);
+
+        assert_eq!(content_length_field(&request), "123");
+    }
+
+    #[test]
+    fn preserves_a_nonzero_content_length_header() {
+        let mut request = Request::new(
+            Url::parse("https://account.blob.core.windows.net/container/blob")
+                .expect("test URL should be valid"),
+            Method::Put,
+        );
+        request.insert_header("content-length", "42");
+        request.set_body(vec![0_u8; 123]);
+
+        assert_eq!(content_length_field(&request), "42");
+    }
+
+    #[test]
+    fn canonicalizes_zero_content_length_as_empty() {
+        let mut request = Request::new(
+            Url::parse("https://account.blob.core.windows.net/container/blob")
+                .expect("test URL should be valid"),
+            Method::Put,
+        );
+        request.insert_header("content-length", "0");
+
+        assert_eq!(content_length_field(&request), "");
+    }
+}
 
 fn append_canonicalized_resource(s: &mut String, account: &str, url: &Url) -> AzureResult<()> {
     // "/{account_name}{path}\n"

--- a/src/sinks/azure_common/shared_key_policy.rs
+++ b/src/sinks/azure_common/shared_key_policy.rs
@@ -13,8 +13,8 @@ use openssl::{hash::MessageDigest, pkey::PKey, sign::Signer};
 
 /// Shared Key authorization policy for Azure Blob Storage requests.
 ///
-/// This policy injects the required headers (x-ms-date, x-ms-version) if missing and
-/// adds the `Authorization: SharedKey {account}:{signature}` header. The signature
+/// This policy injects the required headers (x-ms-date, x-ms-version, and a known
+/// Content-Length) if missing and adds the `Authorization: SharedKey {account}:{signature}` header. The signature
 /// is computed according to the "Authorize with Shared Key" rules for the Blob service:
 ///
 /// StringToSign =
@@ -70,13 +70,24 @@ impl SharedKeyAuthorizationPolicy {
         })
     }
 
-    fn ensure_ms_headers(&self, request: &mut Request) -> AzureResult<(String, String)> {
+    fn ensure_signing_headers(&self, request: &mut Request) -> AzureResult<(String, String)> {
         // Always set x-ms-date and x-ms-version explicitly to known values for signing.
         let now = OffsetDateTime::now_utc();
         let ms_date = to_rfc7231(&now);
         request.insert_header("x-ms-date", ms_date.clone());
         let ms_version = self.storage_version.clone();
         request.insert_header("x-ms-version", ms_version.clone());
+
+        // Set a known body length before signing so the signature and wire request use the
+        // same explicit value. Preserve a Content-Length supplied by the SDK.
+        let has_content_length = request
+            .headers()
+            .iter()
+            .any(|(name, _)| name.as_str().eq_ignore_ascii_case("content-length"));
+        if !has_content_length && let Some(content_length) = request.body().len() {
+            request.insert_header("content-length", content_length.to_string());
+        }
+
         Ok((ms_date, ms_version))
     }
 
@@ -118,19 +129,10 @@ impl SharedKeyAuthorizationPolicy {
         }
         s.push('\n');
 
-        // Azure's Shared Key format represents zero length as an empty field. When the SDK
-        // has not set the header yet, use the known body length that the transport will send.
-        let content_length = header("Content-Length")
-            .filter(|value| *value != "0")
-            .map(str::to_owned)
-            .or_else(|| {
-                req.body()
-                    .len()
-                    .filter(|length| *length != 0)
-                    .map(|length| length.to_string())
-            });
+        // Azure's Shared Key format represents zero length as an empty field.
+        let content_length = header("Content-Length").filter(|value| *value != "0");
         if let Some(content_length) = content_length {
-            s.push_str(&content_length);
+            s.push_str(content_length);
         }
         s.push('\n');
 
@@ -249,8 +251,8 @@ impl Policy for SharedKeyAuthorizationPolicy {
         request: &mut Request,
         next: &[Arc<dyn Policy>],
     ) -> PolicyResult {
-        // Ensure required x-ms headers are present
-        let (ms_date, ms_version) = self.ensure_ms_headers(request)?;
+        // Ensure required signing headers are present
+        let (ms_date, ms_version) = self.ensure_signing_headers(request)?;
         // Build string to sign
         let sts = self.build_string_to_sign(request, &ms_date, &ms_version)?;
         let signature = self.sign(&sts)?;
@@ -283,8 +285,20 @@ mod tests {
         .expect("test key should be valid base64")
     }
 
-    fn content_length_field(request: &Request) -> String {
-        policy()
+    fn content_length_header(request: &Request) -> Option<&str> {
+        request.headers().iter().find_map(|(name, value)| {
+            name.as_str()
+                .eq_ignore_ascii_case("content-length")
+                .then_some(value.as_str())
+        })
+    }
+
+    fn content_length_field(request: &mut Request) -> String {
+        let policy = policy();
+        policy
+            .ensure_signing_headers(request)
+            .expect("signing headers should be added");
+        policy
             .build_string_to_sign(request, "Thu, 30 Jul 2026 16:02:25 GMT", "2025-11-05")
             .expect("request should be signed")
             .lines()
@@ -294,7 +308,7 @@ mod tests {
     }
 
     #[test]
-    fn uses_the_body_length_when_content_length_is_missing() {
+    fn sets_and_signs_the_body_length_when_content_length_is_missing() {
         let mut request = Request::new(
             Url::parse("https://account.blob.core.windows.net/container/blob?comp=blocklist")
                 .expect("test URL should be valid"),
@@ -302,7 +316,8 @@ mod tests {
         );
         request.set_body(vec![0_u8; 123]);
 
-        assert_eq!(content_length_field(&request), "123");
+        assert_eq!(content_length_field(&mut request), "123");
+        assert_eq!(content_length_header(&request), Some("123"));
     }
 
     #[test]
@@ -315,7 +330,8 @@ mod tests {
         request.insert_header("content-length", "42");
         request.set_body(vec![0_u8; 123]);
 
-        assert_eq!(content_length_field(&request), "42");
+        assert_eq!(content_length_field(&mut request), "42");
+        assert_eq!(content_length_header(&request), Some("42"));
     }
 
     #[test]
@@ -327,7 +343,8 @@ mod tests {
         );
         request.insert_header("content-length", "0");
 
-        assert_eq!(content_length_field(&request), "");
+        assert_eq!(content_length_field(&mut request), "");
+        assert_eq!(content_length_header(&request), Some("0"));
     }
 }
 

--- a/src/sinks/azure_common/shared_key_policy.rs
+++ b/src/sinks/azure_common/shared_key_policy.rs
@@ -14,7 +14,7 @@ use openssl::{hash::MessageDigest, pkey::PKey, sign::Signer};
 /// Shared Key authorization policy for Azure Blob Storage requests.
 ///
 /// This policy injects the required headers (x-ms-date, x-ms-version, and
-/// Content-Length) if missing and adds the `Authorization: SharedKey {account}:{signature}` header. The signature
+/// content-length) if missing and adds the `Authorization: SharedKey {account}:{signature}` header. The signature
 /// is computed according to the "Authorize with Shared Key" rules for the Blob service:
 ///
 /// StringToSign =

--- a/src/sinks/azure_common/shared_key_policy.rs
+++ b/src/sinks/azure_common/shared_key_policy.rs
@@ -129,6 +129,7 @@ impl SharedKeyAuthorizationPolicy {
         }
         s.push('\n');
 
+        // Content-Length
         // Azure's Shared Key format represents zero length as an empty field.
         let content_length = header("Content-Length").filter(|value| *value != "0");
         if let Some(content_length) = content_length {


### PR DESCRIPTION
## Summary

Fix Azure Blob Storage uploads that use an account-key connection string and are large enough to be sent in multiple parts.

When Vector is configured with an account-key connection string, it uses [Shared Key authorization](https://learn.microsoft.com/en-us/rest/api/storageservices/authorize-with-shared-key). Shared Key authorization constructs a signature from several parts of the request, including its `Content-Length`.

For uploads of 4 MiB or less, the Azure SDK sends a single request and provides its `content-length` before Vector constructs the signature. Larger uploads are divided into blocks. After uploading those blocks, the SDK sends a final `Put Block List` request containing an XML body that identifies the blocks belonging to a single upload.

Previously, this final block-list request was signed before the HTTP transport determined the XML body's `content-length`. Vector therefore signed an empty content-length field, while Azure validated the signature using the body length it received. Because the two signatures were based on different values, Azure rejected the request with `403 AuthorizationFailure`.

This change makes Vector's Shared Key policy add an explicit `content-length` header from the known request body length when the SDK has not already provided one. Vector then constructs the signature from that header, and the HTTP transport sends the same header to Azure. The policy preserves an explicit nonzero header supplied by the SDK and represents a zero-length body as an empty field in the signature, as required by Azure's Shared Key rules.

Example of the affected request flow before this change:

```text
PUT blob?comp=block&blockid=first   -> 201
PUT blob?comp=block&blockid=second  -> 201
PUT blob?comp=blocklist             -> 403 AuthorizationFailure
```

After this change:

```text
PUT blob?comp=block&blockid=first   -> 201
PUT blob?comp=block&blockid=second  -> 201
PUT blob?comp=blocklist             -> 201
```

## Vector configuration

No configuration changes are needed. This affects existing Azure Blob sink configurations that use a connection string with an account key, for example:

```yaml
sinks:
  archive:
    type: azure_blob
    container_name: logs
    connection_string: >-
      DefaultEndpointsProtocol=https;
      AccountName=exampleaccount;
      AccountKey=<account-key>;
      EndpointSuffix=core.windows.net
```

SAS URL and Microsoft Entra ID authentication are not affected because they do not use this per-request Shared Key signature.

## How did you test this PR?

- Added unit tests for Shared Key content-length handling:
  - add and sign the known body length when the header is missing;
  - preserve an existing nonzero header;
  - send `Content-Length: 0` while representing it as an empty canonical field.
- Added Azurite integration coverage on both sides of the SDK's 4 MiB multipart boundary:
  - a 3 MiB one-shot upload succeeds;
  - a 5 MiB multipart upload succeeds using Shared Key authentication.
- Confirmed the new 5 MiB test fails before the fix: Azurite accepts both block uploads and rejects `?comp=blocklist` with `403 AuthorizationFailure`.
- Confirmed the fixed run accepts both block uploads and the final `?comp=blocklist` request with `201`.
- Ran:

```text
cargo vdev int test --retries 0 azure 3.35.0 \
  azure_blob_uploads_one_shot_with_shared_key \
  azure_blob_uploads_multipart_with_shared_key

cargo test --lib --no-default-features --features sinks-azure_blob \
  shared_key_policy::tests

cargo clippy --lib --no-default-features --features sinks-azure_blob -- -D warnings
cargo vdev check changelog-fragments
cargo fmt
```

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [x] Yes. Added `changelog.d/azure_blob_shared_key_multipart.fix.md`.
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Azure Shared Key signing format: https://learn.microsoft.com/rest/api/storageservices/authorize-with-shared-key
- Azure Put Block List request: https://learn.microsoft.com/rest/api/storageservices/put-block-list

