### PR TITLE
sources: add configurable TLS handshake timeout for TCP sources

### DIFF
--- a/changelog.d/tls_handshake_timeout.feature.md
+++ b/changelog.d/tls_handshake_timeout.feature.md
@@ -1,0 +1,5 @@
+Added an optional `tls_handshake_timeout_secs` setting to the `socket` (TCP mode), `syslog` (TCP mode), `logstash`, `fluent`, and `statsd` (TCP mode) sources. When set, a TLS-enabled connection that does not complete its TLS handshake within the configured number of seconds is closed.
+
+Previously, TLS handshakes on these sources had no timeout: a client that opened a TCP connection and never completed (or never started) the TLS handshake would hold its slot against `connection_limit` indefinitely, since neither TCP keepalive nor `max_connection_duration_secs` are evaluated until after the handshake succeeds. This could let misbehaving or unresponsive clients gradually exhaust the connection limit and block legitimate traffic. The new setting is unset by default, preserving prior behavior.
+
+authors: vladimir-dd

--- a/src/internal_events/tcp.rs
+++ b/src/internal_events/tcp.rs
@@ -129,6 +129,40 @@ impl InternalEvent for TcpSocketTlsConnectionError {
     }
 }
 
+/// Emitted when a TLS handshake does not complete within the configured
+/// handshake timeout. Without this, a peer that opens a TCP connection but
+/// never completes (or never starts) the TLS handshake — a bare TCP
+/// healthcheck, a stalled client, or deliberate slow-handshake abuse — would
+/// hold its connection-limit slot indefinitely, since neither TCP keepalive
+/// nor `max_connection_duration_secs` are wired up until after the handshake
+/// succeeds.
+#[derive(Debug, NamedInternalEvent)]
+pub struct TcpSocketTlsHandshakeTimeout {
+    pub peer_addr: SocketAddr,
+    pub timeout: std::time::Duration,
+}
+
+impl InternalEvent for TcpSocketTlsHandshakeTimeout {
+    fn emit(self) {
+        warn!(
+            message = "TLS handshake timed out.",
+            peer_addr = %self.peer_addr,
+            timeout_secs = self.timeout.as_secs(),
+            error_code = "tls_handshake_timeout",
+            error_type = error_type::TIMED_OUT,
+            stage = error_stage::RECEIVING,
+        );
+        counter!(
+            CounterName::ComponentErrorsTotal,
+            "error_code" => "tls_handshake_timeout",
+            "error_type" => error_type::TIMED_OUT,
+            "stage" => error_stage::RECEIVING,
+            "mode" => "tcp",
+        )
+        .increment(1);
+    }
+}
+
 #[derive(Debug, NamedInternalEvent)]
 pub struct TcpSendAckError {
     pub error: std::io::Error,

--- a/src/sources/fluent/mod.rs
+++ b/src/sources/fluent/mod.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, io, net::SocketAddr, time::Duration};
+use std::{collections::HashMap, io, net::SocketAddr, num::NonZeroU64, time::Duration};
 
 use base64::prelude::{BASE64_STANDARD, Engine as _};
 use bytes::{Buf, Bytes, BytesMut};
