### PR TITLE
security(http): prevent proxy credential leakage

### DIFF
--- a/changelog.d/proxy_credentials.security.md
+++ b/changelog.d/proxy_credentials.security.md
@@ -1,3 +1,3 @@
-Prevent proxy credentials from being forwarded to origin servers when Vector uses an authenticated HTTP proxy.
+Prevent configured HTTP proxy credentials from being sent in the `Authorization` header to origin servers; they are now sent only in `Proxy-Authorization`.
 
 authors: pront

--- a/changelog.d/proxy_credentials.security.md
+++ b/changelog.d/proxy_credentials.security.md
@@ -1,3 +1,3 @@
-Prevent configured HTTP proxy credentials from being sent in the `Authorization` header to origin servers; they are now sent only in `Proxy-Authorization`.
+Prevent configured HTTP proxy credentials from being sent in the `Authorization` header to origin servers for plaintext `http://` requests; they are now sent only in `Proxy-Authorization`.
 
 authors: pront

--- a/changelog.d/proxy_credentials.security.md
+++ b/changelog.d/proxy_credentials.security.md
@@ -1,0 +1,3 @@
+Prevent proxy credentials from being forwarded to origin servers when Vector uses an authenticated HTTP proxy.
+
+authors: pront

--- a/lib/vector-core/src/config/proxy.rs
+++ b/lib/vector-core/src/config/proxy.rs
@@ -1,5 +1,5 @@
-use headers::Authorization;
-use http::uri::InvalidUri;
+use headers::{Authorization, authorization::Credentials};
+use http::{header::PROXY_AUTHORIZATION, uri::InvalidUri};
 use hyper_proxy::{Custom, Intercept, Proxy, ProxyConnector};
 use no_proxy::NoProxy;
 use url::Url;
@@ -167,7 +167,10 @@ impl ProxyConfig {
                             .expect("username must be valid UTF-8.");
                         let decoded_pw =
                             urlencoding::decode(password).expect("Password must be valid UTF-8.");
-                        proxy.set_authorization(Authorization::basic(&decoded_user, &decoded_pw));
+                        let mut authorization =
+                            Authorization::basic(&decoded_user, &decoded_pw).0.encode();
+                        authorization.set_sensitive(true);
+                        proxy.set_header(PROXY_AUTHORIZATION, authorization);
                     }
                     proxy
                 })
@@ -205,13 +208,8 @@ impl ProxyConfig {
 mod tests {
     use base64::prelude::{BASE64_STANDARD, Engine as _};
     use env_test_util::TempEnvVar;
-    use http::{
-        HeaderName, HeaderValue, Uri,
-        header::{AUTHORIZATION, PROXY_AUTHORIZATION},
-    };
+    use http::{HeaderValue, Uri, header::AUTHORIZATION};
     use proptest::prelude::*;
-
-    const PROXY_HEADERS: [HeaderName; 2] = [AUTHORIZATION, PROXY_AUTHORIZATION];
 
     use super::*;
 
@@ -383,18 +381,22 @@ mod tests {
             Some(first.uri()),
             Uri::try_from("http://user:pass@1.2.3.4:5678").as_ref().ok()
         );
-        for h in &PROXY_HEADERS {
-            assert_eq!(first.headers().get(h), expected_header_value.as_ref().ok());
-        }
+        assert_eq!(
+            first.headers().get(PROXY_AUTHORIZATION),
+            expected_header_value.as_ref().ok()
+        );
+        assert!(!first.headers().contains_key(AUTHORIZATION));
         assert_eq!(
             Some(second.uri()),
             Uri::try_from("https://user:pass@2.3.4.5:9876")
                 .as_ref()
                 .ok()
         );
-        for h in &PROXY_HEADERS {
-            assert_eq!(second.headers().get(h), expected_header_value.as_ref().ok());
-        }
+        assert_eq!(
+            second.headers().get(PROXY_AUTHORIZATION),
+            expected_header_value.as_ref().ok()
+        );
+        assert!(!second.headers().contains_key(AUTHORIZATION));
     }
 
     #[test]
@@ -410,8 +412,10 @@ mod tests {
             .expect("should not be None");
         let encoded_header = format!("Basic {}", BASE64_STANDARD.encode("user:P@ssw0rd"));
         let expected_header_value = HeaderValue::from_str(encoded_header.as_str());
-        for h in &PROXY_HEADERS {
-            assert_eq!(first.headers().get(h), expected_header_value.as_ref().ok());
-        }
+        assert_eq!(
+            first.headers().get(PROXY_AUTHORIZATION),
+            expected_header_value.as_ref().ok()
+        );
+        assert!(!first.headers().contains_key(AUTHORIZATION));
     }
 }

