### PR TITLE
docs(component docs): commit generated config examples

### DIFF
--- a/.github/workflows/changes.yml
+++ b/.github/workflows/changes.yml
@@ -237,7 +237,14 @@ jobs:
               - "vdev/Cargo.toml"
               - ".github/workflows/changes.yml"
             component_docs:
+              - 'Makefile'
               - "vdev/Cargo.toml"
+              - 'website/Makefile'
+              - 'website/package.json'
+              - 'website/yarn.lock'
+              - 'website/generated/example-configs/**'
+              - 'website/scripts/create-config-examples.js'
+              - 'website/scripts/validate-config-examples.js'
               - 'website/cue/**/*.cue'
               - 'docs/generated/**'
               # If changes to the VRL sha is made the combined generated cue file will change which

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -149,6 +149,7 @@ jobs:
           cue: true
           libsasl2: true
           cargo-cache: true
+      - run: cd website && yarn install --frozen-lockfile
       - run: make check-generated-docs
 
   check-rust-docs:

--- a/Makefile
+++ b/Makefile
@@ -449,8 +449,14 @@ check-events: ## Check that events satisfy patterns set in https://github.com/ve
 	$(VDEV) check events
 
 .PHONY: check-generated-docs
-check-generated-docs: generate-docs ## Checks that the machine-generated component Cue docs are up-to-date.
+check-generated-docs: generate-docs ## Checks that machine-generated component docs and examples are up-to-date.
 	$(VDEV) check generated-docs
+	@if test -n "$$(git status --porcelain -- website/generated/example-configs)"; then \
+		echo "Generated component examples are out of date. Run 'make generate-example-configs' and commit the changes."; \
+		git status --short -- website/generated/example-configs; \
+		exit 1; \
+	fi
+	VECTOR_BIN=$(abspath $(CARGO_TARGET_DIR)/debug/vector) $(MAKE) -C website validate-config-examples
 
 ##@ Rustdoc
 build-rustdoc: ## Build Vector's Rustdocs
@@ -539,8 +545,12 @@ generate-vector-vrl-docs: ## Generate VRL function documentation from Rust sourc
 generate-vrl-docs: ## Generate combined VRL function documentation for the website.
 	$(MAKE) -C website generate-vrl-docs
 
+.PHONY: generate-example-configs
+generate-example-configs: generate-component-docs ## Generate committed component configuration examples.
+	$(MAKE) -C website config-examples
+
 .PHONY: generate-docs
-generate-docs: generate-component-docs generate-vector-vrl-docs generate-vrl-docs
+generate-docs: generate-component-docs generate-vector-vrl-docs generate-vrl-docs generate-example-configs
 
 .PHONY: signoff
 signoff: ## Signsoff all previous commits since branch creation

--- a/website/Makefile
+++ b/website/Makefile
@@ -10,6 +10,7 @@ export SERVER_PORT ?= 1313
 clean:
 	rm -rf public resources data/cargo-lock.toml data/docs.json
 
+.PHONY: setup
 setup:
 	yarn
 
@@ -21,11 +22,25 @@ cargo-data:
 cue-%:
 	${CUE} $*
 
-config-examples:
+.PHONY: config-examples
+config-examples: setup cue-build
 	yarn config-examples
 
-validate-config-examples: cue-build config-examples
-	yarn validate-config-examples
+CARGO_TARGET_DIR ?= ../target
+
+ifeq ($(origin VECTOR_BIN), undefined)
+VALIDATE_VECTOR_BIN := $(abspath $(CARGO_TARGET_DIR)/debug/vector)
+VALIDATE_VECTOR_BUILD := true
+else
+VALIDATE_VECTOR_BIN := $(VECTOR_BIN)
+endif
+
+.PHONY: validate-config-examples
+validate-config-examples: config-examples
+ifeq ($(VALIDATE_VECTOR_BUILD),true)
+	CARGO_TARGET_DIR="$(abspath $(CARGO_TARGET_DIR))" cargo build --manifest-path ../Cargo.toml
+endif
+	VECTOR_BIN="$(VALIDATE_VECTOR_BIN)" yarn validate-config-examples
 
 VDEV ?= cargo vdev
 
@@ -36,7 +51,7 @@ generate-vrl-docs:
 generate-deprecations-json:
 	$(VDEV) deprecation generate
 
-structured-data: generate-vrl-docs generate-deprecations-json cue-build config-examples
+structured-data: generate-vrl-docs generate-deprecations-json config-examples
 
 serve: clean setup cargo-data structured-data
 	hugo server \

--- a/website/generated/example-configs/sinks/amqp/advanced.yaml
+++ b/website/generated/example-configs/sinks/amqp/advanced.yaml
@@ -1,0 +1,11 @@
+sinks:
+  my_sink_id:
+    type: amqp
+    inputs:
+      - my-source-or-transform-id
+    connection_string: amqp://user:password@127.0.0.1:5672/%2f?timeout=10
+    dangerously_allow_unconfined_template_resolution: false
+    encoding:
+      codec: json
+    exchange: my-exchange
+    max_channels: 4

--- a/website/generated/example-configs/sinks/amqp/minimal.yaml
+++ b/website/generated/example-configs/sinks/amqp/minimal.yaml
@@ -1,0 +1,9 @@
+sinks:
+  my_sink_id:
+    type: amqp
+    inputs:
+      - my-source-or-transform-id
+    connection_string: amqp://user:password@127.0.0.1:5672/%2f?timeout=10
+    encoding:
+      codec: json
+    exchange: my-exchange

--- a/website/generated/example-configs/sinks/appsignal/advanced.yaml
+++ b/website/generated/example-configs/sinks/appsignal/advanced.yaml
@@ -1,0 +1,8 @@
+sinks:
+  my_sink_id:
+    type: appsignal
+    inputs:
+      - my-source-or-transform-id
+    compression: gzip
+    endpoint: https://appsignal-endpoint.net
+    push_api_key: 00000000-0000-0000-0000-000000000000

--- a/website/generated/example-configs/sinks/appsignal/minimal.yaml
+++ b/website/generated/example-configs/sinks/appsignal/minimal.yaml
@@ -1,0 +1,6 @@
+sinks:
+  my_sink_id:
+    type: appsignal
+    inputs:
+      - my-source-or-transform-id
+    push_api_key: 00000000-0000-0000-0000-000000000000

--- a/website/generated/example-configs/sinks/aws_cloudwatch_logs/advanced.yaml
+++ b/website/generated/example-configs/sinks/aws_cloudwatch_logs/advanced.yaml
@@ -1,0 +1,15 @@
+sinks:
+  my_sink_id:
+    type: aws_cloudwatch_logs
+    inputs:
+      - my-source-or-transform-id
+    compression: none
+    create_missing_group: true
+    create_missing_stream: true
+    dangerously_allow_unconfined_template_resolution: false
+    encoding:
+      codec: json
+    endpoint: http://127.0.0.0:5000/path/to/service
+    group_name: group-name
+    region: us-east-1
+    stream_name: "{{ host }}"

--- a/website/generated/example-configs/sinks/aws_cloudwatch_logs/minimal.yaml
+++ b/website/generated/example-configs/sinks/aws_cloudwatch_logs/minimal.yaml
@@ -1,0 +1,9 @@
+sinks:
+  my_sink_id:
+    type: aws_cloudwatch_logs
+    inputs:
+      - my-source-or-transform-id
+    encoding:
+      codec: json
+    group_name: group-name
+    stream_name: "{{ host }}"

--- a/website/generated/example-configs/sinks/aws_cloudwatch_metrics/advanced.yaml
+++ b/website/generated/example-configs/sinks/aws_cloudwatch_metrics/advanced.yaml
@@ -1,0 +1,9 @@
+sinks:
+  my_sink_id:
+    type: aws_cloudwatch_metrics
+    inputs:
+      - my-source-or-transform-id
+    compression: none
+    default_namespace: service
+    endpoint: http://127.0.0.0:5000/path/to/service
+    region: us-east-1

--- a/website/generated/example-configs/sinks/aws_cloudwatch_metrics/minimal.yaml
+++ b/website/generated/example-configs/sinks/aws_cloudwatch_metrics/minimal.yaml
@@ -1,0 +1,6 @@
+sinks:
+  my_sink_id:
+    type: aws_cloudwatch_metrics
+    inputs:
+      - my-source-or-transform-id
+    default_namespace: service

--- a/website/generated/example-configs/sinks/aws_kinesis_firehose/advanced.yaml
+++ b/website/generated/example-configs/sinks/aws_kinesis_firehose/advanced.yaml
@@ -1,0 +1,13 @@
+sinks:
+  my_sink_id:
+    type: aws_kinesis_firehose
+    inputs:
+      - my-source-or-transform-id
+    compression: none
+    encoding:
+      codec: json
+    endpoint: http://127.0.0.0:5000/path/to/service
+    partition_key_field: user_id
+    region: us-east-1
+    request_retry_partial: false
+    stream_name: my-stream

--- a/website/generated/example-configs/sinks/aws_kinesis_firehose/minimal.yaml
+++ b/website/generated/example-configs/sinks/aws_kinesis_firehose/minimal.yaml
@@ -1,0 +1,8 @@
+sinks:
+  my_sink_id:
+    type: aws_kinesis_firehose
+    inputs:
+      - my-source-or-transform-id
+    encoding:
+      codec: json
+    stream_name: my-stream

--- a/website/generated/example-configs/sinks/aws_kinesis_streams/advanced.yaml
+++ b/website/generated/example-configs/sinks/aws_kinesis_streams/advanced.yaml
@@ -1,0 +1,13 @@
+sinks:
+  my_sink_id:
+    type: aws_kinesis_streams
+    inputs:
+      - my-source-or-transform-id
+    compression: none
+    encoding:
+      codec: json
+    endpoint: http://127.0.0.0:5000/path/to/service
+    partition_key_field: user_id
+    region: us-east-1
+    request_retry_partial: false
+    stream_name: my-stream

--- a/website/generated/example-configs/sinks/aws_kinesis_streams/minimal.yaml
+++ b/website/generated/example-configs/sinks/aws_kinesis_streams/minimal.yaml
@@ -1,0 +1,8 @@
+sinks:
+  my_sink_id:
+    type: aws_kinesis_streams
+    inputs:
+      - my-source-or-transform-id
+    encoding:
+      codec: json
+    stream_name: my-stream

--- a/website/generated/example-configs/sinks/aws_s3/advanced.yaml
+++ b/website/generated/example-configs/sinks/aws_s3/advanced.yaml
@@ -1,0 +1,32 @@
+sinks:
+  my_sink_id:
+    type: aws_s3
+    inputs:
+      - my-source-or-transform-id
+    acl: authenticated-read
+    bucket: my-bucket
+    compression: gzip
+    content_encoding: gzip
+    content_type: application/gzip
+    dangerously_allow_unconfined_template_resolution: false
+    encoding:
+      codec: json
+    endpoint: http://127.0.0.0:5000/path/to/service
+    filename_append_uuid: true
+    filename_extension: json
+    filename_time_format: "%s"
+    force_path_style: true
+    grant_full_control: 79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be
+    grant_read: 79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be
+    grant_read_acp: 79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be
+    grant_write_acp: 79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be
+    key_prefix: date=%F
+    region: us-east-1
+    server_side_encryption: AES256
+    ssekms_key_id: abcd1234
+    storage_class: STANDARD
+    tags:
+      Classification: confidential
+      PHI: "True"
+      Project: Blue
+    timezone: local

--- a/website/generated/example-configs/sinks/aws_s3/minimal.yaml
+++ b/website/generated/example-configs/sinks/aws_s3/minimal.yaml
@@ -1,0 +1,8 @@
+sinks:
+  my_sink_id:
+    type: aws_s3
+    inputs:
+      - my-source-or-transform-id
+    bucket: my-bucket
+    encoding:
+      codec: json

--- a/website/generated/example-configs/sinks/aws_sns/advanced.yaml
+++ b/website/generated/example-configs/sinks/aws_sns/advanced.yaml
@@ -1,0 +1,12 @@
+sinks:
+  my_sink_id:
+    type: aws_sns
+    inputs:
+      - my-source-or-transform-id
+    encoding:
+      codec: json
+    endpoint: http://127.0.0.0:5000/path/to/service
+    message_deduplication_id: "{{ transaction_id }}"
+    message_group_id: vector
+    region: us-east-1
+    topic_arn: arn:aws:sns:us-east-2:123456789012:MyTopic

--- a/website/generated/example-configs/sinks/aws_sns/minimal.yaml
+++ b/website/generated/example-configs/sinks/aws_sns/minimal.yaml
@@ -1,0 +1,8 @@
+sinks:
+  my_sink_id:
+    type: aws_sns
+    inputs:
+      - my-source-or-transform-id
+    encoding:
+      codec: json
+    topic_arn: arn:aws:sns:us-east-2:123456789012:MyTopic

--- a/website/generated/example-configs/sinks/aws_sqs/advanced.yaml
+++ b/website/generated/example-configs/sinks/aws_sqs/advanced.yaml
@@ -1,0 +1,12 @@
+sinks:
+  my_sink_id:
+    type: aws_sqs
+    inputs:
+      - my-source-or-transform-id
+    encoding:
+      codec: json
+    endpoint: http://127.0.0.0:5000/path/to/service
+    message_deduplication_id: "{{ transaction_id }}"
+    message_group_id: vector
+    queue_url: https://sqs.us-east-2.amazonaws.com/123456789012/MyQueue
+    region: us-east-1

--- a/website/generated/example-configs/sinks/aws_sqs/minimal.yaml
+++ b/website/generated/example-configs/sinks/aws_sqs/minimal.yaml
@@ -1,0 +1,8 @@
+sinks:
+  my_sink_id:
+    type: aws_sqs
+    inputs:
+      - my-source-or-transform-id
+    encoding:
+      codec: json
+    queue_url: https://sqs.us-east-2.amazonaws.com/123456789012/MyQueue

--- a/website/generated/example-configs/sinks/axiom/advanced.yaml
+++ b/website/generated/example-configs/sinks/axiom/advanced.yaml
@@ -1,0 +1,12 @@
+sinks:
+  my_sink_id:
+    type: axiom
+    inputs:
+      - my-source-or-transform-id
+    compression: zstd
+    dangerously_allow_unconfined_template_resolution: false
+    dataset: ${AXIOM_DATASET}
+    org_id: ${AXIOM_ORG_ID}
+    region: ${AXIOM_REGION}
+    token: ${AXIOM_TOKEN}
+    url: https://api.eu.axiom.co

--- a/website/generated/example-configs/sinks/axiom/minimal.yaml
+++ b/website/generated/example-configs/sinks/axiom/minimal.yaml
@@ -1,0 +1,7 @@
+sinks:
+  my_sink_id:
+    type: axiom
+    inputs:
+      - my-source-or-transform-id
+    dataset: ${AXIOM_DATASET}
+    token: ${AXIOM_TOKEN}

--- a/website/generated/example-configs/sinks/azure_blob/advanced.yaml
+++ b/website/generated/example-configs/sinks/azure_blob/advanced.yaml
@@ -1,0 +1,15 @@
+sinks:
+  my_sink_id:
+    type: azure_blob
+    inputs:
+      - my-source-or-transform-id
+    account_name: mylogstorage
+    blob_append_uuid: false
+    blob_endpoint: https://mylogstorage.blob.core.windows.net/
+    blob_prefix: blob/%F/
+    compression: gzip
+    connection_string: DefaultEndpointsProtocol=https;AccountName=mylogstorage;AccountKey=storageaccountkeybase64encoded;EndpointSuffix=core.windows.net
+    container_name: my-logs
+    dangerously_allow_unconfined_template_resolution: false
+    encoding:
+      codec: json

--- a/website/generated/example-configs/sinks/azure_blob/minimal.yaml
+++ b/website/generated/example-configs/sinks/azure_blob/minimal.yaml
@@ -1,0 +1,8 @@
+sinks:
+  my_sink_id:
+    type: azure_blob
+    inputs:
+      - my-source-or-transform-id
+    container_name: my-logs
+    encoding:
+      codec: json

