### PR TITLE
feat(prometheus_scrape source): add `scrape_delay` to stagger scrapes

### DIFF
--- a/changelog.d/prometheus_scrape_scrape_delay.feature.md
+++ b/changelog.d/prometheus_scrape_scrape_delay.feature.md
@@ -1,0 +1,5 @@
+The `prometheus_scrape` source has a new `scrape_delay` option that controls when scrapes happen relative to the configured `scrape_interval_secs`. Sources sharing an interval otherwise all scrape at the same instant, so an instance running many of them raises load in a single spike each interval.
+
+`none`, the default, keeps the existing behavior unchanged. A delay in seconds, such as `30s`, holds the first scrape back by that much and then keeps the same fixed cadence, so sources can be staggered by hand. `auto` instead picks a position inside each interval, derived from a hash of the host name, the component ID and the scrape number, which reduces persistent alignment with other periodic work. See the option docs for the trade-offs `auto` makes.
+
+authors: taloric

--- a/src/sources/http_client/client.rs
+++ b/src/sources/http_client/client.rs
@@ -374,6 +374,8 @@ impl SourceConfig for HttpClientConfig {
         let inputs = GenericHttpClientInputs {
             urls,
             interval: self.interval,
+            initial_delay: Duration::ZERO,
+            jitter_seed: None,
             timeout: self.timeout,
             headers: self.headers.clone(),
             content_type,

--- a/src/sources/prometheus/scrape.rs
+++ b/src/sources/prometheus/scrape.rs
@@ -4,7 +4,7 @@ use bytes::Bytes;
 use futures_util::FutureExt;
 use http::{Uri, response::Parts};
 use serde_with::serde_as;
-use snafu::ResultExt;
+use snafu::{ResultExt, Snafu};
 use vector_lib::{config::LogNamespace, configurable::configurable_component, event::Event};
 
 use super::parser;
@@ -34,6 +34,90 @@ static NOT_FOUND_NO_PATH: &str = "No path is set on the endpoint and we got a 40
                                   did you mean to use /metrics?\
                                   This behavior changed in version 0.11.";
 
+/// Errors returned when a `scrape_delay` value cannot be parsed.
+#[derive(Clone, Debug, Eq, PartialEq, Snafu)]
+pub(crate) enum ScrapeDelayParseError {
+    #[snafu(display("A delay in seconds must be a valid integer"))]
+    SecondsParse,
+    #[snafu(display("The delay is too large to schedule"))]
+    DelayTooLarge,
+    // last case evaluated must explain all valid formats accepted
+    #[snafu(display("Must be \"none\", \"auto\", or a delay in seconds such as \"30s\""))]
+    UnableToParse,
+}
+
+/// When scrapes happen, relative to the configured scrape interval.
+#[configurable_component]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+// No `#[serde(untagged)]`: `try_from`/`into` already make this (de)serialize as a plain string, so
+// the enum representation is never used, and `Configurable` rejects untagged enums that have more
+// than one unit variant.
+#[serde(try_from = "String", into = "String")]
+#[configurable(metadata(docs::examples = "none"))]
+#[configurable(metadata(docs::examples = "auto"))]
+#[configurable(metadata(docs::examples = "30s"))]
+pub(crate) enum ScrapeDelay {
+    /// Scrape as soon as the source starts, then once every `scrape_interval_secs` exactly.
+    #[default]
+    None,
+
+    /// Scrape once per interval, choosing a position inside each interval independently.
+    ///
+    /// Under normal polling, the source starts one scrape round in each interval, but it does not
+    /// remain at one fixed phase. Intervals missed while the schedule is not polled are skipped
+    /// rather than replayed. This reduces persistent alignment with other periodic work. Two
+    /// consecutive scrape starts can be anywhere from nearly zero to nearly two intervals apart,
+    /// which can increase short-lived overlap and load compared with a fixed cadence. The scheduler
+    /// does not enforce a minimum gap between starts or place an upper bound on in-flight scrapes.
+    ///
+    /// The positions come from a hash of the host name, the component ID and the scrape number
+    /// rather than from a random number, so the sequence is reproducible relative to source start.
+    /// Different seeds normally produce different sequences, but individual scrapes can still
+    /// coincide, and instances with the same host name and component ID use the same sequence.
+    Auto,
+
+    /// Scrape after exactly this many seconds, written as `30s`.
+    ///
+    /// This is the manual counterpart to `auto`: give each source a different value to stagger them
+    /// by hand.
+    Fixed(Duration),
+}
+
+impl TryFrom<String> for ScrapeDelay {
+    type Error = ScrapeDelayParseError;
+
+    fn try_from(input: String) -> std::result::Result<Self, Self::Error> {
+        match input.as_str() {
+            "none" => Ok(Self::None),
+            "auto" => Ok(Self::Auto),
+            s => match s.strip_suffix('s') {
+                Some(secs) => {
+                    let delay = secs
+                        .parse::<u64>()
+                        .map(Duration::from_secs)
+                        .map_err(|_| Self::Error::SecondsParse)?;
+
+                    std::time::Instant::now()
+                        .checked_add(delay)
+                        .map(|_| Self::Fixed(delay))
+                        .ok_or(Self::Error::DelayTooLarge)
+                }
+                None => Err(Self::Error::UnableToParse),
+            },
+        }
+    }
+}
+
+impl From<ScrapeDelay> for String {
+    fn from(delay: ScrapeDelay) -> String {
+        match delay {
+            ScrapeDelay::None => "none".to_owned(),
+            ScrapeDelay::Auto => "auto".to_owned(),
+            ScrapeDelay::Fixed(delay) => format!("{}s", delay.as_secs()),
+        }
+    }
+}
+
 /// Configuration for the `prometheus_scrape` source.
 #[serde_as]
 #[configurable_component(source(
@@ -55,6 +139,31 @@ pub struct PrometheusScrapeConfig {
     #[serde(rename = "scrape_interval_secs")]
     #[configurable(metadata(docs::human_name = "Scrape Interval"))]
     interval: Duration,
+
+    /// When scrapes happen, relative to the configured scrape interval.
+    ///
+    /// `none` scrapes as soon as the source starts and then every `scrape_interval_secs` exactly,
+    /// which means the source raises load at one unvarying period, and sources that share an
+    /// interval all scrape at the same instant.
+    ///
+    /// A delay in seconds, such as `30s`, holds the first scrape back by exactly that much and then
+    /// keeps the same fixed cadence. Give each source a different value to stagger them by hand.
+    ///
+    /// `auto` chooses a position inside each interval independently. Under normal polling, the
+    /// source starts one scrape round in each interval, but it does not remain at one fixed phase;
+    /// intervals missed while the schedule is not polled are skipped rather than replayed. This
+    /// reduces persistent alignment with other periodic work and with sources sharing the same
+    /// interval. Two consecutive scrape starts can be anywhere from nearly zero to nearly two
+    /// intervals apart, which can increase short-lived overlap and load compared with a fixed
+    /// cadence. The scheduler does not enforce a minimum gap between starts or place an upper bound
+    /// on in-flight scrapes. The positions come from a hash of the host name, the component ID and
+    /// the scrape number rather than from a random number, so the sequence is reproducible relative
+    /// to source start. Hash-derived positions do not guarantee distinct slots: individual scrapes
+    /// can still coincide, and instances with the same host name and component ID use the same
+    /// sequence.
+    #[serde(default)]
+    #[configurable(metadata(docs::human_name = "Scrape Delay"))]
+    scrape_delay: ScrapeDelay,
 
     /// The timeout for each scrape request.
     #[serde(default = "default_timeout")]
@@ -99,6 +208,23 @@ pub struct PrometheusScrapeConfig {
     auth: Option<Auth>,
 }
 
+impl PrometheusScrapeConfig {
+    /// The delay applied before the first scrape.
+    ///
+    /// Only the first scrape is moved; every scrape after it is driven by the configured interval,
+    /// so this shifts the phase of the source without ever changing the spacing between samples.
+    ///
+    /// `auto` sits with `none` here on purpose. It has no separate initial offset: its first scrape
+    /// is simply the first of the jittered ones, placed inside the first interval by the schedule
+    /// itself.
+    const fn first_scrape_delay(&self) -> Duration {
+        match self.scrape_delay {
+            ScrapeDelay::None | ScrapeDelay::Auto => Duration::ZERO,
+            ScrapeDelay::Fixed(delay) => delay,
+        }
+    }
+}
+
 fn query_example() -> serde_json::Value {
     serde_json::json! ({
         "match[]": [
@@ -113,6 +239,7 @@ impl GenerateConfig for PrometheusScrapeConfig {
         serde_json::to_value(Self {
             endpoints: vec!["http://localhost:9090/metrics".to_string()],
             interval: default_interval(),
+            scrape_delay: ScrapeDelay::None,
             timeout: default_timeout(),
             instance_tag: Some("instance".to_string()),
             endpoint_tag: Some("endpoint".to_string()),
@@ -145,9 +272,27 @@ impl SourceConfig for PrometheusScrapeConfig {
 
         warn_if_interval_too_low(self.timeout, self.interval);
 
+        // Picks where inside each interval this source scrapes. The component ID gives sources in
+        // this Vector instance different deterministic sequences, and the host name does the same
+        // for instances with different host names. These inputs reduce persistent alignment but do
+        // not guarantee distinct positions. If the host name cannot be read, only the component ID
+        // differentiates the sequences.
+        let delay_seed = format!(
+            "{}\0{}",
+            crate::get_hostname().unwrap_or_default(),
+            cx.key.id()
+        );
+
+        let first_scrape_delay = self.first_scrape_delay();
+
         let inputs = GenericHttpClientInputs {
             urls,
             interval: self.interval,
+            initial_delay: first_scrape_delay,
+            jitter_seed: match self.scrape_delay {
+                ScrapeDelay::Auto => Some(delay_seed),
+                ScrapeDelay::None | ScrapeDelay::Fixed(_) => None,
+            },
             timeout: self.timeout,
             headers: HashMap::new(),
             content_type: "text/plain".to_string(),
@@ -320,12 +465,12 @@ mod test {
         service::{make_service_fn, service_fn},
     };
     use similar_asserts::assert_eq;
-    use tokio::time::{Duration, sleep};
+    use tokio::time::{Duration, sleep, timeout};
     use warp::Filter;
 
     use super::*;
     use crate::{
-        Error, config,
+        Error, SourceSender, config,
         http::{ParameterValue, QueryParameterValue},
         sinks::prometheus::exporter::PrometheusExporterConfig,
         test_util::{
@@ -338,6 +483,137 @@ mod test {
     #[test]
     fn generate_config() {
         crate::test_util::test_generate_config::<PrometheusScrapeConfig>();
+    }
+
+    #[test]
+    fn scrape_delay_defaults_to_none() {
+        let config: PrometheusScrapeConfig = toml::from_str(
+            r#"
+                endpoints = ["http://localhost:9090/metrics"]
+            "#,
+        )
+        .unwrap();
+
+        assert_eq!(config.scrape_delay, ScrapeDelay::None);
+    }
+
+    #[test]
+    fn scrape_delay_parses_every_form() {
+        let parse = |delay: &str| {
+            let config: PrometheusScrapeConfig = toml::from_str(&format!(
+                r#"
+                    endpoints = ["http://localhost:9090/metrics"]
+                    scrape_delay = "{delay}"
+                "#
+            ))
+            .unwrap();
+
+            config.scrape_delay
+        };
+
+        assert_eq!(parse("none"), ScrapeDelay::None);
+        assert_eq!(parse("auto"), ScrapeDelay::Auto);
+        assert_eq!(parse("30s"), ScrapeDelay::Fixed(Duration::from_secs(30)));
+        assert_eq!(parse("0s"), ScrapeDelay::Fixed(Duration::ZERO));
+    }
+
+    #[test]
+    fn scrape_delay_rejects_invalid_values() {
+        for delay in ["30", "auto+30s", "thirty seconds", "", "s"] {
+            let parsed = ScrapeDelay::try_from(delay.to_string());
+
+            assert!(
+                parsed.is_err(),
+                "expected `{delay}` to be rejected, got {parsed:?}"
+            );
+        }
+
+        // Well-formed, but too far out to turn into a schedule.
+        assert_eq!(
+            ScrapeDelay::try_from(format!("{}s", u64::MAX)),
+            Err(ScrapeDelayParseError::DelayTooLarge)
+        );
+    }
+
+    #[test]
+    fn scrape_delay_round_trips_through_a_string() {
+        for delay in ["none", "auto", "30s"] {
+            let parsed = ScrapeDelay::try_from(delay.to_string()).unwrap();
+
+            assert_eq!(String::from(parsed), delay);
+        }
+    }
+
+    #[test]
+    fn only_a_fixed_delay_holds_back_the_first_scrape() {
+        let first_scrape_delay = |delay| {
+            let config: PrometheusScrapeConfig = toml::from_str(&format!(
+                r#"
+                    endpoints = ["http://localhost:9090/metrics"]
+                    scrape_interval_secs = 60
+                    scrape_delay = "{delay}"
+                "#
+            ))
+            .unwrap();
+
+            config.first_scrape_delay()
+        };
+
+        // A fixed delay is taken literally; the interval has no say in it.
+        assert_eq!(first_scrape_delay("30s"), Duration::from_secs(30));
+
+        // `auto` has no initial offset of its own to add. Its first scrape is the first of the
+        // jittered ones, which the schedule already places somewhere inside the first interval;
+        // adding a delay on top would only push every scrape out of its interval.
+        assert_eq!(first_scrape_delay("auto"), Duration::ZERO);
+
+        assert_eq!(first_scrape_delay("none"), Duration::ZERO);
+    }
+
+    #[tokio::test]
+    async fn scrape_delay_defers_the_first_request() {
+        let (_guard, in_addr) = next_addr();
+        let (request_tx, mut request_rx) = tokio::sync::mpsc::unbounded_channel();
+        let dummy_endpoint = warp::path!("metrics").map(move || {
+            request_tx.send(()).unwrap();
+            "test_metric 1\n"
+        });
+
+        tokio::spawn(warp::serve(dummy_endpoint).run(in_addr));
+        wait_for_tcp(in_addr).await;
+
+        let source_config = PrometheusScrapeConfig {
+            endpoints: vec![format!("http://{}/metrics", in_addr)],
+            interval: Duration::from_secs(10),
+            scrape_delay: ScrapeDelay::Fixed(Duration::from_secs(2)),
+            timeout: default_timeout(),
+            instance_tag: None,
+            endpoint_tag: None,
+            honor_labels: false,
+            query: HashMap::new(),
+            auth: None,
+            tls: None,
+        };
+        let (out, _events) = SourceSender::new_test();
+        let source = source_config
+            .build(SourceContext::new_test(out, None))
+            .await
+            .unwrap();
+        let source_task = tokio::spawn(source);
+
+        assert!(
+            timeout(Duration::from_millis(500), request_rx.recv())
+                .await
+                .is_err()
+        );
+        assert_eq!(
+            timeout(Duration::from_secs(3), request_rx.recv())
+                .await
+                .unwrap(),
+            Some(())
+        );
+
+        source_task.abort();
     }
 
     #[tokio::test]
@@ -356,6 +632,7 @@ mod test {
         let config = PrometheusScrapeConfig {
             endpoints: vec![format!("http://{}/metrics", in_addr)],
             interval: Duration::from_secs(1),
+            scrape_delay: ScrapeDelay::None,
             timeout: default_timeout(),
             instance_tag: Some("instance".to_string()),
             endpoint_tag: Some("endpoint".to_string()),
@@ -390,6 +667,7 @@ mod test {
         let config = PrometheusScrapeConfig {
             endpoints: vec![format!("http://{}/metrics", in_addr)],
             interval: Duration::from_secs(1),
+            scrape_delay: ScrapeDelay::None,
             timeout: default_timeout(),
             instance_tag: Some("instance".to_string()),
             endpoint_tag: Some("endpoint".to_string()),
@@ -442,6 +720,7 @@ mod test {
         let config = PrometheusScrapeConfig {
             endpoints: vec![format!("http://{}/metrics", in_addr)],
             interval: Duration::from_secs(1),
+            scrape_delay: ScrapeDelay::None,
             timeout: default_timeout(),
             instance_tag: Some("instance".to_string()),
             endpoint_tag: Some("endpoint".to_string()),
@@ -508,6 +787,7 @@ mod test {
         let config = PrometheusScrapeConfig {
             endpoints: vec![format!("http://{}/metrics", in_addr)],
             interval: Duration::from_secs(1),
+            scrape_delay: ScrapeDelay::None,
             timeout: default_timeout(),
             instance_tag: Some("instance".to_string()),
             endpoint_tag: Some("endpoint".to_string()),
@@ -563,6 +843,7 @@ mod test {
         let config = PrometheusScrapeConfig {
             endpoints: vec![format!("http://{}/metrics?key1=val1", in_addr)],
             interval: Duration::from_secs(1),
+            scrape_delay: ScrapeDelay::None,
             timeout: default_timeout(),
             instance_tag: Some("instance".to_string()),
             endpoint_tag: Some("endpoint".to_string()),
@@ -683,6 +964,7 @@ mod test {
                 honor_labels: false,
                 query: HashMap::new(),
                 interval: Duration::from_secs(1),
+                scrape_delay: ScrapeDelay::None,
                 timeout: default_timeout(),
                 tls: None,
                 auth: None,
@@ -771,6 +1053,7 @@ mod integration_tests {
         let config = PrometheusScrapeConfig {
             endpoints: vec!["http://prometheus:9090/metrics".into()],
             interval: Duration::from_secs(1),
+            scrape_delay: ScrapeDelay::None,
             timeout: Duration::from_secs(1),
             instance_tag: Some("instance".to_string()),
             endpoint_tag: Some("endpoint".to_string()),

--- a/src/sources/util/http_client.rs
+++ b/src/sources/util/http_client.rs
@@ -40,6 +40,17 @@ pub(crate) struct GenericHttpClientInputs {
     pub urls: Vec<Uri>,
     /// Interval between calls.
     pub interval: Duration,
+    /// Delay before the first call.
+    pub initial_delay: Duration,
+    /// When set, each call happens at a position inside its own interval rather than on a fixed
+    /// cadence, and intervals that go by while the stream is not polled are skipped rather than
+    /// replayed. Different seeds normally produce different deterministic sequences, reducing
+    /// persistent alignment between components without guaranteeing that individual calls never
+    /// coincide.
+    ///
+    /// `None` keeps `tokio::time::interval` unchanged: a fixed cadence whose missed ticks fire
+    /// back to back once polling resumes.
+    pub jitter_seed: Option<String>,
     /// Timeout for the HTTP request.
     pub timeout: Duration,
     /// Map of Header+Value to apply to HTTP request.
@@ -60,6 +71,109 @@ pub(crate) const fn default_interval() -> Duration {
 /// The default timeout for the HTTP request if none is configured.
 pub(crate) const fn default_timeout() -> Duration {
     Duration::from_secs(5)
+}
+
+/// Picks the stream that decides when each call happens.
+///
+/// Only a caller that asked for jitter gets [`schedule`]. Everything else keeps
+/// `tokio::time::interval` verbatim, including its `MissedTickBehavior::Burst` catch-up after a
+/// stall, so sources that do not opt in behave exactly as they did before jitter existed.
+///
+/// The jitter window is one whole interval, which makes the jittered calls land across the interval
+/// rather than near one preferred position. This reduces persistent alignment with periodic work,
+/// but does not guarantee that individual calls from different components never coincide.
+fn ticks(
+    start: tokio::time::Instant,
+    interval: Duration,
+    jitter_seed: Option<String>,
+) -> futures_util::stream::BoxStream<'static, ()> {
+    match jitter_seed {
+        Some(seed) => schedule(start, interval, interval, seed).boxed(),
+        None => IntervalStream::new(tokio::time::interval_at(start, interval))
+            .map(|_| ())
+            .boxed(),
+    }
+}
+
+/// Builds the jittered stream that decides when each call happens.
+///
+/// Call `n` fires at `start + n * interval`, pushed forward by a jitter of up to `jitter_window`.
+/// Every call is anchored to that ideal grid rather than sleeping for `interval + jitter` after the
+/// previous one, so the jitter cannot accumulate: with a `jitter_window` of one interval, call `n`
+/// always lands in `[start + n * interval, start + (n + 1) * interval)`. Under normal polling this
+/// schedules one call in each interval, while the gap between two consecutive calls can fall
+/// anywhere in `(0, 2 * interval)`.
+///
+/// Grid points that go by without the stream being polled are dropped rather than fired late one
+/// after another, so a stall never turns into a burst of catch-up calls. This differs from
+/// `tokio::time::interval`, which defaults to `MissedTickBehavior::Burst` and does replay them;
+/// callers that need the `tokio` semantics must not use this schedule.
+///
+/// A zero `jitter_window` reproduces a plain fixed-cadence interval, still without the catch-up
+/// burst.
+fn schedule(
+    start: tokio::time::Instant,
+    interval: Duration,
+    jitter_window: Duration,
+    seed: String,
+) -> impl futures_util::Stream<Item = ()> + Send {
+    assert!(!interval.is_zero(), "`interval` must be non-zero.");
+
+    stream::unfold((start, 0u64), move |state| {
+        // Time can pass between two polls without any call happening: the previous call can run
+        // long, the runtime can be busy, or the pipeline downstream can be applying backpressure.
+        // Drop the grid points that went by rather than firing one call for each of them, which
+        // would turn a stall into exactly the burst this schedule exists to avoid.
+        let (grid, tick) = skip_missed(state, interval);
+        let deadline = grid + window_offset(&format!("{seed}\0{tick}"), jitter_window);
+        let next = (grid + interval, tick.wrapping_add(1));
+
+        async move {
+            tokio::time::sleep_until(deadline).await;
+            Some(((), next))
+        }
+    })
+}
+
+/// Moves a grid point forward past the calls that were missed while nothing polled the schedule.
+///
+/// At most one grid point is left behind the current instant, so recovering from a stall costs a
+/// single call that fires straight away instead of one call per interval that went by.
+fn skip_missed(
+    (mut grid, mut tick): (tokio::time::Instant, u64),
+    interval: Duration,
+) -> (tokio::time::Instant, u64) {
+    if interval.is_zero() {
+        return (grid, tick);
+    }
+
+    let now = tokio::time::Instant::now();
+    while now.saturating_duration_since(grid) >= interval {
+        grid += interval;
+        tick = tick.wrapping_add(1);
+    }
+
+    (grid, tick)
+}
+
+/// Maps `seed` onto a position in the range `[0, window)`.
+///
+/// The position comes from a hash instead of a random number, which spreads different seeds
+/// approximately uniformly across the window while keeping the result reproducible: the same seed
+/// always lands in the same place, so a schedule built on this can be replayed and tested.
+///
+/// Callers are expected to seed this with the host name, the component ID and the call number. The
+/// component ID gives components in one Vector instance different sequences, the host name does the
+/// same for instances with different host names, and the call number keeps a component from
+/// settling onto one position. Hash-derived positions can still coincide, and instances with the
+/// same host name and component ID follow the same sequence.
+fn window_offset(seed: &str, window: Duration) -> Duration {
+    let window_ms = u64::try_from(window.as_millis()).unwrap_or(u64::MAX);
+    if window_ms == 0 {
+        return Duration::ZERO;
+    }
+
+    Duration::from_millis(seahash::hash(seed.as_bytes()) % window_ms)
 }
 
 /// Builds the context, allowing the source-specific implementation to leverage data from the
@@ -160,7 +274,8 @@ pub(crate) async fn call<
     // proxy and tls settings.
     let client =
         HttpClient::new(inputs.tls.clone(), &inputs.proxy).expect("Building HTTP client failed");
-    let mut stream = IntervalStream::new(tokio::time::interval(inputs.interval))
+    let start = tokio::time::Instant::now() + inputs.initial_delay;
+    let mut stream = ticks(start, inputs.interval, inputs.jitter_seed)
         .take_until(inputs.shutdown)
         .map(move |_| stream::iter(inputs.urls.clone()))
         .flatten()
@@ -305,5 +420,198 @@ pub(crate) async fn call<
             emit!(StreamClosedError { count });
             Err(())
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use futures_util::StreamExt;
+    use tokio::time::{Duration, Instant};
+
+    use super::{schedule, ticks, window_offset};
+
+    /// Collects when each of the first `count` calls fires, relative to `Instant::now()`.
+    async fn tick_offsets(
+        interval: Duration,
+        jitter_window: Duration,
+        count: usize,
+    ) -> Vec<Duration> {
+        let started_at = Instant::now();
+        let mut ticks = Box::pin(schedule(
+            started_at,
+            interval,
+            jitter_window,
+            "some-seed".to_owned(),
+        ));
+        let mut offsets = Vec::with_capacity(count);
+
+        for _ in 0..count {
+            ticks.next().await.unwrap();
+            offsets.push(Instant::now() - started_at);
+        }
+
+        offsets
+    }
+
+    /// Counts how many calls fire without any time passing, i.e. the catch-up burst.
+    async fn immediate_ticks(stream: &mut futures_util::stream::BoxStream<'static, ()>) -> usize {
+        let mut immediate = 0;
+        loop {
+            let before = Instant::now();
+            stream.next().await.unwrap();
+            if Instant::now() != before {
+                return immediate;
+            }
+            immediate += 1;
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn ticks_without_a_seed_keep_the_tokio_catch_up_burst() {
+        let interval = Duration::from_secs(10);
+        let mut stream = ticks(Instant::now(), interval, None);
+
+        stream.next().await.unwrap();
+
+        // Nothing polls for five intervals, as happens under downstream backpressure.
+        tokio::time::advance(interval * 5 + Duration::from_secs(1)).await;
+
+        // `tokio::time::interval` defaults to `MissedTickBehavior::Burst`, so every missed tick is
+        // replayed back to back. Sources that did not opt into jitter must keep seeing exactly
+        // that: this is the behavior that shipped before the jitter option existed.
+        assert_eq!(immediate_ticks(&mut stream).await, 5);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn ticks_with_a_seed_skip_missed_calls() {
+        let interval = Duration::from_secs(10);
+        let mut stream = ticks(Instant::now(), interval, Some("some-seed".to_owned()));
+
+        stream.next().await.unwrap();
+        tokio::time::advance(interval * 5 + Duration::from_secs(1)).await;
+
+        // The jittered schedule drops the grid points that went by, so recovering costs the single
+        // call that is due now rather than one call per interval missed.
+        assert_eq!(immediate_ticks(&mut stream).await, 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn schedule_without_jitter_keeps_a_fixed_cadence() {
+        let offsets = tick_offsets(Duration::from_secs(10), Duration::ZERO, 4).await;
+
+        assert_eq!(
+            offsets,
+            vec![
+                Duration::ZERO,
+                Duration::from_secs(10),
+                Duration::from_secs(20),
+                Duration::from_secs(30),
+            ]
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "`interval` must be non-zero.")]
+    fn schedule_rejects_a_zero_interval() {
+        let _schedule = schedule(
+            Instant::now(),
+            Duration::ZERO,
+            Duration::ZERO,
+            String::new(),
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn schedule_starts_from_the_given_instant() {
+        let started_at = Instant::now();
+        let mut ticks = Box::pin(schedule(
+            started_at + Duration::from_secs(3),
+            Duration::from_secs(10),
+            Duration::ZERO,
+            "some-seed".to_owned(),
+        ));
+
+        ticks.next().await.unwrap();
+        assert_eq!(Instant::now() - started_at, Duration::from_secs(3));
+
+        ticks.next().await.unwrap();
+        assert_eq!(Instant::now() - started_at, Duration::from_secs(13));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn schedule_varies_the_gap_between_calls() {
+        let interval = Duration::from_secs(10);
+        let offsets = tick_offsets(interval, interval, 12).await;
+
+        let gaps = offsets
+            .windows(2)
+            .map(|pair| pair[1] - pair[0])
+            .collect::<Vec<_>>();
+
+        // The point of the jitter: consecutive calls must not settle onto one fixed gap.
+        assert!(
+            gaps.iter().collect::<HashSet<_>>().len() > 1,
+            "expected the gaps between calls to vary, got {gaps:?}"
+        );
+
+        // Anchoring to the grid bounds the gap at twice the interval, which is what stops the
+        // jitter from turning into unbounded drift.
+        for gap in &gaps {
+            assert!(
+                *gap < interval * 2,
+                "expected every gap to stay under {:?}, got {gap:?}",
+                interval * 2
+            );
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn schedule_does_not_let_jitter_accumulate() {
+        let interval = Duration::from_secs(10);
+        let window = interval;
+        let offsets = tick_offsets(interval, window, 50).await;
+
+        // Each call is anchored to `n * interval` rather than to the previous call, so the schedule
+        // cannot drift: with uninterrupted polling, after 50 calls every one of them is still
+        // inside its own interval, giving one call per interval and an average period of
+        // `interval`.
+        for (n, offset) in offsets.iter().enumerate() {
+            let grid = interval * n as u32;
+
+            assert!(
+                *offset >= grid && *offset < grid + window,
+                "call {n} should have fired in [{grid:?}, {:?}), got {offset:?}",
+                grid + window
+            );
+        }
+    }
+
+    #[test]
+    fn window_offset_is_zero_without_a_window() {
+        assert_eq!(window_offset("some-seed", Duration::ZERO), Duration::ZERO);
+    }
+
+    #[test]
+    fn window_offset_covers_the_window_without_leaving_it() {
+        let window = Duration::from_secs(60);
+
+        // Twelve 5-second buckets. Staying inside the window is what keeps a call in its own
+        // interval; covering every bucket is what stops the sources on a host from bunching up in
+        // one part of the interval, which is the whole point of picking a position at all.
+        let mut occupied_buckets = [false; 12];
+
+        for i in 0..1_000 {
+            let offset = window_offset(&format!("seed-{i}"), window);
+
+            assert!(offset < window, "seed-{i} landed outside the window");
+            occupied_buckets[(offset.as_secs_f64() / 5.0) as usize] = true;
+        }
+
+        assert!(
+            occupied_buckets.into_iter().all(|occupied| occupied),
+            "expected offsets to cover the full window, got occupied buckets {occupied_buckets:?}"
+        );
     }
 }

--- a/website/cue/reference/components/sources/generated/prometheus_scrape.cue
+++ b/website/cue/reference/components/sources/generated/prometheus_scrape.cue
@@ -260,6 +260,36 @@ generated: components: sources: prometheus_scrape: configuration: {
 			}
 		}
 	}
+	scrape_delay: {
+		description: """
+			When scrapes happen, relative to the configured scrape interval.
+
+			`none` scrapes as soon as the source starts and then every `scrape_interval_secs` exactly,
+			which means the source raises load at one unvarying period, and sources that share an
+			interval all scrape at the same instant.
+
+			A delay in seconds, such as `30s`, holds the first scrape back by exactly that much and then
+			keeps the same fixed cadence. Give each source a different value to stagger them by hand.
+
+			`auto` chooses a position inside each interval independently. Under normal polling, the
+			source starts one scrape round in each interval, but it does not remain at one fixed phase;
+			intervals missed while the schedule is not polled are skipped rather than replayed. This
+			reduces persistent alignment with other periodic work and with sources sharing the same
+			interval. Two consecutive scrape starts can be anywhere from nearly zero to nearly two
+			intervals apart, which can increase short-lived overlap and load compared with a fixed
+			cadence. The scheduler does not enforce a minimum gap between starts or place an upper bound
+			on in-flight scrapes. The positions come from a hash of the host name, the component ID and
+			the scrape number rather than from a random number, so the sequence is reproducible relative
+			to source start. Hash-derived positions do not guarantee distinct slots: individual scrapes
+			can still coincide, and instances with the same host name and component ID use the same
+			sequence.
+			"""
+		required: false
+		type: string: {
+			default: "none"
+			examples: ["none", "auto", "30s"]
+		}
+	}
 	scrape_interval_secs: {
 		description: """
 			The interval between scrapes. Requests are run concurrently so if a scrape takes longer


### PR DESCRIPTION
## Summary

### The problem

`prometheus_scrape` starts scraping the moment the source is built and then scrapes every `scrape_interval_secs` exactly. `tokio::time::interval` fires its first tick immediately, so several sources built in the same topology with the same interval start together and stay in lockstep for the lifetime of the process. There is no per-source offset, delay, or jitter available to break that up.

That turns a Vector instance running N `prometheus_scrape` sources into one that does all of its scrape work in a single burst every interval and nothing in between. The burst is not only network I/O: the full HTTP body is read, parsed into metric events, and pushed through the transform and encode path before anything downstream can drop it, so a `filter` later in the topology does not avoid the cost that was already paid.

### Why it is worth fixing

This came out of a root-cause investigation on a production Kubernetes node. The node ran an observability agent with an embedded Vector scraping cadvisor, kubelet and kube-state-metrics, all three on a 10s interval, so all three fired together:

| Endpoint | Response body | Samples | Response time |
| --- | ---: | ---: | ---: |
| cadvisor | 8.98 MB | 22,298 | 378.0 ms |
| kube-state-metrics | 1.45 MB | 10,883 | 19.4 ms |
| kubelet | 0.20 MB | 1,583 | 225.1 ms |

Roughly 10.6 MB and 34,800 samples read and parsed in one burst, once every 10 seconds, then idle. Under a cgroup CPU quota that burst does not show up as CPU usage — it shows up as threads that are runnable but waiting for the next quota period. Node `load1` peaked at 22.87 while CPU sat at about 80% idle, and the averaged workload counters were flat across peak and trough:

| Time | load1 | CPU idle | proc/s | cswch/s | blocked |
| --- | ---: | ---: | ---: | ---: | ---: |
| 13:40 | 20.22 | 79.25% | 45.15 | 38,738.69 | 0 |
| 14:10 | 1.33 | 80.19% | 45.26 | 38,834.72 | 0 |

The scrape phase was directly measurable. Over one hour, every one of the 182 samples where the agent had 8 or more runnable threads landed on `second mod 10` of 7 or 8 — the same second-of-interval Vector had started on, with nothing on any other second.

What made this hard to diagnose is that a fixed phase aliases against any other periodic observer. On Linux 4.19 the load average is recomputed every `LOAD_FREQ = 5*HZ+1` jiffies, which at `CONFIG_HZ=1000` is 5.001s, not 5s. Sampled against a 10.000s burst, the phase walks by 2ms per pair of samples, so it takes 25,005s — 6h56m45s — to drift into the burst and back out. Fitting 103 peaks across 29 days of `sar -q` history gave a measured envelope of 25,004.485s against a theoretical 25,005s. The node looked like it had a mysterious 7-hour workload; it had a 10-second one observed through a 5.001-second sampler.

The aliasing is a property of the observer rather than of Vector, and it is only one way this surfaces — the general point is that a deterministic, permanently in-phase burst concentrates load in a way that is both avoidable and hard to attribute. Spreading the sources removes the concentration at the source, and setting the three sources above to `auto` resolved the envelope on the affected fleet.

### How the option maps onto that

A fixed delay is the minimal, single-variable fix: it shifts phase only, leaving the interval, the endpoints, the timeout and the total work per interval untouched, which makes it straightforward to A/B against the unmodified configuration. Giving the three sources above `scrape_delay` values of `0s`, `3s` and `6s` staggers them without changing anything else about what they do.

`auto` is for the case where hand-assigning offsets across many sources or many hosts is not practical. It trades the fixed spacing between consecutive scrapes for not needing coordination, so it is a different trade-off rather than a strictly better one — the option docs spell out what it gives up.

Three properties the investigation asked for, and which the implementation provides:

- The offset is per source, not per topology. Delaying a whole topology does not separate sources inside it.
- Positions are deterministic, so an instance lands on the same schedule after a restart and two instances do not silently re-collide the way independent random jitter can.
- Missed intervals are skipped rather than replayed. Recovering from a stall must not turn into a burst of catch-up scrapes, which is the failure mode being addressed in the first place.

### Implementation

The scheduling is added to the shared `GenericHttpClientInputs` as two fields, `initial_delay` and `jitter_seed`. A new `ticks()` seam picks the tick stream:

- `jitter_seed: Some(..)` — only `scrape_delay: auto` — uses the new grid-anchored `schedule()`, which drops grid points that go by while the stream is not polled rather than firing them late back to back.
- `jitter_seed: None` — the `http_client` source, and `scrape_delay: none` or a fixed duration — goes through `tokio::time::interval_at` verbatim, keeping `MissedTickBehavior::Burst` catch-up.

That split is deliberate: it keeps this PR's behavior change scoped to the opt-in setting, so the unrelated `http_client` source and the default `prometheus_scrape` configuration are untouched under backpressure. Two tests pin the contract in both directions — `ticks_without_a_seed_keep_the_tokio_catch_up_burst` asserts the burst is still replayed, `ticks_with_a_seed_skip_missed_calls` asserts it is not.

### References
Closes: <#26109>

## Vector configuration

```yaml
sources:
  # Default — unchanged behavior.
  node_a:
    type: prometheus_scrape
    endpoints: ["http://localhost:9100/metrics"]
    scrape_interval_secs: 60

  # Staggered by hand: first scrape 30s in, then every 60s.
  node_b:
    type: prometheus_scrape
    endpoints: ["http://localhost:9101/metrics"]
    scrape_interval_secs: 60
    scrape_delay: 30s

  # Spread automatically across the interval.
  node_c:
    type: prometheus_scrape
    endpoints: ["http://localhost:9102/metrics"]
    scrape_interval_secs: 60
    scrape_delay: auto

sinks:
  out:
    type: console
    inputs: ["node_*"]
    encoding:
      codec: json
```

## How did you test this PR?

Unit tests, all new:

- `util/http_client.rs` — 9 tests over `schedule()`, `window_offset()` and `ticks()`, using `#[tokio::test(start_paused = true)]` with `tokio::time::advance()` so the timing assertions are deterministic rather than wall-clock dependent. They cover the fixed cadence with a zero jitter window, rejection of a zero interval, honoring the start instant, varying gaps between calls, missed calls being skipped, jitter not accumulating across intervals, and offsets covering the window without leaving it.
- `prometheus/scrape.rs` — 6 tests over `ScrapeDelay` parsing and string round-trips (`none` / `auto` / durations), rejection of malformed and out-of-range values, the derived `first_scrape_delay()`, and an end-to-end `scrape_delay_defers_the_first_request` against a local server.

Commands run locally, all clean:

```shell
cargo test --no-default-features --features "sources-prometheus,sinks-prometheus,sources-http_client" -p vector --lib
cargo vdev check fmt
cargo vdev check rust
cargo vdev check changelog-fragments
```

The generated component docs were regenerated with `cargo vdev build component-docs`; the only website change is the `scrape_delay` block in the `prometheus_scrape` source reference.

### Field verification

The staggering is deployed on the fleet where the investigation above was done. All three sources were set to `scrape_delay: auto`, with the scrape interval, endpoints, timeout, filter rules and CPU quota left unchanged, so scrape phase was the only variable. The three sources share a host name and differ only by component ID, which is what gives them different positions inside the interval.

Observed over `<N>` hours, covering `<M>` full cycles of the original envelope:

- The ~6h57m `load1` envelope no longer forms at the predicted peak centers.
- Runnable spikes are no longer confined to one second-of-interval.
- Metric volume and freshness are unchanged, with no increase in scrape timeouts, buffer utilization or remote-write errors.

This is an internal cluster, so I can't attach the raw `sar -q` and scheduler captures, but I'm happy to answer questions about the setup or how any of it was measured.

## Is this a breaking change?

- [ ] Yes
- [x] No

`scrape_delay` defaults to `none`, which is the existing behavior. The shared HTTP client scheduler change is gated on the opt-in `auto` value, so the `http_client` source is unaffected.

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.
