### PR TITLE
fix(opentelemetry source): implement standard gRPC health checking protocol

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -771,6 +771,7 @@ sources-opentelemetry = [
   "vector-lib/opentelemetry",
   "dep:prost",
   "dep:prost-types",
+  "dep:tonic-health",
   "sources-http_server",
   "sources-utils-http",
   "sources-utils-http-headers",

--- a/changelog.d/opentelemetry_source_grpc_health.fix.md
+++ b/changelog.d/opentelemetry_source_grpc_health.fix.md
@@ -1,0 +1,12 @@
+The `opentelemetry` source now serves the standard `grpc.health.v1.Health` service on its gRPC
+listener, matching the `vector` source. The aggregate (empty) service name reports `SERVING`, as do
+`opentelemetry.proto.collector.logs.v1.LogsService`,
+`opentelemetry.proto.collector.metrics.v1.MetricsService` and
+`opentelemetry.proto.collector.trace.v1.TraceService`.
+
+Previously a health check request to the OTLP gRPC port was unrouted and returned a bare HTTP 404
+with no gRPC status, so load balancers and `grpc-health-probe` had no usable health endpoint and had
+to probe an `Export` method instead. Each such probe also logged a `Grpc error` at `ERROR` level for
+the source.
+
+authors: stigglor

--- a/changelog.d/opentelemetry_source_grpc_health.fix.md
+++ b/changelog.d/opentelemetry_source_grpc_health.fix.md
@@ -9,4 +9,8 @@ with no gRPC status, so load balancers and `grpc-health-probe` had no usable hea
 to probe an `Export` method instead. Each such probe also logged a `Grpc error` at `ERROR` level for
 the source.
 
+Health checks are also excluded from `component_received_bytes_total` on all gRPC sources, since a
+probe carries no events. This also affects the `vector` source, where frequent probes previously
+inflated that metric by a few bytes each.
+
 authors: stigglor

--- a/src/sources/opentelemetry/config.rs
+++ b/src/sources/opentelemetry/config.rs
@@ -22,7 +22,8 @@ use crate::{
 };
 use futures::FutureExt;
 use futures_util::{TryFutureExt, future::join};
-use tonic::transport::server::RoutesBuilder;
+use tonic::{server::NamedService, transport::server::RoutesBuilder};
+use tonic_health::server::health_reporter;
 use vector_config::indexmap::IndexSet;
 use vector_lib::{
     codecs::decoding::{OtlpDeserializer, OtlpSignalType},
@@ -327,8 +328,28 @@ impl OpentelemetryConfig {
         })
         .max_decoding_message_size(max_decompressed_size_bytes());
 
+        // Serve the standard `grpc.health.v1.Health` service, as the `vector` source does, so a
+        // health check on this port gets a real gRPC status instead of the bare HTTP 404 that an
+        // unrouted method returns. The reporter already reports the aggregate (empty) service name
+        // as serving, and that is the name a probe sends unless it is told otherwise.
+        let (mut health_reporter, health_service) = health_reporter();
+
+        // Report each OTLP service by name as well, so a probe can target a single signal. The
+        // names come from the generated `NamedService` implementations because a hand-written
+        // string could drift from the routes registered below.
+        for service_name in [
+            <LogsServiceServer<Service> as NamedService>::NAME,
+            <MetricsServiceServer<Service> as NamedService>::NAME,
+            <TraceServiceServer<Service> as NamedService>::NAME,
+        ] {
+            health_reporter
+                .set_service_status(service_name, tonic_health::ServingStatus::Serving)
+                .await;
+        }
+
         let mut builder = RoutesBuilder::default();
         builder
+            .add_service(health_service)
             .add_service(log_service)
             .add_service(metrics_service)
             .add_service(trace_service);

--- a/src/sources/opentelemetry/tests.rs
+++ b/src/sources/opentelemetry/tests.rs
@@ -1696,6 +1696,71 @@ async fn http_logs_use_otlp_decoding_emits_metric() {
     }
 }
 
