### PR TITLE
fix(codecs): preserve logical types in generated Avro schema fixtures

### DIFF
--- a/lib/codecs/tests/bin/generate-avro-fixtures.rs
+++ b/lib/codecs/tests/bin/generate-avro-fixtures.rs
@@ -476,7 +476,7 @@ fn generate_test_case_from_value(schema: &str, value: Value, filename: &str) -> 
 
     let mut schema_file = File::create(format!("{FIXTURES_PATH}/{filename}.avsc"))?;
     let mut avro_file = File::create(format!("{FIXTURES_PATH}/{filename}.avro"))?;
-    schema_file.write_all(schema.canonical_form().as_bytes())?;
+    schema_file.write_all(serde_json::to_string(&schema)?.as_bytes())?;
     avro_file.write_all(&bytes)?;
     Ok(())
 }

--- a/lib/codecs/tests/data/avro/generated/array.avsc
+++ b/lib/codecs/tests/data/avro/generated/array.avsc
@@ -1,1 +1,1 @@
-{"name":"test","type":"record","fields":[{"name":"array_field","type":{"type":"array","items":"string"}}]}
+{"type":"record","name":"test","fields":[{"name":"array_field","type":{"type":"array","items":"string"},"items":"string"}]}

--- a/lib/codecs/tests/data/avro/generated/boolean.avsc
+++ b/lib/codecs/tests/data/avro/generated/boolean.avsc
@@ -1,1 +1,1 @@
-{"name":"test","type":"record","fields":[{"name":"bool_field","type":"boolean"}]}
+{"type":"record","name":"test","fields":[{"name":"bool_field","type":"boolean","default":false}]}

--- a/lib/codecs/tests/data/avro/generated/bytes.avsc
+++ b/lib/codecs/tests/data/avro/generated/bytes.avsc
@@ -1,1 +1,1 @@
-{"name":"test","type":"record","fields":[{"name":"bytes_field","type":"bytes"}]}
+{"type":"record","name":"test","fields":[{"name":"bytes_field","type":"bytes"}]}

--- a/lib/codecs/tests/data/avro/generated/double.avsc
+++ b/lib/codecs/tests/data/avro/generated/double.avsc
@@ -1,1 +1,1 @@
-{"name":"test","type":"record","fields":[{"name":"double_field","type":"double"}]}
+{"type":"record","name":"test","fields":[{"name":"double_field","type":"double","default":0}]}

--- a/lib/codecs/tests/data/avro/generated/enum.avsc
+++ b/lib/codecs/tests/data/avro/generated/enum.avsc
@@ -1,1 +1,1 @@
-{"name":"test","type":"record","fields":[{"name":"enum_field","type":{"name":"enum_field","type":"enum","symbols":["Spades","Hearts","Diamonds","Clubs"]}}]}
+{"type":"record","name":"test","fields":[{"name":"enum_field","type":{"type":"enum","name":"enum_field","symbols":["Spades","Hearts","Diamonds","Clubs"]}}]}

--- a/lib/codecs/tests/data/avro/generated/float.avsc
+++ b/lib/codecs/tests/data/avro/generated/float.avsc
@@ -1,1 +1,1 @@
-{"name":"test","type":"record","fields":[{"name":"float_field","type":"float"}]}
+{"type":"record","name":"test","fields":[{"name":"float_field","type":"float","default":0}]}

--- a/lib/codecs/tests/data/avro/generated/int.avsc
+++ b/lib/codecs/tests/data/avro/generated/int.avsc
@@ -1,1 +1,1 @@
-{"name":"test","type":"record","fields":[{"name":"int_field","type":"int"}]}
+{"type":"record","name":"test","fields":[{"name":"int_field","type":"int","default":0}]}

--- a/lib/codecs/tests/data/avro/generated/local-timestamp_micros.avsc
+++ b/lib/codecs/tests/data/avro/generated/local-timestamp_micros.avsc
@@ -1,1 +1,1 @@
-{"name":"test","type":"record","fields":[{"name":"local_timestamp_micros_field","type":{"type":"long","logicalType":"local-timestamp-micros"}}]}
+{"type":"record","name":"test","fields":[{"name":"local_timestamp_micros_field","type":{"type":"long","logicalType":"local-timestamp-micros"}}]}

--- a/lib/codecs/tests/data/avro/generated/local-timestamp_millis.avsc
+++ b/lib/codecs/tests/data/avro/generated/local-timestamp_millis.avsc
@@ -1,1 +1,1 @@
-{"name":"test","type":"record","fields":[{"name":"local_timestamp_millis_field","type":{"type":"long","logicalType":"local-timestamp-millis"}}]}
+{"type":"record","name":"test","fields":[{"name":"local_timestamp_millis_field","type":{"type":"long","logicalType":"local-timestamp-millis"}}]}

