### PR TITLE
chore(http): remove obsolete const lint allow

### DIFF
--- a/src/http.rs
+++ b/src/http.rs
@@ -754,11 +754,9 @@ impl ParameterValue {
     }
 
     /// Returns the raw string value of the parameter.
-    #[allow(clippy::missing_const_for_fn)]
-    pub fn value(&self) -> &str {
+    pub const fn value(&self) -> &str {
         match self {
-            ParameterValue::String(s) => s,
-            ParameterValue::Typed { value, .. } => value,
+            ParameterValue::String(value) | ParameterValue::Typed { value, .. } => value.as_str(),
         }
     }
 


### PR DESCRIPTION
## Summary

Removes an obsolete `clippy::missing_const_for_fn` allowance by making `ParameterValue::value` a `const fn`. It also combines the two equivalent match arms without changing behavior.

### References

Related: #23659

## Vector configuration

Not applicable; this is an internal code cleanup with no configuration changes.

## How did you test this PR?

- `cargo fmt --all -- --check`
- `git diff --check origin/master...HEAD`
- Started `cargo clippy --no-default-features --lib -- -D warnings`; dependency compilation proceeded until the local environment stopped because `protoc` is not installed. Full validation is left to CI.

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.
