### PR TITLE
chore(sinks): log response body in debug mode for http / otel/ prometheus sinks.

### DIFF
--- a/src/sinks/util/http.rs
+++ b/src/sinks/util/http.rs
@@ -954,7 +954,17 @@ pub fn http_response_retry_logic<Request: Clone + Send + Sync + 'static>(
     HttpResponse,
 > {
     HttpStatusRetryLogic::new(
-        |req: &HttpResponse| req.http_response.status(),
+        |req: &HttpResponse| {
+            let status = req.http_response.status();
+            if !status.is_success() {
+                debug!(
+                    message = "HTTP response.",
+                    %status,
+                    body = %String::from_utf8_lossy(req.http_response.body()),
+                );
+            }
+            status
+        },
         retry_strategy,
     )
 }

--- a/src/sinks/util/http.rs
+++ b/src/sinks/util/http.rs
@@ -9,6 +9,9 @@ use http::{HeaderValue, Request, Response, StatusCode, header};
 use http_body::Body as _;
 use tracing::debug;
 
+/// Maximum number of response body bytes to include in a non-retriable error's reason.
+const MAX_ERROR_BODY_BYTES: usize = 1024;
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct OrderedHeaderName(HeaderName);
 
@@ -956,11 +959,13 @@ pub fn http_response_retry_logic<Request: Clone + Send + Sync + 'static>(
     HttpStatusRetryLogic::new(
         |req: &HttpResponse| {
             let status = req.http_response.status();
+            let body = req.http_response.body();
+            let truncated = &body[..body.len().min(MAX_ERROR_BODY_BYTES)];
             if !status.is_success() {
                 debug!(
                     message = "HTTP response.",
                     %status,
-                    body = %String::from_utf8_lossy(req.http_response.body()),
+                    body = %String::from_utf8_lossy(truncated),
                 );
             }
             status


### PR DESCRIPTION


## Summary

Sometimes we need to see the reason for a non 2xx status code and now we should be able to turn on debug mode to see it. 

Debug logs look like so:

```
2026-07-31T19:42:01.382949Z DEBUG sink{component_kind="sink" component_id=prometheus_out component_type=prometheus_remote_write}:request{request_id=24}: vector::sinks::util::http: Internal log [HTTP response.] has been suppressed 7 times.
2026-07-31T19:42:01.382996Z DEBUG sink{component_kind="sink" component_id=prometheus_out component_type=prometheus_remote_write}:request{request_id=24}: vector::sinks::util::http: HTTP response. status=400 Bad Request body=out of bounds
```

## Vector configuration
<!-- Include Vector configuration(s) you used to test and debug your changes. -->

## How did you test this PR?
<!-- Please describe how you tested your changes. Also include any information about your setup. -->

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Closes: #<issue/PR number or link>
-->
<!--
- Related: #<issue/PR number or link>
-->

## Notes

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details on the [dd-rust-license-tool](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert, perf
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional but appreciated; letters, digits, spaces, hyphens, underscores (e.g. `kafka source`, `amazon-linux`)
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
