### PR TITLE
chore(releasing): remove commits from release CUE generation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,6 @@ Vector team member will find this document useful.
   - [Git Commits](#git-commits)
     - [Style](#style)
   - [GitHub Pull Requests](#github-pull-requests)
-    - [Title](#title)
     - [Reviews & Approvals](#reviews--approvals)
     - [Merge Style](#merge-style)
   - [CI](#ci)

--- a/docs/DOCUMENTING.md
+++ b/docs/DOCUMENTING.md
@@ -151,8 +151,10 @@ Contributors document user-facing changes by adding a fragment under
 [`changelog.d/`](../changelog.d/README.md); the release CUE file's user-facing
 changelog section is assembled from those fragments by `cargo vdev release
 prepare` during release prep. The CUE file's `commits:` array is populated
-from the git log via [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)
-titles, so PR titles must follow that spec.
+from the git log. Titles can follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)
+schema (`<type>[optional scope]: <description>`); if they do, the type is
+extracted and recorded in the entry's `type` field, otherwise the entry is
+included without a `type` field.
 
 ### Release highlights
 

--- a/docs/DOCUMENTING.md
+++ b/docs/DOCUMENTING.md
@@ -150,9 +150,7 @@ watchexec "make check-docs"
 Contributors document user-facing changes by adding a fragment under
 [`changelog.d/`](../changelog.d/README.md); the release CUE file's user-facing
 changelog section is assembled from those fragments by `cargo vdev release
-prepare` during release prep. The CUE file's `commits:` array is populated
-from the git log. Titles can follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)
-schema (`<type>[optional scope]: <description>`).
+prepare` during release prep.
 
 ### Release highlights
 

--- a/docs/DOCUMENTING.md
+++ b/docs/DOCUMENTING.md
@@ -152,9 +152,7 @@ Contributors document user-facing changes by adding a fragment under
 changelog section is assembled from those fragments by `cargo vdev release
 prepare` during release prep. The CUE file's `commits:` array is populated
 from the git log. Titles can follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/)
-schema (`<type>[optional scope]: <description>`); if they do, the type is
-extracted and recorded in the entry's `type` field, otherwise the entry is
-included without a `type` field.
+schema (`<type>[optional scope]: <description>`).
 
 ### Release highlights
 

--- a/vdev/src/commands/release/generate_cue.rs
+++ b/vdev/src/commands/release/generate_cue.rs
@@ -8,7 +8,6 @@ use std::{
 
 use anyhow::{Context, Result, anyhow, bail};
 use chrono::Utc;
-use regex::Regex;
 use semver::Version;
 use serde_json::json;
 
@@ -50,7 +49,6 @@ pub(super) fn run(new_version: &Version) -> Result<PathBuf> {
     info!("Creating release meta file...");
 
     let last_version = git::latest_release_version()?;
-    let commits = fetch_commits_since(&last_version)?;
 
     validate_single_bump(&last_version, new_version)?;
     let new_version = new_version.clone();
@@ -88,32 +86,13 @@ pub(super) fn run(new_version: &Version) -> Result<PathBuf> {
     // write it — so a manually-authored upgrade guide doesn't block a release with no
     // breaking fragments.
 
-    // Drop any commits that have already been recorded in a previous
-    // release CUE file. `--cherry-pick --right-only` only catches
-    // patch-id-equivalent commits, so non-identical backports of the same
-    // change (different SHA, same PR number) can otherwise re-appear in the
-    // next release CUE.
-    let already_released = collect_released_identifiers(&repo_root.join(RELEASES_DIR))?;
-    let commits: Vec<Commit> = commits
-        .into_iter()
-        .filter(|c| {
-            !already_released.shas.contains(&c.sha)
-                && c.pr_number
-                    .is_none_or(|pr| !already_released.pr_numbers.contains(&pr))
-        })
-        .collect();
-
-    if commits.is_empty() {
-        bail!("No commits found since v{last_version}; nothing to release.");
-    }
-
     let changelog_dir = repo_root.join(CHANGELOG_DIR);
     let changelog_entries = read_changelog_fragments(&changelog_dir)?;
 
     // Validate + render everything IN MEMORY before touching disk, so a validation
     // failure doesn't leave a partial CUE file behind (which would then trip the
     // "file already exists" guard on the next run).
-    let cue_text = render_release_cue(&new_version, &changelog_entries, &commits);
+    let cue_text = render_release_cue(&new_version, &changelog_entries);
     let breaking: Vec<&BreakingDetails> = changelog_entries
         .iter()
         .filter_map(|e| e.breaking_details.as_ref())
@@ -268,49 +247,6 @@ pub(super) fn write_release_stub(repo_root: &Path, version: &Version) -> Result<
 
 // ---------- Tag / version discovery ----------
 
-/// Set of commit identifiers already recorded in `website/cue/reference/releases/*.cue`.
-struct ReleasedIdentifiers {
-    shas: std::collections::HashSet<String>,
-    pr_numbers: std::collections::HashSet<u64>,
-}
-
-/// Scan every existing release CUE file for the `sha:` and `pr_number:`
-/// fields inside its `commits:` array and return the union as two sets.
-///
-/// We extract via simple regexes rather than running `cue export`. The shape
-/// of these files is well-defined (auto-generated and `cue fmt`-normalised
-/// against `urls.cue`) so this is the cheapest correct option, and avoids a
-/// runtime dependency on the `cue` binary just for de-duplication.
-fn collect_released_identifiers(releases_dir: &Path) -> Result<ReleasedIdentifiers> {
-    let mut out = ReleasedIdentifiers {
-        shas: std::collections::HashSet::new(),
-        pr_numbers: std::collections::HashSet::new(),
-    };
-    if !releases_dir.is_dir() {
-        return Ok(out);
-    }
-    let sha_re = Regex::new(r#"sha:[ \t]*"([0-9a-fA-F]{7,64})""#).unwrap();
-    let pr_re = Regex::new(r"pr_number:[ \t]*([0-9]+)").unwrap();
-    for entry in fs::read_dir(releases_dir)? {
-        let entry = entry?;
-        let path = entry.path();
-        if path.extension().is_none_or(|e| e != "cue") {
-            continue;
-        }
-        let text = fs::read_to_string(&path)
-            .with_context(|| format!("Failed to read {}", path.display()))?;
-        for caps in sha_re.captures_iter(&text) {
-            out.shas.insert(caps[1].to_string());
-        }
-        for caps in pr_re.captures_iter(&text) {
-            if let Ok(n) = caps[1].parse::<u64>() {
-                out.pr_numbers.insert(n);
-            }
-        }
-    }
-    Ok(out)
-}
-
 fn validate_single_bump(last: &Version, new: &Version) -> Result<()> {
     if bump_type(last, new).is_none() {
         bail!(
@@ -340,196 +276,6 @@ fn bump_type(last: &Version, new: &Version) -> Option<&'static str> {
         Some("major")
     } else {
         None
-    }
-}
-
-// ---------- Commit fetching / parsing ----------
-
-#[derive(Debug, Clone)]
-struct Commit {
-    sha: String,
-    author: String,
-    date: String,
-    description: String,
-    r#type: Option<String>,
-    breaking_change: bool,
-    pr_number: Option<u64>,
-    files_count: u64,
-    insertions_count: u64,
-    deletions_count: u64,
-}
-
-impl Commit {
-    fn render_cue(&self) -> String {
-        let pr_number = match self.pr_number {
-            Some(n) => n.to_string(),
-            None => "null".to_string(),
-        };
-        let type_field = match self.r#type.as_deref() {
-            Some(t) => format!("type: {}, ", json!(t)),
-            None => String::new(),
-        };
-        format!(
-            "{{sha: {sha}, date: {date}, description: {description}, pr_number: {pr_number}, {type_field}breaking_change: {breaking}, author: {author}, files_count: {files}, insertions_count: {ins}, deletions_count: {del}}}",
-            sha = json!(self.sha),
-            date = json!(self.date),
-            description = json!(self.description),
-            type_field = type_field,
-            breaking = self.breaking_change,
-            author = json!(self.author),
-            files = self.files_count,
-            ins = self.insertions_count,
-            del = self.deletions_count,
-        )
-    }
-}
-
-fn fetch_commits_since(last_version: &Version) -> Result<Vec<Commit>> {
-    // Use the three-dot symmetric-difference range so `--cherry-pick`
-    // / `--right-only` filter out commits already released on the previous
-    // tag's branch (matches the Ruby `v#{last_version}...` form).
-    let range = format!("v{last_version}...");
-    let log_output = git::run_and_check_output(&[
-        "log",
-        &range,
-        "--cherry-pick",
-        "--right-only",
-        "--no-merges",
-        "--pretty=format:%H\t%s\t%aN\t%aI",
-    ])?;
-
-    let mut commits: Vec<Commit> = Vec::new();
-    for line in log_output.lines().rev() {
-        let parts: Vec<&str> = line.splitn(4, '\t').collect();
-        if parts.len() != 4 {
-            warn!("Skipping unparsable git log line: {line}");
-            continue;
-        }
-        let sha = parts[0].to_string();
-        let message = parts[1];
-        let author = parts[2].to_string();
-        let date = format_commit_date(parts[3]);
-        let conv = ConventionalParts::parse(message);
-        let (files, ins, del) = commit_stats(&sha)?;
-
-        commits.push(Commit {
-            sha,
-            author,
-            date,
-            description: conv.description,
-            r#type: conv.r#type,
-            breaking_change: conv.breaking_change,
-            pr_number: conv.pr_number,
-            files_count: files,
-            insertions_count: ins,
-            deletions_count: del,
-        });
-    }
-    Ok(commits)
-}
-
-/// Convert an ISO-8601 commit date (`%aI`) to the "YYYY-MM-DD HH:MM:SS UTC" form
-/// used in existing release CUE files.
-fn format_commit_date(iso: &str) -> String {
-    chrono::DateTime::parse_from_rfc3339(iso).map_or_else(
-        |_| iso.to_string(),
-        |dt| {
-            dt.with_timezone(&Utc)
-                .format("%Y-%m-%d %H:%M:%S UTC")
-                .to_string()
-        },
-    )
-}
-
-/// Returns `(files_changed, insertions, deletions)` from `git show --shortstat`.
-fn commit_stats(sha: &str) -> Result<(u64, u64, u64)> {
-    let out = git::run_and_check_output(&["show", "--shortstat", "--oneline", sha])?;
-    let stats_line = out.lines().last().unwrap_or("");
-    if !stats_line.contains("file") {
-        return Ok((0, 0, 0));
-    }
-    let mut files = 0u64;
-    let mut ins = 0u64;
-    let mut del = 0u64;
-    for part in stats_line.split(',') {
-        let part = part.trim();
-        let count: u64 = part
-            .split_whitespace()
-            .next()
-            .and_then(|n| n.parse().ok())
-            .unwrap_or(0);
-        if part.contains("insertion") {
-            ins = count;
-        } else if part.contains("deletion") {
-            del = count;
-        } else if part.contains("file") {
-            files = count;
-        }
-    }
-    Ok((files, ins, del))
-}
-
-#[derive(Debug)]
-struct ConventionalParts {
-    r#type: Option<String>,
-    breaking_change: bool,
-    description: String,
-    pr_number: Option<u64>,
-}
-
-impl ConventionalParts {
-    fn parse(message: &str) -> Self {
-        let re = Regex::new(
-            r"^(?P<type>[a-z]*)(\([a-zA-Z0-9_, -]*\))?(?P<breaking>!)?: (?P<desc>.*?)( \(#(?P<pr>[0-9]+)\))?$",
-        )
-        .unwrap();
-
-        if let Some(caps) = re.captures(message) {
-            let r#type = caps
-                .name("type")
-                .map(|m| m.as_str().to_string())
-                .filter(|s| !s.is_empty());
-            let breaking_change = caps.name("breaking").is_some();
-            let description = caps
-                .name("desc")
-                .map(|m| m.as_str().to_string())
-                .unwrap_or_default();
-            let pr_number = caps.name("pr").and_then(|m| m.as_str().parse::<u64>().ok());
-            ConventionalParts {
-                r#type,
-                breaking_change,
-                description,
-                pr_number,
-            }
-        } else {
-            // Non-conventional subject (e.g. "Update release docs (#123)"):
-            // still extract a trailing PR reference so backport suppression by
-            // PR number keeps working for these commits.
-            let (description, pr_number) = parse_trailing_pr_number(message);
-            ConventionalParts {
-                r#type: None,
-                breaking_change: false,
-                description,
-                pr_number,
-            }
-        }
-    }
-}
-
-/// Extract a trailing ` (#123)` PR reference from a non-conventional subject,
-/// stripping it from the description (mirroring how the conventional branch
-/// drops the ` (#123)` suffix from `desc`).
-fn parse_trailing_pr_number(message: &str) -> (String, Option<u64>) {
-    let re = Regex::new(r"^(?P<desc>.*?) \(#(?P<pr>[0-9]+)\)$").unwrap();
-    if let Some(caps) = re.captures(message) {
-        let description = caps
-            .name("desc")
-            .map(|m| m.as_str().trim().to_string())
-            .unwrap_or_default();
-        let pr_number = caps.name("pr").and_then(|m| m.as_str().parse::<u64>().ok());
-        (description, pr_number)
-    } else {
-        (message.to_string(), None)
     }
 }
 
@@ -698,18 +444,9 @@ fn retire_changelog_fragments(dir: &Path) -> Result<()> {
 
 // ---------- CUE rendering ----------
 
-fn render_release_cue(
-    version: &Version,
-    changelog: &[ChangelogEntry],
-    commits: &[Commit],
-) -> String {
+fn render_release_cue(version: &Version, changelog: &[ChangelogEntry]) -> String {
     let date = Utc::now().format("%Y-%m-%d").to_string();
     let changelog_block = render_changelog(changelog);
-    let commits_block = commits
-        .iter()
-        .map(Commit::render_cue)
-        .collect::<Vec<_>>()
-        .join(",\n    ");
 
     indoc::formatdoc! {"
         package metadata
@@ -721,10 +458,6 @@ fn render_release_cue(
 
         \tchangelog: [
         {changelog_block}
-        \t]
-
-        \tcommits: [
-            {commits_block}
         \t]
         }}
     "}
@@ -876,66 +609,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn parse_conventional_basic() {
-        let p = ConventionalParts::parse("feat(kafka source): add new metric (#123)");
-        assert_eq!(p.r#type.as_deref(), Some("feat"));
-        assert!(!p.breaking_change);
-        assert_eq!(p.description, "add new metric");
-        assert_eq!(p.pr_number, Some(123));
-    }
-
-    #[test]
-    fn parse_conventional_breaking() {
-        let p = ConventionalParts::parse("feat(api)!: drop legacy endpoint (#9)");
-        assert_eq!(p.r#type.as_deref(), Some("feat"));
-        assert!(p.breaking_change);
-        assert_eq!(p.description, "drop legacy endpoint");
-        assert_eq!(p.pr_number, Some(9));
-    }
-
-    #[test]
-    fn parse_conventional_with_scope() {
-        // Scopes are accepted in the commit subject but no longer stored.
-        let p = ConventionalParts::parse("fix(ARC): tweak retry policy (#456)");
-        assert_eq!(p.r#type.as_deref(), Some("fix"));
-        assert_eq!(p.description, "tweak retry policy");
-        assert_eq!(p.pr_number, Some(456));
-    }
-
-    #[test]
-    fn scoped_subject_parses() {
-        // Scoped conventional subjects must parse cleanly after the scope drop.
-        let subjects = [
-            "feat(kafka source): add new metric (#123)",
-            "fix(loki sink): handle empty labels (#9)",
-            "chore(deps): bump tokio (#1)",
-            "enhancement(api, config): tweak schema (#42)",
-        ];
-        for subject in subjects {
-            let p = ConventionalParts::parse(subject);
-            assert!(p.r#type.is_some(), "parse failed for: {subject}");
-        }
-    }
-
-    #[test]
-    fn parse_conventional_unparsable_fallthrough() {
-        let p = ConventionalParts::parse("Merge branch 'foo'");
-        assert!(p.r#type.is_none());
-        assert_eq!(p.description, "Merge branch 'foo'");
-        assert_eq!(p.pr_number, None);
-    }
-
-    #[test]
-    fn parse_non_conventional_with_pr_number() {
-        // Non-conventional subjects (now allowed) should still preserve a
-        // trailing PR reference so backport suppression by PR number works.
-        let p = ConventionalParts::parse("Update release docs (#123)");
-        assert!(p.r#type.is_none());
-        assert_eq!(p.description, "Update release docs");
-        assert_eq!(p.pr_number, Some(123));
-    }
-
-    #[test]
     fn bump_type_patch_minor_major() {
         let last = Version::new(1, 2, 3);
         assert_eq!(bump_type(&last, &Version::new(1, 2, 4)), Some("patch"));
@@ -1042,20 +715,7 @@ mod tests {
                 breaking_details: None,
             },
         ];
-        let commits = vec![Commit {
-            sha: "abc123".into(),
-            author: "Pavlos".into(),
-            date: "2026-05-06 12:00:00 UTC".into(),
-            description: "do stuff".into(),
-            r#type: Some("feat".into()),
-            breaking_change: false,
-            pr_number: Some(42),
-            files_count: 1,
-            insertions_count: 2,
-            deletions_count: 3,
-        }];
-
-        let out = render_release_cue(&Version::new(0, 99, 0), &entries, &commits);
+        let out = render_release_cue(&Version::new(0, 99, 0), &entries);
 
         assert!(out.starts_with("package metadata\n"));
         assert!(out.contains("releases: \"0.99.0\":"));
@@ -1065,74 +725,7 @@ mod tests {
         assert!(out.contains("\t\t\t\tMulti-line.\n"));
         assert!(out.contains("contributors: [\"alice\"]"));
         assert!(out.contains("\t\t\ttype: \"fix\"\n"));
-        assert!(out.contains("sha: \"abc123\""));
-        assert!(!out.contains("scopes:"));
-        assert!(out.contains("pr_number: 42"));
-        assert!(out.contains("files_count: 1"));
-    }
-
-    #[test]
-    fn render_cue_omits_type_only_when_null() {
-        let commit = |r#type: Option<String>| Commit {
-            sha: "x".into(),
-            author: "a".into(),
-            date: "d".into(),
-            description: "desc".into(),
-            r#type,
-            breaking_change: false,
-            pr_number: None,
-            files_count: 0,
-            insertions_count: 0,
-            deletions_count: 0,
-        };
-
-        // Any parsed type is rendered; the schema accepts a free-form string.
-        assert!(
-            commit(Some("feat".into()))
-                .render_cue()
-                .contains("type: \"feat\"")
-        );
-        assert!(
-            commit(Some("ci".into()))
-                .render_cue()
-                .contains("type: \"ci\"")
-        );
-        // An unparsable subject (null type) omits the field.
-        assert!(!commit(None).render_cue().contains("type:"));
-    }
-
-    #[test]
-    fn collect_released_identifiers_extracts_shas_and_pr_numbers() {
-        let tmp = tempfile::tempdir().unwrap();
-        // A trimmed-down CUE file shaped like the real release cues.
-        fs::write(
-            tmp.path().join("0.55.0.cue"),
-            r#"package metadata
-
-releases: "0.55.0": {
-    commits: [
-        {sha: "deadbeefcafe", date: "2026-01-01 00:00:00 UTC", pr_number: 42, type: "fix"},
-        {sha: "abc1234567890abc", pr_number: 99},
-    ]
-}
-"#,
-        )
-        .unwrap();
-        // A non-cue file we should ignore.
-        fs::write(tmp.path().join("README.md"), "not a release").unwrap();
-
-        let ids = collect_released_identifiers(tmp.path()).unwrap();
-        assert!(ids.shas.contains("deadbeefcafe"));
-        assert!(ids.shas.contains("abc1234567890abc"));
-        assert!(ids.pr_numbers.contains(&42));
-        assert!(ids.pr_numbers.contains(&99));
-    }
-
-    #[test]
-    fn collect_released_identifiers_handles_missing_dir() {
-        let ids = collect_released_identifiers(Path::new("/nonexistent")).unwrap();
-        assert!(ids.shas.is_empty());
-        assert!(ids.pr_numbers.is_empty());
+        assert!(!out.contains("commits:"));
     }
 
     #[test]

--- a/vdev/src/commands/release/prepare.rs
+++ b/vdev/src/commands/release/prepare.rs
@@ -115,17 +115,14 @@ impl Prepare {
         debug!("create_release_branches");
 
         if self.dry_run {
-            // In dry-run mode the branches (and the commit range fed to
-            // generate_cue) are based on whatever is currently checked out.
-            // Surface that explicitly so a stale or feature branch doesn't
-            // silently land unrelated commits in the generated release CUE.
+            // In dry-run mode the release is based on whatever is currently
+            // checked out. Surface that explicitly so a stale or feature
+            // branch doesn't silently produce a release from the wrong base.
             let head = git::run_and_check_output(&["rev-parse", "--abbrev-ref", "HEAD"])
                 .unwrap_or_else(|_| "<unknown>".to_string());
-            let last = &self.latest_vector_version;
             warn!(
                 "dry-run: using HEAD ({}) as the release base; \
-                 commits in the generated CUE will be `git log v{last}...HEAD`. \
-                 Verify this matches what you'd expect from master.",
+                 verify this matches what you'd expect from master.",
                 head.trim()
             );
         } else {


### PR DESCRIPTION
## Summary

Followup to #26072.

## Vector configuration

NA

## How did you test this PR?

- `make check-markdown`

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: #26072
