### PR TITLE
chore(deps): correct the quick-xml advisory-ignore rationale in deny.toml

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -49,7 +49,7 @@ ignore = [
   { id = "RUSTSEC-2024-0436", reason = "paste crate is unmaintained - transitive dependency via parquet v56.2.0, no safe upgrade available" },
   { id = "RUSTSEC-2026-0104", reason = "rustls-webpki 0.102/0.101 CRL parsing panic - tonic upgrade (https://github.com/vectordotdev/vector/issues/19179); 0.103 already patched to 0.103.13" },
   { id = "RUSTSEC-2026-0173", reason = "proc-macro-error2 is unmaintained - transitive dep via mlua_derive v0.11.0; unblocked when mlua upgrades its derive macro" },
-  { id = "RUSTSEC-2026-0194", reason = "quick-xml quadratic-time duplicate attribute check - affected versions still in the tree are 0.31 (direct dep, sources-windows_event_log) and 0.37.4 (via opendal); typespec is already on the fixed 0.41" },
-  { id = "RUSTSEC-2026-0195", reason = "quick-xml unbounded namespace-declaration allocation in NsReader - affected versions still in the tree are 0.31 (direct dep, sources-windows_event_log) and 0.37.4 (via opendal); typespec is already on the fixed 0.41" },
+  { id = "RUSTSEC-2026-0194", reason = "quick-xml quadratic-time duplicate attribute check - versions needing upgrade are v0.31 (direct dep) and v0.37.4 (via opendal < 0.58)" },
+  { id = "RUSTSEC-2026-0195", reason = "quick-xml unbounded namespace-declaration allocation in NsReader - versions needing upgrade are v0.31 (direct dep) and v0.37.4 (via opendal < 0.58)" },
   { id = "RUSTSEC-2026-0235", reason = "rkyv 0.7 is vulnerable but unmaintained; upgrading vector-buffers to rkyv 0.8 requires a breaking serialization migration" },
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -49,7 +49,7 @@ ignore = [
   { id = "RUSTSEC-2024-0436", reason = "paste crate is unmaintained - transitive dependency via parquet v56.2.0, no safe upgrade available" },
   { id = "RUSTSEC-2026-0104", reason = "rustls-webpki 0.102/0.101 CRL parsing panic - tonic upgrade (https://github.com/vectordotdev/vector/issues/19179); 0.103 already patched to 0.103.13" },
   { id = "RUSTSEC-2026-0173", reason = "proc-macro-error2 is unmaintained - transitive dep via mlua_derive v0.11.0; unblocked when mlua upgrades its derive macro" },
-  { id = "RUSTSEC-2026-0194", reason = "quick-xml 0.39.2 quadratic-time duplicate attribute check - transitive dep via azure_core/typespec, no newer typespec release available" },
-  { id = "RUSTSEC-2026-0195", reason = "quick-xml 0.39.2 unbounded namespace-declaration allocation in NsReader - transitive dep via azure_core/typespec, no newer typespec release available" },
+  { id = "RUSTSEC-2026-0194", reason = "quick-xml quadratic-time duplicate attribute check - affected versions still in the tree are 0.31 (direct dep, sources-windows_event_log) and 0.37.4 (via opendal); typespec is already on the fixed 0.41" },
+  { id = "RUSTSEC-2026-0195", reason = "quick-xml unbounded namespace-declaration allocation in NsReader - affected versions still in the tree are 0.31 (direct dep, sources-windows_event_log) and 0.37.4 (via opendal); typespec is already on the fixed 0.41" },
   { id = "RUSTSEC-2026-0235", reason = "rkyv 0.7 is vulnerable but unmaintained; upgrading vector-buffers to rkyv 0.8 requires a breaking serialization migration" },
 ]


### PR DESCRIPTION
Both `quick-xml` entries in `deny.toml` say the exposure comes from `azure_core`/`typespec` and that there is no newer `typespec` to move to. I think that has stopped being true, and the comment now points away from where the affected code actually is.

Checking the current lockfile:

| quick-xml | pulled by | affected by RUSTSEC-2026-0194/0195? |
|---|---|---|
| 0.41.0 | `typespec 1.1.0`, `quick-junit 0.6.1` | no — 0.41.0 is the fixed version |
| 0.37.4 | `opendal 0.54.0` | yes |
| 0.31.0 | this repo, `Cargo.toml:489` | yes |
| 0.39.2 | not in the lockfile | — |

So `typespec` has already moved to the fixed 0.41, and the version named in the comment isn't in the tree any more. What is still affected is `opendal`'s 0.37.4 and the direct `quick-xml = "0.31"` this repo declares for the `sources-windows_event_log` feature.

**The ignores are still needed** — 0.31 and 0.37.4 are genuinely affected, so removing them would turn `deny` red. This only updates the two `reason` strings so they describe the paths that are actually there. No code or dependency change.

I mention it because #25076 deliberately consolidated these entries with issue links, so it seemed like the kind of thing worth keeping accurate rather than letting it drift.

Separately, and not part of this PR: the direct `quick-xml = "0.31"` is the one path that isn't blocked on anyone upstream. Moving it to 0.41 would drop one of the two affected paths, though it crosses several breaking releases and the `serialize` usage in the windows_event_log source would need a proper look — happy to open a separate issue for that if it's useful.

Could you add `no-changelog`? There's no user-facing change here.

---

*Disclosure: I used an AI coding agent (Claude Opus 5) to help find this and check the dependency graph. I verified the lockfile paths and the advisory version ranges myself before opening this.*