--- a/src/http/transport_tests.rs
+++ b/src/http/transport_tests.rs
@@ -458,6 +458,29 @@ async fn http_via_authenticated_proxy<F: TestClientFactory>(factory: F) {
     );
 }
 
+async fn http_proxy_credentials_do_not_reach_origin<F: TestClientFactory>(factory: F) {
+    let origin = spawn_origin(no_tls()).await;
+    let proxy = spawn_proxy(no_tls(), true).await;
+    let client = factory
+        .build(no_tls(), &proxy_config(&proxy, false, true))
+        .unwrap();
+
+    assert_success(client.get(&origin.http_uri()).await.unwrap());
+
+    let proxy_observations = proxy.observations();
+    assert_eq!(proxy_observations.len(), 1);
+    assert!(has_proxy_authorization(&proxy_observations[0].headers));
+    assert!(
+        !proxy_observations[0]
+            .headers
+            .contains_key(header::AUTHORIZATION)
+    );
+
+    let origin_headers = &origin.observations()[0].headers;
+    assert!(!origin_headers.contains_key(header::PROXY_AUTHORIZATION));
+    assert!(!origin_headers.contains_key(header::AUTHORIZATION));
+}
+
 async fn https_via_authenticated_connect_proxy<F: TestClientFactory>(factory: F) {
     let origin = spawn_origin(server_tls(false)).await;
     let proxy = spawn_proxy(no_tls(), true).await;
@@ -465,14 +488,32 @@ async fn https_via_authenticated_connect_proxy<F: TestClientFactory>(factory: F)
         .build(trusted_client_tls(), &proxy_config(&proxy, false, true))
         .unwrap();
 
-    assert_success(client.get(&origin.https_uri()).await.unwrap());
+    let mut destination_headers = HeaderMap::new();
+    destination_headers.insert(
+        header::AUTHORIZATION,
+        "Bearer destination-token".parse().unwrap(),
+    );
+    assert_success(
+        client
+            .get_with_headers(&origin.https_uri(), destination_headers)
+            .await
+            .unwrap(),
+    );
     let proxy_observations = proxy.observations();
     assert_eq!(proxy_observations.len(), 1);
     assert_eq!(proxy_observations[0].method, Method::CONNECT);
     assert!(has_proxy_authorization(&proxy_observations[0].headers));
+    assert!(
+        !proxy_observations[0]
+            .headers
+            .contains_key(header::AUTHORIZATION)
+    );
     let origin_headers = &origin.observations()[0].headers;
     assert!(!origin_headers.contains_key(header::PROXY_AUTHORIZATION));
-    assert!(!origin_headers.contains_key(header::AUTHORIZATION));
+    assert_eq!(
+        origin_headers.get(header::AUTHORIZATION).unwrap(),
+        "Bearer destination-token"
+    );
 }
 
 async fn no_proxy_bypasses_proxy<F: TestClientFactory>(factory: F) {
@@ -549,6 +590,11 @@ async fn legacy_direct_https_supports_mtls() {
 #[tokio::test]
 async fn legacy_http_via_authenticated_proxy() {
     http_via_authenticated_proxy(LegacyClientFactory).await;
+}
+
+#[tokio::test]
+async fn legacy_http_proxy_credentials_do_not_reach_origin() {
+    http_proxy_credentials_do_not_reach_origin(LegacyClientFactory).await;
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

### Motivation

When Vector uses an authenticated HTTP proxy, the legacy proxy helper adds the proxy's Basic credential to both `Proxy-Authorization` and `Authorization`. [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110.html#section-11.7.2) defines `Proxy-Authorization` as the proxy-only credential field; `Authorization` authenticates to the origin. A forward proxy can therefore forward the latter to the destination server, exposing the proxy credential.

### Changes

- Send configured proxy credentials only as `Proxy-Authorization`.
- Mark the credential header as sensitive.
- Add a regression contract proving the origin never receives proxy credentials and the proxy never receives destination authorization.

## Vector configuration

No configuration syntax changes. This corrects the behavior of existing authenticated HTTP proxy configuration.

## How did you test this PR?

- `cargo vdev check changelog-fragments`
- `make check-events`
- `make check-fmt`
- `make check-clippy`
- `cargo test -p vector legacy_http_proxy_credentials_do_not_reach_origin --lib`
- Started `make test`; its result is pending behind a Cargo artifact lock.
- `cargo vdev --verbose integration run http-client` (26 passed)

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [x] Yes. A security changelog fragment is included.
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

- Related: #19179
- Discovered while adding proxy transport coverage in #26066.