--- a/website/generated/example-configs/sinks/azure_logs_ingestion/advanced.yaml
+++ b/website/generated/example-configs/sinks/azure_logs_ingestion/advanced.yaml
@@ -1,0 +1,12 @@
+sinks:
+  my_sink_id:
+    type: azure_logs_ingestion
+    inputs:
+      - my-source-or-transform-id
+    auth:
+      azure_credential_kind: azure_cli
+    dcr_immutable_id: dcr-000a00a000a00000a000000aa000a0aa
+    endpoint: https://my-dce-5kyl.eastus-1.ingest.monitor.azure.com
+    stream_name: Custom-MyTable
+    timestamp_field: TimeGenerated
+    token_scope: https://monitor.azure.com/.default

--- a/website/generated/example-configs/sinks/azure_logs_ingestion/minimal.yaml
+++ b/website/generated/example-configs/sinks/azure_logs_ingestion/minimal.yaml
@@ -1,0 +1,10 @@
+sinks:
+  my_sink_id:
+    type: azure_logs_ingestion
+    inputs:
+      - my-source-or-transform-id
+    auth:
+      azure_credential_kind: azure_cli
+    dcr_immutable_id: dcr-000a00a000a00000a000000aa000a0aa
+    endpoint: https://my-dce-5kyl.eastus-1.ingest.monitor.azure.com
+    stream_name: Custom-MyTable

--- a/website/generated/example-configs/sinks/azure_monitor_logs/advanced.yaml
+++ b/website/generated/example-configs/sinks/azure_monitor_logs/advanced.yaml
@@ -1,0 +1,11 @@
+sinks:
+  my_sink_id:
+    type: azure_monitor_logs
+    inputs:
+      - my-source-or-transform-id
+    azure_resource_id: /subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/otherResourceGroup/providers/Microsoft.Storage/storageAccounts/examplestorage
+    customer_id: 5ce893d9-2c32-4b6c-91a9-b0887c2de2d6
+    host: ods.opinsights.azure.com
+    log_type: MyTableName
+    shared_key: SERsIYhgMVlJB6uPsq49gCxNiruf6v0vhMYE+lfzbSGcXjdViZdV/e5pEMTYtw9f8SkVLf4LFlLCc2KxtRZfCA==
+    time_generated_key: time_generated

--- a/website/generated/example-configs/sinks/azure_monitor_logs/minimal.yaml
+++ b/website/generated/example-configs/sinks/azure_monitor_logs/minimal.yaml
@@ -1,0 +1,8 @@
+sinks:
+  my_sink_id:
+    type: azure_monitor_logs
+    inputs:
+      - my-source-or-transform-id
+    customer_id: 5ce893d9-2c32-4b6c-91a9-b0887c2de2d6
+    log_type: MyTableName
+    shared_key: SERsIYhgMVlJB6uPsq49gCxNiruf6v0vhMYE+lfzbSGcXjdViZdV/e5pEMTYtw9f8SkVLf4LFlLCc2KxtRZfCA==

--- a/website/generated/example-configs/sinks/blackhole/advanced.yaml
+++ b/website/generated/example-configs/sinks/blackhole/advanced.yaml
@@ -1,0 +1,7 @@
+sinks:
+  my_sink_id:
+    type: blackhole
+    inputs:
+      - my-source-or-transform-id
+    print_interval_secs: 10
+    rate: 1000

--- a/website/generated/example-configs/sinks/blackhole/minimal.yaml
+++ b/website/generated/example-configs/sinks/blackhole/minimal.yaml
@@ -1,0 +1,5 @@
+sinks:
+  my_sink_id:
+    type: blackhole
+    inputs:
+      - my-source-or-transform-id

--- a/website/generated/example-configs/sinks/clickhouse/advanced.yaml
+++ b/website/generated/example-configs/sinks/clickhouse/advanced.yaml
@@ -1,0 +1,14 @@
+sinks:
+  my_sink_id:
+    type: clickhouse
+    inputs:
+      - my-source-or-transform-id
+    compression: gzip
+    dangerously_allow_unconfined_template_resolution: false
+    database: mydatabase
+    date_time_best_effort: false
+    endpoint: http://localhost:8123
+    format: json_each_row
+    insert_random_shard: false
+    skip_unknown_fields: false
+    table: mytable

--- a/website/generated/example-configs/sinks/clickhouse/minimal.yaml
+++ b/website/generated/example-configs/sinks/clickhouse/minimal.yaml
@@ -1,0 +1,7 @@
+sinks:
+  my_sink_id:
+    type: clickhouse
+    inputs:
+      - my-source-or-transform-id
+    endpoint: http://localhost:8123
+    table: mytable

--- a/website/generated/example-configs/sinks/console/advanced.yaml
+++ b/website/generated/example-configs/sinks/console/advanced.yaml
@@ -1,0 +1,8 @@
+sinks:
+  my_sink_id:
+    type: console
+    inputs:
+      - my-source-or-transform-id
+    encoding:
+      codec: json
+    target: stdout

--- a/website/generated/example-configs/sinks/console/minimal.yaml
+++ b/website/generated/example-configs/sinks/console/minimal.yaml
@@ -1,0 +1,7 @@
+sinks:
+  my_sink_id:
+    type: console
+    inputs:
+      - my-source-or-transform-id
+    encoding:
+      codec: json

--- a/website/generated/example-configs/sinks/databend/advanced.yaml
+++ b/website/generated/example-configs/sinks/databend/advanced.yaml
@@ -1,0 +1,10 @@
+sinks:
+  my_sink_id:
+    type: databend
+    inputs:
+      - my-source-or-transform-id
+    compression: none
+    database: mydatabase
+    endpoint: databend://localhost:8000/default?sslmode=disable
+    missing_field_as: "NULL"
+    table: mytable

--- a/website/generated/example-configs/sinks/databend/minimal.yaml
+++ b/website/generated/example-configs/sinks/databend/minimal.yaml
@@ -1,0 +1,7 @@
+sinks:
+  my_sink_id:
+    type: databend
+    inputs:
+      - my-source-or-transform-id
+    endpoint: databend://localhost:8000/default?sslmode=disable
+    table: mytable

--- a/website/generated/example-configs/sinks/databricks_zerobus/advanced.yaml
+++ b/website/generated/example-configs/sinks/databricks_zerobus/advanced.yaml
@@ -1,0 +1,13 @@
+sinks:
+  my_sink_id:
+    type: databricks_zerobus
+    inputs:
+      - my-source-or-transform-id
+    auth:
+      client_id: ${DATABRICKS_CLIENT_ID}
+      client_secret: ${DATABRICKS_CLIENT_SECRET}
+      strategy: oauth
+    ingestion_endpoint: https://1234567890123456.zerobus.us-west-2.cloud.databricks.com
+    table_name: main.default.logs
+    unity_catalog_endpoint: https://dbc-a1b2c3d4-e5f6.cloud.databricks.com
+    user_agent: my-service/1.2

--- a/website/generated/example-configs/sinks/databricks_zerobus/minimal.yaml
+++ b/website/generated/example-configs/sinks/databricks_zerobus/minimal.yaml
@@ -1,0 +1,12 @@
+sinks:
+  my_sink_id:
+    type: databricks_zerobus
+    inputs:
+      - my-source-or-transform-id
+    auth:
+      client_id: ${DATABRICKS_CLIENT_ID}
+      client_secret: ${DATABRICKS_CLIENT_SECRET}
+      strategy: oauth
+    ingestion_endpoint: https://1234567890123456.zerobus.us-west-2.cloud.databricks.com
+    table_name: main.default.logs
+    unity_catalog_endpoint: https://dbc-a1b2c3d4-e5f6.cloud.databricks.com

--- a/website/generated/example-configs/sinks/datadog_events/advanced.yaml
+++ b/website/generated/example-configs/sinks/datadog_events/advanced.yaml
@@ -1,0 +1,8 @@
+sinks:
+  my_sink_id:
+    type: datadog_events
+    inputs:
+      - my-source-or-transform-id
+    default_api_key: ${DATADOG_API_KEY_ENV_VAR}
+    endpoint: http://127.0.0.1:8080
+    site: us3.datadoghq.com

--- a/website/generated/example-configs/sinks/datadog_events/minimal.yaml
+++ b/website/generated/example-configs/sinks/datadog_events/minimal.yaml
@@ -1,0 +1,5 @@
+sinks:
+  my_sink_id:
+    type: datadog_events
+    inputs:
+      - my-source-or-transform-id

--- a/website/generated/example-configs/sinks/datadog_logs/advanced.yaml
+++ b/website/generated/example-configs/sinks/datadog_logs/advanced.yaml
@@ -1,0 +1,10 @@
+sinks:
+  my_sink_id:
+    type: datadog_logs
+    inputs:
+      - my-source-or-transform-id
+    compression: zstd
+    conforms_as_agent: false
+    default_api_key: ${DATADOG_API_KEY_ENV_VAR}
+    endpoint: http://127.0.0.1:8080
+    site: us3.datadoghq.com

--- a/website/generated/example-configs/sinks/datadog_logs/minimal.yaml
+++ b/website/generated/example-configs/sinks/datadog_logs/minimal.yaml
@@ -1,0 +1,5 @@
+sinks:
+  my_sink_id:
+    type: datadog_logs
+    inputs:
+      - my-source-or-transform-id

--- a/website/generated/example-configs/sinks/datadog_metrics/advanced.yaml
+++ b/website/generated/example-configs/sinks/datadog_metrics/advanced.yaml
@@ -1,0 +1,10 @@
+sinks:
+  my_sink_id:
+    type: datadog_metrics
+    inputs:
+      - my-source-or-transform-id
+    default_api_key: ${DATADOG_API_KEY_ENV_VAR}
+    default_namespace: myservice
+    endpoint: http://127.0.0.1:8080
+    series_api_version: v2
+    site: us3.datadoghq.com

--- a/website/generated/example-configs/sinks/datadog_metrics/minimal.yaml
+++ b/website/generated/example-configs/sinks/datadog_metrics/minimal.yaml
@@ -1,0 +1,5 @@
+sinks:
+  my_sink_id:
+    type: datadog_metrics
+    inputs:
+      - my-source-or-transform-id

--- a/website/generated/example-configs/sinks/datadog_traces/advanced.yaml
+++ b/website/generated/example-configs/sinks/datadog_traces/advanced.yaml
@@ -1,0 +1,9 @@
+sinks:
+  my_sink_id:
+    type: datadog_traces
+    inputs:
+      - my-source-or-transform-id
+    compression: gzip
+    default_api_key: ${DATADOG_API_KEY_ENV_VAR}
+    endpoint: http://127.0.0.1:8080
+    site: us3.datadoghq.com

--- a/website/generated/example-configs/sinks/datadog_traces/minimal.yaml
+++ b/website/generated/example-configs/sinks/datadog_traces/minimal.yaml
@@ -1,0 +1,5 @@
+sinks:
+  my_sink_id:
+    type: datadog_traces
+    inputs:
+      - my-source-or-transform-id

--- a/website/generated/example-configs/sinks/doris/advanced.yaml
+++ b/website/generated/example-configs/sinks/doris/advanced.yaml
@@ -1,0 +1,16 @@
+sinks:
+  my_sink_id:
+    type: doris
+    inputs:
+      - my-source-or-transform-id
+    compression: none
+    dangerously_allow_unconfined_template_resolution: false
+    database: mydatabase
+    encoding:
+      codec: json
+    endpoints:
+      - http://127.0.0.1:8030
+    label_prefix: vector
+    log_request: false
+    max_retries: -1
+    table: mytable

--- a/website/generated/example-configs/sinks/doris/minimal.yaml
+++ b/website/generated/example-configs/sinks/doris/minimal.yaml
@@ -1,0 +1,9 @@
+sinks:
+  my_sink_id:
+    type: doris
+    inputs:
+      - my-source-or-transform-id
+    database: mydatabase
+    encoding:
+      codec: json
+    table: mytable

--- a/website/generated/example-configs/sinks/elasticsearch/advanced.yaml
+++ b/website/generated/example-configs/sinks/elasticsearch/advanced.yaml
@@ -1,0 +1,19 @@
+sinks:
+  my_sink_id:
+    type: elasticsearch
+    inputs:
+      - my-source-or-transform-id
+    api_version: auto
+    compression: none
+    dangerously_allow_unconfined_template_resolution: false
+    doc_type: _doc
+    endpoints:
+      - http://10.24.32.122:9000
+    id_key: id
+    mode: bulk
+    opensearch_service_type: managed
+    pipeline: pipeline-name
+    query:
+      X-Powered-By: Vector
+    request_retry_partial: false
+    suppress_type_name: false

--- a/website/generated/example-configs/sinks/elasticsearch/minimal.yaml
+++ b/website/generated/example-configs/sinks/elasticsearch/minimal.yaml
@@ -1,0 +1,5 @@
+sinks:
+  my_sink_id:
+    type: elasticsearch
+    inputs:
+      - my-source-or-transform-id

--- a/website/generated/example-configs/sinks/file/advanced.yaml
+++ b/website/generated/example-configs/sinks/file/advanced.yaml
@@ -1,0 +1,13 @@
+sinks:
+  my_sink_id:
+    type: file
+    inputs:
+      - my-source-or-transform-id
+    base_dir: /var/log/vector
+    compression: none
+    dangerously_allow_unconfined_template_resolution: false
+    encoding:
+      codec: json
+    idle_timeout_secs: 30
+    path: /tmp/vector-%Y-%m-%d.log
+    timezone: local

--- a/website/generated/example-configs/sinks/file/minimal.yaml
+++ b/website/generated/example-configs/sinks/file/minimal.yaml
@@ -1,0 +1,8 @@
+sinks:
+  my_sink_id:
+    type: file
+    inputs:
+      - my-source-or-transform-id
+    encoding:
+      codec: json
+    path: /tmp/vector-%Y-%m-%d.log

--- a/website/generated/example-configs/sinks/gcp_chronicle_unstructured/advanced.yaml
+++ b/website/generated/example-configs/sinks/gcp_chronicle_unstructured/advanced.yaml
@@ -1,0 +1,17 @@
+sinks:
+  my_sink_id:
+    type: gcp_chronicle_unstructured
+    inputs:
+      - my-source-or-transform-id
+    compression: none
+    customer_id: c8c65bfa-5f2c-42d4-9189-64bb7b939f2c
+    encoding:
+      codec: json
+    endpoint: 127.0.0.1:8080
+    fallback_log_type: VECTOR_DEV
+    labels:
+      source: vector
+      tenant: marketing
+    log_type: WINDOWS_DNS
+    namespace: production
+    region: asia

--- a/website/generated/example-configs/sinks/gcp_chronicle_unstructured/minimal.yaml
+++ b/website/generated/example-configs/sinks/gcp_chronicle_unstructured/minimal.yaml
@@ -1,0 +1,9 @@
+sinks:
+  my_sink_id:
+    type: gcp_chronicle_unstructured
+    inputs:
+      - my-source-or-transform-id
+    customer_id: c8c65bfa-5f2c-42d4-9189-64bb7b939f2c
+    encoding:
+      codec: json
+    log_type: WINDOWS_DNS

--- a/website/generated/example-configs/sinks/gcp_cloud_storage/advanced.yaml
+++ b/website/generated/example-configs/sinks/gcp_cloud_storage/advanced.yaml
@@ -1,0 +1,20 @@
+sinks:
+  my_sink_id:
+    type: gcp_cloud_storage
+    inputs:
+      - my-source-or-transform-id
+    acl: authenticated-read
+    bucket: my-bucket
+    cache_control: no-transform
+    compression: none
+    content_encoding: gzip
+    content_type: text/plain; charset=utf-8
+    dangerously_allow_unconfined_template_resolution: false
+    encoding:
+      codec: json
+    endpoint: https://storage.googleapis.com
+    filename_append_uuid: true
+    filename_time_format: "%s"
+    key_prefix: date=%F/
+    storage_class: ARCHIVE
+    timezone: local

--- a/website/generated/example-configs/sinks/gcp_cloud_storage/minimal.yaml
+++ b/website/generated/example-configs/sinks/gcp_cloud_storage/minimal.yaml
@@ -1,0 +1,8 @@
+sinks:
+  my_sink_id:
+    type: gcp_cloud_storage
+    inputs:
+      - my-source-or-transform-id
+    bucket: my-bucket
+    encoding:
+      codec: json

