### PR TITLE
security(policy): report responsible disclosures via security@datadoghq.com

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -259,7 +259,7 @@ it, we will periodically update you with the status of the fix.
 
 Due to the nature of an open-source project, Vector deployments are fully managed by users. Thus vulnerabilities in Vector deployments could
 potentially be exploited by malicious actors who already have access to the user’s infrastructure. We encourage responsible disclosure
-via opening an [open an issue][urls.new_security_report] so that risks can be properly assessed and mitigated.
+by emailing security@datadoghq.com so that risks can be properly assessed and mitigated.
 
 For us to best investigate your request, please include any of the
 following when reporting:
@@ -276,7 +276,6 @@ following when reporting:
 [urls.git]: https://git-scm.com/
 [urls.github_protected_branches]: https://help.github.com/en/github/administering-a-repository/about-protected-branches
 [urls.least_privilege]: https://en.wikipedia.org/wiki/Principle_of_least_privilege
-[urls.new_security_report]: https://github.com/vectordotdev/vector/issues/new?labels=domain%3A+security
 [urls.rust]: https://www.rust-lang.org/
 [urls.rust_sec]: https://rustsec.org/
 [urls.vector_chat]: https://chat.vector.dev

--- a/changelog.d/security_policy_disclosure_email.security.md
+++ b/changelog.d/security_policy_disclosure_email.security.md
@@ -1,5 +1,0 @@
-Update the security policy so that responsible disclosures of vulnerabilities in Vector deployments are
-reported by emailing security@datadoghq.com instead of opening a public GitHub issue, ensuring risks are
-assessed and mitigated through the standard security triage pipeline.
-
-authors: pront

--- a/changelog.d/security_policy_disclosure_email.security.md
+++ b/changelog.d/security_policy_disclosure_email.security.md
@@ -1,0 +1,5 @@
+Update the security policy so that responsible disclosures of vulnerabilities in Vector deployments are
+reported by emailing security@datadoghq.com instead of opening a public GitHub issue, ensuring risks are
+assessed and mitigated through the standard security triage pipeline.
+
+authors: pront


### PR DESCRIPTION
Direct responsible disclosures of Vector deployment vulnerabilities to `security@datadoghq.com` instead of a public GitHub issue, per the unified COSE policy.
