### PR TITLE
fix(config docs): mark required fields explicitly

### DIFF
--- a/lib/codecs/src/encoding/format/cef.rs
+++ b/lib/codecs/src/encoding/format/cef.rs
@@ -232,7 +232,8 @@ pub struct CefSerializerOptions {
     /// The collection of key-value pairs. Keys are the keys of the extensions, and values are paths that point to the extension values of a log event.
     /// The event can have any number of key-value pairs in any order.
     #[configurable(metadata(
-        docs::additional_props_description = "This is a path that points to the extension value of a log event."
+        docs::additional_props_description = "This is a path that points to the extension value of a log event.",
+        docs::required = true,
     ))]
     pub extensions: HashMap<String, ConfigTargetPath>,
     // TODO: use Template instead of ConfigTargetPath.

--- a/src/secrets/exec.rs
+++ b/src/secrets/exec.rs
@@ -26,6 +26,7 @@ pub enum ExecVersion {
         /// The configuration to pass to the secrets executable. This is the `config` field in the
         /// backend request. Refer to the documentation of your `backend_type `to see which options
         /// are required to be set.
+        #[configurable(metadata(docs::required = true))]
         backend_config: Value,
     },
 }

--- a/src/sources/static_metrics.rs
+++ b/src/sources/static_metrics.rs
@@ -73,7 +73,8 @@ pub struct StaticMetricConfig {
 
     /// Key-value pairs representing tags and their values to add to the metric.
     #[configurable(metadata(
-        docs::additional_props_description = "An individual tag - value pair."
+        docs::additional_props_description = "An individual tag - value pair.",
+        docs::required = true,
     ))]
     pub tags: BTreeMap<String, String>,
 }

