### PR TITLE
fix(codecs): surface oversized-frame discards as errors instead of a silent warn

### DIFF
--- a/changelog.d/character_delimited_silent_drop_metric.fix.md
+++ b/changelog.d/character_delimited_silent_drop_metric.fix.md
@@ -1,0 +1,3 @@
+The `character_delimited` and `newline_delimited` decoding framers now return an error instead of silently logging a `warn!` when discarding a frame that exceeds `max_length`. This surfaces the drop through the standard `component_errors_total` metric (`error_code="decoder_frame"`) so it is observable even when trace-level logs are suppressed, instead of being invisible. The connection is not affected — the offending frame is still discarded and processing continues.
+
+authors: lisaqvu

--- a/lib/codecs/src/decoding/framing/character_delimited.rs
+++ b/lib/codecs/src/decoding/framing/character_delimited.rs
@@ -1,7 +1,7 @@
 use bytes::{Buf, Bytes, BytesMut};
 use memchr::memchr;
-use tokio_util::codec::Decoder;
-use tracing::{trace, warn};
+use tokio_util::codec::{Decoder, LinesCodecError};
+use tracing::trace;
 use vector_config::configurable_component;
 
 use super::BoxedFramingError;
@@ -119,13 +119,14 @@ impl Decoder for CharacterDelimitedDecoder {
                 Some(next_delimiter_idx) => {
                     if next_delimiter_idx > self.max_length {
                         // The discovered sub-buffer is too big, so we discard
-                        // it, taking care to also discard the delimiter.
-                        warn!(
-                            message = "Discarding frame larger than max_length.",
-                            buf_len = buf.len(),
-                            max_length = self.max_length
-                        );
+                        // it, taking care to also discard the delimiter. Report
+                        // this via `Err` rather than only a trace-level log so
+                        // it surfaces through the standard
+                        // `DecoderFramingError`/`component_errors_total` path
+                        // instead of being silently dropped and hidden behind
+                        // log suppression.
                         buf.advance(next_delimiter_idx + 1);
+                        return Err(LinesCodecError::MaxLineLengthExceeded.into());
                     } else {
                         let frame = buf.split_to(next_delimiter_idx).freeze();
                         trace!(
@@ -147,12 +148,8 @@ impl Decoder for CharacterDelimitedDecoder {
                 if buf.is_empty() {
                     Ok(None)
                 } else if buf.len() > self.max_length {
-                    warn!(
-                        message = "Discarding frame larger than max_length.",
-                        buf_len = buf.len(),
-                        max_length = self.max_length
-                    );
-                    Ok(None)
+                    buf.advance(buf.len());
+                    Err(LinesCodecError::MaxLineLengthExceeded.into())
                 } else {
                     let bytes: Bytes = buf.split_to(buf.len()).freeze();
                     Ok(Some(bytes))
@@ -186,10 +183,15 @@ mod tests {
         let mut codec = CharacterDelimitedDecoder::new_with_max_length(b'\n', MAX_LENGTH);
         let buf = &mut BytesMut::new();
 
-        // limit is 6 so it will skip longer lines
+        // limit is 6 so it will skip longer lines, surfacing an `Err` for
+        // each skipped line so the discard is observable via
+        // `DecoderFramingError`/`component_errors_total` rather than only a
+        // suppressible trace-level log.
         buf.put_slice(b"1234567\n123456\n123412314\n123");
 
+        assert!(codec.decode(buf).is_err());
         assert_eq!(codec.decode(buf).unwrap(), Some(Bytes::from("123456")));
+        assert!(codec.decode(buf).is_err());
         assert_eq!(codec.decode(buf).unwrap(), None);
 
         let buf = &mut BytesMut::new();
@@ -197,7 +199,9 @@ mod tests {
         // limit is 6 so it will skip longer lines
         buf.put_slice(b"1234567\n123456\n123412314\n123");
 
+        assert!(codec.decode_eof(buf).is_err());
         assert_eq!(codec.decode_eof(buf).unwrap(), Some(Bytes::from("123456")));
+        assert!(codec.decode_eof(buf).is_err());
         assert_eq!(codec.decode_eof(buf).unwrap(), Some(Bytes::from("123")));
         assert_eq!(codec.decode_eof(buf).unwrap(), None);
     }

--- a/lib/codecs/src/decoding/framing/newline_delimited.rs
+++ b/lib/codecs/src/decoding/framing/newline_delimited.rs
@@ -134,6 +134,7 @@ mod tests {
         let mut decoder = NewlineDelimitedDecoder::new_with_max_length(3);
 
         assert_eq!(decoder.decode(&mut input).unwrap().unwrap(), "foo");
+        assert!(decoder.decode(&mut input).is_err());
         assert_eq!(decoder.decode(&mut input).unwrap().unwrap(), "baz");
         assert_eq!(decoder.decode(&mut input).unwrap(), None);
     }
@@ -165,6 +166,7 @@ mod tests {
         let mut decoder = NewlineDelimitedDecoder::new_with_max_length(3);
 
         assert_eq!(decoder.decode_eof(&mut input).unwrap().unwrap(), "foo");
+        assert!(decoder.decode_eof(&mut input).is_err());
         assert_eq!(decoder.decode_eof(&mut input).unwrap().unwrap(), "baz");
         assert_eq!(decoder.decode_eof(&mut input).unwrap(), None);
     }


### PR DESCRIPTION
## Summary

`CharacterDelimitedDecoder` (used directly, and via `NewlineDelimitedDecoder`) discards frames larger than the configured `max_length`, but only reports this via a bare `tracing::warn!`. Because of this, the discard:

- Is not reflected in the standard `component_errors_total` metric.
- Is invisible whenever trace/warn-level logs are suppressed or not scraped, making the data loss effectively silent from an observability standpoint.

This is inconsistent with the `octet_counting` framer, which already returns an `Err` on an oversized frame and correctly routes through the metric/error pipeline.

## Change

- `character_delimited.rs`: both `decode()` and `decode_eof()` now return `Err(LinesCodecError::MaxLineLengthExceeded.into())` when discarding an oversized frame, instead of only logging a `warn!`.
- This routes through `Decoder::decode`/`decode_eof`'s existing `emit(DecoderFramingError { .. })` call, which both logs at `error!` and increments `component_errors_total` with `error_code="decoder_frame"` — the same path already used by `octet_counting`.
- `LinesCodecError::MaxLineLengthExceeded` is used deliberately rather than a raw `io::Error`: `StreamDecodingError::can_continue()` returns `true` for it (vs. `false` for `io::Error`), so the connection is **not** torn down — the oversized frame is discarded and processing continues with the next frame, preserving existing recovery behavior.
- Also fixes a latent issue in `decode_eof()`'s oversized-frame branch, which never advanced/drained the buffer before returning.

## Test plan

- [x] Updated `character_delimited::tests::decode_max_length` to assert an `Err` is returned at each point an oversized frame is discarded (both `decode()` and `decode_eof()`).
- [x] Updated `newline_delimited::tests::decode_bytes_with_newlines_and_max_length` and `decode_eof_bytes_with_newlines_and_max_length` for the same reason, since `NewlineDelimitedDecoder` wraps `CharacterDelimitedDecoder`.
- [x] `cargo test -p codecs --lib decoding` — 107 passed, 0 failed.
- [x] `cargo test --lib sources::socket::test::tcp_continue_after_long_line` (vector crate) — confirms the TCP source still discards the oversized frame and continues delivering subsequent lines, now with the discard visible as `ERROR codecs::internal_events: Failed framing bytes. error=max line length exceeded error_code="decoder_frame"` instead of a silent warn.