### PR TITLE
chore(regression): prefix syslog_loki host label with h-

### DIFF
--- a/regression/cases/syslog_loki/vector/vector.yaml
+++ b/regression/cases/syslog_loki/vector/vector.yaml
@@ -33,4 +33,4 @@ sinks:
     out_of_order_action: "accept"
 
     labels:
-      host: "{{ .host }}"
+      host: "h-{{ .host }}"


### PR DESCRIPTION
## Summary

Fixes the `host` label in the `syslog_loki` regression case (broke by the recent confinement changes).  This is safe for the regression harness because it measures ingress throughput only and does not assert on label values.

Follow-up: validate all vector configs used by the regression detector.
 
## Vector configuration

N/A — regression case config only.

## How did you test this PR?

- Verified the label template `h-{{ .host }}` is valid (static prefix + dynamic field render) against the loki sink's `build_template_pair_map` label rendering.
- Confirmed `.host` is always populated for syslog5424 (the syslog source parses the RFC 5424 header hostname), so the label never renders empty.
- `make check-fmt` passes (Prettier validated on push).

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

<!--
- Closes: #<issue/PR number or link>
-->
<!--
- Related: #<issue/PR number or link>
-->

## Notes

- This is a CI/regression-infra-only change, so it does not require a changelog fragment (`no-changelog` label applies).