--- a/lib/codecs/tests/data/avro/generated/long.avsc
+++ b/lib/codecs/tests/data/avro/generated/long.avsc
@@ -1,1 +1,1 @@
-{"name":"test","type":"record","fields":[{"name":"long_field","type":"long"}]}
+{"type":"record","name":"test","fields":[{"name":"long_field","type":"long","default":0}]}

--- a/lib/codecs/tests/data/avro/generated/map.avsc
+++ b/lib/codecs/tests/data/avro/generated/map.avsc
@@ -1,1 +1,1 @@
-{"name":"test","type":"record","fields":[{"name":"map_field","type":{"type":"map","values":"long"}}]}
+{"type":"record","name":"test","fields":[{"name":"map_field","type":{"type":"map","values":"long","default":{}},"default":{},"values":"long"}]}

--- a/lib/codecs/tests/data/avro/generated/record.avsc
+++ b/lib/codecs/tests/data/avro/generated/record.avsc
@@ -1,1 +1,1 @@
-{"name":"test","type":"record","fields":[{"name":"name","type":"string"},{"name":"age","type":"int"}]}
+{"type":"record","name":"test","fields":[{"name":"name","type":"string"},{"name":"age","type":"int"}]}

--- a/lib/codecs/tests/data/avro/generated/string.avsc
+++ b/lib/codecs/tests/data/avro/generated/string.avsc
@@ -1,1 +1,1 @@
-{"name":"test","type":"record","fields":[{"name":"string_field","type":"string"}]}
+{"type":"record","name":"test","fields":[{"name":"string_field","type":"string"}]}

--- a/lib/codecs/tests/data/avro/generated/time_micros.avsc
+++ b/lib/codecs/tests/data/avro/generated/time_micros.avsc
@@ -1,1 +1,1 @@
-{"name":"test","type":"record","fields":[{"name":"time_micros_field","type":{"type":"long","logicalType":"time-micros"}}]}
+{"type":"record","name":"test","fields":[{"name":"time_micros_field","type":{"type":"long","logicalType":"time-micros"}}]}

--- a/lib/codecs/tests/data/avro/generated/timestamp_micros.avsc
+++ b/lib/codecs/tests/data/avro/generated/timestamp_micros.avsc
@@ -1,1 +1,1 @@
-{"name":"test","type":"record","fields":[{"name":"timestamp_micros_field","type":{"type":"long","logicalType":"timestamp-micros"}}]}
+{"type":"record","name":"test","fields":[{"name":"timestamp_micros_field","type":{"type":"long","logicalType":"timestamp-micros"}}]}

--- a/lib/codecs/tests/data/avro/generated/timestamp_millis.avsc
+++ b/lib/codecs/tests/data/avro/generated/timestamp_millis.avsc
@@ -1,1 +1,1 @@
-{"name":"test","type":"record","fields":[{"name":"timestamp_millis_field","type":{"type":"long","logicalType":"timestamp-millis"}}]}
+{"type":"record","name":"test","fields":[{"name":"timestamp_millis_field","type":{"type":"long","logicalType":"timestamp-millis"}}]}

--- a/lib/codecs/tests/data/avro/generated/union.avsc
+++ b/lib/codecs/tests/data/avro/generated/union.avsc
@@ -1,1 +1,1 @@
-{"name":"test","type":"record","fields":[{"name":"union_field","type":["string","int"]}]}
+{"type":"record","name":"test","fields":[{"name":"union_field","type":["string","int"]}]}

--- a/lib/codecs/tests/data/avro/generated/uuid.avsc
+++ b/lib/codecs/tests/data/avro/generated/uuid.avsc
@@ -1,1 +1,1 @@
-{"name":"test","type":"record","fields":[{"name":"uuid_field","type":{"type":"string","logicalType":"uuid"}}]}
+{"type":"record","name":"test","fields":[{"name":"uuid_field","type":{"type":"string","logicalType":"uuid"}}]}


### PR DESCRIPTION
## Summary
The current Avro schema fixtures drop any schema metadata such as `logicalType` which makes it impossible to test the encoding/decoding of fields containing logical types e.g. 
```
{
  "type": "int",
  "logicalType": "date"
}
```

To fix, serialize the schema with `serde_json` instead of `canonical_form()` to preserve the logical type annotations.

## Vector configuration
N/A

## How did you test this PR?
Re-ran `cargo run --package codecs --bin generate-avro-fixtures` and `cargo test -p codecs avro` passes.

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References
- Related: https://github.com/vectordotdev/vector/issues/24773

## Notes

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details on the [dd-rust-license-tool](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert, perf
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional but appreciated; letters, digits, spaces, hyphens, underscores (e.g. `kafka source`, `amazon-linux`)
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
