### PR TITLE
chore(ci): add bots to CLA allowlist

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -41,7 +41,7 @@ jobs:
           branch: "vector"
           remote-repository-name: cla-signatures
           remote-organization-name: DataDog
-          allowlist: step-security-bot
+          allowlist: step-security-bot,datadog-vectordotdev[bot],cose-datadog[bot]
 
           custom-notsigned-prcomment: |
             Thank you for your contribution! Before we can merge this PR, please sign our [Contributor License Agreement](https://gist.github.com/bits-bot/55bdc97a4fdad52d97feb4d6c3d1d618).


### PR DESCRIPTION
## Summary
Add the Datadog bot accounts (`datadog-vectordotdev[bot]`, `cose-datadog[bot]`) to the CLA allowlist so their PRs are not blocked on CLA signing.

## Vector configuration
NA

## How did you test this PR?
NA

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

NA