### PR TITLE
chore(deps): bump ordered-float to 5.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1909,7 +1909,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "proc-macro2 1.0.106",
  "quote 1.0.45",
  "regex",
@@ -2652,7 +2652,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -3665,7 +3665,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -5560,7 +5560,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing 0.1.44",
@@ -8685,7 +8685,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "once_cell",
@@ -8705,7 +8705,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -8739,7 +8739,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2 1.0.106",
  "quote 1.0.45",
  "syn 2.0.117",
@@ -8752,7 +8752,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2 1.0.106",
  "quote 1.0.45",
  "syn 2.0.117",
@@ -10024,7 +10024,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -10140,7 +10140,7 @@ dependencies = [
  "security-framework 3.6.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -11569,7 +11569,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.0",
 ]
 
 [[package]]
@@ -13597,7 +13597,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 [[package]]
 name = "vrl"
 version = "0.34.0"
-source = "git+https://github.com/vectordotdev/vrl.git?branch=pront-ordered-float-5#995680d4f1f47bf1d7c8728d15b6d0e8616fdeef"
+source = "git+https://github.com/vectordotdev/vrl.git?branch=main#ca05c29ab61f5288e858b32089add9a4cb13718c"
 dependencies = [
  "aes 0.9.1",
  "aes-siv",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2595,7 +2595,7 @@ dependencies = [
  "memchr",
  "metrics",
  "opentelemetry-proto",
- "ordered-float 4.6.0",
+ "ordered-float 5.3.0",
  "parquet",
  "pin-project",
  "prost 0.12.6",
@@ -7844,7 +7844,7 @@ dependencies = [
  "chrono",
  "glob",
  "hex",
- "ordered-float 4.6.0",
+ "ordered-float 5.3.0",
  "prost 0.12.6",
  "prost-build 0.12.6",
  "tonic 0.11.0",
@@ -7875,6 +7875,15 @@ name = "ordered-float"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "ordered-float"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
 dependencies = [
  "num-traits",
 ]
@@ -13056,7 +13065,7 @@ dependencies = [
  "openssl",
  "openssl-probe",
  "openssl-src",
- "ordered-float 4.6.0",
+ "ordered-float 5.3.0",
  "parquet",
  "pastey",
  "percent-encoding",
@@ -13193,7 +13202,7 @@ dependencies = [
  "metrics-tracing-context",
  "metrics-util",
  "num-traits",
- "ordered-float 4.6.0",
+ "ordered-float 5.3.0",
  "pastey",
  "proptest",
  "quickcheck",
@@ -13342,7 +13351,7 @@ dependencies = [
  "no-proxy",
  "noisy_float",
  "openssl",
- "ordered-float 4.6.0",
+ "ordered-float 5.3.0",
  "parking_lot",
  "pin-project",
  "proptest",
@@ -13588,7 +13597,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 [[package]]
 name = "vrl"
 version = "0.34.0"
-source = "git+https://github.com/vectordotdev/vrl.git?branch=main#3158cbafb4ffed840dbced6a0dec906c31aeb864"
+source = "git+https://github.com/vectordotdev/vrl.git?branch=pront-ordered-float-5#995680d4f1f47bf1d7c8728d15b6d0e8616fdeef"
 dependencies = [
  "aes 0.9.1",
  "aes-siv",
@@ -13647,7 +13656,7 @@ dependencies = [
  "nu-ansi-term",
  "ofb",
  "onig",
- "ordered-float 4.6.0",
+ "ordered-float 5.3.0",
  "parse-size",
  "peeking_take_while",
  "percent-encoding",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -236,7 +236,7 @@ vector-common-macros = { path = "lib/vector-common-macros" }
 vector-lib = { path = "lib/vector-lib", default-features = false }
 vector-vrl-category = { path = "lib/vector-vrl/category" }
 vector-vrl-functions = { path = "lib/vector-vrl/functions", default-features = false }
-vrl = { git = "https://github.com/vectordotdev/vrl.git", branch = "pront-ordered-float-5", default-features = false, features = ["arbitrary", "cli", "test", "test_framework", "stdlib-base"] }
+vrl = { git = "https://github.com/vectordotdev/vrl.git", branch = "main", default-features = false, features = ["arbitrary", "cli", "test", "test_framework", "stdlib-base"] }
 zstd = { version = "0.13.0", default-features = false }
 mock_instant = { version = "0.6" }
 serial_test = { version = "3.4" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -187,7 +187,7 @@ metrics-tracing-context = { version = "0.17.0", default-features = false }
 metrics-util = { version = "0.18.0", default-features = false, features = ["registry"] }
 mlua = { version = "0.11", default-features = false, features = ["lua54", "send", "vendored"] }
 nom = { version = "8.0.0", default-features = false }
-ordered-float = { version = "4.6.0", default-features = false }
+ordered-float = { version = "5.3.0", default-features = false }
 pastey = { version = "0.2", default-features = false }
 pin-project = { version = "1.1.11", default-features = false }
 proptest = { version = "1.11" }
@@ -236,7 +236,7 @@ vector-common-macros = { path = "lib/vector-common-macros" }
 vector-lib = { path = "lib/vector-lib", default-features = false }
 vector-vrl-category = { path = "lib/vector-vrl/category" }
 vector-vrl-functions = { path = "lib/vector-vrl/functions", default-features = false }
-vrl = { git = "https://github.com/vectordotdev/vrl.git", branch = "main", default-features = false, features = ["arbitrary", "cli", "test", "test_framework", "stdlib-base"] }
+vrl = { git = "https://github.com/vectordotdev/vrl.git", branch = "pront-ordered-float-5", default-features = false, features = ["arbitrary", "cli", "test", "test_framework", "stdlib-base"] }
 zstd = { version = "0.13.0", default-features = false }
 mock_instant = { version = "0.6" }
 serial_test = { version = "3.4" }

--- a/changelog.d/26022_reduce_sum_nan.fix.md
+++ b/changelog.d/26022_reduce_sum_nan.fix.md
@@ -1,0 +1,4 @@
+Reduce transforms using the `sum` merge strategy now return an error instead of panicking when
+floating-point addition would produce NaN.
+
+authors: pront

--- a/src/transforms/reduce/merge_strategy.rs
+++ b/src/transforms/reduce/merge_strategy.rs
@@ -5,6 +5,7 @@ use chrono::{DateTime, Utc};
 use dyn_clone::DynClone;
 use ordered_float::NotNan;
 use vector_lib::configurable::configurable_component;
+use vrl::compiler::value::VrlValueArithmetic;
 use vrl::path::{OwnedSegment, OwnedTargetPath};
 
 use crate::event::{LogEvent, Value};
@@ -412,29 +413,17 @@ impl ReduceValueMerger for AddNumbersMerger {
     fn add(&mut self, v: Value) -> Result<(), String> {
         // Try and keep max precision with integer values, but once we've
         // received a float downgrade to float precision.
-        match v {
-            Value::Integer(i) => match self.v {
-                NumberMergerValue::Int(j) => self.v = NumberMergerValue::Int(i + j),
-                NumberMergerValue::Float(j) => {
-                    self.v = NumberMergerValue::Float(NotNan::new(i as f64).unwrap() + j)
-                }
-            },
-            Value::Float(f) => match self.v {
-                NumberMergerValue::Int(j) => {
-                    self.v = NumberMergerValue::Float(
-                        NotNan::new(f + j as f64)
-                            .expect("adding an integer to a non-NaN float cannot produce NaN"),
-                    )
-                }
-                NumberMergerValue::Float(j) => self.v = NumberMergerValue::Float(f + j),
-            },
-            _ => {
-                return Err(format!(
-                    "expected numeric value, found: '{}'",
-                    v.to_string_lossy()
-                ));
-            }
-        }
+        let current = match &self.v {
+            NumberMergerValue::Int(value) => Value::Integer(*value),
+            NumberMergerValue::Float(value) => Value::Float(*value),
+        };
+        let sum = current.try_add(v).map_err(|error| error.to_string())?;
+        self.v = match sum {
+            Value::Integer(value) => NumberMergerValue::Int(value),
+            Value::Float(value) => NumberMergerValue::Float(value),
+            _ => return Err("summing numeric values produced a non-numeric value".to_owned()),
+        };
+
         Ok(())
     }
 
@@ -837,6 +826,10 @@ mod test {
             Ok(42.0.into())
         );
         assert_eq!(
+            merge(21.0.into(), 21.into(), &MergeStrategy::Sum),
+            Ok(42.0.into())
+        );
+        assert_eq!(
             merge(41.into(), 42.into(), &MergeStrategy::Max),
             Ok(42.into())
         );
@@ -941,6 +934,18 @@ mod test {
         } else {
             panic!("Not array");
         }
+    }
+
+    #[test]
+    fn sum_returns_nan_errors() {
+        assert_eq!(
+            merge(
+                f64::INFINITY.into(),
+                f64::NEG_INFINITY.into(),
+                &MergeStrategy::Sum,
+            ),
+            Err("operation would produce NaN".to_owned())
+        );
     }
 
     fn merge(initial: Value, additional: Value, strategy: &MergeStrategy) -> Result<Value, String> {

--- a/src/transforms/reduce/merge_strategy.rs
+++ b/src/transforms/reduce/merge_strategy.rs
@@ -420,7 +420,12 @@ impl ReduceValueMerger for AddNumbersMerger {
                 }
             },
             Value::Float(f) => match self.v {
-                NumberMergerValue::Int(j) => self.v = NumberMergerValue::Float(f + j as f64),
+                NumberMergerValue::Int(j) => {
+                    self.v = NumberMergerValue::Float(
+                        NotNan::new(f + j as f64)
+                            .expect("adding an integer to a non-NaN float cannot produce NaN"),
+                    )
+                }
                 NumberMergerValue::Float(j) => self.v = NumberMergerValue::Float(f + j),
             },
             _ => {
@@ -826,6 +831,10 @@ mod test {
         assert_eq!(
             merge(21.into(), 21.into(), &MergeStrategy::Sum),
             Ok(42.into())
+        );
+        assert_eq!(
+            merge(21.into(), 21.0.into(), &MergeStrategy::Sum),
+            Ok(42.0.into())
         );
         assert_eq!(
             merge(41.into(), 42.into(), &MergeStrategy::Max),


### PR DESCRIPTION
## Motivation

Vector and VRL share ordered-float-backed value types, so they must remain on compatible major
versions. VRL's ordered-float v5 work has now landed on `main`, allowing Vector to complete the
upgrade without a temporary branch dependency. The reduce transform should also reuse VRL's
fallible arithmetic so NaN-producing sums return an error instead of panicking inside `NotNan`.

## Summary

- Bump `ordered-float` from 4.6.0 to 5.3.0.
- Point the VRL dependency back to `main`.
- Delegate reduce sum arithmetic to VRL's fallible `try_add`.
- Add coverage for both mixed integer/float directions and NaN-producing sums.

## Vector configuration

No configuration changes are required.

## How did you test this PR?

- `cargo check --workspace`
- `make fmt`
- `make check-clippy`
- `cargo test --lib transforms::reduce::merge_strategy::test`
- `make check-markdown`
- `cargo vdev check changelog-fragments`

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [x] Yes. A changelog fragment is included.
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- https://github.com/vectordotdev/vrl/pull/1890
