### PR TITLE
chore(dev): honor CARGO_TARGET_DIR when generating component docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,11 @@ export CURRENT_DIR = $(shell pwd)
 # via .github/actions/setup; falling back to `cargo vdev` recompiles vdev).
 VDEV ?= cargo vdev
 
+# Cargo writes artifacts to CARGO_TARGET_DIR when it is set, so recipes that run
+# a freshly built binary have to resolve the same directory rather than assume
+# `target` — otherwise they silently execute a stale binary from a previous build.
+CARGO_TARGET_DIR ?= target
+
 # Set dummy AWS credentials if not present - used for AWS and ES integration tests
 export AWS_ACCESS_KEY_ID ?= "dummy"
 export AWS_SECRET_ACCESS_KEY ?= "dummy"
@@ -513,7 +518,7 @@ generate-kubernetes-manifests: ## Generate Kubernetes manifests from latest Helm
 .PHONY: generate-component-docs
 generate-component-docs: ## Generate per-component Cue docs from the configuration schema.
 	cargo build $(if $(findstring true,$(CI)),--quiet,)
-	target/debug/vector generate-schema > /tmp/vector-config-schema.json 2>/dev/null
+	$(CARGO_TARGET_DIR)/debug/vector generate-schema > /tmp/vector-config-schema.json 2>/dev/null
 	$(VDEV) build component-docs /tmp/vector-config-schema.json \
 		$(if $(findstring true,$(CI)),>/dev/null,)
 	./scripts/cue.sh fmt


### PR DESCRIPTION
## Summary

`make generate-component-docs` builds Vector with cargo and then runs the binary from a hardcoded `target/debug/vector`:

```make
cargo build $(if $(findstring true,$(CI)),--quiet,)
target/debug/vector generate-schema > /tmp/vector-config-schema.json 2>/dev/null
```

Cargo writes artifacts to `CARGO_TARGET_DIR` when that variable is set, so with it exported the recipe builds the current tree into one directory and then generates the schema from whatever stale binary happens to be sitting in `target/debug`.

What makes this worth fixing is that it does not fail. It produces confident, plausible-looking output from an old schema. In my case the regeneration left the component I had actually changed untouched (its new options were missing from the schema) while reverting `required_one_of` / `required_one_of_group` across 35 unrelated generated files, undoing #25948. Nothing errored, and `git status` looked like a legitimate regeneration.

This affects anyone with `CARGO_TARGET_DIR` set — shared build caches across worktrees, sccache-style setups, and sandboxed editor environments.

The fix resolves the same directory cargo used:

```make
CARGO_TARGET_DIR ?= target
...
$(CARGO_TARGET_DIR)/debug/vector generate-schema > /tmp/vector-config-schema.json 2>/dev/null
```

Make imports environment variables, so `?=` takes an exported value when present and otherwise falls back to `target`. This is the only hardcoded target path in the Makefile. `vdev_publish.yml` already uses the equivalent `${CARGO_TARGET_DIR:-target}` fallback.

## How did you test this PR?

Confirmed the recipe expands correctly in all three cases with `make -n`:

```
# CARGO_TARGET_DIR exported
/path/to/custom/cargo-target/debug/vector generate-schema > /tmp/vector-config-schema.json

# unset (default contributor setup, unchanged from today)
target/debug/vector generate-schema > /tmp/vector-config-schema.json

# explicit override
/custom/build/debug/vector generate-schema > /tmp/vector-config-schema.json
```

The unset case is byte-identical to the current behavior, so contributors who do not set the variable see no change.

I also hit the original bug end to end: running `make generate-component-docs` with `CARGO_TARGET_DIR` exported produced the bogus 35-file diff described above, and re-running the generation against the correctly-resolved binary produced only the expected changes.

CI does not set `CARGO_TARGET_DIR`, so there is no change in CI behavior.

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: #25948 (the `required_one_of` output that the stale-binary regeneration silently reverted)

Made with [Cursor](https://cursor.com)