### PR TITLE
feat(influxdb_logs sink)!: remove deprecated namespace option

### DIFF
--- a/changelog.d/influxdb_logs_namespace_removed.breaking.md
+++ b/changelog.d/influxdb_logs_namespace_removed.breaking.md
@@ -7,8 +7,12 @@ deprecated since v0.24.0 in favor of `measurement`. Configurations using it now 
 
 ## Migration
 
-Replace `namespace` with `measurement`. Previously, `namespace` prefixed the measurement name
-with `<namespace>.vector`, so set `measurement` to `<namespace>.vector` for the same effect:
+If your configuration sets both `namespace` and `measurement`, the old sink used `measurement` and
+ignored `namespace`; remove the `namespace` option and leave `measurement` unchanged.
+
+If your configuration only sets `namespace`, replace it with `measurement`. Previously, `namespace`
+prefixed the measurement name with `<namespace>.vector`, so set `measurement` to
+`<namespace>.vector` for the same effect:
 
 #### Old
 

--- a/changelog.d/influxdb_logs_namespace_removed.breaking.md
+++ b/changelog.d/influxdb_logs_namespace_removed.breaking.md
@@ -7,12 +7,8 @@ deprecated since v0.24.0 in favor of `measurement`. Configurations using it now 
 
 ## Migration
 
-If your configuration sets both `namespace` and `measurement`, the old sink used `measurement` and
-ignored `namespace`; remove the `namespace` option and leave `measurement` unchanged.
-
-If your configuration only sets `namespace`, replace it with `measurement`. Previously, `namespace`
-prefixed the measurement name with `<namespace>.vector`, so set `measurement` to
-`<namespace>.vector` for the same effect:
+Replace `namespace` with `measurement`. Previously, `namespace` prefixed the measurement name
+with `<namespace>.vector`, so set `measurement` to `<namespace>.vector` for the same effect:
 
 #### Old
 
@@ -33,5 +29,8 @@ sinks:
     measurement: my-namespace.vector
     endpoint: http://localhost:8086
 ```
+
+Note: if your configuration sets both `namespace` and `measurement`, the old sink used `measurement`
+and ignored `namespace`; remove the `namespace` option and leave `measurement` unchanged.
 
 authors: thomasqueirozb

--- a/changelog.d/influxdb_logs_namespace_removed.breaking.md
+++ b/changelog.d/influxdb_logs_namespace_removed.breaking.md
@@ -10,6 +10,9 @@ deprecated since v0.24.0 in favor of `measurement`. Configurations using it now 
 Replace `namespace` with `measurement`. Previously, `namespace` prefixed the measurement name
 with `<namespace>.vector`, so set `measurement` to `<namespace>.vector` for the same effect:
 
+Note: if your configuration sets both `namespace` and `measurement`, `measurement` was used and
+`namespace` ignored; remove the `namespace` option and leave `measurement` unchanged.
+
 #### Old
 
 ```yaml
@@ -29,8 +32,5 @@ sinks:
     measurement: my-namespace.vector
     endpoint: http://localhost:8086
 ```
-
-Note: if your configuration sets both `namespace` and `measurement`, `measurement` was used and
-`namespace` ignored; remove the `namespace` option and leave `measurement` unchanged.
 
 authors: thomasqueirozb

--- a/changelog.d/influxdb_logs_namespace_removed.breaking.md
+++ b/changelog.d/influxdb_logs_namespace_removed.breaking.md
@@ -1,0 +1,33 @@
+# `influxdb_logs` sink `namespace` option removed {#influxdb-logs-namespace-removed}
+
+## Summary
+
+The deprecated `namespace` option has been removed from the `influxdb_logs` sink. It has been
+deprecated since v0.24.0 in favor of `measurement`. Configurations using it now fail validation.
+
+## Migration
+
+Replace `namespace` with `measurement`. Previously, `namespace` prefixed the measurement name
+with `<namespace>.vector`, so set `measurement` to `<namespace>.vector` for the same effect:
+
+#### Old
+
+```yaml
+sinks:
+  my_sink_id:
+    type: influxdb_logs
+    namespace: my-namespace
+    endpoint: http://localhost:8086
+```
+
+#### New
+
+```yaml
+sinks:
+  my_sink_id:
+    type: influxdb_logs
+    measurement: my-namespace.vector
+    endpoint: http://localhost:8086
+```
+
+authors: thomasqueirozb

--- a/changelog.d/influxdb_logs_namespace_removed.breaking.md
+++ b/changelog.d/influxdb_logs_namespace_removed.breaking.md
@@ -30,7 +30,7 @@ sinks:
     endpoint: http://localhost:8086
 ```
 
-Note: if your configuration sets both `namespace` and `measurement`, the old sink used `measurement`
-and ignored `namespace`; remove the `namespace` option and leave `measurement` unchanged.
+Note: if your configuration sets both `namespace` and `measurement`, `measurement` was used and
+`namespace` ignored; remove the `namespace` option and leave `measurement` unchanged.
 
 authors: thomasqueirozb

--- a/src/sinks/influxdb/logs.rs
+++ b/src/sinks/influxdb/logs.rs
@@ -47,16 +47,6 @@ impl SinkBatchSettings for InfluxDbLogsDefaultBatchSettings {
 #[derive(Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct InfluxDbLogsConfig {
-    /// The namespace of the measurement name to use.
-    ///
-    /// When specified, the measurement name is `<namespace>.vector`.
-    ///
-    #[configurable(
-        deprecated = "This field is deprecated, and `measurement` should be used instead."
-    )]
-    #[configurable(metadata(docs::examples = "service"))]
-    pub namespace: Option<String>,
-
     /// The name of the InfluxDB measurement that is written to.
     #[configurable(metadata(docs::examples = "vector-logs"))]
     pub measurement: Option<String>,
