### PR TITLE
chore(tests): remove confinement and env-var interpolation escape hatches from tests

### DIFF
--- a/src/sinks/http/tests.rs
+++ b/src/sinks/http/tests.rs
@@ -288,13 +288,12 @@ async fn http_passes_custom_headers() {
 async fn http_passes_template_headers() {
     run_sink_with_events(
         indoc::indoc! {r#"
-        dangerously_allow_unconfined_template_resolution: true
         request:
           headers:
             Static-Header: static-value
             Accept: "application/vnd.api+json"
-            X-Event-Level: "{{level}}"
-            X-Event-Message: "{{message}}"
+            X-Event-Level: "level-{{level}}"
+            X-Event-Message: "message-{{message}}"
             X-Static-Template: constant-value
         "#},
         || {
@@ -329,14 +328,14 @@ async fn http_passes_template_headers() {
             );
 
             assert_eq!(
-                Some("info"),
+                Some("level-info"),
                 parts
                     .headers
                     .get("X-Event-Level")
                     .map(|v| v.to_str().unwrap())
             );
             assert_eq!(
-                Some("templated message"),
+                Some("message-templated message"),
                 parts
                     .headers
                     .get("X-Event-Message")
@@ -351,10 +350,9 @@ async fn http_passes_template_headers() {
 async fn http_template_headers_missing_fields() {
     run_sink_with_events(
         indoc::indoc! {r#"
-        dangerously_allow_unconfined_template_resolution: true
         request:
           headers:
-            X-Required-Field: "{{required_field}}"
+            X-Required-Field: "required-{{required_field}}"
             X-Static: static-value
         "#},
         || {
@@ -367,7 +365,7 @@ async fn http_template_headers_missing_fields() {
         10,
         |parts| {
             assert_eq!(
-                Some("present"),
+                Some("required-present"),
                 parts
                     .headers
                     .get("X-Required-Field")

--- a/src/sinks/loki/integration_tests.rs
+++ b/src/sinks/loki/integration_tests.rs
@@ -390,13 +390,13 @@ async fn interpolate_stream_key() {
 
     let config = format!("endpoint = \"{}\"", loki_address())
         + r#"
-            labels = {"key-{{ stream_key }}" = "placeholder"}
+            labels = {"key_{{ stream_key }}" = "placeholder"}
             encoding.codec = "text"
             tenant_id = "default"
         "#;
     let (mut config, cx) = load_sink::<LokiConfig>(config.as_str()).unwrap();
     config.labels.insert(
-        Template::try_from("key-{{ stream_key }}").unwrap(),
+        Template::try_from("key_{{ stream_key }}").unwrap(),
         Template::try_from(stream.to_string()).unwrap(),
     );
 
@@ -419,7 +419,7 @@ async fn interpolate_stream_key() {
 
     tokio::time::sleep(tokio::time::Duration::new(1, 0)).await;
 
-    let (_, outputs) = fetch_stream_with_key("key-test_name", stream.to_string(), "default").await;
+    let (_, outputs) = fetch_stream_with_key("key_test_name", stream.to_string(), "default").await;
 
     assert_eq!(outputs.len(), lines.len());
 

--- a/src/sinks/loki/integration_tests.rs
+++ b/src/sinks/loki/integration_tests.rs
@@ -330,10 +330,9 @@ async fn many_streams() {
 
     let config = format!("endpoint = \"{}\"", loki_address())
         + r#"
-            labels = {test_name = "{{ stream_id }}"}
+            labels = {test_name = "stream-{{ stream_id }}"}
             encoding.codec = "text"
             tenant_id = "default"
-            dangerously_allow_unconfined_template_resolution = true
         "#;
     let (config, cx) = load_sink::<LokiConfig>(config.as_str()).unwrap();
 
@@ -359,8 +358,8 @@ async fn many_streams() {
 
     tokio::time::sleep(tokio::time::Duration::new(1, 0)).await;
 
-    let (_, outputs1) = fetch_stream(stream1.to_string(), "default").await;
-    let (_, outputs2) = fetch_stream(stream2.to_string(), "default").await;
+    let (_, outputs1) = fetch_stream(format!("stream-{stream1}"), "default").await;
+    let (_, outputs2) = fetch_stream(format!("stream-{stream2}"), "default").await;
 
     assert_eq!(outputs1.len() + outputs2.len(), lines.len());
 
@@ -391,14 +390,13 @@ async fn interpolate_stream_key() {
 
     let config = format!("endpoint = \"{}\"", loki_address())
         + r#"
-            labels = {"{{ stream_key }}" = "placeholder"}
+            labels = {"key-{{ stream_key }}" = "placeholder"}
             encoding.codec = "text"
             tenant_id = "default"
-            dangerously_allow_unconfined_template_resolution = true
         "#;
     let (mut config, cx) = load_sink::<LokiConfig>(config.as_str()).unwrap();
     config.labels.insert(
-        Template::try_from("{{ stream_key }}").unwrap(),
+        Template::try_from("key-{{ stream_key }}").unwrap(),
         Template::try_from(stream.to_string()).unwrap(),
     );
 
@@ -421,7 +419,7 @@ async fn interpolate_stream_key() {
 
     tokio::time::sleep(tokio::time::Duration::new(1, 0)).await;
 
-    let (_, outputs) = fetch_stream(stream.to_string(), "default").await;
+    let (_, outputs) = fetch_stream_with_key("key-test_name", stream.to_string(), "default").await;
 
     assert_eq!(outputs.len(), lines.len());
 
@@ -683,7 +681,11 @@ fn get_timestamp(event: &Event) -> DateTime<Utc> {
 }
 
 async fn fetch_stream(stream: String, tenant: &str) -> (Vec<i64>, Vec<String>) {
-    let query = format!("%7Btest_name%3D\"{stream}\"%7D");
+    fetch_stream_with_key("test_name", stream, tenant).await
+}
+
+async fn fetch_stream_with_key(key: &str, stream: String, tenant: &str) -> (Vec<i64>, Vec<String>) {
+    let query = format!("%7B{key}%3D\"{stream}\"%7D");
     let query = format!(
         "{}/loki/api/v1/query_range?query={}&direction=forward",
         loki_address(),

--- a/src/sinks/loki/tests.rs
+++ b/src/sinks/loki/tests.rs
@@ -21,10 +21,9 @@ async fn interpolate_labels() {
     let (config, cx) = load_sink::<LokiConfig>(
         r#"
         endpoint = "http://localhost:3100"
-        labels = {label1 = "{{ foo }}", label2 = "some-static-label", label3 = "{{ foo }}", "{{ foo }}" = "{{ foo }}"}
+        labels = {label1 = "l1-{{ foo }}", label2 = "some-static-label", label3 = "l3-{{ foo }}", "k-{{ foo }}" = "v-{{ foo }}"}
         encoding.codec = "json"
         remove_label_fields = true
-        dangerously_allow_unconfined_template_resolution = true
     "#,
     )
     .unwrap();
@@ -48,14 +47,20 @@ async fn interpolate_labels() {
 
     assert_eq!(record.event.event, expected_line);
 
-    assert_eq!(record.labels[0], ("bar".to_string(), "bar".to_string()));
-    assert_eq!(record.labels[1], ("label1".to_string(), "bar".to_string()));
+    assert_eq!(record.labels[0], ("k-bar".to_string(), "v-bar".to_string()));
+    assert_eq!(
+        record.labels[1],
+        ("label1".to_string(), "l1-bar".to_string())
+    );
     assert_eq!(
         record.labels[2],
         ("label2".to_string(), "some-static-label".to_string())
     );
     // make sure we can reuse fields across labels.
-    assert_eq!(record.labels[3], ("label3".to_string(), "bar".to_string()));
+    assert_eq!(
+        record.labels[3],
+        ("label3".to_string(), "l3-bar".to_string())
+    );
 }
 
 #[tokio::test]
@@ -63,10 +68,9 @@ async fn use_label_from_dropped_fields() {
     let (config, cx) = load_sink::<LokiConfig>(
         r#"
             endpoint = "http://localhost:3100"
-            labels.bar = "{{ foo }}"
+            labels.bar = "bar-{{ foo }}"
             encoding.codec = "json"
             encoding.except_fields = ["foo"]
-            dangerously_allow_unconfined_template_resolution = true
         "#,
     )
     .unwrap();
@@ -86,7 +90,7 @@ async fn use_label_from_dropped_fields() {
 
     assert_eq!(record.event.event, expected_line);
 
-    assert_eq!(record.labels[0], ("bar".to_string(), "bar".to_string()));
+    assert_eq!(record.labels[0], ("bar".to_string(), "bar-bar".to_string()));
 }
 
 #[tokio::test]
@@ -159,9 +163,8 @@ async fn timestamp_out_of_range() {
     let (config, cx) = load_sink::<LokiConfig>(
         r#"
         endpoint = "http://localhost:3100"
-        labels = {label1 = "{{ foo }}", label2 = "some-static-label", label3 = "{{ foo }}", "{{ foo }}" = "{{ foo }}"}
+        labels = {label1 = "l1-{{ foo }}", label2 = "some-static-label", label3 = "l3-{{ foo }}", "k-{{ foo }}" = "v-{{ foo }}"}
         encoding.codec = "json"
-        dangerously_allow_unconfined_template_resolution = true
     "#,
     )
     .unwrap();
@@ -189,10 +192,9 @@ async fn structured_metadata_as_json() {
         r#"
         endpoint = "http://localhost:3100"
         labels = {test = "structured_metadata"}
-        structured_metadata.bar = "{{ foo }}"
+        structured_metadata.bar = "bar-{{ foo }}"
         encoding.codec = "json"
         encoding.except_fields = ["foo"]
-        dangerously_allow_unconfined_template_resolution = true
         "#,
     )
     .unwrap();
@@ -204,7 +206,7 @@ async fn structured_metadata_as_json() {
 
     let event = sink.encoder.encode_event(e1).unwrap();
     let body = serde_json::json!(event.event);
-    let expected_metadata = serde_json::json!({"bar": "bar"});
+    let expected_metadata = serde_json::json!({"bar": "bar-bar"});
 
     assert_eq!(body[2], expected_metadata);
 }

--- a/tests/e2e/Dockerfile
+++ b/tests/e2e/Dockerfile
@@ -7,6 +7,10 @@ FROM docker.io/rust:${RUST_VERSION}-slim-trixie AS base
 COPY scripts/environment/install-debian-build-deps.sh /
 RUN bash /install-debian-build-deps.sh
 
+# Provide `envsubst` (from gettext-base) so e2e compose services can render
+# config templates with environment-variable substitution at container startup.
+RUN apt-get update && apt-get install -y --no-install-recommends gettext-base && rm -rf /var/lib/apt/lists/*
+
 COPY tests/data/ca/certs /certs
 
 COPY scripts/environment/install-protoc.sh /

--- a/tests/e2e/datadog-metrics/config/compose.yaml
+++ b/tests/e2e/datadog-metrics/config/compose.yaml
@@ -36,16 +36,17 @@ services:
     image: ${CONFIG_VECTOR_IMAGE}
     environment:
       - FEATURES=e2e-tests-datadog
+      # Read by envsubst (below) to render the config template; Vector's own
+      # env-var interpolation stays disabled.
       - CONFIG_SERIES_API_VERSION
-      # The vector.yaml config uses ${CONFIG_SERIES_API_VERSION} interpolation,
-      # which is disabled by default since #25699. Opt back in for the test.
-      - VECTOR_DANGEROUSLY_ALLOW_ENV_VAR_INTERPOLATION=true
     working_dir: /home/vector
     command:
-      - "/usr/bin/vector"
-      - "-vvv"
+      - "sh"
       - "-c"
-      - "/home/vector/tests/e2e/datadog-metrics/data/vector.yaml"
+      # Render the config template with envsubst ($${...} escapes docker-compose
+      # interpolation so the literal ${...} reaches the container), then run
+      # Vector against the rendered file.
+      - "envsubst '$${CONFIG_SERIES_API_VERSION}' < /home/vector/tests/e2e/datadog-metrics/data/vector.yaml > /tmp/vector.yaml && exec /usr/bin/vector -vvv -c /tmp/vector.yaml"
     volumes:
       - ../../../..:/home/vector
 


### PR DESCRIPTION
## Summary

Removes the `dangerously_allow_unconfined_template_resolution` and `VECTOR_DANGEROUSLY_ALLOW_ENV_VAR_INTERPOLATION` escape hatches from Vector's own tests. Tests now use confined templates (with literal prefixes) and the datadog-metrics e2e test renders its config with `envsubst` instead of enabling Vector's env-var interpolation.

## Vector configuration

NA

## How did you test this PR?

- `cargo test` for `sinks::loki::tests` and `sinks::http::tests`
- `cargo check --features loki-integration-tests --test integration`
- `cargo clippy` on changed modules
- Local simulation of the compose `envsubst` command

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

NA
