### PR TITLE
chore: improve pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,10 @@
 <!-- Please provide a brief summary about what this PR does.
 This should help the reviewers give feedback faster and with higher quality. -->
 
+### References
+<!-- Closes: <#issue/#PR or full link> -->
+<!-- Related: <#issue/#PR or full link> -->
+
 ## Vector configuration
 <!-- Include Vector configuration(s) you used to test and debug your changes. -->
 
@@ -20,25 +24,14 @@ Changes to CI, website, playground and similar are generally not considered user
 - [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
 - [ ] No. A maintainer will apply the `no-changelog` label to this PR.
 
-## References
-
-<!--
-- Closes: #<issue/PR number or link>
--->
-<!--
-- Related: #<issue/PR number or link>
--->
-
-## Notes
+## Contributor Guidelines
 
 - Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
 - Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
-- Some CI checks run only after we manually approve them.
-  - We recommend adding a `pre-push` hook, please see [this template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push).
-  - Alternatively, we recommend running the following locally before pushing to the remote branch:
-    - `make fmt`
-    - `make check-clippy` (if there are failures it's possible some of them can be fixed with `make clippy-fix`)
-    - `make test`
+- Some CI checks run only after we manually approve them. To catch issues early, add a `pre-push` hook ([template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push)) or run the following locally before pushing:
+  - `make fmt`
+  - `make check-clippy` (auto-fix with `make clippy-fix`)
+  - `make test`
 - After a review is requested, please avoid force pushes to help us review incrementally.
   - Feel free to push as many commits as you want. They will be squashed into one before merging.
   - For example, you can run `git merge origin master` and `git push`.


### PR DESCRIPTION
## Summary
Improve the pull request template so reviewers get context faster and contributors spend less effort filling it in:

- Move `References` up under `Summary` as `### References`, with single-line comments (`<!-- Closes: ... -->` / `<!-- Related: ... -->`) that are easier to edit than the previous multi-line comment blocks.
- Rename the generic `Notes` section to `Contributor Guidelines`.
- Tighten the CI guidance bullet (pre-push hook / local checks) into a single sentence.

### References
<!-- Related: none — standalone process change -->

## Vector configuration
N/A — no configuration changes.

## How did you test this PR?
- Ran `make check-markdown` — 0 issues across 698 files.

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?
<!-- This is a contributor-facing process change, not a user-facing behavior change. -->

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.