--- a/website/generated/example-configs/sinks/gcp_pubsub/advanced.yaml
+++ b/website/generated/example-configs/sinks/gcp_pubsub/advanced.yaml
@@ -1,0 +1,10 @@
+sinks:
+  my_sink_id:
+    type: gcp_pubsub
+    inputs:
+      - my-source-or-transform-id
+    encoding:
+      codec: json
+    endpoint: https://pubsub.googleapis.com
+    project: vector-123456
+    topic: this-is-a-topic

--- a/website/generated/example-configs/sinks/gcp_pubsub/minimal.yaml
+++ b/website/generated/example-configs/sinks/gcp_pubsub/minimal.yaml
@@ -1,0 +1,9 @@
+sinks:
+  my_sink_id:
+    type: gcp_pubsub
+    inputs:
+      - my-source-or-transform-id
+    encoding:
+      codec: json
+    project: vector-123456
+    topic: this-is-a-topic

--- a/website/generated/example-configs/sinks/gcp_stackdriver_logs/advanced.yaml
+++ b/website/generated/example-configs/sinks/gcp_stackdriver_logs/advanced.yaml
@@ -1,0 +1,17 @@
+sinks:
+  my_sink_id:
+    type: gcp_stackdriver_logs
+    inputs:
+      - my-source-or-transform-id
+    dangerously_allow_unconfined_template_resolution: false
+    labels:
+      label_1: value_1
+      label_2: "{{ template_value_2 }}"
+    labels_key: logging.googleapis.com/labels
+    log_id: my-log
+    project_id: my-project
+    resource:
+      instanceId: Twilight
+      zone: "{{ zone }}"
+      type: gce_instance
+    severity_key: severity

--- a/website/generated/example-configs/sinks/gcp_stackdriver_logs/minimal.yaml
+++ b/website/generated/example-configs/sinks/gcp_stackdriver_logs/minimal.yaml
@@ -1,0 +1,11 @@
+sinks:
+  my_sink_id:
+    type: gcp_stackdriver_logs
+    inputs:
+      - my-source-or-transform-id
+    log_id: my-log
+    project_id: my-project
+    resource:
+      instanceId: Twilight
+      zone: "{{ zone }}"
+      type: gce_instance

--- a/website/generated/example-configs/sinks/gcp_stackdriver_metrics/advanced.yaml
+++ b/website/generated/example-configs/sinks/gcp_stackdriver_metrics/advanced.yaml
@@ -1,0 +1,12 @@
+sinks:
+  my_sink_id:
+    type: gcp_stackdriver_metrics
+    inputs:
+      - my-source-or-transform-id
+    default_namespace: namespace
+    project_id: my-project
+    resource:
+      instanceId: Twilight
+      projectId: vector-123456
+      type: global
+      zone: us-central1-a

--- a/website/generated/example-configs/sinks/gcp_stackdriver_metrics/minimal.yaml
+++ b/website/generated/example-configs/sinks/gcp_stackdriver_metrics/minimal.yaml
@@ -1,0 +1,11 @@
+sinks:
+  my_sink_id:
+    type: gcp_stackdriver_metrics
+    inputs:
+      - my-source-or-transform-id
+    project_id: my-project
+    resource:
+      instanceId: Twilight
+      projectId: vector-123456
+      type: global
+      zone: us-central1-a

--- a/website/generated/example-configs/sinks/greptimedb_logs/advanced.yaml
+++ b/website/generated/example-configs/sinks/greptimedb_logs/advanced.yaml
@@ -1,0 +1,16 @@
+sinks:
+  my_sink_id:
+    type: greptimedb_logs
+    inputs:
+      - my-source-or-transform-id
+    compression: gzip
+    dangerously_allow_unconfined_template_resolution: false
+    dbname: public
+    endpoint: http://localhost:4000
+    extra_params:
+      source: vector
+    password: password
+    pipeline_name: greptime_identity
+    pipeline_version: 2024-06-07 06:46:23.858293
+    table: mytable
+    username: username

--- a/website/generated/example-configs/sinks/greptimedb_logs/minimal.yaml
+++ b/website/generated/example-configs/sinks/greptimedb_logs/minimal.yaml
@@ -1,0 +1,7 @@
+sinks:
+  my_sink_id:
+    type: greptimedb_logs
+    inputs:
+      - my-source-or-transform-id
+    endpoint: http://localhost:4000
+    table: mytable

--- a/website/generated/example-configs/sinks/greptimedb_metrics/advanced.yaml
+++ b/website/generated/example-configs/sinks/greptimedb_metrics/advanced.yaml
@@ -1,0 +1,11 @@
+sinks:
+  my_sink_id:
+    type: greptimedb_metrics
+    inputs:
+      - my-source-or-transform-id
+    dbname: public
+    endpoint: example.com:4001
+    grpc_compression: none
+    new_naming: false
+    password: password
+    username: username

--- a/website/generated/example-configs/sinks/greptimedb_metrics/minimal.yaml
+++ b/website/generated/example-configs/sinks/greptimedb_metrics/minimal.yaml
@@ -1,0 +1,6 @@
+sinks:
+  my_sink_id:
+    type: greptimedb_metrics
+    inputs:
+      - my-source-or-transform-id
+    endpoint: example.com:4001

--- a/website/generated/example-configs/sinks/honeycomb/advanced.yaml
+++ b/website/generated/example-configs/sinks/honeycomb/advanced.yaml
@@ -1,0 +1,9 @@
+sinks:
+  my_sink_id:
+    type: honeycomb
+    inputs:
+      - my-source-or-transform-id
+    api_key: ${HONEYCOMB_API_KEY}
+    compression: zstd
+    dataset: my-honeycomb-dataset
+    endpoint: https://api.honeycomb.io

--- a/website/generated/example-configs/sinks/honeycomb/minimal.yaml
+++ b/website/generated/example-configs/sinks/honeycomb/minimal.yaml
@@ -1,0 +1,7 @@
+sinks:
+  my_sink_id:
+    type: honeycomb
+    inputs:
+      - my-source-or-transform-id
+    api_key: ${HONEYCOMB_API_KEY}
+    dataset: my-honeycomb-dataset

--- a/website/generated/example-configs/sinks/http/advanced.yaml
+++ b/website/generated/example-configs/sinks/http/advanced.yaml
@@ -1,0 +1,13 @@
+sinks:
+  my_sink_id:
+    type: http
+    inputs:
+      - my-source-or-transform-id
+    compression: none
+    dangerously_allow_unconfined_template_resolution: false
+    encoding:
+      codec: json
+    method: post
+    payload_prefix: '{"data":'
+    payload_suffix: "}"
+    uri: https://10.22.212.22:9000/endpoint

--- a/website/generated/example-configs/sinks/http/minimal.yaml
+++ b/website/generated/example-configs/sinks/http/minimal.yaml
@@ -1,0 +1,8 @@
+sinks:
+  my_sink_id:
+    type: http
+    inputs:
+      - my-source-or-transform-id
+    encoding:
+      codec: json
+    uri: https://10.22.212.22:9000/endpoint

--- a/website/generated/example-configs/sinks/humio_logs/advanced.yaml
+++ b/website/generated/example-configs/sinks/humio_logs/advanced.yaml
@@ -1,0 +1,16 @@
+sinks:
+  my_sink_id:
+    type: humio_logs
+    inputs:
+      - my-source-or-transform-id
+    compression: none
+    dangerously_allow_unconfined_template_resolution: false
+    encoding:
+      codec: json
+    endpoint: https://cloud.humio.com
+    event_type: json
+    host_key: .host
+    index: "{{ host }}"
+    timestamp_key: .timestamp
+    timestamp_nanos_key: "@timestamp.nanos"
+    token: ${HUMIO_TOKEN}

--- a/website/generated/example-configs/sinks/humio_logs/minimal.yaml
+++ b/website/generated/example-configs/sinks/humio_logs/minimal.yaml
@@ -1,0 +1,8 @@
+sinks:
+  my_sink_id:
+    type: humio_logs
+    inputs:
+      - my-source-or-transform-id
+    encoding:
+      codec: json
+    token: ${HUMIO_TOKEN}

--- a/website/generated/example-configs/sinks/humio_metrics/advanced.yaml
+++ b/website/generated/example-configs/sinks/humio_metrics/advanced.yaml
@@ -1,0 +1,15 @@
+sinks:
+  my_sink_id:
+    type: humio_metrics
+    inputs:
+      - my-source-or-transform-id
+    compression: none
+    dangerously_allow_unconfined_template_resolution: false
+    endpoint: https://cloud.humio.com
+    event_type: json
+    host_key: host
+    host_tag: host
+    index: "{{ host }}"
+    metric_tag_values: single
+    timezone: local
+    token: ${HUMIO_TOKEN}

--- a/website/generated/example-configs/sinks/humio_metrics/minimal.yaml
+++ b/website/generated/example-configs/sinks/humio_metrics/minimal.yaml
@@ -1,0 +1,6 @@
+sinks:
+  my_sink_id:
+    type: humio_metrics
+    inputs:
+      - my-source-or-transform-id
+    token: ${HUMIO_TOKEN}

--- a/website/generated/example-configs/sinks/influxdb_logs/advanced.yaml
+++ b/website/generated/example-configs/sinks/influxdb_logs/advanced.yaml
@@ -1,0 +1,21 @@
+sinks:
+  my_sink_id:
+    type: influxdb_logs
+    inputs:
+      - my-source-or-transform-id
+    bucket: vector-bucket
+    consistency: any
+    database: vector-database
+    endpoint: http://localhost:8086
+    host_key: hostname
+    measurement: vector-logs
+    message_key: text
+    namespace: service
+    org: my-org
+    password: ${INFLUXDB_PASSWORD}
+    retention_policy_name: autogen
+    source_type_key: source
+    tags:
+      - field1
+    token: ${INFLUXDB_TOKEN}
+    username: todd

--- a/website/generated/example-configs/sinks/influxdb_logs/minimal.yaml
+++ b/website/generated/example-configs/sinks/influxdb_logs/minimal.yaml
@@ -1,0 +1,10 @@
+sinks:
+  my_sink_id:
+    type: influxdb_logs
+    inputs:
+      - my-source-or-transform-id
+    bucket: vector-bucket
+    database: vector-database
+    endpoint: http://localhost:8086
+    org: my-org
+    token: ${INFLUXDB_TOKEN}

--- a/website/generated/example-configs/sinks/influxdb_metrics/advanced.yaml
+++ b/website/generated/example-configs/sinks/influxdb_metrics/advanced.yaml
@@ -1,0 +1,17 @@
+sinks:
+  my_sink_id:
+    type: influxdb_metrics
+    inputs:
+      - my-source-or-transform-id
+    bucket: vector-bucket
+    consistency: any
+    database: vector-database
+    default_namespace: service
+    endpoint: http://localhost:8086/
+    org: my-org
+    password: ${INFLUXDB_PASSWORD}
+    retention_policy_name: autogen
+    tags:
+      region: us-west-1
+    token: ${INFLUXDB_TOKEN}
+    username: todd

--- a/website/generated/example-configs/sinks/influxdb_metrics/minimal.yaml
+++ b/website/generated/example-configs/sinks/influxdb_metrics/minimal.yaml
@@ -1,0 +1,10 @@
+sinks:
+  my_sink_id:
+    type: influxdb_metrics
+    inputs:
+      - my-source-or-transform-id
+    bucket: vector-bucket
+    database: vector-database
+    endpoint: http://localhost:8086/
+    org: my-org
+    token: ${INFLUXDB_TOKEN}

--- a/website/generated/example-configs/sinks/kafka/advanced.yaml
+++ b/website/generated/example-configs/sinks/kafka/advanced.yaml
@@ -1,0 +1,20 @@
+sinks:
+  my_sink_id:
+    type: kafka
+    inputs:
+      - my-source-or-transform-id
+    bootstrap_servers: 10.14.22.123:9092,10.14.23.332:9092
+    compression: none
+    dangerously_allow_unconfined_template_resolution: false
+    encoding:
+      codec: json
+    headers_key: headers
+    key_field: user_id
+    librdkafka_options:
+      client.id: ${ENV_VAR}
+      fetch.error.backoff.ms: "1000"
+      socket.send.buffer.bytes: "100"
+    message_timeout_ms: 300000
+    rate_limit_duration_secs: 1
+    socket_timeout_ms: 60000
+    topic: topic-1234

--- a/website/generated/example-configs/sinks/kafka/minimal.yaml
+++ b/website/generated/example-configs/sinks/kafka/minimal.yaml
@@ -1,0 +1,9 @@
+sinks:
+  my_sink_id:
+    type: kafka
+    inputs:
+      - my-source-or-transform-id
+    bootstrap_servers: 10.14.22.123:9092,10.14.23.332:9092
+    encoding:
+      codec: json
+    topic: topic-1234

--- a/website/generated/example-configs/sinks/keep/advanced.yaml
+++ b/website/generated/example-configs/sinks/keep/advanced.yaml
@@ -1,0 +1,7 @@
+sinks:
+  my_sink_id:
+    type: keep
+    inputs:
+      - my-source-or-transform-id
+    api_key: ${KEEP_API_KEY}
+    endpoint: http://localhost:8080/alerts/event/vectordev?provider_id=test

--- a/website/generated/example-configs/sinks/keep/minimal.yaml
+++ b/website/generated/example-configs/sinks/keep/minimal.yaml
@@ -1,0 +1,6 @@
+sinks:
+  my_sink_id:
+    type: keep
+    inputs:
+      - my-source-or-transform-id
+    api_key: ${KEEP_API_KEY}

--- a/website/generated/example-configs/sinks/loki/advanced.yaml
+++ b/website/generated/example-configs/sinks/loki/advanced.yaml
@@ -1,0 +1,26 @@
+sinks:
+  my_sink_id:
+    type: loki
+    inputs:
+      - my-source-or-transform-id
+    compression: snappy
+    dangerously_allow_unconfined_template_resolution: false
+    encoding:
+      codec: json
+    endpoint: http://localhost:3100
+    labels:
+      '"*"': "{{ metadata }}"
+      '"pod_labels_*"': "{{ kubernetes.pod_labels }}"
+      source: vector
+      "{{ event_field }}": "{{ some_other_event_field }}"
+    out_of_order_action: accept
+    path: /loki/api/v1/push
+    remove_label_fields: false
+    remove_structured_metadata_fields: false
+    remove_timestamp: true
+    structured_metadata:
+      '"*"': "{{ metadata }}"
+      '"pod_labels_*"': "{{ kubernetes.pod_labels }}"
+      source: vector
+      "{{ event_field }}": "{{ some_other_event_field }}"
+    tenant_id: some_tenant_id

--- a/website/generated/example-configs/sinks/loki/minimal.yaml
+++ b/website/generated/example-configs/sinks/loki/minimal.yaml
@@ -1,0 +1,13 @@
+sinks:
+  my_sink_id:
+    type: loki
+    inputs:
+      - my-source-or-transform-id
+    encoding:
+      codec: json
+    endpoint: http://localhost:3100
+    labels:
+      '"*"': "{{ metadata }}"
+      '"pod_labels_*"': "{{ kubernetes.pod_labels }}"
+      source: vector
+      "{{ event_field }}": "{{ some_other_event_field }}"

--- a/website/generated/example-configs/sinks/mezmo/advanced.yaml
+++ b/website/generated/example-configs/sinks/mezmo/advanced.yaml
@@ -1,0 +1,14 @@
+sinks:
+  my_sink_id:
+    type: mezmo
+    inputs:
+      - my-source-or-transform-id
+    api_key: ${LOGDNA_API_KEY}
+    default_app: vector
+    default_env: production
+    endpoint: https://logs.mezmo.com/
+    hostname: ${HOSTNAME}
+    ip: 0.0.0.0
+    mac: my-mac-address
+    tags:
+      - tag1

--- a/website/generated/example-configs/sinks/mezmo/minimal.yaml
+++ b/website/generated/example-configs/sinks/mezmo/minimal.yaml
@@ -1,0 +1,7 @@
+sinks:
+  my_sink_id:
+    type: mezmo
+    inputs:
+      - my-source-or-transform-id
+    api_key: ${LOGDNA_API_KEY}
+    hostname: ${HOSTNAME}