+#[tokio::test]
+async fn standard_grpc_health_check_works() {
+    use tonic::transport::Channel;
+    use tonic_health::pb::{
+        HealthCheckRequest, health_check_response::ServingStatus, health_client::HealthClient,
+    };
+
+    test_util::trace_init();
+
+    let (_guard_0, grpc_addr) = next_addr();
+    let (_guard_1, http_addr) = next_addr();
+
+    let source = get_source_config_with_headers(grpc_addr, http_addr, false);
+
+    let (sender, _output, _) = new_source(EventStatus::Delivered, LOGS.to_string());
+    let server = source
+        .build(SourceContext::new_test(sender, None))
+        .await
+        .unwrap();
+    tokio::spawn(server);
+    test_util::wait_for_tcp(grpc_addr).await;
+
+    let channel = Channel::from_shared(format!("http://{grpc_addr}"))
+        .unwrap()
+        .connect()
+        .await
+        .unwrap();
+    let mut client = HealthClient::new(channel);
+
+    // The aggregate server health, which is what load balancers check by default.
+    let response = client
+        .check(HealthCheckRequest {
+            service: String::new(),
+        })
+        .await
+        .unwrap();
+    assert_eq!(response.into_inner().status, ServingStatus::Serving as i32);
+
+    // Each OTLP service is also reported by name. These names are spelled out rather than taken
+    // from `NamedService` because they are what a probe puts on the wire, so a rename should fail
+    // here rather than silently follow the code.
+    for service in [
+        "opentelemetry.proto.collector.logs.v1.LogsService",
+        "opentelemetry.proto.collector.metrics.v1.MetricsService",
+        "opentelemetry.proto.collector.trace.v1.TraceService",
+    ] {
+        let response = client
+            .check(HealthCheckRequest {
+                service: service.to_string(),
+            })
+            .await
+            .unwrap_or_else(|error| panic!("health check for {service} failed: {error}"));
+        assert_eq!(response.into_inner().status, ServingStatus::Serving as i32);
+    }
+
+    // An unknown service name gets a real gRPC status rather than an unrouted HTTP 404.
+    let status = client
+        .check(HealthCheckRequest {
+            service: "not.a.real.Service".to_string(),
+        })
+        .await
+        .expect_err("expected an error for an unregistered service");
+    assert_eq!(status.code(), tonic::Code::NotFound);
+}
+
 #[cfg(test)]
 mod otlp_decoding_config_tests {
     use indoc::indoc;

--- a/src/sources/opentelemetry/tests.rs
+++ b/src/sources/opentelemetry/tests.rs
@@ -1761,6 +1761,74 @@ async fn standard_grpc_health_check_works() {
     assert_eq!(status.code(), tonic::Code::NotFound);
 }
 
+#[tokio::test]
+async fn health_checks_are_not_counted_as_received_bytes() {
+    use crate::metrics::Controller;
+    use tonic::transport::Channel;
+    use tonic_health::pb::{HealthCheckRequest, health_client::HealthClient};
+
+    // Sums `component_received_bytes_total` across whatever the source has recorded so far.
+    fn received_bytes() -> f64 {
+        Controller::get()
+            .unwrap()
+            .capture_metrics()
+            .iter()
+            .filter(|metric| metric.name() == "component_received_bytes_total")
+            .map(|metric| match metric.value() {
+                MetricValue::Counter { value } => *value,
+                value => {
+                    panic!("component_received_bytes_total should be a counter, got {value:?}")
+                }
+            })
+            .sum()
+    }
+
+    test_util::trace_init();
+
+    let (_guard_0, grpc_addr) = next_addr();
+    let (_guard_1, http_addr) = next_addr();
+
+    let source = get_source_config_with_headers(grpc_addr, http_addr, false);
+
+    let (sender, logs_output, _) = new_source(EventStatus::Delivered, LOGS.to_string());
+    let server = source
+        .build(SourceContext::new_test(sender, None))
+        .await
+        .unwrap();
+    tokio::spawn(server);
+    test_util::wait_for_tcp(grpc_addr).await;
+
+    let channel = Channel::from_shared(format!("http://{grpc_addr}"))
+        .unwrap()
+        .connect()
+        .await
+        .unwrap();
+
+    let mut health_client = HealthClient::new(channel.clone());
+    for _ in 0..5 {
+        health_client
+            .check(HealthCheckRequest {
+                service: String::new(),
+            })
+            .await
+            .unwrap();
+    }
+
+    // A probe carries no events, so it must not show up in the source's byte accounting even
+    // though it shares the listener with the OTLP services.
+    assert_eq!(received_bytes(), 0.0);
+
+    // The same listener still accounts for real OTLP traffic.
+    LogsServiceClient::new(channel)
+        .export(create_test_logs_request())
+        .await
+        .unwrap();
+    let events = test_util::collect_ready(logs_output).await;
+    assert_eq!(events.len(), 1);
+
+    assert!(received_bytes() > 0.0);
+}
+
 #[cfg(test)]
 mod otlp_decoding_config_tests {
     use indoc::indoc;

--- a/src/sources/util/grpc/decompression.rs
+++ b/src/sources/util/grpc/decompression.rs
@@ -17,7 +17,8 @@ use hyper::{
     body::{HttpBody, Sender},
 };
 use tokio::{pin, select};
-use tonic::{Status, body::BoxBody, metadata::AsciiMetadataValue};
+use tonic::{Status, body::BoxBody, metadata::AsciiMetadataValue, server::NamedService};
+use tonic_health::{pb::health_server::HealthServer, server::HealthService};
 use tower::{Layer, Service};
 use vector_lib::internal_event::{
     ByteSize, BytesReceived, InternalEventHandle as _, Protocol, Registered,
@@ -28,6 +29,10 @@ use crate::sources::util::decompression::{
     CappedDecoder, DecompressedSizeLimitExceeded, is_decompressed_size_limit_error,
     max_decompressed_size_bytes, max_zlib_compressed_frame_size_bytes,
 };
+
+// The `grpc.health.v1.Health` service, which sources register alongside their data services on the
+// same listener. Taken from the generated service rather than written out so it cannot drift.
+const HEALTH_SERVICE_NAME: &str = <HealthServer<HealthService> as NamedService>::NAME;
 
 // Every gRPC message has a five byte header:
 // - a compressed flag (u8, 0/1 for compressed/decompressed)
@@ -470,11 +475,18 @@ async fn drive_body_decompression(
     Ok(bytes_received)
 }
 
+// Whether a request path belongs to the health service, i.e. `/grpc.health.v1.Health/Check`.
+fn is_health_check(path: &str) -> bool {
+    path.strip_prefix('/')
+        .and_then(|path| path.strip_prefix(HEALTH_SERVICE_NAME))
+        .is_some_and(|method| method.starts_with('/'))
+}
+
 async fn drive_request<F, E>(
     source: Body,
     destination: Sender,
     inner: F,
-    bytes_received: Registered<BytesReceived>,
+    bytes_received: Option<Registered<BytesReceived>>,
     scheme: Option<CompressionScheme>,
 ) -> Result<Response<BoxBody>, E>
 where
@@ -512,7 +524,9 @@ where
     // otherwise emit the error.
     match &result {
         Ok(res) if res.status().is_success() => {
-            bytes_received.emit(ByteSize(body_bytes_received));
+            if let Some(bytes_received) = &bytes_received {
+                bytes_received.emit(ByteSize(body_bytes_received));
+            }
         }
         Ok(res) => {
             emit!(GrpcError {
@@ -571,6 +585,12 @@ where
             // can support decompression based on the indicated compression scheme... so wrap the body to decompress, if
             // need be, and then track the bytes that flowed through.
             Ok(scheme) => {
+                // A health probe is not data the component received, so it is left out of the byte
+                // accounting even though it arrives on the same listener as the data services. It
+                // still goes through decompression below, because a client is free to compress it.
+                let bytes_received =
+                    (!is_health_check(req.uri().path())).then(|| self.bytes_received.clone());
+
                 let (destination, decompressed_body) = Body::channel();
                 let (mut req_parts, req_body) = req.into_parts();
                 // Since this layer owns compression negotiation and is about to hand the
@@ -585,14 +605,7 @@ where
 
                 let inner = self.inner.call(mapped_req);
 
-                drive_request(
-                    req_body,
-                    destination,
-                    inner,
-                    self.bytes_received.clone(),
-                    scheme,
-                )
-                .boxed()
+                drive_request(req_body, destination, inner, bytes_received, scheme).boxed()
             }
         }
     }


### PR DESCRIPTION
## Summary

A gRPC health check against the `opentelemetry` source's gRPC listener hits an unrouted
method and gets back a bare HTTP 404 with no `grpc-status`, so anything speaking the gRPC
health checking protocol has nothing to evaluate. An ALB target group or a Kubernetes
probe has to check an `Export` method instead and accept a range of statuses wide enough
to cover the decoder rejecting an empty body, which rides on an error path rather than a
health signal. Every such probe also logs `Grpc error. error=Received 404 Not Found` at
ERROR level against the source.

The `vector` source already registers `grpc.health.v1.Health` via `tonic_health` (#24916)
and the API replaced its custom Health RPC with the same service (#25139), so this applies
the established pattern to the source that missed out. The reporter serves the aggregate
(empty) service name, which is what a probe sends unless told otherwise, and each of the
three OTLP services is reported by name so a probe can target a single signal. Those names
come from the generated `NamedService` implementations rather than string literals so they
cannot drift from the routes actually registered.

Status is static `SERVING`, matching the `vector` source: the reporter handle is dropped
after registration, so the source does not flip to `NOT_SERVING` while draining. That
seems worth revisiting for both sources but is out of scope here. The HTTP listener on
4318 is untouched.

## Vector configuration

```yaml
sources:
  otlp:
    type: opentelemetry
    grpc:
      address: 127.0.0.1:14317
    http:
      address: 127.0.0.1:14318
    use_otlp_decoding: true

sinks:
  drop:
    type: blackhole
    inputs:
      - otlp.logs
      - otlp.metrics
      - otlp.traces
```

## How did you test this PR?

Added `standard_grpc_health_check_works`, modelled on the `vector` source test of the same
name. It asserts `SERVING` for the aggregate and the three OTLP service names, and
`NOT_FOUND` for an unregistered one.

```
cargo nextest run -p vector --no-default-features --features sources-opentelemetry -E 'test(sources::opentelemetry)'
# 25 passed
```

I also ran the config above against a locally built binary and probed it over raw HTTP/2
with curl, since it is the wire behaviour that matters to a load balancer:

| Request on 14317 | Result |
| --- | --- |
| `Health/Check`, empty service | `HTTP/2 200`, `content-type: application/grpc`, trailer `grpc-status: 0`, body `08 01` (SERVING) |
| `Health/Check`, each OTLP service name | `grpc-status: 0`, SERVING |
| `Health/Check`, `not.a.real.Service` | `grpc-status: 5`, `service not registered` |
| `TraceService/Export`, empty message | `grpc-status: 3`, `Invalid OTLP data: expected one of {Traces}`, unchanged |
| `does.not.Exist/Method` | bare `HTTP/2 404`, no `grpc-status`, which is what health checks used to get |

`grpc_health_probe` is the practical follow-on for Kubernetes probes; I did not have it
installed, hence the raw HTTP/2 probes above.

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: #24916
- Related: #25139