@@ -190,7 +190,7 @@ pub struct FluentTcpConfig {
     /// before the TLS handshake finishes, protecting against clients that open a
     /// connection but never complete (or never start) a handshake.
     #[configurable(metadata(docs::type_unit = "seconds"))]
-    tls_handshake_timeout_secs: Option<u64>,
+    tls_handshake_timeout_secs: Option<NonZeroU64>,
 
     #[configurable(derived)]
     tls: Option<TlsSourceConfig>,

--- a/src/sources/fluent/mod.rs
+++ b/src/sources/fluent/mod.rs
@@ -184,6 +184,14 @@ pub struct FluentTcpConfig {
     #[configurable(metadata(docs::examples = 65536))]
     receive_buffer_bytes: Option<usize>,
 
+    /// The timeout, in seconds, before a TLS handshake is aborted if it has not completed.
+    ///
+    /// This bounds how long a connection can hold its slot against `connection_limit`
+    /// before the TLS handshake finishes, protecting against clients that open a
+    /// connection but never complete (or never start) a handshake.
+    #[configurable(metadata(docs::type_unit = "seconds"))]
+    tls_handshake_timeout_secs: Option<u64>,
+
     #[configurable(derived)]
     tls: Option<TlsSourceConfig>,
 
@@ -216,6 +224,7 @@ impl FluentTcpConfig {
             tls_client_metadata_key,
             self.receive_buffer_bytes,
             None,
+            self.tls_handshake_timeout_secs,
             cx,
             self.acknowledgements,
             self.connection_limit,
@@ -277,6 +286,7 @@ impl GenerateConfig for FluentConfig {
                 permit_origin: None,
                 tls: None,
                 receive_buffer_bytes: None,
+                tls_handshake_timeout_secs: None,
                 acknowledgements: Default::default(),
                 connection_limit: Some(2),
             }),
@@ -1167,6 +1177,7 @@ mod tests {
                 keepalive: None,
                 permit_origin: None,
                 receive_buffer_bytes: None,
+                tls_handshake_timeout_secs: None,
                 acknowledgements: true.into(),
                 connection_limit: None,
             }),
@@ -1240,6 +1251,7 @@ mod tests {
                 keepalive: None,
                 permit_origin: None,
                 receive_buffer_bytes: None,
+                tls_handshake_timeout_secs: None,
                 acknowledgements: false.into(),
                 connection_limit: None,
             }),
@@ -1298,6 +1310,7 @@ mod tests {
                 keepalive: None,
                 permit_origin: None,
                 receive_buffer_bytes: None,
+                tls_handshake_timeout_secs: None,
                 acknowledgements: false.into(),
                 connection_limit: None,
             }),
@@ -1527,6 +1540,7 @@ mod integration_tests {
                     keepalive: None,
                     permit_origin: None,
                     receive_buffer_bytes: None,
+                    tls_handshake_timeout_secs: None,
                     acknowledgements: false.into(),
                     connection_limit: None,
                 }),

--- a/src/sources/logstash.rs
+++ b/src/sources/logstash.rs
@@ -62,6 +62,14 @@ pub struct LogstashConfig {
     #[configurable(metadata(docs::type_unit = "connections"))]
     connection_limit: Option<u32>,
 
+    /// The timeout, in seconds, before a TLS handshake is aborted if it has not completed.
+    ///
+    /// This bounds how long a connection can hold its slot against `connection_limit`
+    /// before the TLS handshake finishes, protecting against clients that open a
+    /// connection but never complete (or never start) a handshake.
+    #[configurable(metadata(docs::type_unit = "seconds"))]
+    tls_handshake_timeout_secs: Option<u64>,
+
     #[configurable(derived)]
     #[serde(default, deserialize_with = "bool_or_struct")]
     acknowledgements: SourceAcknowledgementsConfig,
@@ -125,6 +133,7 @@ impl Default for LogstashConfig {
             receive_buffer_bytes: None,
             acknowledgements: Default::default(),
             connection_limit: None,
+            tls_handshake_timeout_secs: None,
             log_namespace: None,
         }
     }
