### PR TITLE
fix(metrics): deserializer can read integer

### DIFF
--- a/changelog.d/fix_metric_bucket_upper_limit_integer_deserialization.fix.md
+++ b/changelog.d/fix_metric_bucket_upper_limit_integer_deserialization.fix.md
@@ -1,0 +1,4 @@
+Fix deserialization of `aggregated_histogram` bucket `upper_limit` when the value is provided as
+an integer instead of a float.
+
+authors: dd-sebastien-lb

--- a/lib/vector-core/src/event/metric/value.rs
+++ b/lib/vector-core/src/event/metric/value.rs
@@ -637,6 +637,8 @@ where
             Ok(value)
         }
 
+        // f64 represents integers exactly up to 2^53 (~9 quadrillion), which covers any realistic
+        // histogram bucket boundary. The precision loss only affects values beyond that threshold.
         #[allow(clippy::cast_precision_loss)]
         fn visit_i64<E: de::Error>(self, value: i64) -> Result<Self::Value, E> {
             Ok(value as f64)
@@ -766,6 +768,12 @@ mod tests {
         let bucket: Bucket = serde_json::from_str(r#"{"upper_limit": 1, "count": 5}"#).unwrap();
         assert_eq!(bucket.upper_limit, 1.0_f64);
         assert_eq!(bucket.count, 5);
+    }
+
+    #[test]
+    fn bucket_upper_limit_deserializes_negative_integer() {
+        let bucket: Bucket = serde_json::from_str(r#"{"upper_limit": -1, "count": 0}"#).unwrap();
+        assert_eq!(bucket.upper_limit, -1.0_f64);
     }
 
     #[test]

--- a/lib/vector-core/src/event/metric/value.rs
+++ b/lib/vector-core/src/event/metric/value.rs
@@ -637,6 +637,16 @@ where
             Ok(value)
         }
 
+        #[allow(clippy::cast_precision_loss)]
+        fn visit_i64<E: de::Error>(self, value: i64) -> Result<Self::Value, E> {
+            Ok(value as f64)
+        }
+
+        #[allow(clippy::cast_precision_loss)]
+        fn visit_u64<E: de::Error>(self, value: u64) -> Result<Self::Value, E> {
+            Ok(value as f64)
+        }
+
         fn visit_str<E: de::Error>(self, value: &str) -> Result<Self::Value, E> {
             match value {
                 NAN => Ok(f64::NAN),
@@ -743,5 +753,37 @@ impl Quantile {
 impl ByteSizeOf for Quantile {
     fn allocated_bytes(&self) -> usize {
         0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bucket_upper_limit_deserializes_integer() {
+        // JSON integers (e.g. 1) must deserialize into Bucket.upper_limit as f64.
+        let bucket: Bucket = serde_json::from_str(r#"{"upper_limit": 1, "count": 5}"#).unwrap();
+        assert_eq!(bucket.upper_limit, 1.0_f64);
+        assert_eq!(bucket.count, 5);
+    }
+
+    #[test]
+    fn bucket_upper_limit_deserializes_float() {
+        let bucket: Bucket = serde_json::from_str(r#"{"upper_limit": 1.5, "count": 3}"#).unwrap();
+        assert_eq!(bucket.upper_limit, 1.5_f64);
+    }
+
+    #[test]
+    fn bucket_upper_limit_deserializes_special_strings() {
+        let inf: Bucket = serde_json::from_str(r#"{"upper_limit": "inf", "count": 0}"#).unwrap();
+        assert!(inf.upper_limit.is_infinite() && inf.upper_limit > 0.0);
+
+        let neg_inf: Bucket =
+            serde_json::from_str(r#"{"upper_limit": "-inf", "count": 0}"#).unwrap();
+        assert!(neg_inf.upper_limit.is_infinite() && neg_inf.upper_limit < 0.0);
+
+        let nan: Bucket = serde_json::from_str(r#"{"upper_limit": "NaN", "count": 0}"#).unwrap();
+        assert!(nan.upper_limit.is_nan());
     }
 }


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->

The current custom deserializer `deserialize_f64` fails to correctly deserialize integers which makes it unable to read object containing `{"upper_limit": 1}`. Still works with `{"upper_limit": 1.0}` but the trailing 0 here needs to be present. Serde default deserializer for f64 supports integer, I believe it should be the same for this custom deserializer. 

## Vector configuration
<!-- Include Vector configuration(s) you used to test and debug your changes. -->

NA

## How did you test this PR?
<!-- Please describe how you tested your changes. Also include any information about your setup. -->

Added unit test 

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Closes: #<issue/PR number or link>
-->
<!--
- Related: #<issue/PR number or link>
-->

## Notes

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details on the [dd-rust-license-tool](https://crates.io/crates/dd-rust-license-tool).


<!--
  Your PR title must conform to the conventional commit spec:
  https://www.conventionalcommits.org/en/v1.0.0/

  <type>(<scope>)!: <description>

  * `type` = chore, enhancement, feat, fix, docs, revert, perf
  * `!` = OPTIONAL: signals a breaking change
  * `scope` = Optional but appreciated; letters, digits, spaces, hyphens, underscores (e.g. `kafka source`, `amazon-linux`)
  * `description` = short description of the change

Examples:

  * enhancement(file source): Add `sort` option to sort discovered files
  * feat(new source): Initial `statsd` source
  * fix(file source): Fix a bug discovering new files
  * chore(external docs): Clarify `batch_size` option
-->
