### PR TITLE
fix(dev): avoid stale cached vdev binary

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -220,8 +220,7 @@ runs:
           ~/.cargo/bin/cargo-llvm-cov
           ~/.cargo/bin/dd-rust-license-tool
           ~/.cargo/bin/wasm-pack
-          ~/.cargo/bin/vdev
-        key: ${{ runner.os }}-cargo-binaries-${{ hashFiles('scripts/environment/*.sh', 'vdev/Cargo.toml') }}
+        key: ${{ runner.os }}-cargo-binaries-${{ hashFiles('scripts/environment/*.sh') }}
         restore-keys: |
           ${{ runner.os }}-cargo-binaries-
 

--- a/scripts/environment/prepare.sh
+++ b/scripts/environment/prepare.sh
@@ -146,27 +146,14 @@ maybe_install_cargo_tool() {
   # --manifest-path, so vdev/Cargo.toml is the single source of truth.
   # `--disable-strategies compile` skips binstall's own crates.io compile
   # fallback (which would fail anyway on an unpublished version, and
-  # silently slow-paths a cache flake into a multi-minute build). If
-  # binstall fails for any reason — missing prebuilt for a freshly bumped
-  # version, or a transient cache/network issue — we fall back to building
-  # from the working tree. That gives PRs that bump vdev's version a
-  # working binary built from their own changes, and keeps master CI green
-  # in the gap between merging a vdev version bump and pushing the tag.
+  # silently slow-paths a cache flake into a multi-minute build). We always
+  # force the install because the version alone cannot identify the source
+  # code of an unmerged checkout. If no prebuilt binary exists, build the
+  # current checkout instead.
   if [[ "$tool" == "vdev" ]]; then
-    # Skip the install entirely when the cached binary already matches the
-    # version in vdev/Cargo.toml (the setup workflow restores ~/.cargo/bin/vdev
-    # from cache, but not binstall's resolution metadata, so without this check
-    # every job with `vdev: true` would re-hit GitHub releases).
-    local cargo_toml_version
-    cargo_toml_version=$(grep -E '^version = ' vdev/Cargo.toml | head -1 | sed -E 's/.*"([^"]+)".*/\1/')
-    if vdev --version 2>/dev/null | grep -q "^vdev ${cargo_toml_version}$"; then
-      echo "vdev ${cargo_toml_version} already installed"
-      return 0
-    fi
-
     local installer=("${install[@]}")
     if [[ "${installer[0]}" == "binstall" ]]; then
-      installer+=(--disable-strategies compile)
+      installer+=(--force --disable-strategies compile)
       if ! cargo "${installer[@]}" --manifest-path vdev/Cargo.toml vdev; then
         echo "binstall failed; building vdev from the working tree..."
         cargo install -f --path vdev --locked


### PR DESCRIPTION
## Motivation

`prepare.sh` is intended to resolve vdev from its matching release artifact, then compile the checked-out source only when that artifact has not been published. The shared cargo-tool cache bypasses that policy by restoring a `vdev` binary and accepting it solely because its version matches `vdev/Cargo.toml`; a stale binary can therefore run for an unmerged checkout.

This restores the intended artifact-or-source behavior and removes the custom vdev caching layer that interferes with it.

## Changes

- Remove `vdev` from the shared CI cargo-tool cache.
- Force vdev installation so binstall resolves the matching artifact on every setup; when unavailable, retain the existing checkout-source fallback.
- Keep the generic cache stable across vdev-version changes.

## Vector configuration

Not applicable.

## How did you test this PR?

- `bash -n scripts/environment/prepare.sh`
- Prettier check for `.github/actions/setup/action.yml`
- Isolated install-root experiment: a published vdev version is resolved from its artifact even after a same-version source-only edit.
- GitHub Test Suite passed, including script, formatting, Clippy, generated-docs, and unit checks.

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: #26007