@@ -164,6 +173,7 @@ impl SourceConfig for LogstashConfig {
             tls_client_metadata_key,
             self.receive_buffer_bytes,
             None,
+            self.tls_handshake_timeout_secs,
             cx,
             self.acknowledgements,
             self.connection_limit,
@@ -902,6 +912,7 @@ mod test {
             receive_buffer_bytes: None,
             acknowledgements: true.into(),
             connection_limit: None,
+            tls_handshake_timeout_secs: None,
             log_namespace: None,
         }
         .build(SourceContext::new_test(sender, None))
@@ -1667,6 +1678,7 @@ mod integration_tests {
                 receive_buffer_bytes: None,
                 acknowledgements: false.into(),
                 connection_limit: None,
+                tls_handshake_timeout_secs: None,
                 log_namespace: None,
             }
             .build(SourceContext::new_test(sender, None))

--- a/src/sources/logstash.rs
+++ b/src/sources/logstash.rs
@@ -3,7 +3,7 @@ use std::{
     convert::TryFrom,
     io,
     net::SocketAddr,
-    num::NonZeroUsize,
+    num::{NonZeroU64, NonZeroUsize},
     time::Duration,
 };
 
@@ -68,7 +68,7 @@ pub struct LogstashConfig {
     /// before the TLS handshake finishes, protecting against clients that open a
     /// connection but never complete (or never start) a handshake.
     #[configurable(metadata(docs::type_unit = "seconds"))]
-    tls_handshake_timeout_secs: Option<u64>,
+    tls_handshake_timeout_secs: Option<NonZeroU64>,
 
     #[configurable(derived)]
     #[serde(default, deserialize_with = "bool_or_struct")]

--- a/src/sources/socket/mod.rs
+++ b/src/sources/socket/mod.rs
@@ -971,19 +971,13 @@ mod test {
         let timeout = tokio::time::sleep(Duration::from_millis(2000));
         let mut buffer = [0u8; 10];
 
-        tokio::select! {
-             _ = timeout => {
-                 panic!("timed out waiting for stream to close")
-             },
-             read_result = stream.read(&mut buffer) => {
-                 match read_result {
-                    // read resulting with 0 bytes -> the connection was closed
-                    Ok(0) => assert_relative_eq!(start.elapsed().as_secs_f64(), 1.0, epsilon = 0.5),
-                    Ok(_) => panic!("unexpectedly read data from stream"),
-                    Err(e) => panic!("{e:}")
-                 }
-             }
-        }
+    let bytes_read = timeout(Duration::from_secs(2), stream.read(&mut [0]))
+        .await
+        .expect("timed out waiting for stream to close")
+        .expect("failed to read from stream");
+        
+        assert_eq!(bytes_read, 0, "unexpectedly read data from stream");
+        assert_relative_eq!(start.elapsed().as_secs_f64(), 1.0, epsilon = 0.5);
     }
 
     //////// UDP TESTS ////////

--- a/src/sources/socket/mod.rs
+++ b/src/sources/socket/mod.rs
@@ -323,6 +323,7 @@ mod test {
     use std::{
         collections::HashMap,
         net::{IpAddr, Ipv4Addr, SocketAddr, UdpSocket},
+        num::NonZeroU64,
         sync::{
             Arc,
             atomic::{AtomicBool, Ordering},
@@ -939,18 +940,9 @@ mod test {
         let mut config = TcpConfig::from_address(addr.into());
         config.set_tls(Some(TlsSourceConfig {
             tls_config: TlsEnableableConfig::test_config(),
-                enabled: Some(true),
-                options: TlsConfig {
-                    verify_certificate: Some(true),
-                    crt_file: Some(tls::TEST_PEM_CRT_PATH.into()),
-                    key_file: Some(tls::TEST_PEM_KEY_PATH.into()),
-                    ca_file: Some(tls::TEST_PEM_CA_PATH.into()),
-                    ..Default::default()
-                },
-            },
             client_metadata_key: None,
         }));
-        config.set_tls_handshake_timeout_secs(Some(1));
+        config.set_tls_handshake_timeout_secs(Some(NonZeroU64::new(1).unwrap()));
 
         let source_task = SocketConfig::from(config)
             .build(SourceContext::new_test(tx, None))
@@ -968,14 +960,11 @@ mod test {
             .expect("stream should be able to connect");
         let start = Instant::now();
 
-        let timeout = tokio::time::sleep(Duration::from_millis(2000));
-        let mut buffer = [0u8; 10];
+        let bytes_read = timeout(Duration::from_secs(2), stream.read(&mut [0]))
+            .await
+            .expect("timed out waiting for stream to close")
+            .expect("failed to read from stream");
 
-    let bytes_read = timeout(Duration::from_secs(2), stream.read(&mut [0]))
-        .await
-        .expect("timed out waiting for stream to close")
-        .expect("failed to read from stream");
-        
         assert_eq!(bytes_read, 0, "unexpectedly read data from stream");
         assert_relative_eq!(start.elapsed().as_secs_f64(), 1.0, epsilon = 0.5);
     }

--- a/src/sources/socket/mod.rs
+++ b/src/sources/socket/mod.rs
@@ -143,6 +143,7 @@ impl SourceConfig for SocketConfig {
                     tls_client_metadata_key,
                     config.receive_buffer_bytes(),
                     config.max_connection_duration_secs(),
+                    config.tls_handshake_timeout_secs(),
                     cx,
                     false.into(),
                     config.connection_limit,
@@ -923,6 +924,61 @@ mod test {
                  match read_result {
                     // read resulting with 0 bytes -> the connection was closed
                     Ok(0) => assert_relative_eq!(start.elapsed().as_secs_f64(), 1.0, epsilon = 0.3),
+                    Ok(_) => panic!("unexpectedly read data from stream"),
+                    Err(e) => panic!("{e:}")
+                 }
+             }
+        }
+    }
+
+    #[tokio::test]
+    async fn tcp_tls_handshake_timeout() {
+        let (tx, _) = SourceSender::new_test();
+        let (guard, addr) = next_addr();
+
+        let mut config = TcpConfig::from_address(addr.into());
+        config.set_tls(Some(TlsSourceConfig {
+            tls_config: TlsEnableableConfig {
+                enabled: Some(true),
+                options: TlsConfig {
+                    verify_certificate: Some(true),
+                    crt_file: Some(tls::TEST_PEM_CRT_PATH.into()),
+                    key_file: Some(tls::TEST_PEM_KEY_PATH.into()),
+                    ca_file: Some(tls::TEST_PEM_CA_PATH.into()),
+                    ..Default::default()
+                },
+            },
+            client_metadata_key: None,
+        }));
+        config.set_tls_handshake_timeout_secs(Some(1));
+
+        let source_task = SocketConfig::from(config)
+            .build(SourceContext::new_test(tx, None))
+            .await
+            .unwrap();
+
+        // Spawn the source task and wait until we're sure it's listening:
+        drop(tokio::spawn(source_task));
+        wait_for_tcp_and_release(guard, addr).await;
+
+        // Open a plain TCP connection but deliberately never send a TLS
+        // ClientHello, so the server's handshake never completes on its own.
+        let mut stream: TcpStream = TcpStream::connect(addr)
+            .await
+            .expect("stream should be able to connect");
+        let start = Instant::now();
+
+        let timeout = tokio::time::sleep(Duration::from_millis(2000));
+        let mut buffer = [0u8; 10];
+
+        tokio::select! {
+             _ = timeout => {
+                 panic!("timed out waiting for stream to close")
+             },
+             read_result = stream.read(&mut buffer) => {
+                 match read_result {
+                    // read resulting with 0 bytes -> the connection was closed
+                    Ok(0) => assert_relative_eq!(start.elapsed().as_secs_f64(), 1.0, epsilon = 0.5),
                     Ok(_) => panic!("unexpectedly read data from stream"),
                     Err(e) => panic!("{e:}")
                  }

--- a/src/sources/socket/mod.rs
+++ b/src/sources/socket/mod.rs
@@ -938,7 +938,7 @@ mod test {
 
         let mut config = TcpConfig::from_address(addr.into());
         config.set_tls(Some(TlsSourceConfig {
-            tls_config: TlsEnableableConfig {
+            tls_config: TlsEnableableConfig::test_config(),
                 enabled: Some(true),
                 options: TlsConfig {
                     verify_certificate: Some(true),

--- a/src/sources/socket/tcp.rs
+++ b/src/sources/socket/tcp.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::{num::NonZeroU64, time::Duration};
 
 use chrono::Utc;
 use serde_with::serde_as;
@@ -81,7 +81,7 @@ pub struct TcpConfig {
     /// before the TLS handshake finishes, protecting against clients that open a
     /// connection but never complete (or never start) a handshake.
     #[configurable(metadata(docs::type_unit = "seconds"))]
-    tls_handshake_timeout_secs: Option<u64>,
+    tls_handshake_timeout_secs: Option<NonZeroU64>,
 
     /// The maximum number of TCP connections that are allowed at any given time.
     #[configurable(metadata(docs::type_unit = "connections"))]
@@ -173,11 +173,11 @@ impl TcpConfig {
         self
     }
 
-    pub const fn tls_handshake_timeout_secs(&self) -> Option<u64> {
+    pub const fn tls_handshake_timeout_secs(&self) -> Option<NonZeroU64> {
         self.tls_handshake_timeout_secs
     }
 
-    pub const fn set_tls_handshake_timeout_secs(&mut self, val: Option<u64>) -> &mut Self {
+    pub const fn set_tls_handshake_timeout_secs(&mut self, val: Option<NonZeroU64>) -> &mut Self {
         self.tls_handshake_timeout_secs = val;
         self
     }

--- a/src/sources/socket/tcp.rs
+++ b/src/sources/socket/tcp.rs
@@ -75,6 +75,14 @@ pub struct TcpConfig {
     #[configurable(metadata(docs::type_unit = "seconds"))]
     max_connection_duration_secs: Option<u64>,
 
+    /// The timeout, in seconds, before a TLS handshake is aborted if it has not completed.
+    ///
+    /// This bounds how long a connection can hold its slot against `connection_limit`
+    /// before the TLS handshake finishes, protecting against clients that open a
+    /// connection but never complete (or never start) a handshake.
+    #[configurable(metadata(docs::type_unit = "seconds"))]
+    tls_handshake_timeout_secs: Option<u64>,
+
     /// The maximum number of TCP connections that are allowed at any given time.
     #[configurable(metadata(docs::type_unit = "connections"))]
     pub connection_limit: Option<u32>,
@@ -112,6 +120,7 @@ impl TcpConfig {
             tls: None,
             receive_buffer_bytes: None,
             max_connection_duration_secs: None,
+            tls_handshake_timeout_secs: None,
             framing: None,
             decoding: default_decoding(),
             connection_limit: None,
@@ -161,6 +170,15 @@ impl TcpConfig {
 
     pub const fn set_max_connection_duration_secs(&mut self, val: Option<u64>) -> &mut Self {
         self.max_connection_duration_secs = val;
+        self
+    }
+
+    pub const fn tls_handshake_timeout_secs(&self) -> Option<u64> {
+        self.tls_handshake_timeout_secs
+    }
+
+    pub const fn set_tls_handshake_timeout_secs(&mut self, val: Option<u64>) -> &mut Self {
+        self.tls_handshake_timeout_secs = val;
         self
     }
 

--- a/src/sources/statsd/mod.rs
+++ b/src/sources/statsd/mod.rs
@@ -1,5 +1,6 @@
 use std::{
     net::{Ipv4Addr, SocketAddr, SocketAddrV4},
+    num::NonZeroU64,
     time::Duration,
 };
 
@@ -145,7 +146,7 @@ pub struct TcpConfig {
     /// before the TLS handshake finishes, protecting against clients that open a
     /// connection but never complete (or never start) a handshake.
     #[configurable(metadata(docs::type_unit = "seconds"))]
-    tls_handshake_timeout_secs: Option<u64>,
+    tls_handshake_timeout_secs: Option<NonZeroU64>,
 
     ///	Whether or not to sanitize incoming statsd key names. When "true", keys are sanitized by:
     /// - "/" is replaced with "-"

--- a/src/sources/statsd/mod.rs
+++ b/src/sources/statsd/mod.rs
@@ -139,6 +139,14 @@ pub struct TcpConfig {
     #[configurable(metadata(docs::type_unit = "connections"))]
     connection_limit: Option<u32>,
 
+    /// The timeout, in seconds, before a TLS handshake is aborted if it has not completed.
+    ///
+    /// This bounds how long a connection can hold its slot against `connection_limit`
+    /// before the TLS handshake finishes, protecting against clients that open a
+    /// connection but never complete (or never start) a handshake.
+    #[configurable(metadata(docs::type_unit = "seconds"))]
+    tls_handshake_timeout_secs: Option<u64>,
+
     ///	Whether or not to sanitize incoming statsd key names. When "true", keys are sanitized by:
     /// - "/" is replaced with "-"
     /// - All whitespace is replaced with "_"
@@ -163,6 +171,7 @@ impl TcpConfig {
             shutdown_timeout_secs: default_shutdown_timeout_secs(),
             receive_buffer_bytes: None,
             connection_limit: None,
+            tls_handshake_timeout_secs: None,
             sanitize: default_sanitize(),
             convert_to: default_convert_to(),
         }
@@ -223,6 +232,7 @@ impl SourceConfig for StatsdConfig {
                     tls_client_metadata_key,
                     config.receive_buffer_bytes,
                     None,
+                    config.tls_handshake_timeout_secs,
                     cx,
                     false.into(),
                     config.connection_limit,

--- a/src/sources/syslog.rs
+++ b/src/sources/syslog.rs
@@ -1,6 +1,6 @@
 #[cfg(unix)]
 use std::path::PathBuf;
-use std::{net::SocketAddr, time::Duration};
+use std::{net::SocketAddr, num::NonZeroU64, time::Duration};
 
 use bytes::Bytes;
 use chrono::Utc;
@@ -107,7 +107,7 @@ pub enum Mode {
         /// before the TLS handshake finishes, protecting against clients that open a
         /// connection but never complete (or never start) a handshake.
         #[configurable(metadata(docs::type_unit = "seconds"))]
-        tls_handshake_timeout_secs: Option<u64>,
+        tls_handshake_timeout_secs: Option<NonZeroU64>,
     },
 
     /// Listen on UDP.

--- a/src/sources/syslog.rs
+++ b/src/sources/syslog.rs
@@ -100,6 +100,14 @@ pub enum Mode {
 
         /// The maximum number of TCP connections that are allowed at any given time.
         connection_limit: Option<u32>,
+
+        /// The timeout, in seconds, before a TLS handshake is aborted if it has not completed.
+        ///
+        /// This bounds how long a connection can hold its slot against `connection_limit`
+        /// before the TLS handshake finishes, protecting against clients that open a
+        /// connection but never complete (or never start) a handshake.
+        #[configurable(metadata(docs::type_unit = "seconds"))]
+        tls_handshake_timeout_secs: Option<u64>,
     },
 
     /// Listen on UDP.
@@ -155,6 +163,7 @@ impl Default for SyslogConfig {
                 tls: None,
                 receive_buffer_bytes: None,
                 connection_limit: None,
+                tls_handshake_timeout_secs: None,
             },
             host_key: None,
             max_length: crate::serde::default_max_length(),
@@ -188,6 +197,7 @@ impl SourceConfig for SyslogConfig {
                 tls,
                 receive_buffer_bytes,
                 connection_limit,
+                tls_handshake_timeout_secs,
             } => {
                 let source = SyslogTcpSource {
                     max_length: self.max_length,
@@ -210,6 +220,7 @@ impl SourceConfig for SyslogConfig {
                     tls_client_metadata_key,
                     receive_buffer_bytes,
                     None,
+                    tls_handshake_timeout_secs,
                     cx,
                     false.into(),
                     connection_limit,
@@ -1149,6 +1160,7 @@ mod test {
                 tls: None,
                 receive_buffer_bytes: None,
                 connection_limit: None,
+                tls_handshake_timeout_secs: None,
             });
 
             let key = ComponentKey::from("in");
@@ -1360,6 +1372,7 @@ mod test {
                 tls: None,
                 receive_buffer_bytes: None,
                 connection_limit: None,
+                tls_handshake_timeout_secs: None,
             });
 
             let key = ComponentKey::from("in");

--- a/src/sources/util/net/tcp/mod.rs
+++ b/src/sources/util/net/tcp/mod.rs
@@ -40,7 +40,7 @@ use crate::{
     internal_events::{
         ConnectionOpen, OpenGauge, SocketBindError, SocketEventsReceived, SocketMode,
         SocketReceiveError, StreamClosedError, TcpBytesReceived, TcpSendAckError,
-        TcpSocketTlsConnectionError, TcpSourceConnectionClosed,
+        TcpSocketTlsConnectionError, TcpSocketTlsHandshakeTimeout, TcpSourceConnectionClosed,
     },
     net::is_graceful_tls_shutdown,
     sources::util::{AfterReadExt, LenientFramedRead},
@@ -126,6 +126,7 @@ where
         tls_client_metadata_key: Option<OwnedValuePath>,
         receive_buffer_bytes: Option<usize>,
         max_connection_duration_secs: Option<u64>,
+        tls_handshake_timeout_secs: Option<u64>,
         cx: SourceContext,
         acknowledgements: SourceAcknowledgementsConfig,
         max_connections: Option<u32>,
@@ -215,6 +216,7 @@ where
                                 keepalive,
                                 receive_buffer_bytes,
                                 max_connection_duration_secs,
+                                tls_handshake_timeout_secs,
                                 source,
                                 tripwire,
                                 peer_addr,
@@ -255,6 +257,7 @@ async fn handle_stream<T>(
     keepalive: Option<TcpKeepaliveConfig>,
     receive_buffer_bytes: Option<usize>,
     max_connection_duration_secs: Option<u64>,
+    tls_handshake_timeout_secs: Option<u64>,
     source: T,
     mut tripwire: BoxFuture<'static, ()>,
     peer_addr: SocketAddr,
@@ -268,12 +271,24 @@ async fn handle_stream<T>(
     <<T as TcpSource>::Decoder as tokio_util::codec::Decoder>::Item: std::marker::Send,
     T: TcpSource,
 {
+    let handshake_timeout = OptionFuture::from(
+        tls_handshake_timeout_secs.map(|secs| tokio::time::sleep(Duration::from_secs(secs))),
+    );
+    tokio::pin!(handshake_timeout);
+
     tokio::select! {
         result = socket.handshake() => {
             if let Err(error) = result {
                 emit!(TcpSocketTlsConnectionError { error });
                 return;
             }
+        },
+        Some(_) = &mut handshake_timeout => {
+            emit!(TcpSocketTlsHandshakeTimeout {
+                peer_addr,
+                timeout: Duration::from_secs(tls_handshake_timeout_secs.unwrap_or_default()),
+            });
+            return;
         },
         _ = &mut shutdown_signal => {
             return;

--- a/src/sources/util/net/tcp/mod.rs
+++ b/src/sources/util/net/tcp/mod.rs
@@ -1,6 +1,6 @@
 pub mod request_limiter;
 
-use std::{io, mem::drop, net::SocketAddr, time::Duration};
+use std::{io, mem::drop, net::SocketAddr, num::NonZeroU64, time::Duration};
 
 use bytes::Bytes;
 use futures::{FutureExt, StreamExt, future::BoxFuture};
@@ -126,7 +126,7 @@ where
         tls_client_metadata_key: Option<OwnedValuePath>,
         receive_buffer_bytes: Option<usize>,
         max_connection_duration_secs: Option<u64>,
-        tls_handshake_timeout_secs: Option<u64>,
+        tls_handshake_timeout_secs: Option<NonZeroU64>,
         cx: SourceContext,
         acknowledgements: SourceAcknowledgementsConfig,
         max_connections: Option<u32>,
@@ -257,7 +257,7 @@ async fn handle_stream<T>(
     keepalive: Option<TcpKeepaliveConfig>,
     receive_buffer_bytes: Option<usize>,
     max_connection_duration_secs: Option<u64>,
-    tls_handshake_timeout_secs: Option<u64>,
+    tls_handshake_timeout_secs: Option<NonZeroU64>,
     source: T,
     mut tripwire: BoxFuture<'static, ()>,
     peer_addr: SocketAddr,
@@ -272,7 +272,7 @@ async fn handle_stream<T>(
     T: TcpSource,
 {
     let handshake_timeout = OptionFuture::from(
-        tls_handshake_timeout_secs.map(|secs| tokio::time::sleep(Duration::from_secs(secs))),
+        tls_handshake_timeout_secs.map(|secs| tokio::time::sleep(Duration::from_secs(secs.get()))),
     );
     tokio::pin!(handshake_timeout);
 
@@ -286,7 +286,9 @@ async fn handle_stream<T>(
         Some(_) = &mut handshake_timeout => {
             emit!(TcpSocketTlsHandshakeTimeout {
                 peer_addr,
-                timeout: Duration::from_secs(tls_handshake_timeout_secs.unwrap_or_default()),
+                timeout: Duration::from_secs(
+                    tls_handshake_timeout_secs.map_or(0, NonZeroU64::get),
+                ),
             });
             return;
         },

--- a/website/cue/reference/components/sources/generated/fluent.cue
+++ b/website/cue/reference/components/sources/generated/fluent.cue
@@ -210,4 +210,16 @@ generated: components: sources: fluent: configuration: {
 			}
 		}
 	}
+	tls_handshake_timeout_secs: {
+		description: """
+			The timeout, in seconds, before a TLS handshake is aborted if it has not completed.
+
+			This bounds how long a connection can hold its slot against `connection_limit`
+			before the TLS handshake finishes, protecting against clients that open a
+			connection but never complete (or never start) a handshake.
+			"""
+		relevant_when: "mode = \"tcp\""
+		required:      false
+		type: uint: unit: "seconds"
+	}
 }

--- a/website/cue/reference/components/sources/generated/logstash.cue
+++ b/website/cue/reference/components/sources/generated/logstash.cue
@@ -170,4 +170,15 @@ generated: components: sources: logstash: configuration: {
 			}
 		}
 	}
+	tls_handshake_timeout_secs: {
+		description: """
+			The timeout, in seconds, before a TLS handshake is aborted if it has not completed.
+
+			This bounds how long a connection can hold its slot against `connection_limit`
+			before the TLS handshake finishes, protecting against clients that open a
+			connection but never complete (or never start) a handshake.
+			"""
+		required: false
+		type: uint: unit: "seconds"
+	}
 }

--- a/website/cue/reference/components/sources/generated/socket.cue
+++ b/website/cue/reference/components/sources/generated/socket.cue
@@ -828,4 +828,16 @@ generated: components: sources: socket: configuration: {
 			}
 		}
 	}
+	tls_handshake_timeout_secs: {
+		description: """
+			The timeout, in seconds, before a TLS handshake is aborted if it has not completed.
+
+			This bounds how long a connection can hold its slot against `connection_limit`
+			before the TLS handshake finishes, protecting against clients that open a
+			connection but never complete (or never start) a handshake.
+			"""
+		relevant_when: "mode = \"tcp\""
+		required:      false
+		type: uint: unit: "seconds"
+	}
 }

--- a/website/cue/reference/components/sources/generated/statsd.cue
+++ b/website/cue/reference/components/sources/generated/statsd.cue
@@ -199,4 +199,16 @@ generated: components: sources: statsd: configuration: {
 			}
 		}
 	}
+	tls_handshake_timeout_secs: {
+		description: """
+			The timeout, in seconds, before a TLS handshake is aborted if it has not completed.
+
+			This bounds how long a connection can hold its slot against `connection_limit`
+			before the TLS handshake finishes, protecting against clients that open a
+			connection but never complete (or never start) a handshake.
+			"""
+		relevant_when: "mode = \"tcp\""
+		required:      false
+		type: uint: unit: "seconds"
+	}
 }

--- a/website/cue/reference/components/sources/generated/syslog.cue
+++ b/website/cue/reference/components/sources/generated/syslog.cue
@@ -214,4 +214,16 @@ generated: components: sources: syslog: configuration: {
 			}
 		}
 	}
+	tls_handshake_timeout_secs: {
+		description: """
+			The timeout, in seconds, before a TLS handshake is aborted if it has not completed.
+
+			This bounds how long a connection can hold its slot against `connection_limit`
+			before the TLS handshake finishes, protecting against clients that open a
+			connection but never complete (or never start) a handshake.
+			"""
+		relevant_when: "mode = \"tcp\""
+		required:      false
+		type: uint: unit: "seconds"
+	}
 }


### PR DESCRIPTION
## Summary

TCP sources that support TLS (`socket`, `syslog`, `logstash`, `fluent`, and `statsd`) acquire a permit against `connection_limit` as soon as a connection is accepted, before the TLS handshake runs. The handshake itself has no timeout, so a client that opens a TCP connection and never completes (or never starts) the TLS handshake holds that permit indefinitely.

In practice, the most likely trigger isn't a TLS client stalling partway through a handshake — it's a plain TCP client that never speaks TLS at all against a TLS-configured port (an L4 health check, a port scanner, a client pointed at the wrong port/protocol, etc.). Since it never sends a ClientHello, the handshake future never resolves, and unlike a stalled handshake this requires no cooperation or misbehavior from the client at all — just an ordinary TCP connect with no payload. A steady trickle of these can accumulate over time until `connection_limit` is exhausted, at which point the source stops accepting new connections even though most of the held slots aren't doing anything.

Neither of the two existing mitigations catches this case:
- TCP keepalive only detects a dead *transport-level* connection — the socket here is fully alive and ACKing, it just never progresses past accept. Additionally, keepalive is only configured on the socket after the handshake step succeeds, so it isn't even active yet for a connection stuck in the handshake.
- `max_connection_duration_secs` is only evaluated once the connection has been fully established (i.e. after the handshake succeeds).

## Fix

Adds an optional `tls_handshake_timeout_secs` setting to the TCP mode of `socket`, `syslog`, `logstash`, `fluent`, and `statsd`. When set, the handshake future races against a timer; if the timer fires first, the connection is closed and its `connection_limit` permit is released through the normal cleanup path. The setting is unset by default (`None`), so behavior is unchanged unless explicitly configured.

A new internal event, `TcpSocketTlsHandshakeTimeout`, is emitted (warn log + counter) when a connection is closed this way, mirroring the existing `TcpSocketTlsConnectionError` event.