--- a/website/generated/example-configs/sinks/mqtt/advanced.yaml
+++ b/website/generated/example-configs/sinks/mqtt/advanced.yaml
@@ -1,0 +1,16 @@
+sinks:
+  my_sink_id:
+    type: mqtt
+    inputs:
+      - my-source-or-transform-id
+    clean_session: false
+    dangerously_allow_unconfined_template_resolution: false
+    encoding:
+      codec: json
+    host: mqtt.example.com
+    keep_alive: 60
+    max_packet_size: 10240
+    port: 1883
+    quality_of_service: atleastonce
+    retain: false
+    topic: my-topic

--- a/website/generated/example-configs/sinks/mqtt/minimal.yaml
+++ b/website/generated/example-configs/sinks/mqtt/minimal.yaml
@@ -1,0 +1,9 @@
+sinks:
+  my_sink_id:
+    type: mqtt
+    inputs:
+      - my-source-or-transform-id
+    encoding:
+      codec: json
+    host: mqtt.example.com
+    topic: my-topic

--- a/website/generated/example-configs/sinks/nats/advanced.yaml
+++ b/website/generated/example-configs/sinks/nats/advanced.yaml
@@ -1,0 +1,11 @@
+sinks:
+  my_sink_id:
+    type: nats
+    inputs:
+      - my-source-or-transform-id
+    connection_name: vector
+    dangerously_allow_unconfined_template_resolution: false
+    encoding:
+      codec: json
+    subject: "{{ host }}"
+    url: nats://demo.nats.io

--- a/website/generated/example-configs/sinks/nats/minimal.yaml
+++ b/website/generated/example-configs/sinks/nats/minimal.yaml
@@ -1,0 +1,9 @@
+sinks:
+  my_sink_id:
+    type: nats
+    inputs:
+      - my-source-or-transform-id
+    encoding:
+      codec: json
+    subject: "{{ host }}"
+    url: nats://demo.nats.io

--- a/website/generated/example-configs/sinks/new_relic/advanced.yaml
+++ b/website/generated/example-configs/sinks/new_relic/advanced.yaml
@@ -1,0 +1,10 @@
+sinks:
+  my_sink_id:
+    type: new_relic
+    inputs:
+      - my-source-or-transform-id
+    account_id: xxxx
+    api: events
+    compression: gzip
+    license_key: xxxx
+    region: eu

--- a/website/generated/example-configs/sinks/new_relic/minimal.yaml
+++ b/website/generated/example-configs/sinks/new_relic/minimal.yaml
@@ -1,0 +1,8 @@
+sinks:
+  my_sink_id:
+    type: new_relic
+    inputs:
+      - my-source-or-transform-id
+    account_id: xxxx
+    api: events
+    license_key: xxxx

--- a/website/generated/example-configs/sinks/opentelemetry/advanced.yaml
+++ b/website/generated/example-configs/sinks/opentelemetry/advanced.yaml
@@ -1,0 +1,10 @@
+sinks:
+  my_sink_id:
+    type: opentelemetry
+    inputs:
+      - my-source-or-transform-id
+    protocol:
+      encoding:
+        codec: json
+      type: http
+      uri: https://10.22.212.22:9000/endpoint

--- a/website/generated/example-configs/sinks/opentelemetry/minimal.yaml
+++ b/website/generated/example-configs/sinks/opentelemetry/minimal.yaml
@@ -1,0 +1,10 @@
+sinks:
+  my_sink_id:
+    type: opentelemetry
+    inputs:
+      - my-source-or-transform-id
+    protocol:
+      encoding:
+        codec: json
+      type: http
+      uri: https://10.22.212.22:9000/endpoint

--- a/website/generated/example-configs/sinks/papertrail/advanced.yaml
+++ b/website/generated/example-configs/sinks/papertrail/advanced.yaml
@@ -1,0 +1,9 @@
+sinks:
+  my_sink_id:
+    type: papertrail
+    inputs:
+      - my-source-or-transform-id
+    encoding:
+      codec: json
+    endpoint: logs.papertrailapp.com:12345
+    process: vector

--- a/website/generated/example-configs/sinks/papertrail/minimal.yaml
+++ b/website/generated/example-configs/sinks/papertrail/minimal.yaml
@@ -1,0 +1,8 @@
+sinks:
+  my_sink_id:
+    type: papertrail
+    inputs:
+      - my-source-or-transform-id
+    encoding:
+      codec: json
+    endpoint: logs.papertrailapp.com:12345

--- a/website/generated/example-configs/sinks/postgres/advanced.yaml
+++ b/website/generated/example-configs/sinks/postgres/advanced.yaml
@@ -1,0 +1,8 @@
+sinks:
+  my_sink_id:
+    type: postgres
+    inputs:
+      - my-source-or-transform-id
+    endpoint: postgres://localhost:5432
+    pool_size: 5
+    table: my_table

--- a/website/generated/example-configs/sinks/postgres/minimal.yaml
+++ b/website/generated/example-configs/sinks/postgres/minimal.yaml
@@ -1,0 +1,7 @@
+sinks:
+  my_sink_id:
+    type: postgres
+    inputs:
+      - my-source-or-transform-id
+    endpoint: postgres://localhost:5432
+    table: my_table

--- a/website/generated/example-configs/sinks/prometheus_exporter/advanced.yaml
+++ b/website/generated/example-configs/sinks/prometheus_exporter/advanced.yaml
@@ -1,0 +1,9 @@
+sinks:
+  my_sink_id:
+    type: prometheus_exporter
+    inputs:
+      - my-source-or-transform-id
+    address: 0.0.0.0:9598
+    distributions_as_summaries: false
+    flush_period_secs: 60
+    suppress_timestamp: false

--- a/website/generated/example-configs/sinks/prometheus_exporter/minimal.yaml
+++ b/website/generated/example-configs/sinks/prometheus_exporter/minimal.yaml
@@ -1,0 +1,5 @@
+sinks:
+  my_sink_id:
+    type: prometheus_exporter
+    inputs:
+      - my-source-or-transform-id

--- a/website/generated/example-configs/sinks/prometheus_remote_write/advanced.yaml
+++ b/website/generated/example-configs/sinks/prometheus_remote_write/advanced.yaml
@@ -1,0 +1,10 @@
+sinks:
+  my_sink_id:
+    type: prometheus_remote_write
+    inputs:
+      - my-source-or-transform-id
+    compression: snappy
+    dangerously_allow_unconfined_template_resolution: false
+    default_namespace: service
+    endpoint: https://localhost:8087/api/v1/write
+    tenant_id: my-domain

--- a/website/generated/example-configs/sinks/prometheus_remote_write/minimal.yaml
+++ b/website/generated/example-configs/sinks/prometheus_remote_write/minimal.yaml
@@ -1,0 +1,6 @@
+sinks:
+  my_sink_id:
+    type: prometheus_remote_write
+    inputs:
+      - my-source-or-transform-id
+    endpoint: https://localhost:8087/api/v1/write

--- a/website/generated/example-configs/sinks/pulsar/advanced.yaml
+++ b/website/generated/example-configs/sinks/pulsar/advanced.yaml
@@ -1,0 +1,13 @@
+sinks:
+  my_sink_id:
+    type: pulsar
+    inputs:
+      - my-source-or-transform-id
+    compression: none
+    dangerously_allow_unconfined_template_resolution: false
+    encoding:
+      codec: json
+    endpoint: pulsar://127.0.0.1:6650
+    partition_key_field: message
+    producer_name: producer-name
+    topic: topic-1234

--- a/website/generated/example-configs/sinks/pulsar/minimal.yaml
+++ b/website/generated/example-configs/sinks/pulsar/minimal.yaml
@@ -1,0 +1,9 @@
+sinks:
+  my_sink_id:
+    type: pulsar
+    inputs:
+      - my-source-or-transform-id
+    encoding:
+      codec: json
+    endpoint: pulsar://127.0.0.1:6650
+    topic: topic-1234

--- a/website/generated/example-configs/sinks/redis/advanced.yaml
+++ b/website/generated/example-configs/sinks/redis/advanced.yaml
@@ -1,0 +1,11 @@
+sinks:
+  my_sink_id:
+    type: redis
+    inputs:
+      - my-source-or-transform-id
+    dangerously_allow_unconfined_template_resolution: false
+    data_type: list
+    encoding:
+      codec: json
+    endpoint: redis://127.0.0.1:6379/0
+    key: syslog:{{ app }}

--- a/website/generated/example-configs/sinks/redis/minimal.yaml
+++ b/website/generated/example-configs/sinks/redis/minimal.yaml
@@ -1,0 +1,9 @@
+sinks:
+  my_sink_id:
+    type: redis
+    inputs:
+      - my-source-or-transform-id
+    encoding:
+      codec: json
+    endpoint: redis://127.0.0.1:6379/0
+    key: syslog:{{ app }}

--- a/website/generated/example-configs/sinks/sematext_logs/advanced.yaml
+++ b/website/generated/example-configs/sinks/sematext_logs/advanced.yaml
@@ -1,0 +1,8 @@
+sinks:
+  my_sink_id:
+    type: sematext_logs
+    inputs:
+      - my-source-or-transform-id
+    endpoint: http://127.0.0.1
+    region: us
+    token: ${SEMATEXT_TOKEN}

--- a/website/generated/example-configs/sinks/sematext_logs/minimal.yaml
+++ b/website/generated/example-configs/sinks/sematext_logs/minimal.yaml
@@ -1,0 +1,6 @@
+sinks:
+  my_sink_id:
+    type: sematext_logs
+    inputs:
+      - my-source-or-transform-id
+    token: ${SEMATEXT_TOKEN}

--- a/website/generated/example-configs/sinks/sematext_metrics/advanced.yaml
+++ b/website/generated/example-configs/sinks/sematext_metrics/advanced.yaml
@@ -1,0 +1,9 @@
+sinks:
+  my_sink_id:
+    type: sematext_metrics
+    inputs:
+      - my-source-or-transform-id
+    default_namespace: service
+    endpoint: http://127.0.0.1
+    region: us
+    token: ${SEMATEXT_TOKEN}

--- a/website/generated/example-configs/sinks/sematext_metrics/minimal.yaml
+++ b/website/generated/example-configs/sinks/sematext_metrics/minimal.yaml
@@ -1,0 +1,7 @@
+sinks:
+  my_sink_id:
+    type: sematext_metrics
+    inputs:
+      - my-source-or-transform-id
+    default_namespace: service
+    token: ${SEMATEXT_TOKEN}

--- a/website/generated/example-configs/sinks/socket/advanced.yaml
+++ b/website/generated/example-configs/sinks/socket/advanced.yaml
@@ -1,0 +1,10 @@
+sinks:
+  my_sink_id:
+    type: socket
+    inputs:
+      - my-source-or-transform-id
+    address: 92.12.333.224:5000
+    encoding:
+      codec: json
+    mode: tcp
+    send_buffer_bytes: 65536

--- a/website/generated/example-configs/sinks/socket/minimal.yaml
+++ b/website/generated/example-configs/sinks/socket/minimal.yaml
@@ -1,0 +1,9 @@
+sinks:
+  my_sink_id:
+    type: socket
+    inputs:
+      - my-source-or-transform-id
+    address: 92.12.333.224:5000
+    encoding:
+      codec: json
+    mode: tcp

--- a/website/generated/example-configs/sinks/splunk_hec_logs/advanced.yaml
+++ b/website/generated/example-configs/sinks/splunk_hec_logs/advanced.yaml
@@ -1,0 +1,19 @@
+sinks:
+  my_sink_id:
+    type: splunk_hec_logs
+    inputs:
+      - my-source-or-transform-id
+    auto_extract_timestamp: false
+    compression: none
+    dangerously_allow_unconfined_template_resolution: false
+    default_token: SECRET[splunk_secrets.token]
+    encoding:
+      codec: json
+    endpoint: https://http-inputs-hec.splunkcloud.com
+    endpoint_target: event
+    index: "{{ host }}"
+    indexed_fields:
+      - field1
+    source: "{{ file }}"
+    sourcetype: "{{ sourcetype }}"
+    timestamp_key: timestamp

--- a/website/generated/example-configs/sinks/splunk_hec_logs/minimal.yaml
+++ b/website/generated/example-configs/sinks/splunk_hec_logs/minimal.yaml
@@ -1,0 +1,9 @@
+sinks:
+  my_sink_id:
+    type: splunk_hec_logs
+    inputs:
+      - my-source-or-transform-id
+    default_token: SECRET[splunk_secrets.token]
+    encoding:
+      codec: json
+    endpoint: https://http-inputs-hec.splunkcloud.com

--- a/website/generated/example-configs/sinks/splunk_hec_metrics/advanced.yaml
+++ b/website/generated/example-configs/sinks/splunk_hec_metrics/advanced.yaml
@@ -1,0 +1,14 @@
+sinks:
+  my_sink_id:
+    type: splunk_hec_metrics
+    inputs:
+      - my-source-or-transform-id
+    compression: none
+    dangerously_allow_unconfined_template_resolution: false
+    default_namespace: service
+    default_token: ${SPLUNK_HEC_TOKEN}
+    endpoint: https://http-inputs-hec.splunkcloud.com
+    host_key: host
+    index: "{{ host }}"
+    source: "{{ file }}"
+    sourcetype: "{{ sourcetype }}"

--- a/website/generated/example-configs/sinks/splunk_hec_metrics/minimal.yaml
+++ b/website/generated/example-configs/sinks/splunk_hec_metrics/minimal.yaml
@@ -1,0 +1,7 @@
+sinks:
+  my_sink_id:
+    type: splunk_hec_metrics
+    inputs:
+      - my-source-or-transform-id
+    default_token: ${SPLUNK_HEC_TOKEN}
+    endpoint: https://http-inputs-hec.splunkcloud.com

--- a/website/generated/example-configs/sinks/statsd/advanced.yaml
+++ b/website/generated/example-configs/sinks/statsd/advanced.yaml
@@ -1,0 +1,9 @@
+sinks:
+  my_sink_id:
+    type: statsd
+    inputs:
+      - my-source-or-transform-id
+    address: 92.12.333.224:5000
+    default_namespace: service
+    mode: tcp
+    send_buffer_size: 65536

--- a/website/generated/example-configs/sinks/statsd/minimal.yaml
+++ b/website/generated/example-configs/sinks/statsd/minimal.yaml
@@ -1,0 +1,7 @@
+sinks:
+  my_sink_id:
+    type: statsd
+    inputs:
+      - my-source-or-transform-id
+    address: 92.12.333.224:5000
+    mode: tcp

--- a/website/generated/example-configs/sinks/vector/advanced.yaml
+++ b/website/generated/example-configs/sinks/vector/advanced.yaml
@@ -1,0 +1,7 @@
+sinks:
+  my_sink_id:
+    type: vector
+    inputs:
+      - my-source-or-transform-id
+    address: 92.12.333.224:6000
+    compression: none

--- a/website/generated/example-configs/sinks/vector/minimal.yaml
+++ b/website/generated/example-configs/sinks/vector/minimal.yaml
@@ -1,0 +1,5 @@
+sinks:
+  my_sink_id:
+    type: vector
+    inputs:
+      - my-source-or-transform-id

--- a/website/generated/example-configs/sinks/webhdfs/advanced.yaml
+++ b/website/generated/example-configs/sinks/webhdfs/advanced.yaml
@@ -1,0 +1,10 @@
+sinks:
+  my_sink_id:
+    type: webhdfs
+    inputs:
+      - my-source-or-transform-id
+    compression: gzip
+    dangerously_allow_unconfined_template_resolution: false
+    encoding:
+      codec: json
+    endpoint: http://127.0.0.1:9870

--- a/website/generated/example-configs/sinks/webhdfs/minimal.yaml
+++ b/website/generated/example-configs/sinks/webhdfs/minimal.yaml
@@ -1,0 +1,7 @@
+sinks:
+  my_sink_id:
+    type: webhdfs
+    inputs:
+      - my-source-or-transform-id
+    encoding:
+      codec: json

--- a/website/generated/example-configs/sinks/websocket/advanced.yaml
+++ b/website/generated/example-configs/sinks/websocket/advanced.yaml
@@ -1,0 +1,10 @@
+sinks:
+  my_sink_id:
+    type: websocket
+    inputs:
+      - my-source-or-transform-id
+    encoding:
+      codec: json
+    ping_interval: 30
+    ping_timeout: 5
+    uri: ws://localhost:8080

