### PR TITLE
fix(config): preserve null while loading configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10421,15 +10421,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde-toml-merge"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc44799282f511a5d403d72a4ff028dc2c87f7fe6830abe3c33bb2fa6dfccec"
-dependencies = [
- "toml",
-]
-
-[[package]]
 name = "serde-value"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13115,7 +13106,6 @@ dependencies = [
  "seahash",
  "semver",
  "serde",
- "serde-toml-merge",
  "serde_bytes",
  "serde_json",
  "serde_with",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13108,6 +13108,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
+ "serde_path_to_error",
  "serde_with",
  "serde_yaml",
  "serial_test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -336,7 +336,6 @@ tower = { version = "0.5.2", default-features = false, features = ["buffer", "li
 tower-http = { version = "0.4.4", default-features = false, features = ["compression-full", "decompression-full", "trace"] }
 # Serde
 serde.workspace = true
-serde-toml-merge = { version = "0.3.11", default-features = false }
 serde_bytes = { version = "0.11.17", default-features = false, features = ["std"], optional = true }
 serde_json.workspace = true
 serde_with = { version = "3.14.0", default-features = false, features = ["macros", "std"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -206,6 +206,7 @@ rust_decimal = { version = "1.40.0", default-features = false, features = ["std"
 semver = { version = "1.0.28", default-features = false, features = ["serde", "std"] }
 serde = { version = "1.0.219", default-features = false, features = ["alloc", "derive", "rc"] }
 serde_json = { version = "1.0.150", default-features = false, features = ["preserve_order", "raw_value", "std"] }
+serde_path_to_error = "0.1.14"
 serde_with = { version = "3.21.0", default-features = false, features = ["std", "macros", "chrono_0_4"] }
 serde_yaml = { version = "0.9.34", default-features = false }
 snafu = { version = "0.9.0", default-features = false, features = ["futures", "std"] }
@@ -338,6 +339,7 @@ tower-http = { version = "0.4.4", default-features = false, features = ["compres
 serde.workspace = true
 serde_bytes = { version = "0.11.17", default-features = false, features = ["std"], optional = true }
 serde_json.workspace = true
+serde_path_to_error.workspace = true
 serde_with = { version = "3.14.0", default-features = false, features = ["macros", "std"] }
 serde_yaml.workspace = true
 

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -697,7 +697,6 @@ semver,https://github.com/dtolnay/semver,MIT OR Apache-2.0,David Tolnay <dtolnay
 seq-macro,https://github.com/dtolnay/seq-macro,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 serde,https://github.com/serde-rs/serde,MIT OR Apache-2.0,"Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>"
 serde-aux,https://github.com/iddm/serde-aux,MIT,Victor Polevoy <maintainer@vpolevoy.com>
-serde-toml-merge,https://github.com/jdrouet/serde-toml-merge,MIT,Jeremie Drouet <jeremie.drouet@gmail.com>
 serde-value,https://github.com/arcnmx/serde-value,MIT,arcnmx
 serde_bytes,https://github.com/serde-rs/bytes,MIT OR Apache-2.0,David Tolnay <dtolnay@gmail.com>
 serde_core,https://github.com/serde-rs/serde,MIT OR Apache-2.0,"Erick Tryzelaar <erick.tryzelaar@gmail.com>, David Tolnay <dtolnay@gmail.com>"

--- a/changelog.d/19963_config_null.fix.md
+++ b/changelog.d/19963_config_null.fix.md
@@ -1,0 +1,4 @@
+Allow explicit null values in JSON and YAML configuration files to load without being converted
+through TOML.
+
+authors: pront

--- a/changelog.d/config_error_paths.fix.md
+++ b/changelog.d/config_error_paths.fix.md
@@ -1,0 +1,13 @@
+Improve configuration error messages by including the affected field path. For example, this
+invalid configuration:
+
+```yaml
+sources:
+  broken:
+    type: demo_logs
+    interval: not-a-number
+```
+
+now reports `sources.broken: invalid type: string "not-a-number", expected f64`.
+
+authors: pront

--- a/src/config/loading/config_builder.rs
+++ b/src/config/loading/config_builder.rs
@@ -1,9 +1,11 @@
 use std::{collections::HashMap, io::Read};
 
 use indexmap::IndexMap;
-use toml::value::Table;
 
-use super::{ComponentHint, Process, deserialize_table, loader, prepare_input, secret};
+use super::{
+    ComponentHint, Process, deserialize_config_map, loader, prepare_input,
+    representation::ConfigMap, secret,
+};
 use crate::config::{
     ComponentKey, ConfigBuilder, EnrichmentTableOuter, SinkOuter, SourceOuter, TestDefinition,
     TransformOuter,
@@ -74,40 +76,42 @@ impl Process for ConfigBuilderLoader {
         })
     }
 
-    /// Merge a TOML `Table` with a `ConfigBuilder`. Component types extend specific keys.
-    fn merge(&mut self, table: Table, hint: Option<ComponentHint>) -> Result<(), Vec<String>> {
+    /// Merge a configuration map with a `ConfigBuilder`. Component types extend specific keys.
+    fn merge(&mut self, map: ConfigMap, hint: Option<ComponentHint>) -> Result<(), Vec<String>> {
         match hint {
             Some(ComponentHint::Source) => {
-                self.builder.sources.extend(deserialize_table::<
-                    IndexMap<ComponentKey, SourceOuter>,
-                >(table)?);
+                self.builder
+                    .sources
+                    .extend(deserialize_config_map::<IndexMap<ComponentKey, SourceOuter>>(map)?);
             }
             Some(ComponentHint::Sink) => {
-                self.builder.sinks.extend(
-                    deserialize_table::<IndexMap<ComponentKey, SinkOuter<_>>>(table)?,
-                );
+                self.builder.sinks.extend(deserialize_config_map::<
+                    IndexMap<ComponentKey, SinkOuter<_>>,
+                >(map)?);
             }
             Some(ComponentHint::Transform) => {
-                self.builder.transforms.extend(deserialize_table::<
+                self.builder.transforms.extend(deserialize_config_map::<
                     IndexMap<ComponentKey, TransformOuter<_>>,
-                >(table)?);
+                >(map)?);
             }
             Some(ComponentHint::EnrichmentTable) => {
-                self.builder.enrichment_tables.extend(deserialize_table::<
-                    IndexMap<ComponentKey, EnrichmentTableOuter<_>>,
-                >(table)?);
+                self.builder
+                    .enrichment_tables
+                    .extend(deserialize_config_map::<
+                        IndexMap<ComponentKey, EnrichmentTableOuter<_>>,
+                    >(map)?);
             }
             Some(ComponentHint::Test) => {
                 // This serializes to a `Vec<TestDefinition<_>>`, so we need to first expand
                 // it to an ordered map, and then pull out the value, ignoring the keys.
                 self.builder.tests.extend(
-                    deserialize_table::<IndexMap<String, TestDefinition<String>>>(table)?
+                    deserialize_config_map::<IndexMap<String, TestDefinition<String>>>(map)?
                         .into_iter()
                         .map(|(_, test)| test),
                 );
             }
             None => {
-                self.builder.append(deserialize_table(table)?)?;
+                self.builder.append(deserialize_config_map(map)?)?;
             }
         };
 

--- a/src/config/loading/loader.rs
+++ b/src/config/loading/loader.rs
@@ -4,7 +4,9 @@ use serde_json::Value;
 
 use super::{
     Format, component_name, open_file, read_dir,
-    representation::{ConfigMap, deserialize_config, merge_into_map, merge_values},
+    representation::{
+        ConfigMap, deserialize_config, deserialize_config_value, merge_into_map, merge_values,
+    },
 };
 
 /// Provides a hint to the loading system of the type of components that should be found
@@ -300,5 +302,5 @@ fn merge_with_value(res: &mut ConfigMap, name: String, value: Value) -> Result<(
 pub(super) fn deserialize_config_map<T: serde::de::DeserializeOwned>(
     map: ConfigMap,
 ) -> Result<T, Vec<String>> {
-    serde_json::from_value(Value::Object(map)).map_err(|error| vec![error.to_string()])
+    deserialize_config_value(Value::Object(map))
 }

--- a/src/config/loading/loader.rs
+++ b/src/config/loading/loader.rs
@@ -1,10 +1,11 @@
 use std::path::{Path, PathBuf};
 
-use serde_toml_merge::merge_into_table;
-use toml::value::{Table, Value};
+use serde_json::Value;
 
-use super::{Format, component_name, open_file, read_dir};
-use crate::config::format;
+use super::{
+    Format, component_name, open_file, read_dir,
+    representation::{ConfigMap, deserialize_config, merge_into_map, merge_values},
+};
 
 /// Provides a hint to the loading system of the type of components that should be found
 /// when traversing an explicitly named directory.
@@ -61,17 +62,17 @@ pub(super) mod process {
         where
             T: serde::de::DeserializeOwned,
         {
-            let value = self.prepare(input)?;
+            let content = self.prepare(input)?;
 
-            format::deserialize(&value, format)
+            deserialize_config(&content, format)
         }
 
         /// Helper method used by other methods to recursively handle file/dir loading, merging
-        /// values against a provided TOML `Table`.
+        /// values against a provided configuration map.
         fn load_dir_into(
             &mut self,
             path: &Path,
-            result: &mut Table,
+            result: &mut ConfigMap,
             recurse: bool,
         ) -> Result<(), Vec<String>> {
             let mut errors = Vec::new();
@@ -121,7 +122,7 @@ pub(super) mod process {
 
                 match loaded {
                     Ok(Some((name, inner))) => {
-                        if let Err(errs) = merge_with_value(result, name, Value::Table(inner)) {
+                        if let Err(errs) = merge_with_value(result, name, Value::Object(inner)) {
                             errors.extend(errs);
                         }
                     }
@@ -139,8 +140,8 @@ pub(super) mod process {
                         && !result.contains_key(&name)
                     {
                         match self.load_dir(&entry, true) {
-                            Ok(table) => {
-                                result.insert(name, Value::Table(table));
+                            Ok(map) => {
+                                result.insert(name, Value::Object(map));
                             }
                             Err(errs) => {
                                 errors.extend(errs);
@@ -157,12 +158,12 @@ pub(super) mod process {
             }
         }
 
-        /// Loads and deserializes a file into a TOML `Table`.
+        /// Loads and deserializes a file into a configuration map.
         fn load_file(
             &mut self,
             path: &Path,
             format: Format,
-        ) -> Result<Option<(String, Table)>, Vec<String>> {
+        ) -> Result<Option<(String, ConfigMap)>, Vec<String>> {
             match (component_name(path), open_file(path)) {
                 (Ok(name), Some(file)) => self.load(file, format).map(|value| Some((name, value))),
                 _ => Ok(None),
@@ -170,37 +171,38 @@ pub(super) mod process {
         }
 
         /// Loads a file, and if the path provided contains a sub-folder by the same name as the
-        /// component, descend into it recursively, returning a TOML `Table`.
+        /// component, descend into it recursively, returning a configuration map.
         fn load_file_recursive(
             &mut self,
             path: &Path,
             format: Format,
-        ) -> Result<Option<(String, Table)>, Vec<String>> {
-            if let Some((name, mut table)) = self.load_file(path, format)? {
+        ) -> Result<Option<(String, ConfigMap)>, Vec<String>> {
+            if let Some((name, mut map)) = self.load_file(path, format)? {
                 if let Some(subdir) = path.parent().map(|p| p.join(&name))
                     && subdir.is_dir()
                     && subdir.exists()
                 {
-                    self.load_dir_into(&subdir, &mut table, true)?;
+                    self.load_dir_into(&subdir, &mut map, true)?;
                 }
-                Ok(Some((name, table)))
+                Ok(Some((name, map)))
             } else {
                 Ok(None)
             }
         }
 
-        /// Loads a directory (optionally, recursively), returning a TOML `Table`. This will
-        /// create an initial `Table` and pass it into `load_dir_into` for recursion handling.
-        fn load_dir(&mut self, path: &Path, recurse: bool) -> Result<Table, Vec<String>> {
-            let mut result = Table::new();
+        /// Loads a directory (optionally, recursively), returning a configuration map. This will
+        /// create an initial map and pass it into `load_dir_into` for recursion handling.
+        fn load_dir(&mut self, path: &Path, recurse: bool) -> Result<ConfigMap, Vec<String>> {
+            let mut result = ConfigMap::new();
             self.load_dir_into(path, &mut result, recurse)?;
             Ok(result)
         }
 
-        /// Merge a provided TOML `Table` in an implementation-specific way. Contains an
+        /// Merge a provided configuration map in an implementation-specific way. Contains an
         /// optional component hint, which may affect how components are merged. Takes a `&mut self`
         /// with the intention of merging an inner value that can be `take`n by a `Loader`.
-        fn merge(&mut self, table: Table, hint: Option<ComponentHint>) -> Result<(), Vec<String>>;
+        fn merge(&mut self, map: ConfigMap, hint: Option<ComponentHint>)
+        -> Result<(), Vec<String>>;
     }
 }
 
@@ -218,8 +220,8 @@ where
         input: R,
         format: Format,
     ) -> Result<(), Vec<String>> {
-        if let Some(table) = self.load(input, format)? {
-            self.merge(table, None)?;
+        if let Some(map) = self.load(input, format)? {
+            self.merge(map, None)?;
         }
         Ok(())
     }
@@ -227,8 +229,8 @@ where
     /// Deserializes a file with the provided format, and makes the result available via `take`.
     /// Returns a vector of non-fatal warnings on success, or a vector of error strings on failure.
     fn load_from_file(&mut self, path: &Path, format: Format) -> Result<(), Vec<String>> {
-        if let Some((_, table)) = self.load_file(path, format)? {
-            self.merge(table, None)?;
+        if let Some((_, map)) = self.load_file(path, format)? {
+            self.merge(map, None)?;
             Ok(())
         } else {
             Ok(())
@@ -253,14 +255,14 @@ where
 
         // Get files from the root of the folder. These represent top-level config settings,
         // and need to merged down first to represent a more 'complete' config.
-        let mut root = Table::new();
-        let table = self.load_dir(path, false)?;
+        let mut root = ConfigMap::new();
+        let map = self.load_dir(path, false)?;
 
         // Discard the named part of the path, since these don't form any component names.
-        for (_, value) in table {
+        for (_, value) in map {
             // All files should contain key/value pairs.
-            if let Value::Table(table) = value {
-                merge_into_table(&mut root, table).map_err(|e| vec![e.to_string()])?;
+            if let Value::Object(map) = value {
+                merge_into_map(&mut root, map)?;
             }
         }
 
@@ -274,9 +276,9 @@ where
             if path.exists() && path.is_dir() {
                 // Transforms are treated differently from other component types; they can be
                 // arbitrarily nested.
-                let table = self.load_dir(&path, matches!(hint, ComponentHint::Transform))?;
+                let map = self.load_dir(&path, matches!(hint, ComponentHint::Transform))?;
 
-                self.merge(table, Some(hint))?;
+                self.merge(map, Some(hint))?;
             }
         }
 
@@ -284,13 +286,8 @@ where
     }
 }
 
-/// Merge two TOML `Value`s, returning a new `Value`.
-fn merge_values(value: toml::Value, other: toml::Value) -> Result<toml::Value, Vec<String>> {
-    serde_toml_merge::merge(value, other).map_err(|e| vec![e.to_string()])
-}
-
-/// Updates a TOML `Table` with the merged values of a named key. Inserts if it doesn't exist.
-fn merge_with_value(res: &mut Table, name: String, value: toml::Value) -> Result<(), Vec<String>> {
+/// Updates a configuration map with the merged values of a named key. Inserts if absent.
+fn merge_with_value(res: &mut ConfigMap, name: String, value: Value) -> Result<(), Vec<String>> {
     if let Some(existing) = res.remove(&name) {
         res.insert(name, merge_values(existing, value)?);
     } else {
@@ -299,11 +296,9 @@ fn merge_with_value(res: &mut Table, name: String, value: toml::Value) -> Result
     Ok(())
 }
 
-/// Deserialize a TOML `Table` into a `T`.
-pub(super) fn deserialize_table<T: serde::de::DeserializeOwned>(
-    table: Table,
+/// Deserialize a configuration map into a `T`.
+pub(super) fn deserialize_config_map<T: serde::de::DeserializeOwned>(
+    map: ConfigMap,
 ) -> Result<T, Vec<String>> {
-    Value::Table(table)
-        .try_into()
-        .map_err(|e| vec![e.to_string()])
+    serde_json::from_value(Value::Object(map)).map_err(|error| vec![error.to_string()])
 }

--- a/src/config/loading/mod.rs
+++ b/src/config/loading/mod.rs
@@ -1,5 +1,6 @@
 mod config_builder;
 mod loader;
+mod representation;
 mod secret;
 mod source;
 
@@ -20,8 +21,8 @@ pub use source::*;
 use vector_lib::configurable::NamedComponent;
 
 use super::{
-    Config, ConfigPath, Format, FormatHint, ProviderConfig, builder::ConfigBuilder, format,
-    validation, vars,
+    Config, ConfigPath, Format, FormatHint, ProviderConfig, builder::ConfigBuilder, validation,
+    vars,
 };
 use crate::signal;
 
@@ -269,10 +270,10 @@ where
     }
 }
 
-/// Uses `SourceLoader` to process `ConfigPaths`, deserializing to a toml `SourceMap`.
+/// Uses `SourceLoader` to process `ConfigPaths`, deserializing to a JSON object.
 pub fn load_source_from_paths(
     config_paths: &[ConfigPath],
-) -> Result<toml::value::Table, Vec<String>> {
+) -> Result<serde_json::Map<String, serde_json::Value>, Vec<String>> {
     loader_from_paths(SourceLoader::new(), config_paths)
 }
 
@@ -342,7 +343,7 @@ where
     // Via configurations that load from raw string, skip interpolation of env
     let with_vars = prepare_input(input, false)?;
 
-    format::deserialize(&with_vars, format)
+    representation::deserialize_config(&with_vars, format)
 }
 
 #[cfg(not(windows))]

--- a/src/config/loading/representation.rs
+++ b/src/config/loading/representation.rs
@@ -24,19 +24,14 @@ pub(super) fn parse_config_value(content: &str, format: Format) -> Result<Value,
         Format::Toml => toml::from_str(content)
             .map_err(|error| vec![error.to_string()])
             .and_then(toml_to_json)?,
+        Format::Yaml if is_empty_yaml(content) => Value::Object(ConfigMap::new()),
         Format::Yaml => serde_yaml::from_str::<serde_yaml::Value>(content)
             .and_then(|mut value| {
                 value.apply_merge()?;
                 Ok(value)
             })
             .map_err(|error| vec![error.to_string()])
-            .and_then(|value| {
-                if value.is_null() {
-                    Ok(Value::Object(ConfigMap::new()))
-                } else {
-                    yaml_to_json(value)
-                }
-            })?,
+            .and_then(yaml_to_json)?,
         Format::Json => {
             let value = serde_json::from_str(content).map_err(|error| vec![error.to_string()])?;
             validate_json(&value)?;
@@ -45,6 +40,13 @@ pub(super) fn parse_config_value(content: &str, format: Format) -> Result<Value,
     };
 
     Ok(value)
+}
+
+fn is_empty_yaml(content: &str) -> bool {
+    content.lines().all(|line| {
+        let line = line.trim();
+        line.is_empty() || line.starts_with('#')
+    })
 }
 
 fn toml_to_json(value: toml::Value) -> Result<Value, Vec<String>> {
@@ -244,10 +246,19 @@ mod tests {
 
     #[test]
     fn empty_yaml_parses_as_an_empty_map() {
-        assert_eq!(
-            parse_config_value("", Format::Yaml).unwrap(),
-            Value::Object(ConfigMap::new())
-        );
+        for input in ["", "  \n\t", "# comment", "  # comment\n\n# another"] {
+            assert_eq!(
+                parse_config_value(input, Format::Yaml).unwrap(),
+                Value::Object(ConfigMap::new())
+            );
+        }
+    }
+
+    #[test]
+    fn explicit_top_level_yaml_null_is_rejected() {
+        for input in ["null", "~", "--- null"] {
+            assert!(deserialize_config::<ConfigMap>(input, Format::Yaml).is_err());
+        }
     }
 
     #[test]

--- a/src/config/loading/representation.rs
+++ b/src/config/loading/representation.rs
@@ -1,4 +1,4 @@
-use serde::de::DeserializeOwned;
+use serde::de::{DeserializeOwned, IntoDeserializer};
 use serde_json::{Map, Number, Value};
 
 use super::Format;
@@ -16,7 +16,15 @@ where
 {
     let value = parse_config_value(content, format)?;
 
-    serde_json::from_value(value).map_err(|error| vec![error.to_string()])
+    deserialize_config_value(value)
+}
+
+pub(super) fn deserialize_config_value<T>(value: Value) -> Result<T, Vec<String>>
+where
+    T: DeserializeOwned,
+{
+    serde_path_to_error::deserialize(value.into_deserializer())
+        .map_err(|error| vec![error.to_string()])
 }
 
 pub(super) fn parse_config_value(content: &str, format: Format) -> Result<Value, Vec<String>> {
@@ -249,6 +257,18 @@ mod tests {
         value: Option<String>,
     }
 
+    #[derive(Debug, Deserialize)]
+    struct NestedValue {
+        #[serde(rename = "outer")]
+        _outer: NestedInnerValue,
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct NestedInnerValue {
+        #[serde(rename = "count")]
+        _count: u64,
+    }
+
     fn default_optional_value() -> Option<String> {
         Some("default".to_string())
     }
@@ -295,6 +315,25 @@ mod tests {
         for input in ["null", "~", "--- null", "---\nnull"] {
             assert!(deserialize_config::<ConfigMap>(input, Format::Yaml).is_err());
         }
+    }
+
+    #[test]
+    fn deserialization_errors_include_the_value_path() {
+        let error = deserialize_config::<NestedValue>(
+            indoc! {"
+                outer:
+                  count: not-a-number
+            "},
+            Format::Yaml,
+        )
+        .unwrap_err();
+
+        assert!(
+            error
+                .first()
+                .is_some_and(|error| error.contains("outer.count")),
+            "expected the error to contain the nested value path, got {error:?}"
+        );
     }
 
     #[test]

--- a/src/config/loading/representation.rs
+++ b/src/config/loading/representation.rs
@@ -1,0 +1,529 @@
+use serde::de::DeserializeOwned;
+use serde_json::{Map, Number, Value};
+
+use super::Format;
+
+pub(super) type ConfigMap = Map<String, Value>;
+
+const LARGE_INTEGER_ERROR: &str =
+    "integer values larger than i64::MAX are not supported in Vector configuration";
+const NON_FINITE_FLOAT_ERROR: &str =
+    "non-finite float values are not supported in Vector configuration";
+
+pub(super) fn deserialize_config<T>(content: &str, format: Format) -> Result<T, Vec<String>>
+where
+    T: DeserializeOwned,
+{
+    let value = parse_config_value(content, format)?;
+
+    serde_json::from_value(value).map_err(|error| vec![error.to_string()])
+}
+
+pub(super) fn parse_config_value(content: &str, format: Format) -> Result<Value, Vec<String>> {
+    let value = match format {
+        Format::Toml => toml::from_str(content)
+            .map_err(|error| vec![error.to_string()])
+            .and_then(toml_to_json)?,
+        Format::Yaml => serde_yaml::from_str::<serde_yaml::Value>(content)
+            .and_then(|mut value| {
+                value.apply_merge()?;
+                Ok(value)
+            })
+            .map_err(|error| vec![error.to_string()])
+            .and_then(|value| {
+                if value.is_null() {
+                    Ok(Value::Object(ConfigMap::new()))
+                } else {
+                    yaml_to_json(value)
+                }
+            })?,
+        Format::Json => {
+            let value = serde_json::from_str(content).map_err(|error| vec![error.to_string()])?;
+            validate_json(&value)?;
+            value
+        }
+    };
+
+    Ok(value)
+}
+
+fn toml_to_json(value: toml::Value) -> Result<Value, Vec<String>> {
+    match value {
+        toml::Value::String(value) => Ok(Value::String(value)),
+        toml::Value::Integer(value) => Ok(Value::Number(value.into())),
+        toml::Value::Float(value) => finite_float_to_json(value),
+        toml::Value::Boolean(value) => Ok(Value::Bool(value)),
+        toml::Value::Datetime(value) => Ok(Value::String(value.to_string())),
+        toml::Value::Array(values) => values
+            .into_iter()
+            .map(toml_to_json)
+            .collect::<Result<Vec<_>, _>>()
+            .map(Value::Array),
+        toml::Value::Table(table) => table
+            .into_iter()
+            .map(|(key, value)| toml_to_json(value).map(|value| (key, value)))
+            .collect::<Result<ConfigMap, _>>()
+            .map(Value::Object),
+    }
+}
+
+fn yaml_to_json(value: serde_yaml::Value) -> Result<Value, Vec<String>> {
+    match value {
+        serde_yaml::Value::Null => Ok(Value::Null),
+        serde_yaml::Value::Bool(value) => Ok(Value::Bool(value)),
+        serde_yaml::Value::Number(value) => yaml_number_to_json(&value),
+        serde_yaml::Value::String(value) => Ok(Value::String(value)),
+        serde_yaml::Value::Sequence(values) => values
+            .into_iter()
+            .map(yaml_to_json)
+            .collect::<Result<Vec<_>, _>>()
+            .map(Value::Array),
+        serde_yaml::Value::Mapping(mapping) => mapping
+            .into_iter()
+            .map(|(key, value)| {
+                let serde_yaml::Value::String(key) = key else {
+                    return Err(vec![
+                        "YAML mapping keys must be strings in Vector configuration".to_string(),
+                    ]);
+                };
+                yaml_to_json(value).map(|value| (key, value))
+            })
+            .collect::<Result<ConfigMap, _>>()
+            .map(Value::Object),
+        serde_yaml::Value::Tagged(_) => Err(vec![
+            "YAML tags are not supported in Vector configuration".to_string(),
+        ]),
+    }
+}
+
+fn yaml_number_to_json(value: &serde_yaml::Number) -> Result<Value, Vec<String>> {
+    if let Some(value) = value.as_i64() {
+        Ok(Value::Number(value.into()))
+    } else if value.is_u64() {
+        Err(vec![LARGE_INTEGER_ERROR.to_string()])
+    } else if let Some(value) = value.as_f64() {
+        finite_float_to_json(value)
+    } else {
+        unreachable!("serde_yaml::Number must be an integer or float")
+    }
+}
+
+fn finite_float_to_json(value: f64) -> Result<Value, Vec<String>> {
+    Number::from_f64(value)
+        .map(Value::Number)
+        .ok_or_else(|| vec![NON_FINITE_FLOAT_ERROR.to_string()])
+}
+
+fn validate_json(value: &Value) -> Result<(), Vec<String>> {
+    match value {
+        Value::Number(number)
+            if number
+                .as_u64()
+                .is_some_and(|number| number > i64::MAX as u64) =>
+        {
+            Err(vec![LARGE_INTEGER_ERROR.to_string()])
+        }
+        Value::Array(values) => values.iter().try_for_each(validate_json),
+        Value::Object(map) => map.values().try_for_each(validate_json),
+        _ => Ok(()),
+    }
+}
+
+pub(super) fn merge_into_map(map: &mut ConfigMap, other: ConfigMap) -> Result<(), Vec<String>> {
+    merge_into_map_at_path(map, other, "$").map_err(|error| vec![error])
+}
+
+fn merge_into_map_at_path(map: &mut ConfigMap, other: ConfigMap, path: &str) -> Result<(), String> {
+    for (name, value) in other {
+        if let Some(existing) = map.remove(&name) {
+            let inner_path = format!("{path}.{name}");
+            map.insert(name, merge_values_at_path(existing, value, &inner_path)?);
+        } else {
+            map.insert(name, value);
+        }
+    }
+
+    Ok(())
+}
+
+pub(super) fn merge_values(value: Value, other: Value) -> Result<Value, Vec<String>> {
+    merge_values_at_path(value, other, "$").map_err(|error| vec![error])
+}
+
+fn merge_values_at_path(value: Value, other: Value, path: &str) -> Result<Value, String> {
+    match (value, other) {
+        (Value::Null, Value::Null) => Ok(Value::Null),
+        (Value::Bool(_), Value::Bool(other)) => Ok(Value::Bool(other)),
+        (Value::String(_), Value::String(other)) => Ok(Value::String(other)),
+        (Value::Number(value), Value::Number(other))
+            if number_type(&value) == number_type(&other) =>
+        {
+            Ok(Value::Number(other))
+        }
+        (Value::Array(mut value), Value::Array(other)) => {
+            value.extend(other);
+            Ok(Value::Array(value))
+        }
+        (Value::Object(mut value), Value::Object(other)) => {
+            merge_into_map_at_path(&mut value, other, path)?;
+            Ok(Value::Object(value))
+        }
+        (value, other) => Err(format!(
+            "Incompatible types at path \"{path}\", expected \"{}\" received \"{}\".",
+            value_type(&value),
+            value_type(&other)
+        )),
+    }
+}
+
+fn value_type(value: &Value) -> &'static str {
+    match value {
+        Value::Null => "null",
+        Value::Bool(_) => "boolean",
+        Value::Number(number) => number_type(number),
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "table",
+    }
+}
+
+fn number_type(number: &Number) -> &'static str {
+    if number.is_i64() || number.is_u64() {
+        "integer"
+    } else {
+        "float"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use indoc::indoc;
+    use serde::Deserialize;
+    use serde_json::{Value, json};
+
+    use super::{ConfigMap, deserialize_config, merge_values, parse_config_value};
+    use crate::config::Format;
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct StringValue {
+        value: String,
+    }
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct OptionalValue {
+        optional: Option<String>,
+        required: String,
+    }
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct DefaultedOptionalValue {
+        #[serde(default = "default_optional_value")]
+        value: Option<String>,
+    }
+
+    fn default_optional_value() -> Option<String> {
+        Some("default".to_string())
+    }
+
+    #[test]
+    fn supported_formats_deserialize_equivalent_values() {
+        for (input, format) in [
+            (r#"required = "present""#, Format::Toml),
+            ("required: present", Format::Yaml),
+            (r#"{"required": "present"}"#, Format::Json),
+        ] {
+            assert_eq!(
+                deserialize_config::<OptionalValue>(input, format).unwrap(),
+                OptionalValue {
+                    optional: None,
+                    required: "present".to_string(),
+                }
+            );
+        }
+    }
+
+    #[test]
+    fn empty_yaml_parses_as_an_empty_map() {
+        assert_eq!(
+            parse_config_value("", Format::Yaml).unwrap(),
+            Value::Object(ConfigMap::new())
+        );
+    }
+
+    #[test]
+    fn explicit_null_is_preserved() {
+        let json = parse_config_value(r#"{"value": null}"#, Format::Json).unwrap();
+        let yaml = parse_config_value("value: null", Format::Yaml).unwrap();
+
+        assert_eq!(json, json!({ "value": null }));
+        assert_eq!(yaml, json!({ "value": null }));
+    }
+
+    #[test]
+    fn explicit_null_deserializes_as_none_for_optional_fields() {
+        for (input, format) in [
+            (r#"{"optional": null, "required": "present"}"#, Format::Json),
+            ("optional: null\nrequired: present", Format::Yaml),
+        ] {
+            assert_eq!(
+                deserialize_config::<OptionalValue>(input, format).unwrap(),
+                OptionalValue {
+                    optional: None,
+                    required: "present".to_string(),
+                }
+            );
+        }
+    }
+
+    #[test]
+    fn explicit_null_is_rejected_for_required_fields() {
+        for (input, format) in [
+            (r#"{"required": null}"#, Format::Json),
+            ("required: null", Format::Yaml),
+        ] {
+            assert!(deserialize_config::<OptionalValue>(input, format).is_err());
+        }
+    }
+
+    #[test]
+    fn defaulted_optional_field_preserves_missing_null_and_string_semantics() {
+        for (input, format, expected) in [
+            ("", Format::Toml, Some("default")),
+            ("", Format::Yaml, Some("default")),
+            ("{}", Format::Json, Some("default")),
+            (
+                indoc! {r#"
+                    value = "custom"
+                "#},
+                Format::Toml,
+                Some("custom"),
+            ),
+            (
+                indoc! {"
+                    value: custom
+                "},
+                Format::Yaml,
+                Some("custom"),
+            ),
+            (
+                indoc! {r#"
+                    {
+                      "value": "custom"
+                    }
+                "#},
+                Format::Json,
+                Some("custom"),
+            ),
+            (
+                indoc! {r#"
+                    value = ""
+                "#},
+                Format::Toml,
+                Some(""),
+            ),
+            (
+                indoc! {r#"
+                    value: ""
+                "#},
+                Format::Yaml,
+                Some(""),
+            ),
+            (
+                indoc! {r#"
+                    {
+                      "value": ""
+                    }
+                "#},
+                Format::Json,
+                Some(""),
+            ),
+            (
+                indoc! {r#"
+                    value = "null"
+                "#},
+                Format::Toml,
+                Some("null"),
+            ),
+            (
+                indoc! {r#"
+                    value: "null"
+                "#},
+                Format::Yaml,
+                Some("null"),
+            ),
+            (
+                indoc! {r#"
+                    {
+                      "value": "null"
+                    }
+                "#},
+                Format::Json,
+                Some("null"),
+            ),
+            (
+                indoc! {"
+                    value: null
+                "},
+                Format::Yaml,
+                None,
+            ),
+            (
+                indoc! {r#"
+                    {
+                      "value": null
+                    }
+                "#},
+                Format::Json,
+                None,
+            ),
+        ] {
+            let config = deserialize_config::<DefaultedOptionalValue>(input, format).unwrap();
+
+            assert_eq!(config.value.as_deref(), expected);
+        }
+    }
+
+    #[test]
+    fn yaml_merge_keys_are_applied() {
+        let value: Value = deserialize_config(
+            "defaults: &defaults\n  codec: json\nencoding:\n  <<: *defaults",
+            Format::Yaml,
+        )
+        .unwrap();
+
+        assert_eq!(
+            value,
+            json!({
+                "defaults": { "codec": "json" },
+                "encoding": { "codec": "json" }
+            })
+        );
+    }
+
+    #[test]
+    fn toml_datetime_deserializes_as_a_string() {
+        let value: StringValue =
+            deserialize_config("value = 1979-05-27T07:32:00Z", Format::Toml).unwrap();
+
+        assert_eq!(
+            value,
+            StringValue {
+                value: "1979-05-27T07:32:00Z".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_large_json_and_yaml_integers() {
+        for (input, format) in [
+            (r#"{"value": 9223372036854775808}"#, Format::Json),
+            ("value: 9223372036854775808", Format::Yaml),
+        ] {
+            assert_eq!(
+                deserialize_config::<ConfigMap>(input, format).unwrap_err(),
+                vec![super::LARGE_INTEGER_ERROR.to_string()]
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_non_finite_toml_and_yaml_floats() {
+        for (input, format) in [("value = inf", Format::Toml), ("value: .nan", Format::Yaml)] {
+            assert_eq!(
+                deserialize_config::<ConfigMap>(input, format).unwrap_err(),
+                vec![super::NON_FINITE_FLOAT_ERROR.to_string()]
+            );
+        }
+    }
+
+    #[test]
+    fn merge_replaces_same_type_scalars() {
+        assert_eq!(
+            merge_values(json!("first"), json!("second")).unwrap(),
+            json!("second")
+        );
+    }
+
+    #[test]
+    fn merge_concatenates_arrays_in_order() {
+        assert_eq!(
+            merge_values(json!([1, 2]), json!([3, 4])).unwrap(),
+            json!([1, 2, 3, 4])
+        );
+    }
+
+    #[test]
+    fn merge_recurses_into_maps() {
+        assert_eq!(
+            merge_values(
+                json!({
+                    "nested": {
+                        "first": 1,
+                        "replaced": "old"
+                    }
+                }),
+                json!({
+                    "nested": {
+                        "second": 2,
+                        "replaced": "new"
+                    }
+                }),
+            )
+            .unwrap(),
+            json!({
+                "nested": {
+                    "first": 1,
+                    "second": 2,
+                    "replaced": "new"
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn merge_reports_nested_type_conflicts() {
+        let error = merge_values(
+            json!({ "nested": { "value": "string" } }),
+            json!({ "nested": { "value": 1 } }),
+        )
+        .unwrap_err();
+
+        assert_eq!(
+            error,
+            vec![
+                r#"Incompatible types at path "$.nested.value", expected "string" received "integer"."#
+                    .to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn merge_treats_integers_and_floats_as_different_types() {
+        let error = merge_values(json!(1), json!(1.0)).unwrap_err();
+
+        assert_eq!(
+            error,
+            vec![
+                r#"Incompatible types at path "$", expected "integer" received "float"."#
+                    .to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn merge_only_accepts_null_with_null() {
+        assert_eq!(merge_values(Value::Null, Value::Null).unwrap(), Value::Null);
+
+        for (first, second, expected, received) in [
+            (Value::Null, json!(1), "null", "integer"),
+            (json!(1), Value::Null, "integer", "null"),
+        ] {
+            assert_eq!(
+                merge_values(first, second).unwrap_err(),
+                vec![format!(
+                    r#"Incompatible types at path "$", expected "{expected}" received "{received}"."#
+                )]
+            );
+        }
+    }
+}

--- a/src/config/loading/representation.rs
+++ b/src/config/loading/representation.rs
@@ -24,14 +24,20 @@ pub(super) fn parse_config_value(content: &str, format: Format) -> Result<Value,
         Format::Toml => toml::from_str(content)
             .map_err(|error| vec![error.to_string()])
             .and_then(toml_to_json)?,
-        Format::Yaml if is_empty_yaml(content) => Value::Object(ConfigMap::new()),
+        Format::Yaml if is_blank_or_comment_only_yaml(content) => Value::Object(ConfigMap::new()),
         Format::Yaml => serde_yaml::from_str::<serde_yaml::Value>(content)
             .and_then(|mut value| {
                 value.apply_merge()?;
                 Ok(value)
             })
             .map_err(|error| vec![error.to_string()])
-            .and_then(yaml_to_json)?,
+            .and_then(|value| {
+                if value.is_null() && is_empty_yaml_document(content) {
+                    Ok(Value::Object(ConfigMap::new()))
+                } else {
+                    yaml_to_json(value)
+                }
+            })?,
         Format::Json => {
             let value = serde_json::from_str(content).map_err(|error| vec![error.to_string()])?;
             validate_json(&value)?;
@@ -42,10 +48,30 @@ pub(super) fn parse_config_value(content: &str, format: Format) -> Result<Value,
     Ok(value)
 }
 
-fn is_empty_yaml(content: &str) -> bool {
+fn is_blank_or_comment_only_yaml(content: &str) -> bool {
     content.lines().all(|line| {
         let line = line.trim();
         line.is_empty() || line.starts_with('#')
+    })
+}
+
+fn is_empty_yaml_document(content: &str) -> bool {
+    let content = content.strip_prefix('\u{feff}').unwrap_or(content);
+
+    content.lines().all(|line| {
+        let line = line.trim();
+        line.is_empty()
+            || line.starts_with('#')
+            || line.starts_with('%')
+            || is_yaml_document_marker(line, "---")
+            || is_yaml_document_marker(line, "...")
+    })
+}
+
+fn is_yaml_document_marker(line: &str, marker: &str) -> bool {
+    line.strip_prefix(marker).is_some_and(|suffix| {
+        let suffix = suffix.trim_start();
+        suffix.is_empty() || suffix.starts_with('#')
     })
 }
 
@@ -246,7 +272,17 @@ mod tests {
 
     #[test]
     fn empty_yaml_parses_as_an_empty_map() {
-        for input in ["", "  \n\t", "# comment", "  # comment\n\n# another"] {
+        for input in [
+            "",
+            "  \n\t",
+            "# comment",
+            "  # comment\n\n# another",
+            "---",
+            "--- # comment",
+            "%YAML 1.2\n---",
+            "---\n...",
+            "\u{feff}",
+        ] {
             assert_eq!(
                 parse_config_value(input, Format::Yaml).unwrap(),
                 Value::Object(ConfigMap::new())
@@ -256,7 +292,7 @@ mod tests {
 
     #[test]
     fn explicit_top_level_yaml_null_is_rejected() {
-        for input in ["null", "~", "--- null"] {
+        for input in ["null", "~", "--- null", "---\nnull"] {
             assert!(deserialize_config::<ConfigMap>(input, Format::Yaml).is_err());
         }
     }

--- a/src/config/loading/secret.rs
+++ b/src/config/loading/secret.rs
@@ -8,13 +8,15 @@ use futures::TryFutureExt;
 use indexmap::IndexMap;
 use regex::{Captures, Regex};
 use serde::{Deserialize, Serialize};
-use toml::value::Table;
 use vector_lib::config::ComponentKey;
 
 use crate::{
     config::{
         SecretBackend,
-        loading::{ComponentHint, Loader, deserialize_table, prepare_input, process::Process},
+        loading::{
+            ComponentHint, Loader, deserialize_config_map, prepare_input, process::Process,
+            representation::ConfigMap,
+        },
     },
     secrets::SecretBackends,
     signal,
@@ -115,9 +117,9 @@ impl Process for SecretBackendLoader {
         Ok(config_string)
     }
 
-    fn merge(&mut self, table: Table, _: Option<ComponentHint>) -> Result<(), Vec<String>> {
-        if table.contains_key("secret") {
-            let additional = deserialize_table::<SecretBackendOuter>(table)?;
+    fn merge(&mut self, map: ConfigMap, _: Option<ComponentHint>) -> Result<(), Vec<String>> {
+        if map.contains_key("secret") {
+            let additional = deserialize_config_map::<SecretBackendOuter>(map)?;
             self.backends.extend(additional.secret);
         }
         Ok(())

--- a/src/config/loading/source.rs
+++ b/src/config/loading/source.rs
@@ -1,17 +1,19 @@
 use std::io::Read;
 
-use serde_toml_merge::merge_into_table;
-use toml::{map::Map, value::Table};
-
-use super::{ComponentHint, Loader, Process};
+use super::{
+    ComponentHint, Loader, Process,
+    representation::{ConfigMap, merge_into_map},
+};
 
 pub struct SourceLoader {
-    table: Table,
+    map: ConfigMap,
 }
 
 impl SourceLoader {
     pub fn new() -> Self {
-        Self { table: Map::new() }
+        Self {
+            map: ConfigMap::new(),
+        }
     }
 }
 
@@ -33,15 +35,40 @@ impl Process for SourceLoader {
         Ok(source_string)
     }
 
-    /// Merge values by combining with the internal TOML `Table`.
-    fn merge(&mut self, table: Table, _hint: Option<ComponentHint>) -> Result<(), Vec<String>> {
-        merge_into_table(&mut self.table, table).map_err(|e| vec![e.to_string()])
+    /// Merge values by combining with the internal configuration map.
+    fn merge(&mut self, map: ConfigMap, _hint: Option<ComponentHint>) -> Result<(), Vec<String>> {
+        merge_into_map(&mut self.map, map)
     }
 }
 
-impl Loader<Table> for SourceLoader {
-    /// Returns the resulting TOML `Table`.
-    fn take(self) -> Table {
-        self.table
+impl Loader<ConfigMap> for SourceLoader {
+    /// Returns the resulting configuration map.
+    fn take(self) -> ConfigMap {
+        self.map
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::{Value, json};
+
+    use super::SourceLoader;
+    use crate::config::{
+        Format,
+        loading::{loader_from_input, representation::ConfigMap},
+    };
+
+    #[test]
+    fn preserves_explicit_json_and_yaml_null() {
+        for (input, format) in [
+            (r#"{"optional": null}"#, Format::Json),
+            ("optional: null", Format::Yaml),
+        ] {
+            let map: ConfigMap =
+                loader_from_input(SourceLoader::new(), input.as_bytes(), format).unwrap();
+
+            assert_eq!(map.get("optional"), Some(&Value::Null));
+            assert_eq!(Value::Object(map), json!({ "optional": null }));
+        }
     }
 }

--- a/tests/data/cmd/config/config_1.yaml
+++ b/tests/data/cmd/config/config_1.yaml
@@ -18,6 +18,7 @@ transforms:
     metric_tag_values: single
     reroute_dropped: false
     runtime: ast
+    source: "."
     type: remap
 sinks:
   sink0:

--- a/tests/data/cmd/config/config_2.toml
+++ b/tests/data/cmd/config/config_2.toml
@@ -24,6 +24,7 @@ drop_on_error = false
 metric_tag_values = "single"
 reroute_dropped = false
 runtime = "ast"
+source = "."
 type = "remap"
 
 [sinks.sink0]

--- a/tests/data/cmd/config/config_3.json
+++ b/tests/data/cmd/config/config_3.json
@@ -22,6 +22,7 @@
       "metric_tag_values": "single",
       "reroute_dropped": false,
       "runtime": "ast",
+      "source": ".",
       "type": "remap"
     }
   },


### PR DESCRIPTION
## Summary

Allow explicit null values in JSON and YAML configuration files. Previously, configuration from every format passed through TOML during loading; because TOML cannot represent null, nullable JSON and YAML values failed before reaching component deserialization.

Nulls now follow the component's normal Serde semantics: optional fields accept null as `None`, while required fields reject it. Existing TOML configurations are unaffected.

## Vector configuration

For a defaulted optional field, omission and explicit null can have meaningfully different behavior:

```yaml
sinks:
  humio:
    type: humio_logs
    inputs:
      - source
    token: "${HUMIO_TOKEN}"
    encoding:
      codec: json
    timestamp_nanos_key: null
```

Omitting `timestamp_nanos_key` uses the default `@timestamp.nanos`; setting it to null disables that field.

## How did you test this PR?

- `make check-clippy`
- `make check-fmt`
- `make check-markdown`
- `make check-changelog-fragments`
- `cargo test --lib --no-default-features config::loading`
- `cargo test --lib config::cmd::tests`
- `cargo test --lib --no-default-features --features sources-demo_logs,transforms-remap,sinks-console convert_config::tests`
- Validated the equivalent YAML, TOML, and JSON config-command fixtures with `vector validate --no-environment`
- Ran `vector config` against the YAML fixture and confirmed that an explicit null is preserved

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [x] Yes. A changelog fragment is included.
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Closes: #19963
- Closes: #22327
- Closes: #https://github.com/vectordotdev/vector/issues/12832 (but rejected proposal)
- Related: https://github.com/vectordotdev/vector/issues/23008
- Related: #25905
