### PR TITLE
fix(sinks): replace panicking From<Uri> for UriSerde with TryFrom<Uri>

### DIFF
--- a/changelog.d/uriserde_malformed_uri.fix.md
+++ b/changelog.d/uriserde_malformed_uri.fix.md
@@ -1,0 +1,3 @@
+Fix a panic in Vector when a sink endpoint or URI contains a non-numeric port (e.g. `http://localhost:notaport`). Malformed URIs now produce a validation error instead of crashing Vector.
+
+authors: thomasqueirozb

--- a/src/sinks/azure_logs_ingestion/tests.rs
+++ b/src/sinks/azure_logs_ingestion/tests.rs
@@ -176,7 +176,7 @@ async fn correct_request() {
     let (sink, healthcheck) = config
         .build_inner(
             context,
-            mock_endpoint.into(),
+            mock_endpoint.try_into().unwrap(),
             config.dcr_immutable_id.clone(),
             config.stream_name.clone(),
             credential,
@@ -288,7 +288,7 @@ async fn mock_healthcheck_with_400_response() {
     let (_sink, healthcheck) = config
         .build_inner(
             context,
-            mock_endpoint.into(),
+            mock_endpoint.try_into().unwrap(),
             config.dcr_immutable_id.clone(),
             config.stream_name.clone(),
             credential,
@@ -355,7 +355,7 @@ async fn mock_healthcheck_with_403_response() {
     let (_sink, healthcheck) = config
         .build_inner(
             context,
-            mock_endpoint.into(),
+            mock_endpoint.try_into().unwrap(),
             config.dcr_immutable_id.clone(),
             config.stream_name.clone(),
             credential,

--- a/src/sinks/azure_monitor_logs/tests.rs
+++ b/src/sinks/azure_monitor_logs/tests.rs
@@ -37,7 +37,7 @@ async fn component_spec_compliance() {
 
     let context = SinkContext::default();
     let (sink, _healthcheck) = config
-        .build_inner(context, mock_endpoint.into())
+        .build_inner(context, mock_endpoint.try_into().unwrap())
         .await
         .unwrap();
 
@@ -184,7 +184,7 @@ async fn correct_request() {
 
     let context = SinkContext::default();
     let (sink, _healthcheck) = config
-        .build_inner(context, mock_endpoint.into())
+        .build_inner(context, mock_endpoint.try_into().unwrap())
         .await
         .unwrap();
 

--- a/src/sinks/clickhouse/config.rs
+++ b/src/sinks/clickhouse/config.rs
@@ -580,7 +580,11 @@ mod tests {
         batch_encoding: Option<ClickhouseBatchEncoding>,
     ) -> ClickhouseConfig {
         ClickhouseConfig {
-            endpoint: "http://localhost:8123".parse::<http::Uri>().unwrap().into(),
+            endpoint: "http://localhost:8123"
+                .parse::<http::Uri>()
+                .unwrap()
+                .try_into()
+                .unwrap(),
             table: "test_table".try_into().unwrap(),
             database: Some("test_db".try_into().unwrap()),
             format,
@@ -617,7 +621,11 @@ mod tests {
     #[test]
     fn preparation_error_on_invalid_batch_encoding_combination() {
         let config = ClickhouseConfig {
-            endpoint: "http://localhost:8123".parse::<http::Uri>().unwrap().into(),
+            endpoint: "http://localhost:8123"
+                .parse::<http::Uri>()
+                .unwrap()
+                .try_into()
+                .unwrap(),
             table: "test_table".try_into().unwrap(),
             format: Format::JsonEachRow, // Incompatible with batch_encoding
             batch_encoding: Some(ClickhouseBatchEncoding::ArrowStream(
@@ -642,7 +650,11 @@ mod tests {
     #[test]
     fn prepares_valid_config() {
         let config = ClickhouseConfig {
-            endpoint: "http://localhost:8123".parse::<http::Uri>().unwrap().into(),
+            endpoint: "http://localhost:8123"
+                .parse::<http::Uri>()
+                .unwrap()
+                .try_into()
+                .unwrap(),
             table: "test_table".try_into().unwrap(),
             database: Some("test_db".try_into().unwrap()),
             format: Format::JsonEachRow,
@@ -660,7 +672,11 @@ mod tests {
     #[test]
     fn rejects_incompatible_batch_encoding() {
         let config = ClickhouseConfig {
-            endpoint: "http://localhost:8123".parse::<http::Uri>().unwrap().into(),
+            endpoint: "http://localhost:8123"
+                .parse::<http::Uri>()
+                .unwrap()
+                .try_into()
+                .unwrap(),
             table: "test_table".try_into().unwrap(),
             format: Format::JsonEachRow, // Incompatible with batch_encoding
             batch_encoding: Some(ClickhouseBatchEncoding::ArrowStream(
@@ -679,7 +695,11 @@ mod tests {
     fn rejects_dynamic_targets_with_arrow_batch_encoding() {
         // Dynamic table (with a static prefix, so it passes confinement)
         let config = ClickhouseConfig {
-            endpoint: "http://localhost:8123".parse::<http::Uri>().unwrap().into(),
+            endpoint: "http://localhost:8123"
+                .parse::<http::Uri>()
+                .unwrap()
+                .try_into()
+                .unwrap(),
             table: "events-{{ tenant }}".try_into().unwrap(),
             format: Format::ArrowStream,
             batch_encoding: Some(ClickhouseBatchEncoding::ArrowStream(
@@ -702,7 +722,11 @@ mod tests {
 
         // Dynamic database
         let config = ClickhouseConfig {
-            endpoint: "http://localhost:8123".parse::<http::Uri>().unwrap().into(),
+            endpoint: "http://localhost:8123"
+                .parse::<http::Uri>()
+                .unwrap()
+                .try_into()
+                .unwrap(),
             table: "test_table".try_into().unwrap(),
             database: Some("events-{{ tenant }}".try_into().unwrap()),
             format: Format::ArrowStream,
@@ -728,7 +752,11 @@ mod tests {
     #[test]
     fn accepts_static_targets_with_arrow_batch_encoding() {
         let config = ClickhouseConfig {
-            endpoint: "http://localhost:8123".parse::<http::Uri>().unwrap().into(),
+            endpoint: "http://localhost:8123"
+                .parse::<http::Uri>()
+                .unwrap()
+                .try_into()
+                .unwrap(),
             table: "test_table".try_into().unwrap(),
             database: Some("test_db".try_into().unwrap()),
             format: Format::ArrowStream,
@@ -744,7 +772,11 @@ mod tests {
     #[test]
     fn rejects_unconfined_template() {
         let config = ClickhouseConfig {
-            endpoint: "http://localhost:8123".parse::<http::Uri>().unwrap().into(),
+            endpoint: "http://localhost:8123"
+                .parse::<http::Uri>()
+                .unwrap()
+                .try_into()
+                .unwrap(),
             table: "{{ table }}".try_into().unwrap(), // No static prefix
             format: Format::JsonEachRow,
             ..Default::default()

--- a/src/sinks/loki/tests.rs
+++ b/src/sinks/loki/tests.rs
@@ -113,7 +113,8 @@ async fn healthcheck_includes_auth() {
         .clone()
         .parse::<http::Uri>()
         .expect("could not create URI")
-        .into();
+        .try_into()
+        .unwrap();
 
     let (rx, _trigger, server) = build_test_server(addr);
     tokio::spawn(server);

--- a/src/sinks/papertrail.rs
+++ b/src/sinks/papertrail.rs
@@ -209,7 +209,7 @@ mod tests {
         let mut config: PapertrailConfig =
             serde_json::from_value(PapertrailConfig::generate_config())
                 .expect("config should be valid");
-        config.endpoint = mock_endpoint.into();
+        config.endpoint = mock_endpoint.try_into().unwrap();
         config.tls = Some(TlsEnableableConfig::default());
 
         let context = SinkContext::default();

--- a/src/sinks/util/uri.rs
+++ b/src/sinks/util/uri.rs
@@ -63,7 +63,7 @@ impl UriSerde {
 }
 
 impl TryFrom<String> for UriSerde {
-    type Error = <Uri as FromStr>::Err;
+    type Error = crate::Error;
 
     fn try_from(value: String) -> Result<Self, Self::Error> {
         value.as_str().parse()
@@ -93,33 +93,44 @@ impl fmt::Display for UriSerde {
 }
 
 impl FromStr for UriSerde {
-    type Err = <Uri as FromStr>::Err;
+    type Err = crate::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        s.parse::<Uri>().map(Into::into)
+        let uri: Uri = s.parse()?;
+        uri.try_into()
     }
 }
 
-impl From<Uri> for UriSerde {
-    fn from(uri: Uri) -> Self {
+impl TryFrom<Uri> for UriSerde {
+    type Error = crate::Error;
+
+    /// Fallible construction from a parsed `Uri`, extracting any basic auth
+    /// credentials from the authority.
+    ///
+    /// This can fail: `http::Uri` accepts authorities that `url::Url` rejects
+    /// (e.g. a non-numeric port), in which case the basic auth cannot be
+    /// extracted.
+    fn try_from(uri: Uri) -> Result<Self, Self::Error> {
         match uri.authority() {
-            None => Self { uri, auth: None },
+            None => Ok(Self { uri, auth: None }),
             Some(authority) => {
-                let (authority, auth) = get_basic_auth(authority);
+                let (authority, auth) = get_basic_auth(authority)?;
 
                 let mut parts = uri.into_parts();
                 parts.authority = Some(authority);
-                let uri = Uri::from_parts(parts).unwrap();
+                let uri = Uri::from_parts(parts)?;
 
-                Self { uri, auth }
+                Ok(Self { uri, auth })
             }
         }
     }
 }
 
-fn get_basic_auth(authority: &Authority) -> (Authority, Option<Auth>) {
-    // We get a valid `Authority` as input, therefore cannot fail here.
-    let mut url = url::Url::parse(&format!("http://{authority}")).expect("invalid authority");
+fn get_basic_auth(authority: &Authority) -> crate::Result<(Authority, Option<Auth>)> {
+    // `http::Uri` accepts authorities that `url::Url` rejects (e.g. a
+    // non-numeric port), so this parse can fail; propagate the error instead
+    // of panicking.
+    let mut url = url::Url::parse(&format!("http://{authority}"))?;
 
     let user = url.username();
     if !user.is_empty() {
@@ -132,25 +143,25 @@ fn get_basic_auth(authority: &Authority) -> (Authority, Option<Auth>) {
 
         // These methods have the same failure condition as `username`,
         // because we have a non-empty username, they cannot fail here.
-        url.set_username("").expect("unexpected empty authority");
-        url.set_password(None).expect("unexpected empty authority");
+        url.set_username("")
+            .map_err(|_| "unexpected empty authority")?;
+        url.set_password(None)
+            .map_err(|_| "unexpected empty authority")?;
 
-        // We get a valid `Authority` as input, therefore cannot fail here.
-        let authority = Uri::from_maybe_shared(String::from(url))
-            .expect("invalid url")
+        let authority = Uri::from_maybe_shared(String::from(url))?
             .authority()
-            .expect("unexpected empty authority")
+            .ok_or_else(|| "unexpected empty authority".to_string())?
             .clone();
 
-        (
+        Ok((
             authority,
             Some(Auth::Basic {
                 user,
                 password: password.into(),
             }),
-        )
+        ))
     } else {
-        (authority.clone(), None)
+        Ok((authority.clone(), None))
     }
 }
 
@@ -228,6 +239,14 @@ mod tests {
         );
 
         test_parse("user@example.com", "example.com", Some(("user", "")));
+    }
+
+    #[test]
+    fn parse_rejects_malformed_authority_without_panicking() {
+        // `http::Uri` accepts a non-numeric port in the authority, but
+        // `url::Url` rejects it. This must be a parse error, not a panic.
+        let result = "http://user:pass@localhost:notaport/path".parse::<UriSerde>();
+        assert!(result.is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Replaces the panicking `From<Uri>` conversion for `UriSerde` with a fallible `TryFrom<Uri>`, so malformed URIs (e.g. non-numeric ports) produce a validation error instead of crashing Vector.

## Vector configuration
Config that previously crashed `vector validate` (and `vector run`) with a panic:

```yaml
sources:
  in:
    type: demo_logs
sinks:
  test:
    type: papertrail
    endpoint: "http://localhost:notaport"
    encoding:
      codec: json
    inputs: [in]
```

## How did you test this PR?
- `vector validate` with `endpoint: "http://localhost:notaport"` previously panicked with `invalid authority: InvalidPort`; now returns a clean validation error.
- Added unit test `parse_rejects_malformed_authority_without_panicking`.
- `cargo check -p vector --all-features --all-targets` and `make fmt` pass.

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

NA
