### PR TITLE
chore(ci): update SMP CLI to 0.28.0 and lading to 0.33.0

### DIFF
--- a/.github/workflows/regression.yml
+++ b/.github/workflows/regression.yml
@@ -116,7 +116,7 @@ jobs:
       - name: Set SMP version
         id: experimental-meta
         run: |
-          export SMP_CRATE_VERSION="0.27.0"
+          export SMP_CRATE_VERSION="0.28.0"
           echo "smp crate version: ${SMP_CRATE_VERSION}"
           echo "SMP_CRATE_VERSION=${SMP_CRATE_VERSION}" >> $GITHUB_OUTPUT
 

--- a/regression/config.yaml
+++ b/regression/config.yaml
@@ -1,5 +1,5 @@
 lading:
-  version: 0.31.2
+  version: 0.33.0
 
 target:
 


### PR DESCRIPTION
Update the SMP CLI version to `0.28.0` ([release notes](https://github.com/DataDog/single-machine-performance/releases/tag/v0.28.0)) and lading to `0.33.0` ([release notes](https://github.com/DataDog/lading/releases/tag/v0.33.0).)

*sent with claude*