--- a/website/generated/example-configs/sinks/websocket/minimal.yaml
+++ b/website/generated/example-configs/sinks/websocket/minimal.yaml
@@ -1,0 +1,8 @@
+sinks:
+  my_sink_id:
+    type: websocket
+    inputs:
+      - my-source-or-transform-id
+    encoding:
+      codec: json
+    uri: ws://localhost:8080

--- a/website/generated/example-configs/sinks/websocket_server/advanced.yaml
+++ b/website/generated/example-configs/sinks/websocket_server/advanced.yaml
@@ -1,0 +1,8 @@
+sinks:
+  my_sink_id:
+    type: websocket_server
+    inputs:
+      - my-source-or-transform-id
+    address: 0.0.0.0:80
+    encoding:
+      codec: json

--- a/website/generated/example-configs/sinks/websocket_server/minimal.yaml
+++ b/website/generated/example-configs/sinks/websocket_server/minimal.yaml
@@ -1,0 +1,8 @@
+sinks:
+  my_sink_id:
+    type: websocket_server
+    inputs:
+      - my-source-or-transform-id
+    address: 0.0.0.0:80
+    encoding:
+      codec: json

--- a/website/generated/example-configs/sources/amqp/advanced.yaml
+++ b/website/generated/example-configs/sources/amqp/advanced.yaml
@@ -1,0 +1,10 @@
+sources:
+  my_source_id:
+    type: amqp
+    connection_string: amqp://user:password@127.0.0.1:5672/%2f?timeout=10
+    consumer: vector
+    exchange_key: exchange
+    offset_key: offset
+    prefetch_count: 100
+    queue: vector
+    routing_key_field: routing

--- a/website/generated/example-configs/sources/amqp/minimal.yaml
+++ b/website/generated/example-configs/sources/amqp/minimal.yaml
@@ -1,0 +1,4 @@
+sources:
+  my_source_id:
+    type: amqp
+    connection_string: amqp://user:password@127.0.0.1:5672/%2f?timeout=10

--- a/website/generated/example-configs/sources/apache_metrics/advanced.yaml
+++ b/website/generated/example-configs/sources/apache_metrics/advanced.yaml
@@ -1,0 +1,7 @@
+sources:
+  my_source_id:
+    type: apache_metrics
+    endpoints:
+      - http://localhost:8080/server-status/?auto
+    namespace: apache
+    scrape_interval_secs: 15

--- a/website/generated/example-configs/sources/apache_metrics/minimal.yaml
+++ b/website/generated/example-configs/sources/apache_metrics/minimal.yaml
@@ -1,0 +1,5 @@
+sources:
+  my_source_id:
+    type: apache_metrics
+    endpoints:
+      - http://localhost:8080/server-status/?auto

--- a/website/generated/example-configs/sources/aws_ecs_metrics/advanced.yaml
+++ b/website/generated/example-configs/sources/aws_ecs_metrics/advanced.yaml
@@ -1,0 +1,7 @@
+sources:
+  my_source_id:
+    type: aws_ecs_metrics
+    endpoint: http://169.254.170.2/v2
+    namespace: awsecs
+    scrape_interval_secs: 15
+    version: v2

--- a/website/generated/example-configs/sources/aws_ecs_metrics/minimal.yaml
+++ b/website/generated/example-configs/sources/aws_ecs_metrics/minimal.yaml
@@ -1,0 +1,3 @@
+sources:
+  my_source_id:
+    type: aws_ecs_metrics

--- a/website/generated/example-configs/sources/aws_kinesis_firehose/advanced.yaml
+++ b/website/generated/example-configs/sources/aws_kinesis_firehose/advanced.yaml
@@ -1,0 +1,11 @@
+sources:
+  my_source_id:
+    type: aws_kinesis_firehose
+    access_key: A94A8FE5CCB19BA61C4C08
+    access_keys:
+      - A94A8FE5CCB19BA61C4C08
+    address: 0.0.0.0:443
+    common_attributes:
+      - environment
+    record_compression: auto
+    store_access_key: false

--- a/website/generated/example-configs/sources/aws_kinesis_firehose/minimal.yaml
+++ b/website/generated/example-configs/sources/aws_kinesis_firehose/minimal.yaml
@@ -1,0 +1,5 @@
+sources:
+  my_source_id:
+    type: aws_kinesis_firehose
+    address: 0.0.0.0:443
+    store_access_key: false

--- a/website/generated/example-configs/sources/aws_s3/advanced.yaml
+++ b/website/generated/example-configs/sources/aws_s3/advanced.yaml
@@ -1,0 +1,7 @@
+sources:
+  my_source_id:
+    type: aws_s3
+    compression: auto
+    endpoint: http://127.0.0.0:5000/path/to/service
+    force_path_style: true
+    region: us-east-1

--- a/website/generated/example-configs/sources/aws_s3/minimal.yaml
+++ b/website/generated/example-configs/sources/aws_s3/minimal.yaml
@@ -1,0 +1,3 @@
+sources:
+  my_source_id:
+    type: aws_s3

--- a/website/generated/example-configs/sources/aws_sqs/advanced.yaml
+++ b/website/generated/example-configs/sources/aws_sqs/advanced.yaml
@@ -1,0 +1,9 @@
+sources:
+  my_source_id:
+    type: aws_sqs
+    delete_message: true
+    endpoint: http://127.0.0.0:5000/path/to/service
+    poll_secs: 15
+    queue_url: https://sqs.us-east-2.amazonaws.com/123456789012/MyQueue
+    region: us-east-1
+    visibility_timeout_secs: 300

--- a/website/generated/example-configs/sources/aws_sqs/minimal.yaml
+++ b/website/generated/example-configs/sources/aws_sqs/minimal.yaml
@@ -1,0 +1,4 @@
+sources:
+  my_source_id:
+    type: aws_sqs
+    queue_url: https://sqs.us-east-2.amazonaws.com/123456789012/MyQueue

--- a/website/generated/example-configs/sources/datadog_agent/advanced.yaml
+++ b/website/generated/example-configs/sources/datadog_agent/advanced.yaml
@@ -1,0 +1,11 @@
+sources:
+  my_source_id:
+    type: datadog_agent
+    address: 0.0.0.0:80
+    disable_logs: false
+    disable_metrics: false
+    disable_traces: false
+    multiple_outputs: false
+    parse_ddtags: false
+    split_metric_namespace: true
+    store_api_key: true

--- a/website/generated/example-configs/sources/datadog_agent/minimal.yaml
+++ b/website/generated/example-configs/sources/datadog_agent/minimal.yaml
@@ -1,0 +1,4 @@
+sources:
+  my_source_id:
+    type: datadog_agent
+    address: 0.0.0.0:80

--- a/website/generated/example-configs/sources/demo_logs/advanced.yaml
+++ b/website/generated/example-configs/sources/demo_logs/advanced.yaml
@@ -1,0 +1,5 @@
+sources:
+  my_source_id:
+    type: demo_logs
+    format: apache_common
+    interval: 1

--- a/website/generated/example-configs/sources/demo_logs/minimal.yaml
+++ b/website/generated/example-configs/sources/demo_logs/minimal.yaml
@@ -1,0 +1,4 @@
+sources:
+  my_source_id:
+    type: demo_logs
+    format: apache_common

--- a/website/generated/example-configs/sources/dnstap/advanced.yaml
+++ b/website/generated/example-configs/sources/dnstap/advanced.yaml
@@ -1,0 +1,13 @@
+sources:
+  my_source_id:
+    type: dnstap
+    address: 0.0.0.0:9000
+    lowercase_hostnames: false
+    max_frame_length: 102400
+    mode: tcp
+    multithreaded: false
+    permit_origin:
+      - 192.168.0.0/16
+    port_key: port
+    raw_data_only: false
+    shutdown_timeout_secs: 30

--- a/website/generated/example-configs/sources/dnstap/minimal.yaml
+++ b/website/generated/example-configs/sources/dnstap/minimal.yaml
@@ -1,0 +1,5 @@
+sources:
+  my_source_id:
+    type: dnstap
+    address: 0.0.0.0:9000
+    mode: tcp

--- a/website/generated/example-configs/sources/docker_logs/advanced.yaml
+++ b/website/generated/example-configs/sources/docker_logs/advanced.yaml
@@ -1,0 +1,15 @@
+sources:
+  my_source_id:
+    type: docker_logs
+    auto_partial_merge: true
+    docker_host: http://localhost:2375
+    exclude_containers:
+      - exclude_
+    include_containers:
+      - include_
+    include_images:
+      - httpd
+    include_labels:
+      - org.opencontainers.image.vendor=Vector
+    partial_event_marker_field: _partial
+    retry_backoff_secs: 2

--- a/website/generated/example-configs/sources/docker_logs/minimal.yaml
+++ b/website/generated/example-configs/sources/docker_logs/minimal.yaml
@@ -1,0 +1,3 @@
+sources:
+  my_source_id:
+    type: docker_logs

--- a/website/generated/example-configs/sources/eventstoredb_metrics/advanced.yaml
+++ b/website/generated/example-configs/sources/eventstoredb_metrics/advanced.yaml
@@ -1,0 +1,6 @@
+sources:
+  my_source_id:
+    type: eventstoredb_metrics
+    default_namespace: eventstoredb
+    endpoint: https://localhost:2113/stats
+    scrape_interval_secs: 15

--- a/website/generated/example-configs/sources/eventstoredb_metrics/minimal.yaml
+++ b/website/generated/example-configs/sources/eventstoredb_metrics/minimal.yaml
@@ -1,0 +1,3 @@
+sources:
+  my_source_id:
+    type: eventstoredb_metrics

--- a/website/generated/example-configs/sources/exec/advanced.yaml
+++ b/website/generated/example-configs/sources/exec/advanced.yaml
@@ -1,0 +1,13 @@
+sources:
+  my_source_id:
+    type: exec
+    clear_environment: false
+    command:
+      - echo
+    environment:
+      LANG: es_ES.UTF-8
+      PATH: /bin:/usr/bin:/usr/local/bin
+      TZ: Etc/UTC
+    include_stderr: true
+    maximum_buffer_size_bytes: 1000000
+    mode: scheduled

--- a/website/generated/example-configs/sources/exec/minimal.yaml
+++ b/website/generated/example-configs/sources/exec/minimal.yaml
@@ -1,0 +1,6 @@
+sources:
+  my_source_id:
+    type: exec
+    command:
+      - echo
+    mode: scheduled

--- a/website/generated/example-configs/sources/file/advanced.yaml
+++ b/website/generated/example-configs/sources/file/advanced.yaml
@@ -1,0 +1,20 @@
+sources:
+  my_source_id:
+    type: file
+    data_dir: /var/local/lib/vector/
+    exclude:
+      - /var/log/binary-file.log
+    file_key: file
+    glob_minimum_cooldown_ms: 1000
+    host_key: hostname
+    ignore_checkpoints: false
+    ignore_not_found: false
+    ignore_older_secs: 600
+    include:
+      - /var/log/**/*.log
+    line_delimiter: "\n"
+    max_line_bytes: 102400
+    max_read_bytes: 2048
+    offset_key: offset
+    oldest_first: false
+    read_from: beginning

--- a/website/generated/example-configs/sources/file/minimal.yaml
+++ b/website/generated/example-configs/sources/file/minimal.yaml
@@ -1,0 +1,5 @@
+sources:
+  my_source_id:
+    type: file
+    include:
+      - /var/log/**/*.log

--- a/website/generated/example-configs/sources/file_descriptor/advanced.yaml
+++ b/website/generated/example-configs/sources/file_descriptor/advanced.yaml
@@ -1,0 +1,5 @@
+sources:
+  my_source_id:
+    type: file_descriptor
+    fd: 10
+    max_length: 102400

--- a/website/generated/example-configs/sources/file_descriptor/minimal.yaml
+++ b/website/generated/example-configs/sources/file_descriptor/minimal.yaml
@@ -1,0 +1,4 @@
+sources:
+  my_source_id:
+    type: file_descriptor
+    fd: 10

--- a/website/generated/example-configs/sources/fluent/advanced.yaml
+++ b/website/generated/example-configs/sources/fluent/advanced.yaml
@@ -1,0 +1,8 @@
+sources:
+  my_source_id:
+    type: fluent
+    address: 0.0.0.0:9000
+    mode: tcp
+    permit_origin:
+      - 192.168.0.0/16
+    receive_buffer_bytes: 65536

--- a/website/generated/example-configs/sources/fluent/minimal.yaml
+++ b/website/generated/example-configs/sources/fluent/minimal.yaml
@@ -1,0 +1,5 @@
+sources:
+  my_source_id:
+    type: fluent
+    address: 0.0.0.0:9000
+    mode: tcp

--- a/website/generated/example-configs/sources/gcp_pubsub/advanced.yaml
+++ b/website/generated/example-configs/sources/gcp_pubsub/advanced.yaml
@@ -1,0 +1,12 @@
+sources:
+  my_source_id:
+    type: gcp_pubsub
+    ack_deadline_secs: 600
+    endpoint: https://pubsub.googleapis.com
+    full_response_size: 100
+    keepalive_secs: 60
+    max_concurrency: 10
+    poll_time_seconds: 2
+    project: my-log-source-project
+    retry_delay_secs: 1
+    subscription: my-vector-source-subscription

--- a/website/generated/example-configs/sources/gcp_pubsub/minimal.yaml
+++ b/website/generated/example-configs/sources/gcp_pubsub/minimal.yaml
@@ -1,0 +1,5 @@
+sources:
+  my_source_id:
+    type: gcp_pubsub
+    project: my-log-source-project
+    subscription: my-vector-source-subscription

--- a/website/generated/example-configs/sources/heroku_logs/advanced.yaml
+++ b/website/generated/example-configs/sources/heroku_logs/advanced.yaml
@@ -1,0 +1,6 @@
+sources:
+  my_source_id:
+    type: heroku_logs
+    address: 0.0.0.0:80
+    query_parameters:
+      - application

--- a/website/generated/example-configs/sources/heroku_logs/minimal.yaml
+++ b/website/generated/example-configs/sources/heroku_logs/minimal.yaml
@@ -1,0 +1,4 @@
+sources:
+  my_source_id:
+    type: heroku_logs
+    address: 0.0.0.0:80

--- a/website/generated/example-configs/sources/host_metrics/advanced.yaml
+++ b/website/generated/example-configs/sources/host_metrics/advanced.yaml
@@ -1,0 +1,7 @@
+sources:
+  my_source_id:
+    type: host_metrics
+    collectors:
+      - cgroups
+    namespace: host
+    scrape_interval_secs: 15

--- a/website/generated/example-configs/sources/host_metrics/minimal.yaml
+++ b/website/generated/example-configs/sources/host_metrics/minimal.yaml
@@ -1,0 +1,3 @@
+sources:
+  my_source_id:
+    type: host_metrics

--- a/website/generated/example-configs/sources/http_client/advanced.yaml
+++ b/website/generated/example-configs/sources/http_client/advanced.yaml
@@ -1,0 +1,25 @@
+sources:
+  my_source_id:
+    type: http_client
+    endpoint: http://127.0.0.1:9898/logs
+    headers:
+      Accept:
+        - text/plain
+        - text/html
+      X-My-Custom-Header:
+        - a
+        - vector
+        - of
+        - values
+    method: GET
+    query:
+      field: value
+      fruit:
+        - mango
+        - papaya
+        - kiwi
+      start_time:
+        type: vrl
+        value: now()
+    scrape_interval_secs: 15
+    scrape_timeout_secs: 5

--- a/website/generated/example-configs/sources/http_client/minimal.yaml
+++ b/website/generated/example-configs/sources/http_client/minimal.yaml
@@ -1,0 +1,4 @@
+sources:
+  my_source_id:
+    type: http_client
+    endpoint: http://127.0.0.1:9898/logs