@@ -213,7 +203,7 @@ impl GenerateConfig for InfluxDbLogsConfig {
     fn generate_config() -> serde_json::Value {
         serde_yaml::from_str(indoc! {r#"
             endpoint: http://localhost:8086/
-            namespace: my-namespace
+            measurement: vector-logs
             tags: []
             version: "2"
             org: my-org
@@ -494,22 +484,9 @@ impl InfluxDbLogsConfig {
     }
 
     fn get_measurement(&self) -> Result<String, &'static str> {
-        match (self.measurement.as_ref(), self.namespace.as_ref()) {
-            (Some(measure), Some(_)) => {
-                warn!("Option `namespace` has been superseded by `measurement`.");
-                Ok(measure.clone())
-            }
-            (Some(measure), None) => Ok(measure.clone()),
-            (None, Some(namespace)) => {
-                warn!(
-                    "Option `namespace` has been deprecated. Use `measurement` instead. \
-                       For example, you can use `measurement=<namespace>.vector` for the \
-                       same effect."
-                );
-                Ok(format!("{namespace}.vector"))
-            }
-            (None, None) => Err("The `measurement` option is required."),
-        }
+        self.measurement
+            .clone()
+            .ok_or("The `measurement` option is required.")
     }
 
     fn healthcheck(&self, client: HttpClient) -> crate::Result<Healthcheck> {
@@ -566,7 +543,7 @@ mod tests {
     #[test]
     fn test_config_without_tags() {
         let config = indoc! {r#"
-            namespace: "vector-logs"
+            measurement: "vector-logs"
             endpoint: "http://localhost:9999"
             version: "2"
             bucket: "my-bucket"
@@ -578,9 +555,8 @@ mod tests {
     }
 
     #[test]
-    fn test_config_measurement_from_namespace() {
+    fn test_config_measurement_required() {
         let config = indoc! {r#"
-            namespace: "ns"
             endpoint: "http://localhost:9999"
             version: "2"
             bucket: "my-bucket"
@@ -589,7 +565,10 @@ mod tests {
         "#};
 
         let sink_config = serde_yaml::from_str::<InfluxDbLogsConfig>(config).unwrap();
-        assert_eq!("ns.vector", sink_config.get_measurement().unwrap());
+        assert_eq!(
+            Err("The `measurement` option is required."),
+            sink_config.get_measurement()
+        );
     }
 
     #[test]
@@ -1172,7 +1151,6 @@ mod integration_tests {
         let cx = SinkContext::default();
 
         let config = InfluxDbLogsConfig {
-            namespace: None,
             measurement: Some(measure.clone()),
             endpoint: endpoint.clone(),
             tags: Default::default(),

--- a/src/sinks/influxdb/logs.rs
+++ b/src/sinks/influxdb/logs.rs
@@ -49,6 +49,7 @@ impl SinkBatchSettings for InfluxDbLogsDefaultBatchSettings {
 pub struct InfluxDbLogsConfig {
     /// The name of the InfluxDB measurement that is written to.
     #[configurable(metadata(docs::examples = "vector-logs"))]
+    #[configurable(metadata(docs::required = true))]
     pub measurement: Option<String>,
 
     /// The endpoint to send data to.

--- a/website/cue/reference/components/sinks/generated/influxdb_logs.cue
+++ b/website/cue/reference/components/sinks/generated/influxdb_logs.cue
@@ -142,7 +142,7 @@ generated: components: sinks: influxdb_logs: configuration: {
 	}
 	measurement: {
 		description: "The name of the InfluxDB measurement that is written to."
-		required:    false
+		required:    true
 		type: string: examples: ["vector-logs"]
 	}
 	message_key: {

--- a/website/cue/reference/components/sinks/generated/influxdb_logs.cue
+++ b/website/cue/reference/components/sinks/generated/influxdb_logs.cue
@@ -156,17 +156,6 @@ generated: components: sinks: influxdb_logs: configuration: {
 			"text",
 		]
 	}
-	namespace: {
-		deprecated:         true
-		deprecated_message: "This field is deprecated, and `measurement` should be used instead."
-		description: """
-			The namespace of the measurement name to use.
-
-			When specified, the measurement name is `<namespace>.vector`.
-			"""
-		required: false
-		type: string: examples: ["service"]
-	}
 	org: {
 		description: """
 			The name of the organization to write into.

--- a/website/generated/example-configs/sinks/influxdb_logs/advanced.yaml
+++ b/website/generated/example-configs/sinks/influxdb_logs/advanced.yaml
@@ -8,7 +8,6 @@ sinks:
     host_key: hostname
     measurement: vector-logs
     message_key: text
-    namespace: service
     org: my-org
     source_type_key: source
     tags:

--- a/website/generated/example-configs/sinks/influxdb_logs/minimal.yaml
+++ b/website/generated/example-configs/sinks/influxdb_logs/minimal.yaml
@@ -5,6 +5,7 @@ sinks:
       - my-source-or-transform-id
     bucket: vector-bucket
     endpoint: http://localhost:8086
+    measurement: vector-logs
     org: my-org
     token: ${INFLUXDB_TOKEN}
     version: "2"


### PR DESCRIPTION
## Summary
Removes the deprecated `namespace` option from the `influxdb_logs` sink, deprecated since v0.24.0 in favor of `measurement`. Configurations using it now fail validation.

### References

NA

## Vector configuration
NA

## How did you test this PR?
Ran `make test SCOPE="-E 'test(influxdb)'"` (55 passed) and regenerated component docs/example configs.

## Is this a breaking change?

- [x] Yes
- [ ] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.
