### PR TITLE
chore(config): use YAML for generated component configs

### DIFF
--- a/docs/tutorials/sinks/1_basic_sink.md
+++ b/docs/tutorials/sinks/1_basic_sink.md
@@ -66,8 +66,8 @@ our struct:
 
 ```rust
 impl GenerateConfig for BasicConfig {
-    fn generate_config() -> toml::Value {
-        toml::from_str("").unwrap()
+    fn generate_config() -> serde_json::Value {
+        serde_yaml::from_str("{}").unwrap()
     }
 }
 ```

--- a/src/sinks/amqp/config.rs
+++ b/src/sinks/amqp/config.rs
@@ -120,13 +120,14 @@ impl Default for AmqpSinkConfig {
 
 impl GenerateConfig for AmqpSinkConfig {
     fn generate_config() -> serde_json::Value {
-        toml::from_str(
-            r#"connection_string = "amqp://localhost:5672/%2f"
-            routing_key = "user_id"
-            exchange = "test"
-            encoding.codec = "json"
-            max_channels = 4"#,
-        )
+        serde_yaml::from_str(indoc::indoc! {
+            r#"connection_string: "amqp://localhost:5672/%2f"
+            routing_key: user_id
+            exchange: test
+            encoding:
+              codec: json
+            max_channels: 4"#,
+        })
         .unwrap()
     }
 }

--- a/src/sinks/aws_kinesis/firehose/config.rs
+++ b/src/sinks/aws_kinesis/firehose/config.rs
@@ -159,10 +159,11 @@ impl SinkConfig for KinesisFirehoseSinkConfig {
 
 impl GenerateConfig for KinesisFirehoseSinkConfig {
     fn generate_config() -> serde_json::Value {
-        toml::from_str(
-            r#"stream_name = "my-stream"
-            encoding.codec = "json""#,
-        )
+        serde_yaml::from_str(indoc::indoc! {
+            r#"stream_name: my-stream
+            encoding:
+              codec: json"#,
+        })
         .unwrap()
     }
 }

--- a/src/sinks/aws_kinesis/streams/config.rs
+++ b/src/sinks/aws_kinesis/streams/config.rs
@@ -158,11 +158,12 @@ impl SinkConfig for KinesisStreamsSinkConfig {
 
 impl GenerateConfig for KinesisStreamsSinkConfig {
     fn generate_config() -> serde_json::Value {
-        toml::from_str(
-            r#"partition_key_field = "foo"
-            stream_name = "my-stream"
-            encoding.codec = "json""#,
-        )
+        serde_yaml::from_str(indoc::indoc! {
+            r#"partition_key_field: foo
+            stream_name: my-stream
+            encoding:
+              codec: json"#,
+        })
         .unwrap()
     }
 }

--- a/src/sinks/aws_s_s/sns/config.rs
+++ b/src/sinks/aws_s_s/sns/config.rs
@@ -35,11 +35,12 @@ pub(super) struct SnsSinkConfig {
 
 impl GenerateConfig for SnsSinkConfig {
     fn generate_config() -> serde_json::Value {
-        toml::from_str(
-            r#"topic_arn = "arn:aws:sns:us-east-2:123456789012:MyTopic"
-            region = "us-east-2"
-            encoding.codec = "json""#,
-        )
+        serde_yaml::from_str(indoc::indoc! {
+            r#"topic_arn: arn:aws:sns:us-east-2:123456789012:MyTopic
+            region: us-east-2
+            encoding:
+              codec: json"#,
+        })
         .unwrap()
     }
 }

--- a/src/sinks/aws_s_s/sqs/config.rs
+++ b/src/sinks/aws_s_s/sqs/config.rs
@@ -38,11 +38,12 @@ pub(super) struct SqsSinkConfig {
 
 impl GenerateConfig for SqsSinkConfig {
     fn generate_config() -> serde_json::Value {
-        toml::from_str(
-            r#"queue_url = "https://sqs.us-east-2.amazonaws.com/123456789012/MyQueue"
-            region = "us-east-2"
-            encoding.codec = "json""#,
-        )
+        serde_yaml::from_str(indoc::indoc! {
+            r#"queue_url: https://sqs.us-east-2.amazonaws.com/123456789012/MyQueue
+            region: us-east-2
+            encoding:
+              codec: json"#,
+        })
         .unwrap()
     }
 }

--- a/src/sinks/axiom/config.rs
+++ b/src/sinks/axiom/config.rs
@@ -137,12 +137,12 @@ pub struct AxiomConfig {
 
 impl GenerateConfig for AxiomConfig {
     fn generate_config() -> serde_json::Value {
-        toml::from_str(
-            r#"token = "${AXIOM_TOKEN}"
-            dataset = "${AXIOM_DATASET}"
-            url = "${AXIOM_URL}"
-            org_id = "${AXIOM_ORG_ID}""#,
-        )
+        serde_yaml::from_str(indoc::indoc! {
+            r#"token: ${AXIOM_TOKEN}
+            dataset: ${AXIOM_DATASET}
+            url: ${AXIOM_URL}
+            org_id: ${AXIOM_ORG_ID}"#,
+        })
         .unwrap()
     }
 }

--- a/src/sinks/databend/config.rs
+++ b/src/sinks/databend/config.rs
@@ -90,11 +90,11 @@ pub struct DatabendConfig {
 
 impl GenerateConfig for DatabendConfig {
     fn generate_config() -> serde_json::Value {
-        toml::from_str(
-            r#"endpoint = "databend://localhost:8000/default?sslmode=disable"
-            table = "default"
+        serde_yaml::from_str(indoc::indoc! {
+            r#"endpoint: "databend://localhost:8000/default?sslmode=disable"
+            table: default
         "#,
-        )
+        })
         .unwrap()
     }
 }

--- a/src/sinks/datadog/events/config.rs
+++ b/src/sinks/datadog/events/config.rs
@@ -44,8 +44,8 @@ pub struct DatadogEventsConfig {
 
 impl GenerateConfig for DatadogEventsConfig {
     fn generate_config() -> serde_json::Value {
-        toml::from_str(indoc! {r#"
-            default_api_key = "${DATADOG_API_KEY_ENV_VAR}"
+        serde_yaml::from_str(indoc! {r#"
+            default_api_key: ${DATADOG_API_KEY_ENV_VAR}
         "#})
         .unwrap()
     }

--- a/src/sinks/datadog/logs/config.rs
+++ b/src/sinks/datadog/logs/config.rs
@@ -83,8 +83,8 @@ const fn default_compression() -> Option<Compression> {
 
 impl GenerateConfig for DatadogLogsConfig {
     fn generate_config() -> serde_json::Value {
-        toml::from_str(indoc! {r#"
-            default_api_key = "${DATADOG_API_KEY_ENV_VAR}"
+        serde_yaml::from_str(indoc! {r#"
+            default_api_key: ${DATADOG_API_KEY_ENV_VAR}
         "#})
         .unwrap()
     }

--- a/src/sinks/datadog/traces/config.rs
+++ b/src/sinks/datadog/traces/config.rs
@@ -76,8 +76,8 @@ pub struct DatadogTracesConfig {
 
 impl GenerateConfig for DatadogTracesConfig {
     fn generate_config() -> serde_json::Value {
-        toml::from_str(indoc! {r#"
-            default_api_key = "${DATADOG_API_KEY_ENV_VAR}"
+        serde_yaml::from_str(indoc! {r#"
+            default_api_key: ${DATADOG_API_KEY_ENV_VAR}
         "#})
         .unwrap()
     }

--- a/src/sinks/gcp/cloud_storage.rs
+++ b/src/sinks/gcp/cloud_storage.rs
@@ -250,11 +250,13 @@ fn default_config(encoding: EncodingConfigWithFraming) -> GcsSinkConfig {
 
 impl GenerateConfig for GcsSinkConfig {
     fn generate_config() -> serde_json::Value {
-        toml::from_str(indoc! {r#"
-            bucket = "my-bucket"
-            credentials_path = "/path/to/credentials.json"
-            framing.method = "newline_delimited"
-            encoding.codec = "json"
+        serde_yaml::from_str(indoc! {r#"
+            bucket: my-bucket
+            credentials_path: /path/to/credentials.json
+            framing:
+              method: newline_delimited
+            encoding:
+              codec: json
         "#})
         .unwrap()
     }

--- a/src/sinks/gcp/pubsub.rs
+++ b/src/sinks/gcp/pubsub.rs
@@ -104,10 +104,11 @@ fn default_endpoint() -> String {
 
 impl GenerateConfig for PubsubConfig {
     fn generate_config() -> serde_json::Value {
-        toml::from_str(indoc! {r#"
-            project = "my-project"
-            topic = "my-topic"
-            encoding.codec = "json"
+        serde_yaml::from_str(indoc! {r#"
+            project: my-project
+            topic: my-topic
+            encoding:
+              codec: json
         "#})
         .unwrap()
     }

--- a/src/sinks/gcp_chronicle/chronicle_unstructured.rs
+++ b/src/sinks/gcp_chronicle/chronicle_unstructured.rs
@@ -259,14 +259,15 @@ fn chronicle_labels_examples() -> HashMap<String, String> {
 
 impl GenerateConfig for ChronicleUnstructuredConfig {
     fn generate_config() -> serde_json::Value {
-        toml::from_str(indoc! {r#"
-            credentials_path = "/path/to/credentials.json"
-            customer_id = "customer_id"
-            namespace = "namespace"
-            compression = "gzip"
-            log_type = "log_type"
-            fallback_log_type = "VECTOR_DEV"
-            encoding.codec = "text"
+        serde_yaml::from_str(indoc! {r#"
+            credentials_path: /path/to/credentials.json
+            customer_id: customer_id
+            namespace: namespace
+            compression: gzip
+            log_type: log_type
+            fallback_log_type: VECTOR_DEV
+            encoding:
+              codec: text
         "#})
         .unwrap()
     }

--- a/src/sinks/honeycomb/config.rs
+++ b/src/sinks/honeycomb/config.rs
@@ -92,10 +92,10 @@ impl SinkBatchSettings for HoneycombDefaultBatchSettings {
 
 impl GenerateConfig for HoneycombConfig {
     fn generate_config() -> serde_json::Value {
-        toml::from_str(
-            r#"api_key = "${HONEYCOMB_API_KEY}"
-            dataset = "my-honeycomb-dataset""#,
-        )
+        serde_yaml::from_str(indoc::indoc! {
+            r#"api_key: ${HONEYCOMB_API_KEY}
+            dataset: my-honeycomb-dataset"#,
+        })
         .unwrap()
     }
 }

--- a/src/sinks/http/config.rs
+++ b/src/sinks/http/config.rs
@@ -177,10 +177,11 @@ impl HttpSinkConfig {
 
 impl GenerateConfig for HttpSinkConfig {
     fn generate_config() -> serde_json::Value {
-        toml::from_str(
-            r#"uri = "https://10.22.212.22:9000/endpoint"
-            encoding.codec = "json""#,
-        )
+        serde_yaml::from_str(indoc::indoc! {
+            r#"uri: https://10.22.212.22:9000/endpoint
+            encoding:
+              codec: json"#,
+        })
         .unwrap()
     }
 }

--- a/src/sinks/humio/metrics.rs
+++ b/src/sinks/humio/metrics.rs
@@ -149,9 +149,9 @@ fn default_endpoint() -> String {
 
 impl GenerateConfig for HumioMetricsConfig {
     fn generate_config() -> serde_json::Value {
-        toml::from_str(indoc! {r#"
-                host_key = "hostname"
-                token = "${HUMIO_TOKEN}"
+        serde_yaml::from_str(indoc! {r#"
+                host_key: hostname
+                token: ${HUMIO_TOKEN}
             "#})
         .unwrap()
     }

--- a/src/sinks/humio/metrics.rs
+++ b/src/sinks/humio/metrics.rs
@@ -150,9 +150,9 @@ fn default_endpoint() -> String {
 impl GenerateConfig for HumioMetricsConfig {
     fn generate_config() -> serde_json::Value {
         serde_yaml::from_str(indoc! {r#"
-                host_key: hostname
-                token: ${HUMIO_TOKEN}
-            "#})
+            host_key: hostname
+            token: ${HUMIO_TOKEN}
+        "#})
         .unwrap()
     }
 }

--- a/src/sinks/influxdb/logs.rs
+++ b/src/sinks/influxdb/logs.rs
@@ -142,13 +142,13 @@ struct InfluxDbLogsSink {
 
 impl GenerateConfig for InfluxDbLogsConfig {
     fn generate_config() -> serde_json::Value {
-        toml::from_str(indoc! {r#"
-            endpoint = "http://localhost:8086/"
-            namespace = "my-namespace"
-            tags = []
-            org = "my-org"
-            bucket = "my-bucket"
-            token = "${INFLUXDB_TOKEN}"
+        serde_yaml::from_str(indoc! {r#"
+            endpoint: http://localhost:8086/
+            namespace: my-namespace
+            tags: []
+            org: my-org
+            bucket: my-bucket
+            token: ${INFLUXDB_TOKEN}
         "#})
         .unwrap()
     }

--- a/src/sinks/keep/config.rs
+++ b/src/sinks/keep/config.rs
@@ -80,10 +80,10 @@ impl SinkBatchSettings for KeepDefaultBatchSettings {
 
 impl GenerateConfig for KeepConfig {
     fn generate_config() -> serde_json::Value {
-        toml::from_str(
-            r#"api_key = "${KEEP_API_KEY}"
+        serde_yaml::from_str(indoc::indoc! {
+            r#"api_key: ${KEEP_API_KEY}
             "#,
-        )
+        })
         .unwrap()
     }
 }

--- a/src/sinks/loki/config.rs
+++ b/src/sinks/loki/config.rs
@@ -197,11 +197,12 @@ pub enum OutOfOrderAction {
 
 impl GenerateConfig for LokiConfig {
     fn generate_config() -> serde_json::Value {
-        toml::from_str(
-            r#"endpoint = "http://localhost:3100"
-            encoding.codec = "json"
-            labels = {}"#,
-        )
+        serde_yaml::from_str(indoc::indoc! {
+            r#"endpoint: http://localhost:3100
+            encoding:
+              codec: json
+            labels: {}"#,
+        })
         .unwrap()
     }
 }

--- a/src/sinks/mezmo.rs
+++ b/src/sinks/mezmo.rs
@@ -146,10 +146,10 @@ fn default_env() -> String {
 
 impl GenerateConfig for MezmoConfig {
     fn generate_config() -> serde_json::Value {
-        toml::from_str(
-            r#"hostname = "hostname"
-            api_key = "${LOGDNA_API_KEY}""#,
-        )
+        serde_yaml::from_str(indoc::indoc! {
+            r#"hostname: hostname
+            api_key: ${LOGDNA_API_KEY}"#,
+        })
         .unwrap()
     }
 }

--- a/src/sinks/opentelemetry/mod.rs
+++ b/src/sinks/opentelemetry/mod.rs
@@ -64,11 +64,12 @@ impl Default for Protocol {
 
 impl GenerateConfig for OpenTelemetryConfig {
     fn generate_config() -> serde_json::Value {
-        toml::from_str(indoc! {r#"
-            [protocol]
-            type = "http"
-            uri = "http://localhost:5318/v1/logs"
-            encoding.codec = "json"
+        serde_yaml::from_str(indoc! {r#"
+            protocol:
+              type: http
+              uri: http://localhost:5318/v1/logs
+              encoding:
+                codec: json
         "#})
         .unwrap()
     }

--- a/src/sinks/papertrail.rs
+++ b/src/sinks/papertrail.rs
@@ -56,10 +56,11 @@ fn default_process() -> UnconfinedTemplate {
 
 impl GenerateConfig for PapertrailConfig {
     fn generate_config() -> serde_json::Value {
-        toml::from_str(
-            r#"endpoint = "logs.papertrailapp.com:12345"
-            encoding.codec = "json""#,
-        )
+        serde_yaml::from_str(indoc::indoc! {
+            r#"endpoint: "logs.papertrailapp.com:12345"
+            encoding:
+              codec: json"#,
+        })
         .unwrap()
     }
 }

--- a/src/sinks/postgres/config.rs
+++ b/src/sinks/postgres/config.rs
@@ -76,11 +76,11 @@ pub struct PostgresConfig {
 
 impl GenerateConfig for PostgresConfig {
     fn generate_config() -> serde_json::Value {
-        toml::from_str(
-            r#"endpoint = "postgres://user:password@localhost/default"
-            table = "table"
+        serde_yaml::from_str(indoc::indoc! {
+            r#"endpoint: "postgres://user:password@localhost/default"
+            table: table
         "#,
-        )
+        })
         .unwrap()
     }
 }

--- a/src/sinks/redis/config.rs
+++ b/src/sinks/redis/config.rs
@@ -183,16 +183,19 @@ pub struct RedisSinkConfig {
 
 impl GenerateConfig for RedisSinkConfig {
     fn generate_config() -> serde_json::Value {
-        toml::from_str(
+        serde_yaml::from_str(indoc::indoc! {
             r#"
-            url = "redis://127.0.0.1:6379/0"
-            key = "vector"
-            data_type = "list"
-            list.method = "lpush"
-            encoding.codec = "json"
-            batch.max_events = 1
+            url: "redis://127.0.0.1:6379/0"
+            key: vector
+            data_type: list
+            list:
+              method: lpush
+            encoding:
+              codec: json
+            batch:
+              max_events: 1
             "#,
-        )
+        })
         .unwrap()
     }
 }

--- a/src/sinks/sematext/logs.rs
+++ b/src/sinks/sematext/logs.rs
@@ -64,8 +64,8 @@ pub struct SematextLogsConfig {
 
 impl GenerateConfig for SematextLogsConfig {
     fn generate_config() -> serde_json::Value {
-        toml::from_str(indoc! {r#"
-            token = "${SEMATEXT_TOKEN}"
+        serde_yaml::from_str(indoc! {r#"
+            token: ${SEMATEXT_TOKEN}
         "#})
         .unwrap()
     }

--- a/src/sinks/sematext/metrics.rs
+++ b/src/sinks/sematext/metrics.rs
@@ -94,9 +94,9 @@ pub struct SematextMetricsConfig {
 
 impl GenerateConfig for SematextMetricsConfig {
     fn generate_config() -> serde_json::Value {
-        toml::from_str(indoc! {r#"
-            default_namespace = "vector"
-            token = "${SEMATEXT_TOKEN}"
+        serde_yaml::from_str(indoc! {r#"
+            default_namespace: vector
+            token: ${SEMATEXT_TOKEN}
         "#})
         .unwrap()
     }

--- a/src/sinks/socket.rs
+++ b/src/sinks/socket.rs
@@ -100,11 +100,12 @@ pub struct UnixSinkConfig {
 
 impl GenerateConfig for SocketSinkConfig {
     fn generate_config() -> serde_json::Value {
-        toml::from_str(
-            r#"address = "92.12.333.224:5000"
-            mode = "tcp"
-            encoding.codec = "json""#,
-        )
+        serde_yaml::from_str(indoc::indoc! {
+            r#"address: "92.12.333.224:5000"
+            mode: tcp
+            encoding:
+              codec: json"#,
+        })
         .unwrap()
     }
 }

--- a/src/sources/nats/config.rs
+++ b/src/sources/nats/config.rs
@@ -183,12 +183,12 @@ pub const fn default_subscription_capacity() -> usize {
 
 impl GenerateConfig for NatsSourceConfig {
     fn generate_config() -> serde_json::Value {
-        toml::from_str(
+        serde_yaml::from_str(indoc::indoc! {
             r#"
-            connection_name = "vector"
-            subject = "from.vector"
-            url = "nats://127.0.0.1:4222""#,
-        )
+            connection_name: vector
+            subject: from.vector
+            url: "nats://127.0.0.1:4222""#,
+        })
         .unwrap()
     }
 }

--- a/src/sources/redis/mod.rs
+++ b/src/sources/redis/mod.rs
@@ -135,15 +135,16 @@ pub struct RedisSourceConfig {
 
 impl GenerateConfig for RedisSourceConfig {
     fn generate_config() -> serde_json::Value {
-        toml::from_str(
+        serde_yaml::from_str(indoc::indoc! {
             r#"
-            url = "redis://127.0.0.1:6379/0"
-            key = "vector"
-            data_type = "list"
-            list.method = "lpop"
-            redis_key = "redis_key"
+            url: "redis://127.0.0.1:6379/0"
+            key: vector
+            data_type: list
+            list:
+              method: lpop
+            redis_key: redis_key
             "#,
-        )
+        })
         .unwrap()
     }
 }

--- a/src/sources/socket/mod.rs
+++ b/src/sources/socket/mod.rs
@@ -99,10 +99,10 @@ impl From<udp::UdpConfig> for SocketConfig {
 
 impl GenerateConfig for SocketConfig {
     fn generate_config() -> serde_json::Value {
-        toml::from_str(
-            r#"mode = "tcp"
-            address = "0.0.0.0:9000""#,
-        )
+        serde_yaml::from_str(indoc::indoc! {
+            r#"mode: tcp
+            address: "0.0.0.0:9000""#,
+        })
         .unwrap()
     }
 }

--- a/src/transforms/filter.rs
+++ b/src/transforms/filter.rs
@@ -36,7 +36,7 @@ impl From<AnyCondition> for FilterConfig {
 
 impl GenerateConfig for FilterConfig {
     fn generate_config() -> serde_json::Value {
-        toml::from_str(r#"condition = ".message == \"value\"""#).unwrap()
+        serde_yaml::from_str(r#"condition: '.message == "value"'"#).unwrap()
     }
 }
 

--- a/src/transforms/lua/mod.rs
+++ b/src/transforms/lua/mod.rs
@@ -73,10 +73,11 @@ pub enum LuaConfig {
 
 impl GenerateConfig for LuaConfig {
     fn generate_config() -> serde_json::Value {
-        toml::from_str(
-            r#"version = "2"
-            hooks.process = """#,
-        )
+        serde_yaml::from_str(indoc::indoc! {
+            r#"version: "2"
+            hooks:
+              process: """#,
+        })
         .unwrap()
     }
 }

--- a/src/transforms/window/config.rs
+++ b/src/transforms/window/config.rs
@@ -43,7 +43,7 @@ pub struct WindowConfig {
 
 impl GenerateConfig for WindowConfig {
     fn generate_config() -> serde_json::Value {
-        toml::from_str(r#"flush_when = ".message == \"value\"""#).unwrap()
+        serde_yaml::from_str(r#"flush_when: '.message == "value"'"#).unwrap()
     }
 }
 


### PR DESCRIPTION
## Summary

### Motivation

Vector configuration examples are YAML-first, but 33 component `GenerateConfig` implementations still parsed TOML fixture strings. Keeping those fixtures in TOML makes the example source inconsistent with the generated format and leaves more TOML configuration to maintain.

### Changes

- Replace the remaining `toml::from_str` calls in `generate_config` implementations with `serde_yaml::from_str`.
- Convert TOML dotted keys and tables to equivalent nested YAML mappings so the generated JSON values remain unchanged.

## Vector configuration

Not applicable. This changes the internal fixture format used to generate component examples.

## How did you test this PR?

- `make check-fmt`
- `make check-clippy`
- `make check-generated-docs`
- Ran the 117 `generate_config` tests from the built Vector test binary; all passed.

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

## Notes

None.