--- a/website/generated/example-configs/sources/http_server/advanced.yaml
+++ b/website/generated/example-configs/sources/http_server/advanced.yaml
@@ -1,0 +1,15 @@
+sources:
+  my_source_id:
+    type: http_server
+    address: 0.0.0.0:80
+    encoding: binary
+    headers:
+      - User-Agent
+    host_key: hostname
+    method: POST
+    path: /
+    path_key: path
+    query_parameters:
+      - application
+    response_code: 200
+    strict_path: true

--- a/website/generated/example-configs/sources/http_server/minimal.yaml
+++ b/website/generated/example-configs/sources/http_server/minimal.yaml
@@ -1,0 +1,4 @@
+sources:
+  my_source_id:
+    type: http_server
+    address: 0.0.0.0:80

--- a/website/generated/example-configs/sources/internal_logs/advanced.yaml
+++ b/website/generated/example-configs/sources/internal_logs/advanced.yaml
@@ -1,0 +1,4 @@
+sources:
+  my_source_id:
+    type: internal_logs
+    pid_key: pid

--- a/website/generated/example-configs/sources/internal_logs/minimal.yaml
+++ b/website/generated/example-configs/sources/internal_logs/minimal.yaml
@@ -1,0 +1,3 @@
+sources:
+  my_source_id:
+    type: internal_logs

--- a/website/generated/example-configs/sources/internal_metrics/advanced.yaml
+++ b/website/generated/example-configs/sources/internal_metrics/advanced.yaml
@@ -1,0 +1,5 @@
+sources:
+  my_source_id:
+    type: internal_metrics
+    namespace: vector
+    scrape_interval_secs: 1

--- a/website/generated/example-configs/sources/internal_metrics/minimal.yaml
+++ b/website/generated/example-configs/sources/internal_metrics/minimal.yaml
@@ -1,0 +1,3 @@
+sources:
+  my_source_id:
+    type: internal_metrics

--- a/website/generated/example-configs/sources/journald/advanced.yaml
+++ b/website/generated/example-configs/sources/journald/advanced.yaml
@@ -1,0 +1,27 @@
+sources:
+  my_source_id:
+    type: journald
+    batch_size: 16
+    current_boot_only: true
+    data_dir: /var/lib/vector
+    emit_cursor: false
+    exclude_matches:
+      _SYSTEMD_UNIT:
+        - sshd.service
+        - ntpd.service
+      _TRANSPORT:
+        - kernel
+    exclude_units:
+      - badservice
+    extra_args:
+      - --merge
+    include_matches:
+      _SYSTEMD_UNIT:
+        - sshd.service
+        - ntpd.service
+      _TRANSPORT:
+        - kernel
+    include_units:
+      - ntpd
+    remap_priority: false
+    since_now: false

--- a/website/generated/example-configs/sources/journald/minimal.yaml
+++ b/website/generated/example-configs/sources/journald/minimal.yaml
@@ -1,0 +1,3 @@
+sources:
+  my_source_id:
+    type: journald

--- a/website/generated/example-configs/sources/kafka/advanced.yaml
+++ b/website/generated/example-configs/sources/kafka/advanced.yaml
@@ -1,0 +1,22 @@
+sources:
+  my_source_id:
+    type: kafka
+    auto_offset_reset: largest
+    bootstrap_servers: 10.14.22.123:9092,10.14.23.332:9092
+    commit_interval_ms: 5000
+    drain_timeout_ms: 2500
+    fetch_wait_max_ms: 100
+    group_id: consumer-group-name
+    headers_key: headers
+    key_field: message_key
+    librdkafka_options:
+      client.id: ${ENV_VAR}
+      fetch.error.backoff.ms: "1000"
+      socket.send.buffer.bytes: "100"
+    offset_key: offset
+    partition_key: partition
+    session_timeout_ms: 10000
+    socket_timeout_ms: 60000
+    topic_key: topic
+    topics:
+      - ^(prefix1|prefix2)-.+

--- a/website/generated/example-configs/sources/kafka/minimal.yaml
+++ b/website/generated/example-configs/sources/kafka/minimal.yaml
@@ -1,0 +1,7 @@
+sources:
+  my_source_id:
+    type: kafka
+    bootstrap_servers: 10.14.22.123:9092,10.14.23.332:9092
+    group_id: consumer-group-name
+    topics:
+      - ^(prefix1|prefix2)-.+

--- a/website/generated/example-configs/sources/kubernetes_logs/advanced.yaml
+++ b/website/generated/example-configs/sources/kubernetes_logs/advanced.yaml
@@ -1,0 +1,26 @@
+sources:
+  my_source_id:
+    type: kubernetes_logs
+    auto_partial_merge: true
+    data_dir: /var/local/lib/vector/
+    delay_deletion_ms: 60000
+    exclude_paths_glob_patterns:
+      - "**/exclude/**"
+    extra_field_selector: metadata.name!=pod-name-to-exclude
+    extra_label_selector: my_custom_label!=my_value
+    extra_namespace_label_selector: my_custom_label!=my_value
+    fingerprint_lines: 1
+    glob_minimum_cooldown_ms: 60000
+    ignore_older_secs: 600
+    include_paths_glob_patterns:
+      - "**/include/**"
+    ingestion_timestamp_field: .ingest_timestamp
+    insert_namespace_fields: true
+    kube_config_file: /path/to/.kube/config
+    max_line_bytes: 32768
+    max_read_bytes: 2048
+    oldest_first: true
+    read_from: beginning
+    self_node_name: ${VECTOR_SELF_NODE_NAME}
+    timezone: local
+    use_apiserver_cache: false

--- a/website/generated/example-configs/sources/kubernetes_logs/minimal.yaml
+++ b/website/generated/example-configs/sources/kubernetes_logs/minimal.yaml
@@ -1,0 +1,3 @@
+sources:
+  my_source_id:
+    type: kubernetes_logs

--- a/website/generated/example-configs/sources/logstash/advanced.yaml
+++ b/website/generated/example-configs/sources/logstash/advanced.yaml
@@ -1,0 +1,7 @@
+sources:
+  my_source_id:
+    type: logstash
+    address: 0.0.0.0:9000
+    permit_origin:
+      - 192.168.0.0/16
+    receive_buffer_bytes: 65536

--- a/website/generated/example-configs/sources/logstash/minimal.yaml
+++ b/website/generated/example-configs/sources/logstash/minimal.yaml
@@ -1,0 +1,4 @@
+sources:
+  my_source_id:
+    type: logstash
+    address: 0.0.0.0:9000

--- a/website/generated/example-configs/sources/mongodb_metrics/advanced.yaml
+++ b/website/generated/example-configs/sources/mongodb_metrics/advanced.yaml
@@ -1,0 +1,7 @@
+sources:
+  my_source_id:
+    type: mongodb_metrics
+    endpoints:
+      - mongodb://localhost:27017
+    namespace: mongodb
+    scrape_interval_secs: 15

--- a/website/generated/example-configs/sources/mongodb_metrics/minimal.yaml
+++ b/website/generated/example-configs/sources/mongodb_metrics/minimal.yaml
@@ -1,0 +1,5 @@
+sources:
+  my_source_id:
+    type: mongodb_metrics
+    endpoints:
+      - mongodb://localhost:27017

--- a/website/generated/example-configs/sources/mqtt/advanced.yaml
+++ b/website/generated/example-configs/sources/mqtt/advanced.yaml
@@ -1,0 +1,9 @@
+sources:
+  my_source_id:
+    type: mqtt
+    host: mqtt.example.com
+    keep_alive: 60
+    max_packet_size: 10240
+    port: 1883
+    topic: vector
+    topic_key: topic

--- a/website/generated/example-configs/sources/mqtt/minimal.yaml
+++ b/website/generated/example-configs/sources/mqtt/minimal.yaml
@@ -1,0 +1,4 @@
+sources:
+  my_source_id:
+    type: mqtt
+    host: mqtt.example.com

--- a/website/generated/example-configs/sources/nats/advanced.yaml
+++ b/website/generated/example-configs/sources/nats/advanced.yaml
@@ -1,0 +1,8 @@
+sources:
+  my_source_id:
+    type: nats
+    connection_name: vector
+    subject: foo
+    subject_key_field: subject
+    subscriber_capacity: 65536
+    url: nats://demo.nats.io

--- a/website/generated/example-configs/sources/nats/minimal.yaml
+++ b/website/generated/example-configs/sources/nats/minimal.yaml
@@ -1,0 +1,6 @@
+sources:
+  my_source_id:
+    type: nats
+    connection_name: vector
+    subject: foo
+    url: nats://demo.nats.io

--- a/website/generated/example-configs/sources/nginx_metrics/advanced.yaml
+++ b/website/generated/example-configs/sources/nginx_metrics/advanced.yaml
@@ -1,0 +1,7 @@
+sources:
+  my_source_id:
+    type: nginx_metrics
+    endpoints:
+      - http://localhost:8000/basic_status
+    namespace: nginx
+    scrape_interval_secs: 15

--- a/website/generated/example-configs/sources/nginx_metrics/minimal.yaml
+++ b/website/generated/example-configs/sources/nginx_metrics/minimal.yaml
@@ -1,0 +1,5 @@
+sources:
+  my_source_id:
+    type: nginx_metrics
+    endpoints:
+      - http://localhost:8000/basic_status

--- a/website/generated/example-configs/sources/okta/advanced.yaml
+++ b/website/generated/example-configs/sources/okta/advanced.yaml
@@ -1,0 +1,7 @@
+sources:
+  my_source_id:
+    type: okta
+    domain: foo.okta.com
+    scrape_interval_secs: 15
+    scrape_timeout_secs: 5
+    token: 00xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx

--- a/website/generated/example-configs/sources/okta/minimal.yaml
+++ b/website/generated/example-configs/sources/okta/minimal.yaml
@@ -1,0 +1,5 @@
+sources:
+  my_source_id:
+    type: okta
+    domain: foo.okta.com
+    token: 00xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx

--- a/website/generated/example-configs/sources/opentelemetry/advanced.yaml
+++ b/website/generated/example-configs/sources/opentelemetry/advanced.yaml
@@ -1,0 +1,11 @@
+sources:
+  my_source_id:
+    type: opentelemetry
+    grpc:
+      address: 0.0.0.0:4317
+    http:
+      address: 0.0.0.0:4318
+      headers: []
+      keepalive:
+        max_connection_age_jitter_factor: 0.1
+        max_connection_age_secs: 300

--- a/website/generated/example-configs/sources/opentelemetry/minimal.yaml
+++ b/website/generated/example-configs/sources/opentelemetry/minimal.yaml
@@ -1,0 +1,11 @@
+sources:
+  my_source_id:
+    type: opentelemetry
+    grpc:
+      address: 0.0.0.0:4317
+    http:
+      address: 0.0.0.0:4318
+      headers: []
+      keepalive:
+        max_connection_age_jitter_factor: 0.1
+        max_connection_age_secs: 300

--- a/website/generated/example-configs/sources/postgresql_metrics/advanced.yaml
+++ b/website/generated/example-configs/sources/postgresql_metrics/advanced.yaml
@@ -1,0 +1,11 @@
+sources:
+  my_source_id:
+    type: postgresql_metrics
+    endpoints:
+      - postgresql://postgres:vector@localhost:5432/postgres
+    exclude_databases:
+      - ^postgres$
+    include_databases:
+      - ^postgres$
+    namespace: postgresql
+    scrape_interval_secs: 15

--- a/website/generated/example-configs/sources/postgresql_metrics/minimal.yaml
+++ b/website/generated/example-configs/sources/postgresql_metrics/minimal.yaml
@@ -1,0 +1,5 @@
+sources:
+  my_source_id:
+    type: postgresql_metrics
+    endpoints:
+      - postgresql://postgres:vector@localhost:5432/postgres

--- a/website/generated/example-configs/sources/prometheus_pushgateway/advanced.yaml
+++ b/website/generated/example-configs/sources/prometheus_pushgateway/advanced.yaml
@@ -1,0 +1,5 @@
+sources:
+  my_source_id:
+    type: prometheus_pushgateway
+    address: 0.0.0.0:9091
+    aggregate_metrics: false

--- a/website/generated/example-configs/sources/prometheus_pushgateway/minimal.yaml
+++ b/website/generated/example-configs/sources/prometheus_pushgateway/minimal.yaml
@@ -1,0 +1,4 @@
+sources:
+  my_source_id:
+    type: prometheus_pushgateway
+    address: 0.0.0.0:9091

--- a/website/generated/example-configs/sources/prometheus_remote_write/advanced.yaml
+++ b/website/generated/example-configs/sources/prometheus_remote_write/advanced.yaml
@@ -1,0 +1,7 @@
+sources:
+  my_source_id:
+    type: prometheus_remote_write
+    address: 0.0.0.0:9090
+    metadata_conflict_strategy: reject
+    path: /
+    skip_nan_values: false

--- a/website/generated/example-configs/sources/prometheus_remote_write/minimal.yaml
+++ b/website/generated/example-configs/sources/prometheus_remote_write/minimal.yaml
@@ -1,0 +1,4 @@
+sources:
+  my_source_id:
+    type: prometheus_remote_write
+    address: 0.0.0.0:9090

--- a/website/generated/example-configs/sources/prometheus_scrape/advanced.yaml
+++ b/website/generated/example-configs/sources/prometheus_scrape/advanced.yaml
@@ -1,0 +1,12 @@
+sources:
+  my_source_id:
+    type: prometheus_scrape
+    endpoints:
+      - http://localhost:9090/metrics
+    honor_labels: false
+    query:
+      "match[]":
+        - '{job="somejob"}'
+        - '{__name__=~"job:.*"}'
+    scrape_interval_secs: 15
+    scrape_timeout_secs: 5

--- a/website/generated/example-configs/sources/prometheus_scrape/minimal.yaml
+++ b/website/generated/example-configs/sources/prometheus_scrape/minimal.yaml
@@ -1,0 +1,5 @@
+sources:
+  my_source_id:
+    type: prometheus_scrape
+    endpoints:
+      - http://localhost:9090/metrics

--- a/website/generated/example-configs/sources/pulsar/advanced.yaml
+++ b/website/generated/example-configs/sources/pulsar/advanced.yaml
@@ -1,0 +1,6 @@
+sources:
+  my_source_id:
+    type: pulsar
+    endpoint: pulsar://127.0.0.1:6650
+    topics:
+      - topic-1234

--- a/website/generated/example-configs/sources/pulsar/minimal.yaml
+++ b/website/generated/example-configs/sources/pulsar/minimal.yaml
@@ -1,0 +1,6 @@
+sources:
+  my_source_id:
+    type: pulsar
+    endpoint: pulsar://127.0.0.1:6650
+    topics:
+      - topic-1234

--- a/website/generated/example-configs/sources/redis/advanced.yaml
+++ b/website/generated/example-configs/sources/redis/advanced.yaml
@@ -1,0 +1,7 @@
+sources:
+  my_source_id:
+    type: redis
+    data_type: list
+    key: vector
+    redis_key: redis_key
+    url: redis://127.0.0.1:6379/0

--- a/website/generated/example-configs/sources/redis/minimal.yaml
+++ b/website/generated/example-configs/sources/redis/minimal.yaml
@@ -1,0 +1,5 @@
+sources:
+  my_source_id:
+    type: redis
+    key: vector
+    url: redis://127.0.0.1:6379/0

--- a/website/generated/example-configs/sources/socket/advanced.yaml
+++ b/website/generated/example-configs/sources/socket/advanced.yaml
@@ -1,0 +1,9 @@
+sources:
+  my_source_id:
+    type: socket
+    address: 0.0.0.0:9000
+    mode: tcp
+    permit_origin:
+      - 192.168.0.0/16
+    port_key: port
+    shutdown_timeout_secs: 30

--- a/website/generated/example-configs/sources/socket/minimal.yaml
+++ b/website/generated/example-configs/sources/socket/minimal.yaml
@@ -1,0 +1,5 @@
+sources:
+  my_source_id:
+    type: socket
+    address: 0.0.0.0:9000
+    mode: tcp

--- a/website/generated/example-configs/sources/splunk_hec/advanced.yaml
+++ b/website/generated/example-configs/sources/splunk_hec/advanced.yaml
@@ -1,0 +1,7 @@
+sources:
+  my_source_id:
+    type: splunk_hec
+    address: 0.0.0.0:8088
+    store_hec_token: false
+    valid_tokens:
+      - A94A8FE5CCB19BA61C4C08

