### PR TITLE
chore(deps): group all metrics dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -92,14 +92,13 @@ updates:
         update-types:
           - "patch"
           - "minor"
+      # These dependencies share metrics-util layer traits and must be updated
+      # together to avoid incompatible trait implementations across versions.
       metrics:
         patterns:
           - "metrics"
           - "metrics-tracing-context"
           - "metrics-util"
-        update-types:
-          - "patch"
-          - "minor"
       netlink:
         patterns:
           - "netlink-*"
@@ -188,6 +187,9 @@ updates:
           - "http-*"
           - "hyper"
           - "hyper-*"
+          - "metrics"
+          - "metrics-tracing-context"
+          - "metrics-util"
           - "prost"
           - "prost-*"
           - "reqwest"


### PR DESCRIPTION
## Summary

Dependabot currently groups `metrics`, `metrics-tracing-context`, and `metrics-util` only for patch and minor updates. In #26060, the incompatible `metrics-util` update instead fell into the catch-all `cargo-major` group while `metrics-tracing-context` remained on a version using the previous `metrics-util` trait definitions.

This change keeps the metrics crates coordinated for every version level by:

- removing the metrics group's `update-types` restriction
- excluding all three metrics crates from the catch-all `cargo-major` group
- documenting why the crates must be updated together

This prevents Dependabot from producing mixed `metrics-util` versions that make the tracing layer incompatible with Vector's directly imported `Layer` trait.

## Vector configuration

Not applicable; this changes only Dependabot grouping configuration.

## How did you test this PR?

- Parsed `.github/dependabot.yml` with Ruby's YAML parser.
- Asserted that the metrics group contains all three packages without an `update-types` restriction.
- Asserted that `cargo-major` excludes all three metrics packages.
- Ran `git diff --check`.

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: #26060
- Related review: https://github.com/vectordotdev/vector/pull/26060#discussion_r3737002718

## Notes

- The metrics packages are deliberately kept out of `cargo-major` so future incompatible updates cannot be split across groups.