### PR TITLE
fix(buffers): recheck disk buffer progress before waiting

### DIFF
--- a/changelog.d/disk_v2_reader_published_progress.fix.md
+++ b/changelog.d/disk_v2_reader_published_progress.fix.md
@@ -1,0 +1,3 @@
+Fixed a `disk_v2` buffer stall where a reader could wait indefinitely for another write even though the buffer already contained a published record.
+
+authors: fernandol-nvidia

--- a/changelog.d/disk_v2_reader_published_progress.fix.md
+++ b/changelog.d/disk_v2_reader_published_progress.fix.md
@@ -1,3 +1,3 @@
-Fixed a `disk_v2` buffer stall where a reader could wait indefinitely for another write even though the buffer already contained a published record.
+Fixed `disk_v2` reader coordination that could stall with published data pending or busy-loop after dropping a corrupt record.
 
 authors: fernandol-nvidia

--- a/lib/vector-buffers/src/variants/disk_v2/ledger.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/ledger.rs
@@ -241,6 +241,11 @@ where
     state: BackedArchive<FS::MutableMemoryMap, LedgerState>,
     // The total size, in bytes, of all unread records in the buffer.
     total_buffer_size: AtomicU64,
+    // Byte offset published as readable within the current writer file.
+    //
+    // This is runtime-only coordination state. The durable writer checkpoint remains the source of
+    // truth across restarts, and writer initialization reconstructs this boundary after recovery.
+    published_writer_data_file_size: AtomicU64,
     // Notifier for reader-related progress.
     reader_notify: Notify,
     // Notifier for writer-related progress.
@@ -372,6 +377,24 @@ where
     /// Gets the current writer file ID.
     pub fn get_current_writer_file_id(&self) -> u16 {
         self.state().get_current_writer_file_id()
+    }
+
+    /// Gets the readable byte boundary in the current writer data file.
+    pub(super) fn get_published_writer_data_file_size(&self) -> u64 {
+        self.published_writer_data_file_size.load(Ordering::Acquire)
+    }
+
+    /// Initializes the readable byte boundary for the current writer data file.
+    pub(super) fn set_published_file_size(&self, published_bytes: u64) {
+        self.published_writer_data_file_size
+            .store(published_bytes, Ordering::Release);
+    }
+
+    /// Advances the writer file and resets its readable byte boundary.
+    pub(super) fn increment_writer_file_id(&self) {
+        self.published_writer_data_file_size
+            .store(0, Ordering::Release);
+        self.state().increment_writer_file_id();
     }
 
     /// Gets the next writer file ID.
@@ -530,6 +553,8 @@ where
         self.increment_total_buffer_size(record_size);
         self.usage_handle
             .increment_received_event_count_and_byte_size(event_count, record_size);
+        self.published_writer_data_file_size
+            .fetch_add(record_size, Ordering::AcqRel);
         self.notify_writer_waiters();
         next_record_id
     }
@@ -802,6 +827,7 @@ where
             lock,
             state: ledger_state,
             total_buffer_size: AtomicU64::new(0),
+            published_writer_data_file_size: AtomicU64::new(0),
             reader_notify: Notify::new(),
             writer_notify: Notify::new(),
             writer_done: AtomicBool::new(false),

--- a/lib/vector-buffers/src/variants/disk_v2/reader.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/reader.rs
@@ -1045,6 +1045,17 @@ where
 
             let (reader_file_id, writer_file_id) = self.ledger.get_current_reader_writer_file_id();
 
+            // A recoverable error is retried immediately by the receiver adapter. Do not let that
+            // retry consume bytes from the active writer file until the writer has published them
+            // as readable; physical file growth happens before shared progress is updated.
+            if self.ready_to_read
+                && reader_file_id == writer_file_id
+                && self.ledger.get_published_writer_data_file_size() <= self.bytes_read
+            {
+                self.ledger.wait_for_writer().await;
+                continue;
+            }
+
             // Essentially: is the writer still writing to this data file or not, and are we
             // actually ready to read (aka initialized)?
             //
@@ -1146,18 +1157,7 @@ where
 
                     self.roll_to_next_data_file();
                     force_check_pending_data_files = true;
-                    continue;
                 }