--- a/website/generated/example-configs/sources/splunk_hec/minimal.yaml
+++ b/website/generated/example-configs/sources/splunk_hec/minimal.yaml
@@ -1,0 +1,3 @@
+sources:
+  my_source_id:
+    type: splunk_hec

--- a/website/generated/example-configs/sources/static_metrics/advanced.yaml
+++ b/website/generated/example-configs/sources/static_metrics/advanced.yaml
@@ -1,0 +1,13 @@
+sources:
+  my_source_id:
+    type: static_metrics
+    interval_secs: 1
+    metrics:
+      - kind: absolute
+        name: my-metric
+        tags:
+          env: production
+        value:
+          gauge:
+            value: 1
+    namespace: static

--- a/website/generated/example-configs/sources/static_metrics/minimal.yaml
+++ b/website/generated/example-configs/sources/static_metrics/minimal.yaml
@@ -1,0 +1,3 @@
+sources:
+  my_source_id:
+    type: static_metrics

--- a/website/generated/example-configs/sources/statsd/advanced.yaml
+++ b/website/generated/example-configs/sources/statsd/advanced.yaml
@@ -1,0 +1,10 @@
+sources:
+  my_source_id:
+    type: statsd
+    address: 0.0.0.0:9000
+    convert_to: seconds
+    mode: tcp
+    permit_origin:
+      - 192.168.0.0/16
+    sanitize: true
+    shutdown_timeout_secs: 30

--- a/website/generated/example-configs/sources/statsd/minimal.yaml
+++ b/website/generated/example-configs/sources/statsd/minimal.yaml
@@ -1,0 +1,5 @@
+sources:
+  my_source_id:
+    type: statsd
+    address: 0.0.0.0:9000
+    mode: tcp

--- a/website/generated/example-configs/sources/stdin/advanced.yaml
+++ b/website/generated/example-configs/sources/stdin/advanced.yaml
@@ -1,0 +1,4 @@
+sources:
+  my_source_id:
+    type: stdin
+    max_length: 102400

--- a/website/generated/example-configs/sources/stdin/minimal.yaml
+++ b/website/generated/example-configs/sources/stdin/minimal.yaml
@@ -1,0 +1,3 @@
+sources:
+  my_source_id:
+    type: stdin

--- a/website/generated/example-configs/sources/syslog/advanced.yaml
+++ b/website/generated/example-configs/sources/syslog/advanced.yaml
@@ -1,0 +1,8 @@
+sources:
+  my_source_id:
+    type: syslog
+    address: 0.0.0.0:9000
+    max_length: 102400
+    mode: tcp
+    permit_origin:
+      - 192.168.0.0/16

--- a/website/generated/example-configs/sources/syslog/minimal.yaml
+++ b/website/generated/example-configs/sources/syslog/minimal.yaml
@@ -1,0 +1,5 @@
+sources:
+  my_source_id:
+    type: syslog
+    address: 0.0.0.0:9000
+    mode: tcp

--- a/website/generated/example-configs/sources/vector/advanced.yaml
+++ b/website/generated/example-configs/sources/vector/advanced.yaml
@@ -1,0 +1,5 @@
+sources:
+  my_source_id:
+    type: vector
+    address: 0.0.0.0:6000
+    version: "2"

--- a/website/generated/example-configs/sources/vector/minimal.yaml
+++ b/website/generated/example-configs/sources/vector/minimal.yaml
@@ -1,0 +1,4 @@
+sources:
+  my_source_id:
+    type: vector
+    address: 0.0.0.0:6000

--- a/website/generated/example-configs/sources/websocket/advanced.yaml
+++ b/website/generated/example-configs/sources/websocket/advanced.yaml
@@ -1,0 +1,9 @@
+sources:
+  my_source_id:
+    type: websocket
+    connect_timeout_secs: 30
+    initial_message: SUBSCRIBE logs
+    initial_message_timeout_secs: 2
+    ping_interval: 30
+    ping_timeout: 5
+    uri: ws://localhost:8080

--- a/website/generated/example-configs/sources/websocket/minimal.yaml
+++ b/website/generated/example-configs/sources/websocket/minimal.yaml
@@ -1,0 +1,4 @@
+sources:
+  my_source_id:
+    type: websocket
+    uri: ws://localhost:8080

--- a/website/generated/example-configs/sources/windows_event_log/advanced.yaml
+++ b/website/generated/example-configs/sources/windows_event_log/advanced.yaml
@@ -1,0 +1,21 @@
+sources:
+  my_source_id:
+    type: windows_event_log
+    batch_size: 100
+    channels:
+      - System,Application,Security
+    checkpoint_interval_secs: 5
+    connection_timeout_secs: 30
+    data_dir: /var/lib/vector
+    event_query: "*[System[Level=1 or Level=2 or Level=3]]"
+    event_timeout_ms: 5000
+    events_per_second: 100
+    ignore_event_ids:
+      - 4624
+    include_xml: false
+    max_event_age_secs: 86400
+    max_event_data_length: 1024
+    only_event_ids:
+      - 1000
+    read_existing_events: false
+    render_message: true

--- a/website/generated/example-configs/sources/windows_event_log/minimal.yaml
+++ b/website/generated/example-configs/sources/windows_event_log/minimal.yaml
@@ -1,0 +1,5 @@
+sources:
+  my_source_id:
+    type: windows_event_log
+    channels:
+      - System,Application,Security

--- a/website/generated/example-configs/transforms/aggregate/advanced.yaml
+++ b/website/generated/example-configs/transforms/aggregate/advanced.yaml
@@ -1,0 +1,8 @@
+transforms:
+  my_transform_id:
+    type: aggregate
+    inputs:
+      - my-source-or-transform-id
+    interval_ms: 10000
+    measure_cpu_usage: false
+    mode: Auto

--- a/website/generated/example-configs/transforms/aggregate/minimal.yaml
+++ b/website/generated/example-configs/transforms/aggregate/minimal.yaml
@@ -1,0 +1,5 @@
+transforms:
+  my_transform_id:
+    type: aggregate
+    inputs:
+      - my-source-or-transform-id

--- a/website/generated/example-configs/transforms/aws_ec2_metadata/advanced.yaml
+++ b/website/generated/example-configs/transforms/aws_ec2_metadata/advanced.yaml
@@ -1,0 +1,14 @@
+transforms:
+  my_transform_id:
+    type: aws_ec2_metadata
+    inputs:
+      - my-source-or-transform-id
+    endpoint: http://169.254.169.254
+    fields:
+      - instance-id
+    measure_cpu_usage: false
+    refresh_interval_secs: 10
+    refresh_timeout_secs: 1
+    required: true
+    tags:
+      - Name

--- a/website/generated/example-configs/transforms/aws_ec2_metadata/minimal.yaml
+++ b/website/generated/example-configs/transforms/aws_ec2_metadata/minimal.yaml
@@ -1,0 +1,5 @@
+transforms:
+  my_transform_id:
+    type: aws_ec2_metadata
+    inputs:
+      - my-source-or-transform-id

--- a/website/generated/example-configs/transforms/dedupe/advanced.yaml
+++ b/website/generated/example-configs/transforms/dedupe/advanced.yaml
@@ -1,0 +1,6 @@
+transforms:
+  my_transform_id:
+    type: dedupe
+    inputs:
+      - my-source-or-transform-id
+    measure_cpu_usage: false

--- a/website/generated/example-configs/transforms/dedupe/minimal.yaml
+++ b/website/generated/example-configs/transforms/dedupe/minimal.yaml
@@ -1,0 +1,5 @@
+transforms:
+  my_transform_id:
+    type: dedupe
+    inputs:
+      - my-source-or-transform-id

--- a/website/generated/example-configs/transforms/delay/advanced.yaml
+++ b/website/generated/example-configs/transforms/delay/advanced.yaml
@@ -1,0 +1,9 @@
+transforms:
+  my_transform_id:
+    type: delay
+    inputs:
+      - my-source-or-transform-id
+    delay_ms: 5000
+    measure_cpu_usage: false
+    overflow_strategy: block
+    queue_capacity: 500

--- a/website/generated/example-configs/transforms/delay/minimal.yaml
+++ b/website/generated/example-configs/transforms/delay/minimal.yaml
@@ -1,0 +1,6 @@
+transforms:
+  my_transform_id:
+    type: delay
+    inputs:
+      - my-source-or-transform-id
+    delay_ms: 5000

--- a/website/generated/example-configs/transforms/exclusive_route/advanced.yaml
+++ b/website/generated/example-configs/transforms/exclusive_route/advanced.yaml
@@ -1,0 +1,11 @@
+transforms:
+  my_transform_id:
+    type: exclusive_route
+    inputs:
+      - my-source-or-transform-id
+    measure_cpu_usage: false
+    routes:
+      - condition:
+          source: exists(.foo) && exists(.bar)
+          type: vrl
+        name: foo-and-bar-exist

--- a/website/generated/example-configs/transforms/exclusive_route/minimal.yaml
+++ b/website/generated/example-configs/transforms/exclusive_route/minimal.yaml
@@ -1,0 +1,10 @@
+transforms:
+  my_transform_id:
+    type: exclusive_route
+    inputs:
+      - my-source-or-transform-id
+    routes:
+      - condition:
+          source: exists(.foo) && exists(.bar)
+          type: vrl
+        name: foo-and-bar-exist

--- a/website/generated/example-configs/transforms/filter/advanced.yaml
+++ b/website/generated/example-configs/transforms/filter/advanced.yaml
@@ -1,0 +1,9 @@
+transforms:
+  my_transform_id:
+    type: filter
+    inputs:
+      - my-source-or-transform-id
+    condition:
+      type: vrl
+      source: .status_code != 200 && !includes(["info", "debug"], .severity)
+    measure_cpu_usage: false

--- a/website/generated/example-configs/transforms/filter/minimal.yaml
+++ b/website/generated/example-configs/transforms/filter/minimal.yaml
@@ -1,0 +1,8 @@
+transforms:
+  my_transform_id:
+    type: filter
+    inputs:
+      - my-source-or-transform-id
+    condition:
+      type: vrl
+      source: .status_code != 200 && !includes(["info", "debug"], .severity)

--- a/website/generated/example-configs/transforms/incremental_to_absolute/advanced.yaml
+++ b/website/generated/example-configs/transforms/incremental_to_absolute/advanced.yaml
@@ -1,0 +1,6 @@
+transforms:
+  my_transform_id:
+    type: incremental_to_absolute
+    inputs:
+      - my-source-or-transform-id
+    measure_cpu_usage: false

--- a/website/generated/example-configs/transforms/incremental_to_absolute/minimal.yaml
+++ b/website/generated/example-configs/transforms/incremental_to_absolute/minimal.yaml
@@ -1,0 +1,5 @@
+transforms:
+  my_transform_id:
+    type: incremental_to_absolute
+    inputs:
+      - my-source-or-transform-id

--- a/website/generated/example-configs/transforms/log_to_metric/advanced.yaml
+++ b/website/generated/example-configs/transforms/log_to_metric/advanced.yaml
@@ -1,0 +1,11 @@
+transforms:
+  my_transform_id:
+    type: log_to_metric
+    inputs:
+      - my-source-or-transform-id
+    all_metrics: false
+    measure_cpu_usage: false
+    metrics:
+      - field: .my_field
+        kind: incremental
+        type: counter

--- a/website/generated/example-configs/transforms/log_to_metric/minimal.yaml
+++ b/website/generated/example-configs/transforms/log_to_metric/minimal.yaml
@@ -1,0 +1,5 @@
+transforms:
+  my_transform_id:
+    type: log_to_metric
+    inputs:
+      - my-source-or-transform-id

--- a/website/generated/example-configs/transforms/lua/advanced.yaml
+++ b/website/generated/example-configs/transforms/lua/advanced.yaml
@@ -1,0 +1,50 @@
+transforms:
+  my_transform_id:
+    type: lua
+    inputs:
+      - my-source-or-transform-id
+    hooks:
+      process: >-
+        function (event, emit)
+          event.log.field = "value" -- set value of a field
+          event.log.another_field = nil -- remove field
+          event.log.first, event.log.second = nil, event.log.first -- rename field
+          -- Very important! Emit the processed event.
+          emit(event)
+        end
+    measure_cpu_usage: false
+    metric_tag_values: single
+    search_dirs:
+      - /etc/vector/lua
+    source: |-
+      function init()
+        count = 0
+      end
+
+      function process()
+        count = count + 1
+      end
+
+      function timer_handler(emit)
+        emit(make_counter(counter))
+        counter = 0
+      end
+
+      function shutdown(emit)
+        emit(make_counter(counter))
+      end
+
+      function make_counter(value)
+        return metric = {
+          name = "event_counter",
+          kind = "incremental",
+          timestamp = os.date("!*t"),
+          counter = {
+            value = value
+          }
+         }
+      end
+    timers:
+      - handler: timer_handler
+        interval_seconds: 2
+    version: "2"

--- a/website/generated/example-configs/transforms/lua/minimal.yaml
+++ b/website/generated/example-configs/transforms/lua/minimal.yaml
@@ -1,0 +1,15 @@
+transforms:
+  my_transform_id:
+    type: lua
+    inputs:
+      - my-source-or-transform-id
+    hooks:
+      process: >-
+        function (event, emit)
+          event.log.field = "value" -- set value of a field
+          event.log.another_field = nil -- remove field
+          event.log.first, event.log.second = nil, event.log.first -- rename field
+          -- Very important! Emit the processed event.
+          emit(event)
+        end
+    version: "2"

--- a/website/generated/example-configs/transforms/metric_to_log/advanced.yaml
+++ b/website/generated/example-configs/transforms/metric_to_log/advanced.yaml
@@ -1,0 +1,9 @@
+transforms:
+  my_transform_id:
+    type: metric_to_log
+    inputs:
+      - my-source-or-transform-id
+    host_tag: host
+    measure_cpu_usage: false
+    metric_tag_values: single
+    timezone: local

--- a/website/generated/example-configs/transforms/metric_to_log/minimal.yaml
+++ b/website/generated/example-configs/transforms/metric_to_log/minimal.yaml
@@ -1,0 +1,5 @@
+transforms:
+  my_transform_id:
+    type: metric_to_log
+    inputs:
+      - my-source-or-transform-id

--- a/website/generated/example-configs/transforms/reduce/advanced.yaml
+++ b/website/generated/example-configs/transforms/reduce/advanced.yaml
@@ -1,0 +1,10 @@
+transforms:
+  my_transform_id:
+    type: reduce
+    inputs:
+      - my-source-or-transform-id
+    expire_after_ms: 30000
+    flush_period_ms: 1000
+    group_by:
+      - request_id
+    measure_cpu_usage: false

--- a/website/generated/example-configs/transforms/reduce/minimal.yaml
+++ b/website/generated/example-configs/transforms/reduce/minimal.yaml
@@ -1,0 +1,5 @@
+transforms:
+  my_transform_id:
+    type: reduce
+    inputs:
+      - my-source-or-transform-id

--- a/website/generated/example-configs/transforms/remap/advanced.yaml
+++ b/website/generated/example-configs/transforms/remap/advanced.yaml
@@ -1,0 +1,17 @@
+transforms:
+  my_transform_id:
+    type: remap
+    inputs:
+      - my-source-or-transform-id
+    drop_on_abort: true
+    drop_on_error: false
+    measure_cpu_usage: false
+    metric_tag_values: single
+    reroute_dropped: false
+    source: |-
+      . = parse_json!(.message)
+      .new_field = "new value"
+      .status = to_int!(.status)
+      .duration = parse_duration!(.duration, "s")
+      .new_name = del(.old_name)
+    timezone: local

--- a/website/generated/example-configs/transforms/remap/minimal.yaml
+++ b/website/generated/example-configs/transforms/remap/minimal.yaml
@@ -1,0 +1,11 @@
+transforms:
+  my_transform_id:
+    type: remap
+    inputs:
+      - my-source-or-transform-id
+    source: |-
+      . = parse_json!(.message)
+      .new_field = "new value"
+      .status = to_int!(.status)
+      .duration = parse_duration!(.duration, "s")
+      .new_name = del(.old_name)

