### PR TITLE
fix(sources): only signal shutdown once for TCP sources

### DIFF
--- a/changelog.d/tcp_repeated_shutdown_signal.fix.md
+++ b/changelog.d/tcp_repeated_shutdown_signal.fix.md
@@ -1,0 +1,3 @@
+Fixed a bug in TCP sources where, once `max_connection_duration_secs` elapsed for a connection, Vector would repeatedly re-issue `shutdown(SHUT_WR)` on every subsequent poll instead of just once.
+
+authors: tronboto

--- a/src/sources/util/net/tcp/mod.rs
+++ b/src/sources/util/net/tcp/mod.rs
@@ -319,7 +319,8 @@ async fn handle_stream<T>(
     loop {
         let mut permit = tokio::select! {
             _ = &mut tripwire => break,
-            Some(_) = &mut connection_close_timeout  => {
+            Some(_) = &mut connection_close_timeout => {
+                connection_close_timeout.set(OptionFuture::from(None::<tokio::time::Sleep>));
                 if close_socket(reader.get_ref().get_ref().get_ref()) {
                     break;
                 }


### PR DESCRIPTION
## Summary

Once `max_connection_duration_secs` elapsed, `connection_close_timeout` kept resolving Ready on every poll instead of just once, causing `close_socket`'s `shutdown(SHUT_WR)` to be re-issued on every loop iteration instead of a single time.

Fixed by resetting the timeout future to None after it fires, so the branch only matches once per connection.

## Vector configuration

```yaml
sources:
  tcp_in:
    type: socket
    mode: tcp
    address: "0.0.0.0:9000"
    max_connection_duration_secs: 3
sinks:
  out:
    type: console
    inputs: [tcp_in]
    encoding:
      codec: text
```

## How did you test this PR?

Used `strace` to observe the syscalls made against the connection socket after `max_connection_duration_secs` elapsed, confirming `shutdown(SHUT_WR)` is now issued exactly once instead of being re-issued on every loop iteration.

## Is this a breaking change?

- [ ] Yes
- [X] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [X] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Closes: #<issue/PR number or link>
-->
<!--
- Related: #<issue/PR number or link>
-->

## Notes

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them.
  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
  - Alternatively, we recommend running the following locally before pushing to the remote branch:
    - `make fmt`
    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
    - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details on the [dd-rust-license-tool](https://crates.io/crates/dd-rust-license-tool).