--- a/website/cue/reference/components/sinks/generated/amqp.cue
+++ b/website/cue/reference/components/sinks/generated/amqp.cue
@@ -121,7 +121,7 @@ generated: components: sinks: amqp: configuration: {
 																The collection of key-value pairs. Keys are the keys of the extensions, and values are paths that point to the extension values of a log event.
 																The event can have any number of key-value pairs in any order.
 																"""
-						required: false
+						required: true
 						type: object: options: "*": {
 							description: "This is a path that points to the extension value of a log event."
 							required:    true

--- a/website/cue/reference/components/sinks/generated/aws_cloudwatch_logs.cue
+++ b/website/cue/reference/components/sinks/generated/aws_cloudwatch_logs.cue
@@ -317,7 +317,7 @@ generated: components: sinks: aws_cloudwatch_logs: configuration: {
 																The collection of key-value pairs. Keys are the keys of the extensions, and values are paths that point to the extension values of a log event.
 																The event can have any number of key-value pairs in any order.
 																"""
-						required: false
+						required: true
 						type: object: options: "*": {
 							description: "This is a path that points to the extension value of a log event."
 							required:    true

--- a/website/cue/reference/components/sinks/generated/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sinks/generated/aws_kinesis_firehose.cue
@@ -280,7 +280,7 @@ generated: components: sinks: aws_kinesis_firehose: configuration: {
 																The collection of key-value pairs. Keys are the keys of the extensions, and values are paths that point to the extension values of a log event.
 																The event can have any number of key-value pairs in any order.
 																"""
-						required: false
+						required: true
 						type: object: options: "*": {
 							description: "This is a path that points to the extension value of a log event."
 							required:    true

--- a/website/cue/reference/components/sinks/generated/aws_kinesis_streams.cue
+++ b/website/cue/reference/components/sinks/generated/aws_kinesis_streams.cue
@@ -280,7 +280,7 @@ generated: components: sinks: aws_kinesis_streams: configuration: {
 																The collection of key-value pairs. Keys are the keys of the extensions, and values are paths that point to the extension values of a log event.
 																The event can have any number of key-value pairs in any order.
 																"""
-						required: false
+						required: true
 						type: object: options: "*": {
 							description: "This is a path that points to the extension value of a log event."
 							required:    true

--- a/website/cue/reference/components/sinks/generated/aws_s3.cue
+++ b/website/cue/reference/components/sinks/generated/aws_s3.cue
@@ -478,7 +478,7 @@ generated: components: sinks: aws_s3: configuration: {
 																The collection of key-value pairs. Keys are the keys of the extensions, and values are paths that point to the extension values of a log event.
 																The event can have any number of key-value pairs in any order.
 																"""
-						required: false
+						required: true
 						type: object: options: "*": {
 							description: "This is a path that points to the extension value of a log event."
 							required:    true

--- a/website/cue/reference/components/sinks/generated/aws_sns.cue
+++ b/website/cue/reference/components/sinks/generated/aws_sns.cue
@@ -211,7 +211,7 @@ generated: components: sinks: aws_sns: configuration: {
 																The collection of key-value pairs. Keys are the keys of the extensions, and values are paths that point to the extension values of a log event.
 																The event can have any number of key-value pairs in any order.
 																"""
-						required: false
+						required: true
 						type: object: options: "*": {
 							description: "This is a path that points to the extension value of a log event."
 							required:    true

--- a/website/cue/reference/components/sinks/generated/aws_sqs.cue
+++ b/website/cue/reference/components/sinks/generated/aws_sqs.cue
@@ -211,7 +211,7 @@ generated: components: sinks: aws_sqs: configuration: {
 																The collection of key-value pairs. Keys are the keys of the extensions, and values are paths that point to the extension values of a log event.
 																The event can have any number of key-value pairs in any order.
 																"""
-						required: false
+						required: true
 						type: object: options: "*": {
 							description: "This is a path that points to the extension value of a log event."
 							required:    true

--- a/website/cue/reference/components/sinks/generated/azure_blob.cue
+++ b/website/cue/reference/components/sinks/generated/azure_blob.cue
@@ -394,7 +394,7 @@ generated: components: sinks: azure_blob: configuration: {
 																The collection of key-value pairs. Keys are the keys of the extensions, and values are paths that point to the extension values of a log event.
 																The event can have any number of key-value pairs in any order.
 																"""
-						required: false
+						required: true
 						type: object: options: "*": {
 							description: "This is a path that points to the extension value of a log event."
 							required:    true

--- a/website/cue/reference/components/sinks/generated/console.cue
+++ b/website/cue/reference/components/sinks/generated/console.cue
@@ -89,7 +89,7 @@ generated: components: sinks: console: configuration: {
 																The collection of key-value pairs. Keys are the keys of the extensions, and values are paths that point to the extension values of a log event.
 																The event can have any number of key-value pairs in any order.
 																"""
-						required: false
+						required: true
 						type: object: options: "*": {
 							description: "This is a path that points to the extension value of a log event."
 							required:    true

--- a/website/cue/reference/components/sinks/generated/doris.cue
+++ b/website/cue/reference/components/sinks/generated/doris.cue
@@ -381,7 +381,7 @@ generated: components: sinks: doris: configuration: {
 																The collection of key-value pairs. Keys are the keys of the extensions, and values are paths that point to the extension values of a log event.
 																The event can have any number of key-value pairs in any order.
 																"""
-						required: false
+						required: true
 						type: object: options: "*": {
 							description: "This is a path that points to the extension value of a log event."
 							required:    true

--- a/website/cue/reference/components/sinks/generated/file.cue
+++ b/website/cue/reference/components/sinks/generated/file.cue
@@ -139,7 +139,7 @@ generated: components: sinks: file: configuration: {
 																The collection of key-value pairs. Keys are the keys of the extensions, and values are paths that point to the extension values of a log event.
 																The event can have any number of key-value pairs in any order.
 																"""
-						required: false
+						required: true
 						type: object: options: "*": {
 							description: "This is a path that points to the extension value of a log event."
 							required:    true

--- a/website/cue/reference/components/sinks/generated/gcp_chronicle_unstructured.cue
+++ b/website/cue/reference/components/sinks/generated/gcp_chronicle_unstructured.cue
@@ -177,7 +177,7 @@ generated: components: sinks: gcp_chronicle_unstructured: configuration: {
 																The collection of key-value pairs. Keys are the keys of the extensions, and values are paths that point to the extension values of a log event.
 																The event can have any number of key-value pairs in any order.
 																"""
-						required: false
+						required: true
 						type: object: options: "*": {
 							description: "This is a path that points to the extension value of a log event."
 							required:    true

--- a/website/cue/reference/components/sinks/generated/gcp_cloud_storage.cue
+++ b/website/cue/reference/components/sinks/generated/gcp_cloud_storage.cue
@@ -297,7 +297,7 @@ generated: components: sinks: gcp_cloud_storage: configuration: {
 																The collection of key-value pairs. Keys are the keys of the extensions, and values are paths that point to the extension values of a log event.
 																The event can have any number of key-value pairs in any order.
 																"""
-						required: false
+						required: true
 						type: object: options: "*": {
 							description: "This is a path that points to the extension value of a log event."
 							required:    true

--- a/website/cue/reference/components/sinks/generated/gcp_pubsub.cue
+++ b/website/cue/reference/components/sinks/generated/gcp_pubsub.cue
@@ -156,7 +156,7 @@ generated: components: sinks: gcp_pubsub: configuration: {
 																The collection of key-value pairs. Keys are the keys of the extensions, and values are paths that point to the extension values of a log event.
 																The event can have any number of key-value pairs in any order.
 																"""
-						required: false
+						required: true
 						type: object: options: "*": {
 							description: "This is a path that points to the extension value of a log event."
 							required:    true

--- a/website/cue/reference/components/sinks/generated/http.cue
+++ b/website/cue/reference/components/sinks/generated/http.cue
@@ -355,7 +355,7 @@ generated: components: sinks: http: configuration: {
 																The collection of key-value pairs. Keys are the keys of the extensions, and values are paths that point to the extension values of a log event.
 																The event can have any number of key-value pairs in any order.
 																"""
-						required: false
+						required: true
 						type: object: options: "*": {
 							description: "This is a path that points to the extension value of a log event."
 							required:    true

--- a/website/cue/reference/components/sinks/generated/humio_logs.cue
+++ b/website/cue/reference/components/sinks/generated/humio_logs.cue
@@ -171,7 +171,7 @@ generated: components: sinks: humio_logs: configuration: {
 																The collection of key-value pairs. Keys are the keys of the extensions, and values are paths that point to the extension values of a log event.
 																The event can have any number of key-value pairs in any order.
 																"""
-						required: false
+						required: true
 						type: object: options: "*": {
 							description: "This is a path that points to the extension value of a log event."
 							required:    true

--- a/website/cue/reference/components/sinks/generated/kafka.cue
+++ b/website/cue/reference/components/sinks/generated/kafka.cue
@@ -160,7 +160,7 @@ generated: components: sinks: kafka: configuration: {
 																The collection of key-value pairs. Keys are the keys of the extensions, and values are paths that point to the extension values of a log event.
 																The event can have any number of key-value pairs in any order.
 																"""
-						required: false
+						required: true
 						type: object: options: "*": {
 							description: "This is a path that points to the extension value of a log event."
 							required:    true

--- a/website/cue/reference/components/sinks/generated/loki.cue
+++ b/website/cue/reference/components/sinks/generated/loki.cue
@@ -357,7 +357,7 @@ generated: components: sinks: loki: configuration: {
 																The collection of key-value pairs. Keys are the keys of the extensions, and values are paths that point to the extension values of a log event.
 																The event can have any number of key-value pairs in any order.
 																"""
-						required: false
+						required: true
 						type: object: options: "*": {
 							description: "This is a path that points to the extension value of a log event."
 							required:    true

--- a/website/cue/reference/components/sinks/generated/mqtt.cue
+++ b/website/cue/reference/components/sinks/generated/mqtt.cue
@@ -115,7 +115,7 @@ generated: components: sinks: mqtt: configuration: {
 																The collection of key-value pairs. Keys are the keys of the extensions, and values are paths that point to the extension values of a log event.
 																The event can have any number of key-value pairs in any order.
 																"""
-						required: false
+						required: true
 						type: object: options: "*": {
 							description: "This is a path that points to the extension value of a log event."
 							required:    true

--- a/website/cue/reference/components/sinks/generated/nats.cue
+++ b/website/cue/reference/components/sinks/generated/nats.cue
@@ -205,7 +205,7 @@ generated: components: sinks: nats: configuration: {
 																The collection of key-value pairs. Keys are the keys of the extensions, and values are paths that point to the extension values of a log event.
 																The event can have any number of key-value pairs in any order.
 																"""
-						required: false
+						required: true
 						type: object: options: "*": {
 							description: "This is a path that points to the extension value of a log event."
 							required:    true

--- a/website/cue/reference/components/sinks/generated/opentelemetry.cue
+++ b/website/cue/reference/components/sinks/generated/opentelemetry.cue
@@ -358,7 +358,7 @@ generated: components: sinks: opentelemetry: configuration: protocol: {
 																				The collection of key-value pairs. Keys are the keys of the extensions, and values are paths that point to the extension values of a log event.
 																				The event can have any number of key-value pairs in any order.
 																				"""
-							required: false
+							required: true
 							type: object: options: "*": {
 								description: "This is a path that points to the extension value of a log event."
 								required:    true

--- a/website/cue/reference/components/sinks/generated/papertrail.cue
+++ b/website/cue/reference/components/sinks/generated/papertrail.cue
@@ -89,7 +89,7 @@ generated: components: sinks: papertrail: configuration: {
 																The collection of key-value pairs. Keys are the keys of the extensions, and values are paths that point to the extension values of a log event.
 																The event can have any number of key-value pairs in any order.
 																"""
-						required: false
+						required: true
 						type: object: options: "*": {
 							description: "This is a path that points to the extension value of a log event."
 							required:    true

--- a/website/cue/reference/components/sinks/generated/pulsar.cue
+++ b/website/cue/reference/components/sinks/generated/pulsar.cue
@@ -239,7 +239,7 @@ generated: components: sinks: pulsar: configuration: {
 																The collection of key-value pairs. Keys are the keys of the extensions, and values are paths that point to the extension values of a log event.
 																The event can have any number of key-value pairs in any order.
 																"""
-						required: false
+						required: true
 						type: object: options: "*": {
 							description: "This is a path that points to the extension value of a log event."
 							required:    true

--- a/website/cue/reference/components/sinks/generated/redis.cue
+++ b/website/cue/reference/components/sinks/generated/redis.cue
@@ -164,7 +164,7 @@ generated: components: sinks: redis: configuration: {
 																The collection of key-value pairs. Keys are the keys of the extensions, and values are paths that point to the extension values of a log event.
 																The event can have any number of key-value pairs in any order.
 																"""
-						required: false
+						required: true
 						type: object: options: "*": {
 							description: "This is a path that points to the extension value of a log event."
 							required:    true

--- a/website/cue/reference/components/sinks/generated/socket.cue
+++ b/website/cue/reference/components/sinks/generated/socket.cue
@@ -101,7 +101,7 @@ generated: components: sinks: socket: configuration: {
 																The collection of key-value pairs. Keys are the keys of the extensions, and values are paths that point to the extension values of a log event.
 																The event can have any number of key-value pairs in any order.
 																"""
-						required: false
+						required: true
 						type: object: options: "*": {
 							description: "This is a path that points to the extension value of a log event."
 							required:    true

--- a/website/cue/reference/components/sinks/generated/splunk_hec_logs.cue
+++ b/website/cue/reference/components/sinks/generated/splunk_hec_logs.cue
@@ -221,7 +221,7 @@ generated: components: sinks: splunk_hec_logs: configuration: {
 																The collection of key-value pairs. Keys are the keys of the extensions, and values are paths that point to the extension values of a log event.
 																The event can have any number of key-value pairs in any order.
 																"""
-						required: false
+						required: true
 						type: object: options: "*": {
 							description: "This is a path that points to the extension value of a log event."
 							required:    true

--- a/website/cue/reference/components/sinks/generated/webhdfs.cue
+++ b/website/cue/reference/components/sinks/generated/webhdfs.cue
@@ -171,7 +171,7 @@ generated: components: sinks: webhdfs: configuration: {
 																The collection of key-value pairs. Keys are the keys of the extensions, and values are paths that point to the extension values of a log event.
 																The event can have any number of key-value pairs in any order.
 																"""
-						required: false
+						required: true
 						type: object: options: "*": {
 							description: "This is a path that points to the extension value of a log event."
 							required:    true

--- a/website/cue/reference/components/sinks/generated/websocket.cue
+++ b/website/cue/reference/components/sinks/generated/websocket.cue
@@ -268,7 +268,7 @@ generated: components: sinks: websocket: configuration: {
 																The collection of key-value pairs. Keys are the keys of the extensions, and values are paths that point to the extension values of a log event.
 																The event can have any number of key-value pairs in any order.
 																"""
-						required: false
+						required: true
 						type: object: options: "*": {
 							description: "This is a path that points to the extension value of a log event."
 							required:    true

--- a/website/cue/reference/components/sinks/generated/websocket_server.cue
+++ b/website/cue/reference/components/sinks/generated/websocket_server.cue
@@ -145,7 +145,7 @@ generated: components: sinks: websocket_server: configuration: {
 																The collection of key-value pairs. Keys are the keys of the extensions, and values are paths that point to the extension values of a log event.
 																The event can have any number of key-value pairs in any order.
 																"""
-						required: false
+						required: true
 						type: object: options: "*": {
 							description: "This is a path that points to the extension value of a log event."
 							required:    true

--- a/website/cue/reference/components/sources/generated/static_metrics.cue
+++ b/website/cue/reference/components/sources/generated/static_metrics.cue
@@ -30,7 +30,7 @@ generated: components: sources: static_metrics: configuration: {
 				}
 				tags: {
 					description: "Key-value pairs representing tags and their values to add to the metric."
-					required:    false
+					required:    true
 					type: object: options: "*": {
 						description: "An individual tag - value pair."
 						required:    true

--- a/website/cue/reference/generated/configuration.cue
+++ b/website/cue/reference/generated/configuration.cue
@@ -719,7 +719,7 @@ generated: configuration: {
 																		backend request. Refer to the documentation of your `backend_type `to see which options
 																		are required to be set.
 																		"""
-								required:      false
+								required:      true
 								relevant_when: "version = \"v1_1\""
 							}
 							backend_type: {


### PR DESCRIPTION
## Summary

Correct requiredness in generated configuration-reference docs for three fields.

## Motivation

These fields are required only after their containing configuration section or variant is selected, but their generic schema types do not express that relationship.

## Changes

- Mark CEF `extensions` as required when CEF encoding options are configured.
- Mark `static_metrics.metrics[].tags` as required for each metric entry.
- Mark exec-secret v1.1 `backend_config` as required.
- Regenerate the affected CUE reference files.

## Vector configuration

No configuration syntax or runtime deserialization behavior changes.

An empty CEF extension map remains valid, but it must be present when CEF options are used:

```yaml
encoding:
  codec: cef
  cef:
    extensions: {}
```

Likewise, `tags` is required only for a configured static-metric item, and `backend_config` only for exec-secret version `v1_1`.

## How did you test this PR?

- `make check-fmt`
- `make check-clippy`
- `make check-generated-docs`

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- None.

## Notes

- CEF options are embedded by 29 sink references, so the one CEF annotation updates each corresponding generated page.