--- a/website/generated/example-configs/transforms/route/advanced.yaml
+++ b/website/generated/example-configs/transforms/route/advanced.yaml
@@ -1,0 +1,14 @@
+transforms:
+  my_transform_id:
+    type: route
+    inputs:
+      - my-source-or-transform-id
+    measure_cpu_usage: false
+    reroute_unmatched: true
+    route:
+      foo-does-not-exist:
+        source: "!exists(.foo)"
+        type: vrl
+      foo-exists:
+        source: exists(.foo)
+        type: vrl

--- a/website/generated/example-configs/transforms/route/minimal.yaml
+++ b/website/generated/example-configs/transforms/route/minimal.yaml
@@ -1,0 +1,12 @@
+transforms:
+  my_transform_id:
+    type: route
+    inputs:
+      - my-source-or-transform-id
+    route:
+      foo-does-not-exist:
+        source: "!exists(.foo)"
+        type: vrl
+      foo-exists:
+        source: exists(.foo)
+        type: vrl

--- a/website/generated/example-configs/transforms/sample/advanced.yaml
+++ b/website/generated/example-configs/transforms/sample/advanced.yaml
@@ -1,0 +1,10 @@
+transforms:
+  my_transform_id:
+    type: sample
+    inputs:
+      - my-source-or-transform-id
+    group_by: "{{ service }}"
+    key_field: message
+    measure_cpu_usage: false
+    ratio: 0.13
+    sample_rate_key: sample_rate

--- a/website/generated/example-configs/transforms/sample/minimal.yaml
+++ b/website/generated/example-configs/transforms/sample/minimal.yaml
@@ -1,0 +1,6 @@
+transforms:
+  my_transform_id:
+    type: sample
+    inputs:
+      - my-source-or-transform-id
+    ratio: 0.13

--- a/website/generated/example-configs/transforms/tag_cardinality_limit/advanced.yaml
+++ b/website/generated/example-configs/transforms/tag_cardinality_limit/advanced.yaml
@@ -1,0 +1,10 @@
+transforms:
+  my_transform_id:
+    type: tag_cardinality_limit
+    inputs:
+      - my-source-or-transform-id
+    limit_exceeded_action: drop_tag
+    measure_cpu_usage: false
+    mode: exact
+    tracking_scope: global
+    value_limit: 500

--- a/website/generated/example-configs/transforms/tag_cardinality_limit/minimal.yaml
+++ b/website/generated/example-configs/transforms/tag_cardinality_limit/minimal.yaml
@@ -1,0 +1,6 @@
+transforms:
+  my_transform_id:
+    type: tag_cardinality_limit
+    inputs:
+      - my-source-or-transform-id
+    mode: exact

--- a/website/generated/example-configs/transforms/throttle/advanced.yaml
+++ b/website/generated/example-configs/transforms/throttle/advanced.yaml
@@ -1,0 +1,9 @@
+transforms:
+  my_transform_id:
+    type: throttle
+    inputs:
+      - my-source-or-transform-id
+    key_field: "{{ message }}"
+    measure_cpu_usage: false
+    threshold: 100
+    window_secs: 1

--- a/website/generated/example-configs/transforms/throttle/minimal.yaml
+++ b/website/generated/example-configs/transforms/throttle/minimal.yaml
@@ -1,0 +1,7 @@
+transforms:
+  my_transform_id:
+    type: throttle
+    inputs:
+      - my-source-or-transform-id
+    threshold: 100
+    window_secs: 1

--- a/website/generated/example-configs/transforms/trace_to_log/advanced.yaml
+++ b/website/generated/example-configs/transforms/trace_to_log/advanced.yaml
@@ -1,0 +1,6 @@
+transforms:
+  my_transform_id:
+    type: trace_to_log
+    inputs:
+      - my-source-or-transform-id
+    measure_cpu_usage: false

--- a/website/generated/example-configs/transforms/trace_to_log/minimal.yaml
+++ b/website/generated/example-configs/transforms/trace_to_log/minimal.yaml
@@ -1,0 +1,5 @@
+transforms:
+  my_transform_id:
+    type: trace_to_log
+    inputs:
+      - my-source-or-transform-id

--- a/website/generated/example-configs/transforms/window/advanced.yaml
+++ b/website/generated/example-configs/transforms/window/advanced.yaml
@@ -1,0 +1,10 @@
+transforms:
+  my_transform_id:
+    type: window
+    inputs:
+      - my-source-or-transform-id
+    flush_when:
+      type: vrl
+      source: .status_code != 200 && !includes(["info", "debug"], .severity)
+    measure_cpu_usage: false
+    num_events_before: 100

--- a/website/generated/example-configs/transforms/window/minimal.yaml
+++ b/website/generated/example-configs/transforms/window/minimal.yaml
@@ -1,0 +1,8 @@
+transforms:
+  my_transform_id:
+    type: window
+    inputs:
+      - my-source-or-transform-id
+    flush_when:
+      type: vrl
+      source: .status_code != 200 && !includes(["info", "debug"], .severity)

--- a/website/scripts/create-config-examples.js
+++ b/website/scripts/create-config-examples.js
@@ -1,9 +1,12 @@
 import fs from "fs";
+import path from "path";
 import chalk from "chalk";
 import * as TOML from "@iarna/toml";
 import YAML from "yaml";
 
 const cueJsonOutput = "data/docs.json";
+const generatedExamplesDir = "generated/example-configs";
+const generatedExamplesTmpDir = `${generatedExamplesDir}.tmp`;
 
 // Helper functions
 const getExampleValue = (param, deepFilter) => {
@@ -226,12 +229,20 @@ const toToml = (obj) => {
 
 // Convert object to YAML string
 const toYaml = (obj) => {
-  return `${YAML.stringify(obj)}`;
+  // Tabs in multiline example strings (for example, Lua code) are valid YAML
+  // content, but fail Git's whitespace check. Use spaces in generated examples.
+  return `${YAML.stringify(obj)}`.replaceAll("\t", "  ");
 };
 
 // Convert object to JSON string (indented)
 const toJson = (obj) => {
   return JSON.stringify(obj, null, 2);
+};
+
+const writeYamlExample = (kind, componentType, variant, yaml) => {
+  const componentDir = path.join(generatedExamplesTmpDir, kind, componentType);
+  fs.mkdirSync(componentDir, { recursive: true });
+  fs.writeFileSync(path.join(componentDir, `${variant}.yaml`), yaml, "utf8");
 };
 
 // Set the example value for a given config parameter
@@ -389,14 +400,19 @@ const makeUseCaseExamples = (component) => {
   }
 };
 
+const debug = process.env.DEBUG === "true" || false;
+
 const main = () => {
   try {
-    const debug = process.env.DEBUG === "true" || false;
     const data = fs.readFileSync(cueJsonOutput, "utf8");
     const docs = JSON.parse(data);
     const components = docs.components;
 
     console.log(chalk.blue("Creating example configurations for all Vector components..."));
+
+    if (!debug) {
+      fs.rmSync(generatedExamplesTmpDir, { recursive: true, force: true });
+    }
 
     // Sources, transforms, sinks
     for (const kind in components) {
@@ -469,18 +485,26 @@ const main = () => {
 
         docs["components"][kind][componentType]["examples"] = useCaseExamples;
 
+        const minimalYaml = toYaml(minimalExampleConfig);
+        const advancedYaml = toYaml(advancedExampleConfig);
+
         docs["components"][kind][componentType]["example_configs"] = {
           minimal: {
             toml: toToml(minimalExampleConfig),
-            yaml: toYaml(minimalExampleConfig),
+            yaml: minimalYaml,
             json: toJson(minimalExampleConfig)
           },
           advanced: {
             toml: toToml(advancedExampleConfig),
-            yaml: toYaml(advancedExampleConfig),
+            yaml: advancedYaml,
             json: toJson(advancedExampleConfig)
           }
         };
+
+        if (!debug) {
+          writeYamlExample(kind, componentType, "minimal", minimalYaml);
+          writeYamlExample(kind, componentType, "advanced", advancedYaml);
+        }
       }
     }
 
@@ -490,16 +514,22 @@ const main = () => {
     }
 
     console.log(chalk.green("Success. Finished generating examples for all components."));
-    console.log(chalk.blue(`Writing generated examples as JSON to ${cueJsonOutput}...`));
+    console.log(chalk.blue(`Writing generated YAML examples to ${generatedExamplesDir}...`));
 
-    // Write back to the JSON file only when not in debug mode
+    // Write generated examples only when not in debug mode.
     if (!debug) {
+      fs.rmSync(generatedExamplesDir, { recursive: true, force: true });
+      fs.renameSync(generatedExamplesTmpDir, generatedExamplesDir);
       fs.writeFileSync(cueJsonOutput, JSON.stringify(docs), "utf8");
     }
 
-    console.log(chalk.green(`Success. Finished writing example configs to ${cueJsonOutput}.`));
+    console.log(chalk.green(`Success. Finished writing example configs to ${generatedExamplesDir}.`));
   } catch (err) {
+    if (!debug) {
+      fs.rmSync(generatedExamplesTmpDir, { recursive: true, force: true });
+    }
     console.error(err);
+    process.exitCode = 1;
   }
 };
 

--- a/website/scripts/validate-config-examples.js
+++ b/website/scripts/validate-config-examples.js
@@ -1,17 +1,21 @@
 import fs from "fs";
 import os from "os";
 import path from "path";
-import { execSync } from "child_process";
+import { execFile } from "child_process";
+import { promisify } from "util";
 import chalk from "chalk";
 import YAML from "yaml";
 
 const cueJsonOutput = "data/docs.json";
+const generatedExamplesDir = "generated/example-configs";
 const VECTOR_BIN = process.env.VECTOR_BIN || "vector";
+const validationConcurrency = Math.max(1, Number.parseInt(process.env.VALIDATE_CONFIG_EXAMPLES_JOBS || "4", 10) || 4);
+const execFileAsync = promisify(execFile);
 
 // Use `cargo run` when running inside the Vector repo and no specific binary is needed.
 // Set VECTOR_BIN to point at an existing binary and skip the cargo build.
 const useCargoRun = !process.env.VECTOR_BIN && fs.existsSync(path.join(import.meta.dirname, "../../Cargo.toml"));
-const vectorCmd = useCargoRun ? "cargo run --" : VECTOR_BIN;
+const vectorCommand = useCargoRun ? "cargo" : VECTOR_BIN;
 
 // Pick a source type compatible with the component's accepted input event types.
 // Returns null for trace-only components (no simple trace source available).
@@ -85,15 +89,20 @@ const wrapConfig = (kind, componentYaml, component) => {
   return componentYaml;
 };
 
-const validateYaml = (yaml, tmpPath) => {
+const validateYaml = async (yaml, tmpPath) => {
   fs.writeFileSync(tmpPath, yaml, "utf8");
   try {
-    execSync(`${vectorCmd} validate --no-environment --skip-healthchecks ${tmpPath}`, {
-      stdio: "pipe"
+    const args = ["validate", "--no-environment", "--skip-healthchecks", tmpPath];
+    if (useCargoRun) args.unshift("run", "--");
+
+    await execFileAsync(vectorCommand, args, {
+      maxBuffer: 1024 * 1024
     });
     return null;
   } catch (err) {
     return (err.stderr?.toString() || err.stdout?.toString() || err.message).trim();
+  } finally {
+    if (fs.existsSync(tmpPath)) fs.unlinkSync(tmpPath);
   }
 };
 
@@ -105,57 +114,71 @@ const summarizeError = (error) => {
   return (errorLine || lines[0] || error).trim().replace(/^x /, "");
 };
 
-const main = () => {
+const main = async () => {
   const data = fs.readFileSync(cueJsonOutput, "utf8");
   const docs = JSON.parse(data);
   const components = docs.components;
 
   const failures = [];
+  const validationCases = [];
   let total = 0;
   let skipped = 0;
-  const tmpFile = path.join(os.tmpdir(), "vector-validate-example.yaml");
 
-  try {
-    for (const kind in components) {
-      for (const componentType in components[kind]) {
-        const component = components[kind][componentType];
-        const exampleConfigs = component.example_configs;
-        if (!exampleConfigs) continue;
+  for (const kind in components) {
+    for (const componentType in components[kind]) {
+      const component = components[kind][componentType];
 
-        for (const variant of ["minimal", "advanced"]) {
-          const yaml = exampleConfigs[variant]?.yaml;
-          if (!yaml) continue;
+      for (const variant of ["minimal", "advanced"]) {
+        total++;
+        const key = `${kind}/${componentType} (${variant})`;
+        const examplePath = path.join(generatedExamplesDir, kind, componentType, `${variant}.yaml`);
 
-          total++;
-          const key = `${kind}/${componentType} (${variant})`;
-
-          let wrapped;
-          try {
-            wrapped = wrapConfig(kind, yaml, component);
-          } catch (e) {
-            failures.push({ key, error: `YAML parse error: ${e.message}` });
-            console.error(chalk.red(`FAIL ${key} [parse error]`));
-            continue;
-          }
-
-          if (wrapped === null) {
-            skipped++;
-            continue;
-          }
-
-          const error = validateYaml(wrapped, tmpFile);
-          if (error) {
-            const summary = summarizeError(error);
-            failures.push({ key, error: summary });
-            console.error(chalk.red(`FAIL ${key}: ${summary}`));
-            console.error(chalk.gray("--- config ---\n" + wrapped + "---"));
-          }
+        let yaml;
+        try {
+          yaml = fs.readFileSync(examplePath, "utf8");
+        } catch (err) {
+          failures.push({ key, error: `Could not read ${examplePath}: ${err.message}` });
+          console.error(chalk.red(`FAIL ${key}: Could not read ${examplePath}`));
+          continue;
         }
+
+        let wrapped;
+        try {
+          wrapped = wrapConfig(kind, yaml, component);
+        } catch (e) {
+          failures.push({ key, error: `YAML parse error: ${e.message}` });
+          console.error(chalk.red(`FAIL ${key} [parse error]`));
+          continue;
+        }
+
+        if (wrapped === null) {
+          skipped++;
+          continue;
+        }
+
+        validationCases.push({ key, wrapped });
       }
     }
-  } finally {
-    if (fs.existsSync(tmpFile)) fs.unlinkSync(tmpFile);
   }
+
+  let nextCase = 0;
+  const validateNext = async () => {
+    while (nextCase < validationCases.length) {
+      const caseIndex = nextCase++;
+      const { key, wrapped } = validationCases[caseIndex];
+      const tmpFile = path.join(os.tmpdir(), `vector-validate-example-${process.pid}-${caseIndex}.yaml`);
+      const error = await validateYaml(wrapped, tmpFile);
+
+      if (error) {
+        const summary = summarizeError(error);
+        failures.push({ key, error: summary });
+        console.error(chalk.red(`FAIL ${key}: ${summary}`));
+        console.error(chalk.gray("--- config ---\n" + wrapped + "---"));
+      }
+    }
+  };
+
+  await Promise.all(Array.from({ length: Math.min(validationConcurrency, validationCases.length) }, validateNext));
 
   const validated = total - skipped;
   console.log(chalk.gray(`Validated ${validated} examples (${skipped} skipped).`));
@@ -168,4 +191,7 @@ const main = () => {
   }
 };
 
-main();
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary

Component examples are currently generated into ignored `website/data/docs.json`. That makes config changes unavailable for review and prevents CI from detecting drift or validating the generated configurations. These examples are the first section readers encounter in component documentation, so keeping them valid is essential to making the docs trustworthy. This PR commits the YAML artifacts and makes them an independently validated CI input.

- Generate 254 minimal and advanced YAML examples under `website/generated/example-configs/`.
- Keep Hugo's multi-format examples populated from the same generation pass.
- Detect stale generated examples and validate the committed YAML in the generated-docs CI job.
- Run the job when its generator, validator, CUE, Makefile, or generated-artifact inputs change.
- Reuse the `target/debug/vector` binary already built for schema generation. The job's shared Cargo/target cache avoids a second full Vector build for validation.

## Vector configuration

Not applicable; this changes generated component example artifacts and their validation.

## How did you test this PR?

- `make generate-example-configs`
- `make -C website validate-config-examples` — 250 examples validated; 4 trace-only examples skipped; completed in about 18 seconds.
- `make check-fmt`
- `git diff --check`

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Closes #25943
