### PR TITLE
fix(packaging): use sysconfig environment file in RPMs (#26076)

### DIFF
--- a/changelog.d/26076_rpm_environment_file.fix.md
+++ b/changelog.d/26076_rpm_environment_file.fix.md
@@ -1,3 +1,4 @@
-Use the conventional `/etc/sysconfig/vector` environment file path in RPM packages.
+Use the conventional `/etc/sysconfig/vector` environment file path in RPM packages, migrating
+existing `/etc/default/vector` customizations during upgrades.
 
 authors: inflatador

--- a/changelog.d/26076_rpm_environment_file.fix.md
+++ b/changelog.d/26076_rpm_environment_file.fix.md
@@ -1,0 +1,3 @@
+Use the conventional `/etc/sysconfig/vector` environment file path in RPM packages.
+
+authors: inflatador

--- a/distribution/rpm/vector.spec
+++ b/distribution/rpm/vector.spec
@@ -66,6 +66,15 @@ cp -a %{_builddir}/licenses/. %{buildroot}%{_datadir}/%{_name}/licenses
 cp -a %{_builddir}/NOTICE %{buildroot}%{_datadir}/%{_name}/NOTICE
 cp -a %{_builddir}/LICENSE-3rdparty.csv %{buildroot}%{_datadir}/%{_name}/LICENSE-3rdparty.csv
 
+%pre
+# Preserve environment customizations when upgrading from an RPM that used
+# the Debian-style path. The packaged file is marked noreplace, so RPM keeps
+# this migrated file and installs the new default alongside it as .rpmnew.
+if [ -f %{_sysconfdir}/default/vector ] && [ ! -e %{_sysconfdir}/sysconfig/vector ]; then
+  mkdir -p %{_sysconfdir}/sysconfig
+  cp -a %{_sysconfdir}/default/vector %{_sysconfdir}/sysconfig/vector
+fi
+
 %post
 getent passwd %{_username} > /dev/null || \
   useradd --shell /sbin/nologin --system --home-dir %{_sharedstatedir}/%{_name} --user-group \
@@ -73,6 +82,10 @@ getent passwd %{_username} > /dev/null || \
 chown %{_username} %{_sharedstatedir}/%{_name}
 usermod -aG systemd-journal %{_username}  || true
 usermod -aG systemd-journal-remote %{_username}  || true
+systemctl daemon-reload >/dev/null 2>&1 || true
+
+%postun
+systemctl daemon-reload >/dev/null 2>&1 || true
 
 %clean
 rm -rf %{buildroot}

--- a/distribution/rpm/vector.spec
+++ b/distribution/rpm/vector.spec
@@ -50,7 +50,7 @@ rm -rf %{buildroot}
 mkdir -p %{buildroot}
 mkdir -p %{buildroot}%{_bindir}
 mkdir -p %{buildroot}%{_sysconfdir}/%{_name}
-mkdir -p %{buildroot}%{_sysconfdir}/default
+mkdir -p %{buildroot}%{_sysconfdir}/sysconfig
 mkdir -p %{buildroot}%{_sharedstatedir}/%{_name}
 mkdir -p %{buildroot}%{_datadir}/%{_name}
 mkdir -p %{buildroot}%{_unitdir}
@@ -59,8 +59,9 @@ cp -a %{_builddir}/bin/vector %{buildroot}%{_bindir}
 mkdir -p %{buildroot}%{_datadir}/%{_name}/examples
 cp -a %{_builddir}/config/vector.yaml %{buildroot}%{_datadir}/%{_name}/examples/vector.yaml
 cp -a %{_builddir}/config/examples/. %{buildroot}%{_sysconfdir}/%{_name}/examples
-cp -a %{_builddir}/systemd/vector.service %{buildroot}%{_unitdir}/vector.service
-cp -a %{_builddir}/systemd/vector.default %{buildroot}%{_sysconfdir}/default/vector
+sed 's|EnvironmentFile=-/etc/default/vector|EnvironmentFile=-/etc/sysconfig/vector|' \
+  %{_builddir}/systemd/vector.service > %{buildroot}%{_unitdir}/vector.service
+cp -a %{_builddir}/systemd/vector.default %{buildroot}%{_sysconfdir}/sysconfig/vector
 cp -a %{_builddir}/licenses/. %{buildroot}%{_datadir}/%{_name}/licenses
 cp -a %{_builddir}/NOTICE %{buildroot}%{_datadir}/%{_name}/NOTICE
 cp -a %{_builddir}/LICENSE-3rdparty.csv %{buildroot}%{_datadir}/%{_name}/LICENSE-3rdparty.csv
@@ -80,7 +81,7 @@ rm -rf %{buildroot}
 %defattr(-,root,root,-)
 %{_bindir}/*
 %{_unitdir}/vector.service
-%config(noreplace) %{_sysconfdir}/default/vector
+%config(noreplace) %{_sysconfdir}/sysconfig/vector
 # Older versions installed a demo config at this path; mark it as %ghost so
 # rpm preserves any existing on-disk file during upgrade instead of removing
 # it as orphaned.

--- a/distribution/systemd/vector.default
+++ b/distribution/systemd/vector.default
@@ -1,4 +1,4 @@
-# /etc/default/vector
+# Environment variables for Vector.
 # This file can theoretically contain a bunch of environment variables
 # for Vector.  See https://vector.dev/docs/setup/configuration/#environment-variables
 # for details.

--- a/scripts/verify-install.sh
+++ b/scripts/verify-install.sh
@@ -20,17 +20,26 @@ install_package () {
   esac
 }
 
+case "$package" in
+  *.deb)
+    environment_file=/etc/default/vector
+    ;;
+  *.rpm)
+    environment_file=/etc/sysconfig/vector
+    ;;
+esac
+
 install_package "$package"
 
 getent passwd vector || (echo "vector user missing" && exit 1)
 getent group vector || (echo "vector group  missing" && exit 1)
 vector --version || (echo "vector --version failed" && exit 1)
-test -f /etc/default/vector || (echo "/etc/default/vector doesn't exist" && exit 1)
+test -f "$environment_file" || (echo "$environment_file doesn't exist" && exit 1)
 test ! -e /etc/vector/vector.yaml || (echo "/etc/vector/vector.yaml should not be installed by default" && exit 1)
 test -f /usr/share/vector/examples/vector.yaml || (echo "/usr/share/vector/examples/vector.yaml doesn't exist" && exit 1)
 
 mkdir -p /etc/vector
-echo "FOO=bar" > /etc/default/vector
+echo "FOO=bar" > "$environment_file"
 echo "foo: bar" > /etc/vector/vector.yaml
 
 install_package "$package"
@@ -38,7 +47,7 @@ install_package "$package"
 getent passwd vector || (echo "vector user missing" && exit 1)
 getent group vector || (echo "vector group  missing" && exit 1)
 vector --version || (echo "vector --version failed" && exit 1)
-grep -q "FOO=bar" "/etc/default/vector" || (echo "/etc/default/vector has incorrect contents" && exit 1)
+grep -q "FOO=bar" "$environment_file" || (echo "$environment_file has incorrect contents" && exit 1)
 grep -q "foo: bar" "/etc/vector/vector.yaml" || (echo "user-provided /etc/vector/vector.yaml was not preserved on reinstall" && exit 1)
 
 dd-pkg lint "$package"

--- a/scripts/verify-install.sh
+++ b/scripts/verify-install.sh
@@ -26,6 +26,9 @@ case "$package" in
     ;;
   *.rpm)
     environment_file=/etc/sysconfig/vector
+    # Emulate an upgrade from a package that used the Debian-style path.
+    mkdir -p /etc/default
+    echo "FOO=bar" > /etc/default/vector
     ;;
 esac
 
@@ -39,7 +42,10 @@ test ! -e /etc/vector/vector.yaml || (echo "/etc/vector/vector.yaml should not b
 test -f /usr/share/vector/examples/vector.yaml || (echo "/usr/share/vector/examples/vector.yaml doesn't exist" && exit 1)
 
 mkdir -p /etc/vector
-echo "FOO=bar" > "$environment_file"
+if [[ "$package" == *.deb ]]; then
+  echo "FOO=bar" > "$environment_file"
+fi
+grep -q "FOO=bar" "$environment_file" || (echo "$environment_file did not preserve existing contents" && exit 1)
 echo "foo: bar" > /etc/vector/vector.yaml
 
 install_package "$package"


### PR DESCRIPTION
In RHEL-based Linux distros, service specific environment variable files typically live in /etc/sysconfig (as opposed to /etc/default in Debian).

Vector's RPM currently uses the Debian path in its systemd unit file, which can lead to config not being loaded properly. Avoid this by switching to the RHEL convention.

### References
Closes: #26076

## Vector configuration
N/A

## How did you test this PR?
1) Install the RPM on a RHEL-based OS (I used Fedora 44)
2) Copy `/etc/default/vector` to `/etc/sysconfig/vector`
3) Create a systemd override at `/etc/systemd/system/vector.service.d/vector-envvars.conf` with the following content:
```
[Service]
EnvironmentFile=-
EnvironmentFile=-/etc/sysconfig/vector
```
4)Reload systemd `systemctl daemon-reload`
5) Restart the vector server `systemctl restart vector.service`
6) Verify the service starts cleanly `systemctl status vector.service`
7)Verify the service is using your override `systemctl cat vector.service`

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?
Y
- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

