### PR TITLE
feat: changelog docs major improvement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13145,7 +13145,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vdev"
-version = "0.3.14"
+version = "0.3.15"
 dependencies = [
  "anyhow",
  "cfg-if",

--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -1,17 +1,20 @@
 ## Overview
 
 This directory contains changelog "fragments" that are collected during a release to
-generate the project's user facing changelog.
+generate the project's user-facing changelog.
 
 The conventions used for this changelog logic follow [towncrier](https://towncrier.readthedocs.io/en/stable/markdown.html).
 
 The changelog fragments are located in `changelog.d/`.
 
-## Quick start
+## Prerequisites
 
-The scaffolder is the recommended workflow for all fragment types, but devs can also hand-write changelog fragments.
+Check whether [vdev](https://crates.io/crates/vdev) is installed, and that it is version
+0.3.15 or newer:
 
-Install `vdev`:
+    vdev --version
+
+If not:
 
     cargo binstall --manifest-path vdev/Cargo.toml vdev
     # or
@@ -19,13 +22,17 @@ Install `vdev`:
     # or use the prefix
     # cargo vdev <command>
 
-Then scaffold a fragment:
+## Quick start
+
+The scaffolder is the recommended workflow for all fragment types, but devs can also hand-write changelog fragments.
+
+Scaffold a fragment:
 
     vdev changelog new <type> <slug>
 
 > `vdev` fills in the filename, the required structure, and your authors line (auto-detected from `git config github.user`, `gh api user`, or a `users.noreply.github.com` email)
 
-Edit the file and validate:
+Edit the file and validate with:
 
     vdev check changelog-fragments
 
@@ -35,9 +42,17 @@ Examples:
     vdev changelog new enhancement retry_backoff_config
     vdev changelog new breaking env_var_interpolation
 
+### When do I need a fragment?
+
+Add a fragment when the change is user-observable: it alters behavior, configuration, output
+format, performance, or security posture that a Vector user would notice.
+
+Skip the fragment (and add the `no-changelog` label) for internal-only changes: refactors with
+no behavior change, CI/test tooling, documentation, or dependency bumps that don't affect behavior.
+
 ## Process
 
-Fragments for un-released changes are placed in the root of this directory during PRs.
+Fragments for unreleased changes are placed in the root of this directory during PRs.
 
 During a release when the changelog is generated, the fragments in the root of this
 directory are organized into the [releases directory](../website/cue/reference/releases)
@@ -50,14 +65,16 @@ This is enforced during CI.
 
 To mark a PR as not requiring user-facing changelog notes, add the label 'no-changelog'.
 
-To run the same check that is run in CI to validate that your changelog fragments have
-the correct syntax, commit the fragment additions and then run `vdev check changelog-fragments`.
+To validate your changelog fragments the same way CI does, commit the fragment additions and then run
+`vdev check changelog-fragments`.
+It validates the filename format, the `authors:` line, and the breaking-fragment structure
+(`## Summary` / `## Migration`).
 
 The format for fragments is: `<unique_name>.<fragment_type>.md`
 
 ### Fragment conventions
 
-When fragments used to generate the updated changelog, the content of the fragment file is
+When fragments are used to generate the updated changelog, the content of the fragment file is
 rendered as an item in a bulleted list under the "type" of fragment.
 
 The contents of the file must be valid markdown.
@@ -66,26 +83,37 @@ Filename rules:
 
 - The first segment (unique_name) should be a unique string related to the change.
   Optionally, if there is a GitHub issue associated with the change, it can be used as a prefix.
-  For example `42_very_important_change.breaking.md`, vs `very_important_change.breaking.md`.
-- The type must be one of the valid types in [Fragment types](#fragment-types)
-- Only the two period delimiters can be used.
+  For example, `42_very_important_change.breaking.md` vs `very_important_change.breaking.md`.
+- The type must be one of the valid types reported by `vdev changelog types`.
+- The filename must contain exactly two periods (separating the name, type, and extension).
 - The file must be markdown.
 
 #### Fragment types
 
-- `breaking`: A change that is incompatible with prior versions which requires users to make adjustments.
-- `security`: A change that is has implications for security.
-- `feature`: A change that is introducing a new feature.
-- `enhancement`: A change that is enhancing existing functionality in a user perceivable way.
-- `fix`: A change that is fixing a bug.
+The valid fragment types and their descriptions are defined by `vdev changelog types`:
+
+    $ vdev changelog types
+    breaking     A change that is incompatible with prior versions and requires users to make adjustments. If a change is also a fix or feature, breaking takes precedence.
+    security     A change that has security implications.
+    feature      A change that introduces a new feature.
+    enhancement  A change that enhances existing functionality in a user perceivable way.
+    fix          A change that fixes a bug.
 
 #### Fragment contents
 
 When fragments are rendered in the changelog, each fragment becomes an item in a markdown list.
 For this reason, when creating the content in a fragment, the format must be renderable as a markdown list.
 
-As an example, separating content with markdown header syntax should be avoided, as that will render
-as a heading in the main changelog and not the list. Instead, separate content with newlines.
+For example, avoid separating content with markdown header syntax, as it will render
+as a heading in the main changelog rather than a list item. Instead, separate content with newlines.
+
+A good fragment answers three questions:
+
+1. How does this change affect user-visible behavior?
+2. Which components are affected?
+3. Which config fields are introduced or affected?
+
+Finally, a good fragment is concise and avoids implementation details.
 
 ### Breaking changes
 
@@ -94,18 +122,13 @@ Breaking fragments (`*.breaking.md`) carry extra structured fields (title, optio
 guide from them. See [Examples](#examples) below for the exact shape — or just run the
 scaffolder from [Quick start](#quick-start).
 
-## Community Contributors
+## Authors
 
-When a PR is authored/has commits by a contributor from the Vector community, the fragment contents
-can optionally contain a line which specifies the community members involved in making the change.
-This is later used during the release process to render as a link to the github user profile for
-the authors specified.
-
-The process for adding this is simply to have the last line of the file be in this format:
+Every fragment must end with an `authors:` line:
 
     authors: <author1_gh_username> <author2_gh_username> <...>
 
-Do not include a leading `@` when specifying your username.
+Do not prefix usernames with `@`.
 
 ## Examples
 

--- a/vdev/Cargo.toml
+++ b/vdev/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vdev"
-version = "0.3.14"
+version = "0.3.15"
 edition = "2024"
 authors = ["Vector Contributors <vector@datadoghq.com>"]
 license = "MPL-2.0"

--- a/vdev/src/commands/changelog/mod.rs
+++ b/vdev/src/commands/changelog/mod.rs
@@ -1,10 +1,59 @@
 pub(crate) mod new;
+pub(crate) mod types;
 
 use anyhow::{Result, bail};
+
+/// A valid changelog fragment type and its user-facing description.
+pub struct FragmentType {
+    pub name: &'static str,
+    pub description: &'static str,
+    /// The type emitted for this fragment in the generated release CUE file.
+    pub cue_type: &'static str,
+    /// Whether fragments of this type use the structured breaking-fragment layout
+    /// (`## Summary` / `## Migration`).
+    pub breaking: bool,
+}
+
+/// Valid changelog fragment types and their descriptions. Single source of truth shared by
+/// the scaffolder (`vdev changelog new`), the CI checker (`vdev check changelog-fragments`),
+/// the release CUE generator, and `vdev changelog types`.
+pub const FRAGMENT_TYPES: &[FragmentType] = &[
+    FragmentType {
+        name: "breaking",
+        description: "A change that is incompatible with prior versions and requires users to make adjustments. If a change is also a fix or feature, breaking takes precedence.",
+        cue_type: "chore",
+        breaking: true,
+    },
+    FragmentType {
+        name: "security",
+        description: "A change that has security implications.",
+        cue_type: "security",
+        breaking: false,
+    },
+    FragmentType {
+        name: "feature",
+        description: "A change that introduces a new feature.",
+        cue_type: "feat",
+        breaking: false,
+    },
+    FragmentType {
+        name: "enhancement",
+        description: "A change that enhances existing functionality in a user perceivable way.",
+        cue_type: "enhancement",
+        breaking: false,
+    },
+    FragmentType {
+        name: "fix",
+        description: "A change that fixes a bug.",
+        cue_type: "fix",
+        breaking: false,
+    },
+];
 
 crate::cli_subcommands! {
     "Scaffold and inspect changelog fragments..."
     new,
+    types,
 }
 
 /// Structured view of a `*.breaking.md` fragment. Shared by the checker and the release

--- a/vdev/src/commands/changelog/new.rs
+++ b/vdev/src/commands/changelog/new.rs
@@ -4,10 +4,10 @@ use std::process::Command;
 use anyhow::{Context, Result, bail};
 use indoc::formatdoc;
 
+use crate::commands::changelog::{FRAGMENT_TYPES, FragmentType};
 use crate::utils::paths;
 
 const CHANGELOG_DIR: &str = "changelog.d";
-const FRAGMENT_TYPES: &[&str] = &["breaking", "security", "feature", "enhancement", "fix"];
 
 /// Placeholder written for the author line when no handle can be detected.
 /// The checker rejects fragments still containing this sentinel.
@@ -18,7 +18,9 @@ pub(crate) const TODO_HANDLE: &str = "TODO_your_gh_handle";
 #[command()]
 pub struct Cli {
     /// Fragment type.
-    #[arg(value_parser = clap::builder::PossibleValuesParser::new(FRAGMENT_TYPES))]
+    #[arg(value_parser = clap::builder::PossibleValuesParser::new(
+        FRAGMENT_TYPES.iter().map(|t| t.name)
+    ))]
     fragment_type: String,
     /// Unique slug (used as the filename prefix, e.g. `env_var_interpolation`).
     slug: String,
@@ -39,7 +41,13 @@ impl Cli {
         }
 
         let author = detect_gh_handle().unwrap_or_else(|| TODO_HANDLE.to_string());
-        let content = render_template(&self.fragment_type, &author);
+        let Some(entry) = FRAGMENT_TYPES
+            .iter()
+            .find(|t| t.name == self.fragment_type.as_str())
+        else {
+            bail!("unknown fragment type '{}'", self.fragment_type);
+        };
+        let content = render_template(entry, &author);
         fs::write(&file, content)?;
 
         // `git add` the new fragment so the checker (which scans `git diff --diff-filter=A`)
@@ -80,9 +88,9 @@ fn validate_slug(slug: &str) -> Result<()> {
     Ok(())
 }
 
-fn render_template(fragment_type: &str, author: &str) -> String {
-    match fragment_type {
-        "breaking" => formatdoc! {"
+fn render_template(fragment_type: &FragmentType, author: &str) -> String {
+    if fragment_type.breaking {
+        formatdoc! {"
             # TODO one-line title
 
             ## Summary
@@ -112,12 +120,13 @@ fn render_template(fragment_type: &str, author: &str) -> String {
             ```
 
             authors: {author}
-        "},
-        _ => formatdoc! {"
+        "}
+    } else {
+        formatdoc! {"
             TODO one-item description of the change.
 
             authors: {author}
-        "},
+        "}
     }
 }
 
@@ -197,5 +206,17 @@ mod tests {
         assert!(validate_slug("").is_err());
         assert!(validate_slug("foo.bar").is_err());
         assert!(validate_slug("foo bar").is_err());
+    }
+
+    #[test]
+    fn breaking_template_is_selected_via_flag() {
+        let breaking = FRAGMENT_TYPES
+            .iter()
+            .find(|t| t.name == "breaking")
+            .unwrap();
+        let fix = FRAGMENT_TYPES.iter().find(|t| t.name == "fix").unwrap();
+        assert!(render_template(breaking, "a").contains("## Summary"));
+        assert!(render_template(breaking, "a").contains("## Migration"));
+        assert!(!render_template(fix, "a").contains("## Summary"));
     }
 }

--- a/vdev/src/commands/changelog/types.rs
+++ b/vdev/src/commands/changelog/types.rs
@@ -1,0 +1,17 @@
+use anyhow::Result;
+
+use crate::commands::changelog::FRAGMENT_TYPES;
+
+/// Print the valid changelog fragment types and their descriptions, one per line.
+#[derive(clap::Args, Debug)]
+#[command()]
+pub struct Cli {}
+
+impl Cli {
+    pub fn exec(self) -> Result<()> {
+        for fragment_type in FRAGMENT_TYPES {
+            println!("{:<12} {}", fragment_type.name, fragment_type.description);
+        }
+        Ok(())
+    }
+}

--- a/vdev/src/commands/check/changelog_fragments.rs
+++ b/vdev/src/commands/check/changelog_fragments.rs
@@ -7,18 +7,13 @@ use std::path::PathBuf;
 use anyhow::{Result, bail};
 
 use crate::commands::changelog::{
-    is_valid_anchor, new::TODO_HANDLE, parse_breaking_sections, slugify,
+    FRAGMENT_TYPES, FragmentType, is_valid_anchor, new::TODO_HANDLE, parse_breaking_sections,
+    slugify,
 };
 use crate::utils::{git, paths};
 
 const CHANGELOG_DIR: &str = "changelog.d";
 const DEFAULT_MAX_FRAGMENTS: usize = 1000;
-
-/// Allowed changelog fragment types.
-///
-/// NOTE: keep this list in sync with `vdev/src/commands/release/generate_cue.rs`
-/// and `changelog.d/README.md`.
-const FRAGMENT_TYPES: &[&str] = &["breaking", "security", "feature", "enhancement", "fix"];
 
 /// Validate changelog fragments added on this branch/PR.
 #[derive(clap::Args, Debug)]
@@ -99,16 +94,33 @@ impl Cli {
     }
 }
 
-/// Load every `*.breaking.md` in `changelog.d/`, compute its anchor (explicit override or
-/// slugified title), and verify the resulting set is non-empty, well-formed, and unique.
+/// Load every fragment in `changelog.d/` whose type is flagged `breaking`, compute its anchor
+/// (explicit override or slugified title), and verify the resulting set is non-empty,
+/// well-formed, and unique.
 fn validate_breaking_anchor_set(changelog_dir: &std::path::Path) -> Result<()> {
     let mut seen: std::collections::HashMap<String, String> = std::collections::HashMap::new();
     for entry in std::fs::read_dir(changelog_dir)? {
         let path = entry?.path();
         let name = match path.file_name().and_then(|s| s.to_str()) {
-            Some(n) if n.ends_with(".breaking.md") => n.to_string(),
+            Some(n) => n.to_string(),
             _ => continue,
         };
+        // Only breaking fragments carry an upgrade-guide anchor. Select them via the
+        // canonical type metadata rather than the literal `.breaking.md` suffix, so a
+        // renamed or added type with `breaking: true` is covered too. Require the full
+        // `<name>.<type>.md` shape first so editor backups or disabled files such as
+        // `foo.breaking.md.bak` are skipped, matching release generation.
+        let parts: Vec<&str> = name.split('.').collect();
+        if parts.len() != 3 || parts[2] != "md" {
+            continue;
+        }
+        let fragment_type = parts[1];
+        let Some(entry) = FRAGMENT_TYPES.iter().find(|t| t.name == fragment_type) else {
+            continue;
+        };
+        if !entry.breaking {
+            continue;
+        }
         let content = std::fs::read_to_string(&path)?;
         let body_before_authors = content
             .rsplit_once("\nauthors: ")
@@ -151,7 +163,7 @@ fn diff_fragments(merge_base: &str, filter: &str) -> Result<Vec<PathBuf>> {
         .collect())
 }
 
-fn validate_filename(filename: &str) -> Result<&'static str> {
+fn validate_filename(filename: &str) -> Result<&'static FragmentType> {
     let parts: Vec<&str> = filename.split('.').collect();
     if parts.len() != 3 {
         bail!(
@@ -159,19 +171,27 @@ fn validate_filename(filename: &str) -> Result<&'static str> {
         );
     }
     let fragment_type = parts[1];
-    let Some(known) = FRAGMENT_TYPES.iter().find(|t| **t == fragment_type) else {
+    let Some(known) = FRAGMENT_TYPES.iter().find(|t| t.name == fragment_type) else {
         bail!(
             "invalid fragment filename '{filename}': fragment type must be one of ({}).",
-            FRAGMENT_TYPES.join("|")
+            FRAGMENT_TYPES
+                .iter()
+                .map(|t| t.name)
+                .collect::<Vec<_>>()
+                .join("|")
         );
     };
     if parts[2] != "md" {
         bail!("invalid fragment filename '{filename}': extension must be markdown (.md).");
     }
-    Ok(*known)
+    Ok(known)
 }
 
-fn validate_contents(path: &std::path::Path, filename: &str, fragment_type: &str) -> Result<()> {
+fn validate_contents(
+    path: &std::path::Path,
+    filename: &str,
+    fragment_type: &FragmentType,
+) -> Result<()> {
     let content = std::fs::read_to_string(path)?;
     // Match generate_cue.rs, which reads `lines().last()` verbatim: the authors
     // line must be the last line, no trailing blank lines allowed.
@@ -211,7 +231,7 @@ fn validate_contents(path: &std::path::Path, filename: &str, fragment_type: &str
         );
     }
 
-    if fragment_type == "breaking" {
+    if fragment_type.breaking {
         validate_breaking_fragment(&content, filename)?;
     }
 
@@ -404,5 +424,57 @@ mod tests {
         let raw = wrap("# TODO one-line title", "y", "N/A");
         let err = validate_breaking_fragment(&raw, "x.breaking.md").unwrap_err();
         assert!(err.to_string().contains("placeholder 'TODO'"), "{err}");
+    }
+
+    #[test]
+    fn breaking_anchor_set_rejects_invalid_anchor() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join("bad.breaking.md"),
+            wrap("# One change {#Not Valid!}", "Summary.", "N/A"),
+        )
+        .unwrap();
+        let err = validate_breaking_anchor_set(tmp.path()).unwrap_err();
+        assert!(err.to_string().contains("kebab-case slug"), "{err}");
+    }
+
+    #[test]
+    fn breaking_anchor_set_rejects_duplicate_anchors() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(
+            tmp.path().join("one.breaking.md"),
+            wrap("# One change {#shared}", "Summary.", "N/A"),
+        )
+        .unwrap();
+        std::fs::write(
+            tmp.path().join("two.breaking.md"),
+            wrap("# Two change {#shared}", "Summary.", "N/A"),
+        )
+        .unwrap();
+        let err = validate_breaking_anchor_set(tmp.path()).unwrap_err();
+        assert!(
+            err.to_string().contains("duplicate upgrade-guide anchor"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn breaking_anchor_set_skips_non_breaking_fragments() {
+        let tmp = tempfile::tempdir().unwrap();
+        // A non-breaking fragment must not be anchor-checked, even with a breaking-shaped body.
+        std::fs::write(
+            tmp.path().join("not_breaking.fix.md"),
+            wrap("# One change {#Not Valid!}", "Summary.", "N/A"),
+        )
+        .unwrap();
+        assert!(validate_breaking_anchor_set(tmp.path()).is_ok());
+    }
+
+    #[test]
+    fn breaking_anchor_set_skips_non_fragment_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        // An editor backup like `foo.breaking.md.bak` must not be treated as a breaking fragment.
+        std::fs::write(tmp.path().join("foo.breaking.md.bak"), "not a fragment").unwrap();
+        assert!(validate_breaking_anchor_set(tmp.path()).is_ok());
     }
 }

--- a/vdev/src/commands/release/generate_cue.rs
+++ b/vdev/src/commands/release/generate_cue.rs
@@ -11,6 +11,7 @@ use chrono::Utc;
 use semver::Version;
 use serde_json::json;
 
+use crate::commands::changelog::FRAGMENT_TYPES;
 use crate::utils::{git, paths};
 
 const RELEASES_DIR: &str = "website/cue/reference/releases";
@@ -334,19 +335,20 @@ fn parse_changelog_fragment(path: &Path) -> Result<ChangelogEntry> {
         );
     }
     let fragment_type = parts[1];
-    let breaking = fragment_type == "breaking";
-    let cue_type = match fragment_type {
-        "breaking" => "chore",
-        "security" => "security",
-        "fix" => "fix",
-        "feature" => "feat",
-        "enhancement" => "enhancement",
-        other => bail!(
-            "Changelog fragment {} has unrecognized type '{}'",
+    let Some(entry) = FRAGMENT_TYPES.iter().find(|t| t.name == fragment_type) else {
+        bail!(
+            "Changelog fragment {} has unrecognized type '{}' (valid types: {})",
             path.display(),
-            other
-        ),
+            fragment_type,
+            FRAGMENT_TYPES
+                .iter()
+                .map(|t| t.name)
+                .collect::<Vec<_>>()
+                .join("|")
+        );
     };
+    let breaking = entry.breaking;
+    let cue_type = entry.cue_type;
 
     let raw =
         fs::read_to_string(path).with_context(|| format!("Failed to read {}", path.display()))?;


### PR DESCRIPTION
## Summary

Centralize the changelog fragment type list in a single source of truth and expose it
through a new `vdev changelog types` subcommand, so the scaffolder, CI checker, and release
generator no longer maintain duplicated lists (the checker previously carried a
"keep this list in sync" comment). Update `changelog.d/README.md` to reference the command
instead of hardcoding the types, and add guidance for both humans and agents.

### References

No issue.

## Vector configuration

N/A — this PR touches vdev developer tooling and `changelog.d/README.md` only.

## How did you test this PR?

- `cargo check -p vdev`
- `cargo test -p vdev` — 116 passed (including a new test for `vdev changelog types`)
- `cargo clippy -p vdev --all-targets`
- `cargo fmt -p vdev -- --check`
- `vdev check markdown` — 0 issues across 707 files
- Verified live: `vdev changelog types` prints each type with its description (e.g.
  `breaking     A change that is incompatible with prior versions and requires users to make adjustments...`),
  and `vdev changelog --help` lists the new subcommand.

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## Contributor Guidelines

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them. To catch issues early, add a `pre-push` hook ([template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push)) or run the following locally before pushing:
  - `make fmt`
  - `make check-clippy` (auto-fix with `make clippy-fix`)
  - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details on the [dd-rust-license-tool](https://crates.io/crates/dd-rust-license-tool).
