### PR TITLE
fix(website): safelist dynamic Tailwind classes

### DIFF
--- a/website/assets/css/style.css
+++ b/website/assets/css/style.css
@@ -13,10 +13,10 @@
 @source inline("search-input search-results-list search-result code-sample-filename type block border-gray-200 border-gray-300 border-r border-t font-medium h-2 h-3 h-full inline leading-relaxed mb-1 ml-1 mr-1 p-2 p-4 pl-2 py-4 text-gray-600 text-gray-800 text-sm w-2 w-3");
 
 /* Render-time colors must be available before Hugo writes stats. */
-@source inline("border-blue-400 text-blue-400 border-green-400 text-green-400 border-red-400 text-red-400 border-yellow-400 text-yellow-400 border-violet-400 text-violet-400 border-gray-400 text-gray-400 bg-red-500 bg-yellow-500 bg-green-500");
+@source inline("border-blue-400 text-blue-400 border-green-400 text-green-400 border-red-400 text-red-400 border-yellow-400 text-yellow-400 border-violet-400 text-violet-400 border-gray-400 text-gray-400 bg-red-500 bg-yellow-500 bg-green-500 border-blue-500 border-fuchsia-500 border-green-500 border-orange-500 border-red-500 border-violet-500 border-yellow-500");
 
 /* Social-link colors are assembled from menu data at render time. */
-@source inline("text-black text-gray-300 text-discord-purple text-rss-orange dark:text-white hover:text-black hover:text-gray-500 dark:hover:text-gray-500");
+@source inline("text-black text-gray-300 text-discord-purple text-rss-orange dark:text-white hover:text-black hover:text-discord-purple hover:text-gray-500 hover:text-rss-orange dark:hover:text-black dark:hover:text-gray-500");
 
 /* Class-based dark mode via Alpine JS toggling .dark on <html> */
 @custom-variant dark (&:where(.dark, .dark *));


### PR DESCRIPTION
## Summary

Completes the Tailwind v4 clean-build safelist for classes Hugo assembles at render time.

Without these candidates, PostCSS can run before `hugo_stats.json` exists and omit the highlight-card `border-*-500` colors plus Discord/RSS footer hover colors. The affected styles then appear only after a later build leaves stats behind.

## Vector configuration

NA

## How did you test this PR?

- `cd website && yarn install --frozen-lockfile`
- Compiled `assets/css/style.css` with the local PostCSS CLI and verified every safelisted selector.
- Removed `hugo_stats.json` and ran `make production-build` successfully (553 pages).

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: #25362

## Notes

Follow-up for the final merged-PR review finding: https://github.com/vectordotdev/vector/pull/25362#discussion_r3715440068
