### PR TITLE
chore(lua transform)!: use internally-tagged version enum for config rendering

### DIFF
--- a/changelog.d/lua_transform_version_required.breaking.md
+++ b/changelog.d/lua_transform_version_required.breaking.md
@@ -1,0 +1,20 @@
+# Lua transform now requires the `version` option {#lua-transform-version-required}
+
+## Summary
+
+The `lua` transform now requires the `version` option to be set to either `"1"` or `"2"`.
+Previously, omitting `version` defaulted to version 1.
+
+The transform now also rejects unknown configuration fields, as `deny_unknown_fields` was
+previously bypassed by the flattened versioned configs.
+
+This change also fixes the generated configuration documentation so that version 2-only options
+such as `hooks`, `timers`, and `metric_tag_values` are correctly marked as only relevant when
+`version = "2"`.
+
+## Migration
+
+Add `version: "1"` to any `lua` transform configuration that currently omits the `version`
+option, and remove any unknown fields from `lua` transform configurations.
+
+authors: thomasqueirozb

--- a/src/transforms/lua/mod.rs
+++ b/src/transforms/lua/mod.rs
@@ -9,49 +9,20 @@ use crate::{
     transforms::Transform,
 };
 
-/// Marker type for the version one of the configuration for the `lua` transform.
-#[configurable_component]
-#[derive(Clone, Debug)]
-enum V1 {
-    /// Lua transform API version 1.
-    ///
-    /// This version is deprecated and will be removed in a future version.
-    #[configurable(metadata(deprecated))]
-    #[serde(rename = "1")]
-    V1,
-}
-
 /// Configuration for the version one of the `lua` transform.
 #[configurable_component]
 #[derive(Clone, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct LuaConfigV1 {
-    /// Transform API version.
-    ///
-    /// Specifying this version ensures that backward compatibility is not broken.
-    version: Option<V1>,
-
     #[serde(flatten)]
     config: v1::LuaConfig,
-}
-
-/// Marker type for version two of the configuration for the `lua` transform.
-#[configurable_component]
-#[derive(Clone, Debug)]
-enum V2 {
-    /// Lua transform API version 2.
-    #[serde(rename = "2")]
-    V2,
 }
 
 /// Configuration for the version two of the `lua` transform.
 #[configurable_component]
 #[derive(Clone, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct LuaConfigV2 {
-    /// Transform API version.
-    ///
-    /// Specifying this version ensures that backward compatibility is not broken.
-    version: V2,
-
     #[serde(flatten)]
     config: v2::LuaConfig,
 }
@@ -62,13 +33,21 @@ pub struct LuaConfigV2 {
     "Modify event data using the Lua programming language."
 ))]
 #[derive(Clone, Debug)]
