### PR TITLE
fix(ci): increase build timeout

### DIFF
--- a/.github/workflows/cross.yml
+++ b/.github/workflows/cross.yml
@@ -15,7 +15,7 @@ jobs:
   cross-linux:
     name: Cross - ${{ matrix.target }}
     runs-on: ubuntu-24.04
-    timeout-minutes: 45
+    timeout-minutes: 60
     env:
       CARGO_INCREMENTAL: 0
       CARGO_PROFILE_RELEASE_LTO: thin # fat LTO OOMs/timeouts on standard 16GB runners; thin is sufficient to verify linking


### PR DESCRIPTION
## Summary

Increase the cross-build job timeout from 45 to 60 minutes.

## Motivation

The `arm-unknown-linux-musleabi` merge-queue build was cancelled at the configured 45-minute limit while still compiling. Its log contained no compiler or test failure.

## Vector configuration

Not applicable.

## How did you test this PR?

- `git diff --check`
- Reviewed the failing merge-queue job and recent successful runs of the same target.

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: #26014