-
-                // A writer wake-up can be followed by a transient EOF. Since notifications can be
-                // coalesced, do not wait again when the published writer position proves that an
-                // unread record remains.
-                let next_expected_record_id = self.last_reader_record_id + 1;
-                if self.ledger.state().get_next_writer_record_id() > next_expected_record_id {
-                    continue;
-                }
-
-                self.ledger.wait_for_writer().await;
             } else {
                 debug!(
                     bytes_read = self.bytes_read,

--- a/lib/vector-buffers/src/variants/disk_v2/reader.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/reader.rs
@@ -1149,6 +1149,14 @@ where
                     continue;
                 }
 
+                // A writer wake-up can be followed by a transient EOF. Since notifications can be
+                // coalesced, do not wait again when the published writer position proves that an
+                // unread record remains.
+                let next_expected_record_id = self.last_reader_record_id + 1;
+                if self.ledger.state().get_next_writer_record_id() > next_expected_record_id {
+                    continue;
+                }
+
                 self.ledger.wait_for_writer().await;
             } else {
                 debug!(

--- a/lib/vector-buffers/src/variants/disk_v2/tests/invariants.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/tests/invariants.rs
@@ -11,7 +11,7 @@ use crate::{
     set_data_file_length,
     test::{MultiEventRecord, SizedRecord, acknowledge, install_tracing_helpers, with_temp_dir},
     variants::disk_v2::{
-        Buffer, DiskBufferConfigBuilder,
+        Buffer, DiskBufferConfigBuilder, ReaderError,
         common::{DEFAULT_FLUSH_INTERVAL, MAX_FILE_ID},
         tests::{
             create_buffer_v2_with_write_buffer_size, create_default_buffer_v2,
@@ -103,6 +103,7 @@ async fn publishing_writer_progress_updates_ledger_before_waking_reader() {
             assert_eq!(next_record_id, 2);
             assert_eq!(ledger.state().get_next_writer_record_id(), 2);
             assert_eq!(ledger.get_total_buffer_size(), 128);
+            assert_eq!(ledger.get_published_writer_data_file_size(), 128);
             assert!(wait_for_writer.is_woken());
             assert_ready!(wait_for_writer.poll());
         }
@@ -149,6 +150,75 @@ async fn reader_retries_when_published_record_is_not_immediately_visible() {
                 .expect("read should not fail")
                 .expect("read should produce a record");
             assert_eq!(record, SizedRecord::new(64));
+        }
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn reader_waits_after_dropping_last_published_record() {
+    with_temp_dir(|dir| {
+        let data_dir = dir.to_path_buf();
+
+        async move {
+            let config = DiskBufferConfigBuilder::from_path(data_dir)
+                .filesystem(TestFilesystem::default())
+                .build()
+                .expect("creating buffer config should not fail");
+            let usage_handle = BufferUsageHandle::noop();
+            let (mut writer, mut reader, ledger) =
+                Buffer::<SizedRecord>::from_config_inner(config, usage_handle)
+                    .await
+                    .expect("creating buffer should not fail");
+
+            let bytes_written = writer
+                .write_record(SizedRecord::new(64))
+                .await
+                .expect("write should not fail");
+            writer.flush().await.expect("flush should not fail");
+
+            let data_file_path = ledger.get_current_reader_data_file_path();
+            ledger.filesystem().corrupt_record_checksum(&data_file_path);
+            let dropped_bytes = match reader.next().await {
+                Err(ReaderError::Checksum { record_bytes, .. }) => record_bytes,
+                result => panic!("expected checksum error, got {result:?}"),
+            };
+            assert_eq!(dropped_bytes, bytes_written);
+            assert_eq!(
+                ledger.get_published_writer_data_file_size(),
+                bytes_written as u64
+            );
+
+            // The retry must wait without probing EOF again. Turning that probe into an error
+            // bounds the regression: the old busy loop returns the error instead of hanging this
+            // poll forever.
+            ledger.filesystem().error_at_eof(&data_file_path);
+            let mut blocked_read = spawn(reader.next());
+            assert_pending!(blocked_read.poll());
+            assert!(!blocked_read.is_woken());
+
+            let expected = SizedRecord::new(32);
+            writer
+                .write_record(expected.clone())
+                .await
+                .expect("write should not fail");
+            writer.flush().await.expect("flush should not fail");
+
+            assert!(blocked_read.is_woken());
+            let actual = assert_ready!(blocked_read.poll())
+                .expect("read should not fail")
+                .expect("read should produce a record");
+            assert_eq!(actual, expected);
+
+            // Model bytes reaching the active file before the writer publishes their boundary.
+            // The recoverable-error retry must not consume them merely because they are visible.
+            drop(blocked_read);
+            ledger
+                .filesystem()
+                .append_unpublished_file_contents(&data_file_path);
+            let mut unpublished_read = spawn(reader.next());
+            assert_pending!(unpublished_read.poll());
+            assert!(!unpublished_read.is_woken());
         }
     })
     .await;
@@ -587,6 +657,10 @@ async fn writer_updates_ledger_when_buffered_writer_reports_implicit_flush() {
             // At this point, the entire write buffer should have been flushed, which means whatever
             // event counts/bytes written they generated should be represented in the ledger state:
             assert_buffer_size!(ledger, total_events_written, total_bytes_written);
+            assert_eq!(
+                ledger.get_published_writer_data_file_size(),
+                total_bytes_written as u64
+            );
 
             // Now, do an explicit flush, which should get us our third write:
             writer.flush().await.expect("flush should not fail");
@@ -594,6 +668,10 @@ async fn writer_updates_ledger_when_buffered_writer_reports_implicit_flush() {
             total_events_written += record_events;
             total_bytes_written += bytes_written;
             assert_buffer_size!(ledger, total_events_written, total_bytes_written);
+            assert_eq!(
+                ledger.get_published_writer_data_file_size(),
+                total_bytes_written as u64
+            );
         }
     })
     .await;

--- a/lib/vector-buffers/src/variants/disk_v2/tests/invariants.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/tests/invariants.rs
@@ -6,13 +6,17 @@ use super::{create_buffer_v2_with_max_data_file_size, read_next, read_next_some}
 use crate::{
     EventCount, assert_buffer_is_empty, assert_buffer_records, assert_buffer_size,
     assert_enough_bytes_written, assert_reader_last_writer_next_positions,
-    assert_reader_writer_v2_file_positions, set_data_file_length,
+    assert_reader_writer_v2_file_positions,
+    buffer_usage_data::BufferUsageHandle,
+    set_data_file_length,
     test::{MultiEventRecord, SizedRecord, acknowledge, install_tracing_helpers, with_temp_dir},
     variants::disk_v2::{
+        Buffer, DiskBufferConfigBuilder,
         common::{DEFAULT_FLUSH_INTERVAL, MAX_FILE_ID},
         tests::{
             create_buffer_v2_with_write_buffer_size, create_default_buffer_v2,
             get_corrected_max_record_size, get_minimum_data_file_size_for_record_payload,
+            model::TestFilesystem,
         },
     },
 };
@@ -106,6 +110,48 @@ async fn publishing_writer_progress_updates_ledger_before_waking_reader() {
 
     let parent = trace_span!("publishing_writer_progress_updates_ledger_before_waking_reader");
     fut.instrument(parent.or_current()).await;
+}
+
+#[tokio::test]
+async fn reader_retries_when_published_record_is_not_immediately_visible() {
+    with_temp_dir(|dir| {
+        let data_dir = dir.to_path_buf();
+
+        async move {
+            let config = DiskBufferConfigBuilder::from_path(data_dir)
+                .filesystem(TestFilesystem::default())
+                .build()
+                .expect("creating buffer config should not fail");
+            let usage_handle = BufferUsageHandle::noop();
+            let (mut writer, mut reader, ledger) =
+                Buffer::<SizedRecord>::from_config_inner(config, usage_handle)
+                    .await
+                    .expect("creating buffer should not fail");
+
+            let mut blocked_read = spawn(reader.next());
+            assert_pending!(blocked_read.poll());
+            assert!(!blocked_read.is_woken());
+
+            // Publish one record and wake the reader, then simulate the reader observing EOF once
+            // before the appended record becomes visible.
+            writer
+                .write_record(SizedRecord::new(64))
+                .await
+                .expect("write should not fail");
+            writer.flush().await.expect("flush should not fail");
+            assert_buffer_records!(ledger, 1);
+
+            let data_file_path = ledger.get_current_reader_data_file_path();
+            ledger.filesystem().return_eof_on_next_read(&data_file_path);
+
+            assert!(blocked_read.is_woken());
+            let record = assert_ready!(blocked_read.poll())
+                .expect("read should not fail")
+                .expect("read should produce a record");
+            assert_eq!(record, SizedRecord::new(64));
+        }
+    })
+    .await;
 }
 
 #[tokio::test]

--- a/lib/vector-buffers/src/variants/disk_v2/tests/model/filesystem.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/tests/model/filesystem.rs
@@ -31,6 +31,7 @@ fn io_err_permission_denied() -> io::Error {
 
 struct FileInner {
     buf: Option<Vec<u8>>,
+    return_eof_on_next_read: bool,
 }
 
 impl FileInner {
@@ -48,6 +49,7 @@ impl Default for FileInner {
     fn default() -> Self {
         Self {
             buf: Some(Vec::new()),
+            return_eof_on_next_read: false,
         }
     }
 }
@@ -61,6 +63,7 @@ impl fmt::Debug for FileInner {
 
         f.debug_struct("FileInner")
             .field("buf", &buf_debug)
+            .field("return_eof_on_next_read", &self.return_eof_on_next_read)
             .finish()
     }
 }
@@ -155,6 +158,11 @@ impl AsyncRead for TestFile {
     ) -> Poll<io::Result<()>> {
         let new_read_pos = {
             let mut inner = self.inner.lock().expect("poisoned");
+            if inner.return_eof_on_next_read {
+                inner.return_eof_on_next_read = false;
+                return Poll::Ready(Ok(()));
+            }
+
             let src = inner.buf.as_mut().expect("file buf consumed");
 
             let cap = buf.remaining();
@@ -329,6 +337,16 @@ impl Default for TestFilesystem {
         Self {
             inner: Arc::new(Mutex::new(FilesystemInner::default())),
         }
+    }
+}
+
+impl TestFilesystem {
+    /// Makes one read report EOF without advancing its file position.
+    pub(crate) fn return_eof_on_next_read(&self, path: &Path) {
+        let inner = self.inner.lock().expect("poisoned");
+        let file = inner.files.get(path).expect("file should exist");
+        let mut file_inner = file.inner.lock().expect("poisoned");
+        file_inner.return_eof_on_next_read = true;
     }
 }
 

--- a/lib/vector-buffers/src/variants/disk_v2/tests/model/filesystem.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/tests/model/filesystem.rs
@@ -14,7 +14,9 @@ use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
 use crate::variants::disk_v2::{
     Filesystem,
+    backed_archive::BackedArchive,
     io::{AsyncFile, Metadata, ReadableMemoryMap, WritableMemoryMap},
+    record::Record,
 };
 
 fn io_err_already_exists() -> io::Error {
@@ -32,6 +34,7 @@ fn io_err_permission_denied() -> io::Error {
 struct FileInner {
     buf: Option<Vec<u8>>,
     return_eof_on_next_read: bool,
+    error_at_eof: bool,
 }
 
 impl FileInner {
@@ -50,6 +53,7 @@ impl Default for FileInner {
         Self {
             buf: Some(Vec::new()),
             return_eof_on_next_read: false,
+            error_at_eof: false,
         }
     }
 }
@@ -64,6 +68,7 @@ impl fmt::Debug for FileInner {
         f.debug_struct("FileInner")
             .field("buf", &buf_debug)
             .field("return_eof_on_next_read", &self.return_eof_on_next_read)
+            .field("error_at_eof", &self.error_at_eof)
             .finish()
     }
 }
@@ -163,14 +168,16 @@ impl AsyncRead for TestFile {
                 return Poll::Ready(Ok(()));
             }
 
-            let src = inner.buf.as_mut().expect("file buf consumed");
-
             let cap = buf.remaining();
             let pos = self.read_pos;
-            let available = src.len() - pos;
+            let available = inner.buf.as_ref().expect("file buf consumed").len() - pos;
+            if available == 0 && inner.error_at_eof {
+                return Poll::Ready(Err(io::Error::other("unexpected read at EOF")));
+            }
             let n = cmp::min(cap, available);
 
             let to = pos + n;
+            let src = inner.buf.as_mut().expect("file buf consumed");
             buf.put_slice(&src[pos..to]);
             to
         };
@@ -347,6 +354,36 @@ impl TestFilesystem {
         let file = inner.files.get(path).expect("file should exist");
         let mut file_inner = file.inner.lock().expect("poisoned");
         file_inner.return_eof_on_next_read = true;
+    }
+
+    /// Makes reads fail at EOF.
+    pub(crate) fn error_at_eof(&self, path: &Path) {
+        let inner = self.inner.lock().expect("poisoned");
+        let file = inner.files.get(path).expect("file should exist");
+        let mut file_inner = file.inner.lock().expect("poisoned");
+        file_inner.error_at_eof = true;
+    }
+
+    /// Corrupts the checksum of the only record in a data file.
+    pub(crate) fn corrupt_record_checksum(&self, path: &Path) {
+        let inner = self.inner.lock().expect("poisoned");
+        let file = inner.files.get(path).expect("file should exist");
+        let mut file_inner = file.inner.lock().expect("poisoned");
+        let buf = file_inner.buf.as_mut().expect("file buf consumed");
+        let mut backed_record = BackedArchive::<_, Record>::from_backing(buf.as_mut_slice())
+            .expect("archive should not fail");
+        let record = backed_record.get_archive_mut();
+        let projected_checksum = unsafe { record.map_unchecked_mut(|record| &mut record.checksum) };
+        *projected_checksum.get_mut() ^= 1 << 15;
+    }
+
+    /// Appends a copy of a file's bytes without publishing writer progress.
+    pub(crate) fn append_unpublished_file_contents(&self, path: &Path) {
+        let inner = self.inner.lock().expect("poisoned");
+        let file = inner.files.get(path).expect("file should exist");
+        let mut file_inner = file.inner.lock().expect("poisoned");
+        let buf = file_inner.buf.as_mut().expect("file buf consumed");
+        buf.extend_from_within(..);
     }
 }
 

--- a/lib/vector-buffers/src/variants/disk_v2/tests/model/mod.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/tests/model/mod.rs
@@ -31,7 +31,7 @@ mod common;
 use self::common::{Progress, arb_buffer_config};
 
 mod filesystem;
-use self::filesystem::TestFilesystem;
+pub(super) use self::filesystem::TestFilesystem;
 
 mod record;
 use self::record::Record;

--- a/lib/vector-buffers/src/variants/disk_v2/writer.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/writer.rs
@@ -1049,7 +1049,7 @@ where
 
         let previous_writer_file_id = self.ledger.get_current_writer_file_id();
         self.reset();
-        self.ledger.state().increment_writer_file_id();
+        self.ledger.increment_writer_file_id();
         self.ensure_ready_for_write().await.context(IoSnafu)?;
         self.reconcile_current_data_file_with_checkpoint().await?;
         self.ledger.flush().context(IoSnafu)?;
@@ -1396,19 +1396,15 @@ where
             }
         };
 
-        let recovered_successor = self
+        should_skip_to_next_file &= !self
             .recover_successor_data_file_from_stale_checkpoint()
             .await?;
-        should_skip_to_next_file &= !recovered_successor;
 
-        // Reset our internal state, which closes the initial data file we opened, and mark
-        // ourselves as needing to skip to the next data file.  This is a little convoluted, but we
-        // need to ensure we follow the normal behavior of trying to open the next data file,
-        // waiting for the reader to delete it if it already exists and hasn't been fully read yet,
-        // etc.
-        //
-        // Essentially, we defer the actual skipping to avoid deadlocking here trying to open a
-        // data file we might not be able to open yet.
+        // Recovery removed post-checkpoint and incomplete tails, so all remaining bytes are readable.
+        self.ledger.set_published_file_size(self.data_file_size);
+
+        // Defer rollover to the normal write path, which can wait for the reader without
+        // deadlocking initialization.
         if should_skip_to_next_file {
             self.reset();
             self.mark_for_skip();
@@ -1622,7 +1618,7 @@ where
                 // If we opened the "next" data file, we need to increment the current writer
                 // file ID now to signal that the writer has moved on.
                 if should_open_next {
-                    self.ledger.state().increment_writer_file_id();
+                    self.ledger.increment_writer_file_id();
                     self.ledger.notify_writer_waiters();
 
                     // The writer just rolled to a fresh data file, the boundary the


### PR DESCRIPTION
## Summary

Fix two `disk_v2` reader coordination failures:

- A transient EOF after a writer notification could leave published data unread until another write or shutdown.
- Dropping the final published frame as corrupt could make the reader retry continuously and consume CPU.

This is related to #23605, which reports events remaining in a disk buffer until restart, and #23456, which tracks a rare reader wake-up failure in `vector-buffers`. The race fixed here is reproducible on current master and the latest nightly. These issues cover broader symptoms; this PR addresses one concrete reader-side cause.

The reader now uses a runtime-only published byte boundary for the active writer file. It retries while published bytes remain and waits once those bytes have been consumed. The boundary is reset on file rollover and rebuilt during recovery.

This does not change configuration or the on-disk format.

## How did you test this PR?

- Added deterministic coverage for transient EOF, corrupt-frame recovery, and visible but unpublished bytes.
- `cargo test -p vector-buffers`
- `cargo clippy -p vector-buffers --all-targets --all-features -- -D warnings`
- `cargo build -p vector-buffers --release`
- `make check-changelog-fragments`
- `make check-markdown`

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [x] Yes. A changelog fragment is included.
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.
