### PR TITLE
chore(ci): isolate HTTP 1 dependency upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,28 @@ updates:
         update-types:
           - "patch"
 
+      # These dependencies must cross the http 0.2 / hyper 0.14 to
+      # http 1 / hyper 1 boundary together. Tracked in #19179.
+      http-upgrade:
+        applies-to: version-updates
+        patterns:
+          - "axum"
+          - "headers"
+          - "http"
+          - "http-*"
+          - "hyper"
+          - "hyper-*"
+          - "prost"
+          - "prost-*"
+          - "reqwest"
+          - "tokio-tungstenite"
+          - "tonic"
+          - "tonic-*"
+          - "tower-http"
+          - "warp"
+        update-types:
+          - "major"
+
       amq:
         patterns:
           - "amq-*"
@@ -150,6 +172,21 @@ updates:
         applies-to: version-updates
         patterns:
           - "*"
+        exclude-patterns:
+          - "axum"
+          - "headers"
+          - "http"
+          - "http-*"
+          - "hyper"
+          - "hyper-*"
+          - "prost"
+          - "prost-*"
+          - "reqwest"
+          - "tokio-tungstenite"
+          - "tonic"
+          - "tonic-*"
+          - "tower-http"
+          - "warp"
         update-types:
           - "major"
       cargo-security:


### PR DESCRIPTION
## Summary

The catch-all `cargo-major` group currently combines HTTP 1 migration dependencies with unrelated major upgrades. Vector still spans the `http` 0.2 / `hyper` 0.14 and `http` 1 / `hyper` 1 ecosystems, so these dependencies need to move together; keeping them in the general group makes unrelated major-update PRs larger and prevents them from being handled independently.

This adds a major-only `http-upgrade` group for the coordinated HTTP stack, including the `prost` versions required by `tonic`, and explicitly excludes the same dependencies from `cargo-major`. In the current #26005 update set, this separates 15 HTTP migration dependencies from the other 46 major updates. Patch and minor updates continue through their existing groups.

## Vector configuration

N/A — this only changes Dependabot automation.

## How did you test this PR?

- Parsed `.github/dependabot.yml` with Ruby's YAML parser.
- Ran `make check-prettier`.
- Verified the `http-upgrade` and `cargo-major.exclude-patterns` lists are identical.
- Checked the patterns against #26005's 61 dependencies and confirmed that the expected 15 updates move to `http-upgrade`.
- Ran `git diff --check`.

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: #19179
- Related: #25058
- Related: #26005

## Notes

None.