-#[serde(untagged)]
+#[serde(tag = "version")]
+#[configurable(metadata(
+    docs::enum_tag_description = "Transform API version. Specifying this version ensures that backward compatibility is not broken."
+))]
 pub enum LuaConfig {
-    /// Configuration for version one.
-    V1(LuaConfigV1),
-
     /// Configuration for version two.
+    #[serde(rename = "2")]
     V2(LuaConfigV2),
+
+    /// Configuration for version one.
+    ///
+    /// This version is deprecated and will be removed in a future version.
+    #[configurable(metadata(deprecated))]
+    #[serde(rename = "1")]
+    V1(LuaConfigV1),
 }
 
 impl GenerateConfig for LuaConfig {
@@ -135,6 +114,59 @@ mod test {
             "#})
             .is_err(),
             "metric_tag_values = auto must be rejected at parse time"
+        );
+    }
+
+    #[test]
+    fn version_is_required() {
+        // The `version` field is the enum tag and must always be specified.
+        assert!(
+            serde_yaml::from_str::<super::LuaConfig>(indoc::indoc! {r#"
+                source: |
+                  event["a"] = "b"
+            "#})
+            .is_err(),
+            "a config without `version` must be rejected"
+        );
+    }
+
+    #[test]
+    fn version_dispatches_to_the_correct_config() {
+        let v1 = serde_yaml::from_str::<super::LuaConfig>(indoc::indoc! {r#"
+            version: "1"
+            source: |
+              event["a"] = "b"
+        "#})
+        .unwrap();
+        assert!(matches!(v1, super::LuaConfig::V1(_)));
+
+        let v2 = serde_yaml::from_str::<super::LuaConfig>(indoc::indoc! {r#"
+            version: "2"
+            hooks:
+              process: |
+                function (event, emit)
+                  emit(event)
+                end
+        "#})
+        .unwrap();
+        assert!(matches!(v2, super::LuaConfig::V2(_)));
+    }
+
+    #[test]
+    fn rejects_unknown_fields() {
+        // `deny_unknown_fields` must still be enforced on the versioned configs.
+        assert!(
+            serde_yaml::from_str::<super::LuaConfig>(indoc::indoc! {r#"
+                version: "2"
+                hooks:
+                  process: |
+                    function (event, emit)
+                      emit(event)
+                    end
+                unknown_field: true
+            "#})
+            .is_err(),
+            "unknown fields must be rejected"
         );
     }
 }

--- a/src/transforms/lua/v2/mod.rs
+++ b/src/transforms/lua/v2/mod.rs
@@ -524,7 +524,7 @@ mod tests {
     ) -> T::Output {
         test_util::trace_init();
         assert_transform_compliance(async move {
-            let config = super::super::LuaConfig::V2(serde_yaml::from_str(config).unwrap());
+            let config = serde_yaml::from_str::<super::super::LuaConfig>(config).unwrap();
             let (tx, rx) = mpsc::channel(1);
             let (topology, out) = create_topology(ReceiverStream::new(rx), config).await;
 

--- a/tests/behavior/transforms/lua_v1.yaml
+++ b/tests/behavior/transforms/lua_v1.yaml
@@ -2,6 +2,7 @@ transforms:
   lua_unversioned:
     inputs: []
     type: "lua"
+    version: "1"
     source: |
       event["a"], event["b"] = nil, event["a"]
 

--- a/website/cue/reference/components/transforms/generated/lua.cue
+++ b/website/cue/reference/components/transforms/generated/lua.cue
@@ -7,7 +7,8 @@ generated: components: transforms: lua: configuration: {
 
 			These hooks can be set to perform additional processing during the lifecycle of the transform.
 			"""
-		required: true
+		relevant_when: "version = \"2\""
+		required:      true
 		type: object: options: {
 			init: {
 				description: """
@@ -82,7 +83,8 @@ generated: components: transforms: lua: configuration: {
 			When set to `full`, all metric tags are exposed as arrays of either string or null
 			values.
 			"""
-		required: false
+		relevant_when: "version = \"2\""
+		required:      false
 		type: string: {
 			default: "single"
 			enum: {
@@ -153,8 +155,9 @@ generated: components: transforms: lua: configuration: {
 		}
 	}
 	timers: {
-		description: "A list of timers which should be configured and executed periodically."
-		required:    false
+		description:   "A list of timers which should be configured and executed periodically."
+		relevant_when: "version = \"2\""
+		required:      false
 		type: array: {
 			default: []
 			items: type: object: options: {
@@ -180,19 +183,15 @@ generated: components: transforms: lua: configuration: {
 		}
 	}
 	version: {
-		description: """
-			Transform API version.
-
-			Specifying this version ensures that backward compatibility is not broken.
-			"""
-		required: true
+		description: "Transform API version. Specifying this version ensures that backward compatibility is not broken."
+		required:    true
 		type: string: enum: {
 			"1": """
-				Lua transform API version 1.
+				Configuration for version one.
 
 				This version is deprecated and will be removed in a future version.
 				"""
-			"2": "Lua transform API version 2."
+			"2": "Configuration for version two."
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Restructure the `lua` transform config into a proper internally-tagged `version` enum so the generated docs mark version 2-only options (`hooks`, `timers`, `metric_tag_values`) with `relevant_when: version = "2"`. `version` is now required, and `deny_unknown_fields` is enforced (previously bypassed by the flattened versioned configs).

## Vector configuration

NA

## How did you test this PR?

Ran the lua unit tests (39), the lua behavior tests, clippy, and regenerated the component docs.

## Is this a breaking change?

- [x] Yes
- [ ] No

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## References

NA
