### PR TITLE
chore(internal docs): git convention to preserve open PR history

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -270,6 +270,18 @@ make build-licenses
 - **Commit messages:** Do NOT include co-authoring information from coding agents (i.e. avoid "Co-Authored-By: Claude" attribution)
 - **Pull requests:** Do NOT add "Generated with Claude Code" or similar footers — keep PR descriptions focused on the technical changes
 
+### Preserve Open Pull Request History
+
+Before rewriting a branch that has been pushed, use `gh` when available to check whether the branch has an open pull request:
+
+```bash
+gh pr list --head "$(git branch --show-current)" --state open --json number,url
+```
+
+If `gh` is unavailable or the check fails, assume an open pull request exists.
+
+When an open pull request exists, never rewrite published commits or force-push the branch. Push additional commits normally to preserve incremental review. The commits will be squashed when the pull request is merged.
+
 ## Creating Pull Requests
 
 Before opening a PR, read [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md) and use it as the reference for the PR body structure and title.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -280,7 +280,7 @@ gh pr list --head "$(git branch --show-current)" --state open --json number,url
 
 If `gh` is unavailable or the check fails, assume an open pull request exists.
 
-When an open pull request exists, never rewrite published commits or force-push the branch. Push additional commits normally to preserve incremental review. The commits will be squashed when the pull request is merged.
+When an open pull request exists, never rewrite published commits or force-push the branch. Push additional commits normally to preserve incremental review.
 
 ## Creating Pull Requests
 


### PR DESCRIPTION
## Summary

Agents need an explicit guard against rewriting branch history once a pull request is open so reviewers can review follow-up changes incrementally.

This adds guidance to `AGENTS.md` that:

- checks for an open pull request with `gh` when available
- assumes an open pull request exists when the check is unavailable or fails
- prohibits rewriting published commits and force-pushing open pull request branches
- directs agents to push follow-up commits normally

## Vector configuration

Not applicable.

## How did you test this PR?

- `git diff --check`
- `make check-markdown`

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

Not applicable.
