### PR TITLE
chore(ci): group rkyv dependency upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,14 @@ updates:
       prefix: "chore(deps)"
     open-pull-requests-limit: 100
     groups:
+      # These dependencies share archive validation APIs and must be updated
+      # together, including consideration of disk buffer format compatibility.
+      rkyv-upgrade:
+        applies-to: version-updates
+        patterns:
+          - "bytecheck"
+          - "rkyv"
+
       patches:
         applies-to: version-updates
         patterns:
@@ -38,16 +46,6 @@ updates:
           - "tonic-*"
           - "tower-http"
           - "warp"
-        update-types:
-          - "major"
-
-      # These dependencies share archive validation APIs and must be migrated
-      # together, including consideration of disk buffer format compatibility.
-      rkyv-upgrade:
-        applies-to: version-updates
-        patterns:
-          - "bytecheck"
-          - "rkyv"
         update-types:
           - "major"
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,6 +41,16 @@ updates:
         update-types:
           - "major"
 
+      # These dependencies share archive validation APIs and must be migrated
+      # together, including consideration of disk buffer format compatibility.
+      rkyv-upgrade:
+        applies-to: version-updates
+        patterns:
+          - "bytecheck"
+          - "rkyv"
+        update-types:
+          - "major"
+
       amq:
         patterns:
           - "amq-*"
@@ -174,6 +184,7 @@ updates:
           - "*"
         exclude-patterns:
           - "axum"
+          - "bytecheck"
           - "headers"
           - "http"
           - "http-*"
@@ -182,6 +193,7 @@ updates:
           - "prost"
           - "prost-*"
           - "reqwest"
+          - "rkyv"
           - "tokio-tungstenite"
           - "tonic"
           - "tonic-*"


### PR DESCRIPTION
## Summary

Create a dedicated Dependabot major-version group for `rkyv` and `bytecheck`, and exclude both from the catch-all `cargo-major` group.

These dependencies share archive validation APIs and must be migrated together. In particular, the `rkyv` 0.8 upgrade changes the serialized disk-buffer format, so it needs focused compatibility review rather than being mixed with unrelated major upgrades.

## Vector configuration

Not applicable; this changes Dependabot configuration only.

## How did you test this PR?

- Parsed `.github/dependabot.yml` as YAML.
- Asserted that `rkyv-upgrade` contains exactly `bytecheck` and `rkyv` major updates.
- Asserted that both dependencies are excluded from `cargo-major`.
- Ran `git diff --check`.

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: #26047