### PR TITLE
feat(aws sinks): validate config at compile time

### DIFF
--- a/changelog.d/aws_s3_ssekms_key_id_timezone.enhancement.md
+++ b/changelog.d/aws_s3_ssekms_key_id_timezone.enhancement.md
@@ -1,0 +1,4 @@
+The `ssekms_key_id` option in the `aws_s3` sink now respects the configured timezone when the
+value is a template containing time components, matching the existing behavior of `key_prefix`.
+
+authors: thomasqueirozb

--- a/src/sinks/aws_cloudwatch_logs/config.rs
+++ b/src/sinks/aws_cloudwatch_logs/config.rs
@@ -1,18 +1,22 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use aws_sdk_cloudwatchlogs::Client as CloudwatchLogsClient;
 use futures::FutureExt;
+use http::HeaderValue;
 use serde::{Deserialize, Deserializer, de};
 use tower::ServiceBuilder;
-use vector_lib::{codecs::JsonSerializerConfig, configurable::configurable_component, schema};
+use vector_lib::{
+    codecs::JsonSerializerConfig, configurable::configurable_component, schema,
+    stream::BatcherSettings,
+};
 use vrl::value::Kind;
 
 use crate::{
     aws::{AwsAuthentication, ClientBuilder, RegionOrEndpoint, create_client},
     codecs::{Encoder, EncodingConfig},
     config::{
-        AcknowledgementsConfig, DataType, GenerateConfig, Input, ProxyConfig, SinkConfig,
-        SinkContext,
+        AcknowledgementsConfig, DataType, DynValidatedSink, GenerateConfig, Input, ProxyConfig,
+        SinkConfig, SinkContext, ValidatedSink,
     },
     sinks::{
         Healthcheck, VectorSink,
@@ -21,10 +25,11 @@ use crate::{
             retry::CloudwatchRetryLogic, service::CloudwatchLogsPartitionSvc, sink::CloudwatchSink,
         },
         util::{
-            BatchConfig, Compression, ServiceBuilderExt, SinkBatchSettings, http::RequestConfig,
+            BatchConfig, Compression, ServiceBuilderExt, SinkBatchSettings,
+            http::{OrderedHeaderName, RequestConfig, validate_headers},
         },
     },
-    template::{ConfinementConfig, Template},
+    template::{ConfinedTemplate, ConfinementConfig, Template},
     tls::TlsConfig,
 };
 
@@ -88,7 +93,7 @@ pub struct CloudwatchLogsSinkConfig {
     ///
     /// [group_name]: https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/Working-with-log-groups-and-streams.html
     #[configurable(metadata(docs::examples = "group-name"))]
-    #[configurable(metadata(docs::examples = "{{ file }}"))]
+    #[configurable(metadata(docs::examples = "group-{{ file }}"))]
     pub group_name: Template,
 
     /// The [stream name][stream_name] of the target CloudWatch Logs stream.
@@ -98,7 +103,7 @@ pub struct CloudwatchLogsSinkConfig {
     /// unique per instance.
     ///
     /// [stream_name]: https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/Working-with-log-groups-and-streams.html
-    #[configurable(metadata(docs::examples = "{{ host }}"))]
+    #[configurable(metadata(docs::examples = "stream-{{ host }}"))]
     #[configurable(metadata(docs::examples = "%Y-%m-%d"))]
     #[configurable(metadata(docs::examples = "stream-name"))]
     pub stream_name: Template,
@@ -206,7 +211,40 @@ impl CloudwatchLogsSinkConfig {
 #[async_trait::async_trait]
 #[typetag::serde(name = "aws_cloudwatch_logs")]
 impl SinkConfig for CloudwatchLogsSinkConfig {
-    async fn build(&self, cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
+    fn confinement_config(&self) -> Option<&crate::template::ConfinementConfig> {
+        Some(&self.confinement)
+    }
+
+    fn input(&self) -> Input {
+        let requirement =
+            schema::Requirement::empty().optional_meaning("timestamp", Kind::timestamp());
+
+        Input::new(self.encoding.config().input_type() & DataType::Log)
+            .with_schema_requirement(requirement)
+    }
+
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &self.acknowledgements
+    }
+
+    fn as_dyn_validated(&self) -> Option<&dyn DynValidatedSink> {
+        Some(self)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ValidatedCloudwatchLogs {
+    group_template: ConfinedTemplate,
+    stream_template: ConfinedTemplate,
+    batcher_settings: BatcherSettings,
+    headers: BTreeMap<OrderedHeaderName, HeaderValue>,
+}
+
+#[async_trait::async_trait]
+impl ValidatedSink for CloudwatchLogsSinkConfig {
+    type Validated = ValidatedCloudwatchLogs;
+
+    fn validate(&self) -> crate::Result<ValidatedCloudwatchLogs> {
         let group_template =
             self.group_name
                 .clone()
@@ -215,8 +253,28 @@ impl SinkConfig for CloudwatchLogsSinkConfig {
             self.stream_name
                 .clone()
                 .confine(&self.confinement, Self::NAME, "stream_name")?;
-
         let batcher_settings = self.batch.into_batcher_settings()?;
+        let headers = validate_headers(&self.request.headers)?;
+
+        Ok(ValidatedCloudwatchLogs {
+            group_template,
+            stream_template,
+            batcher_settings,
+            headers,
+        })
+    }
+
+    async fn build(
+        &self,
+        validated: &ValidatedCloudwatchLogs,
+        cx: SinkContext,
+    ) -> crate::Result<(VectorSink, Healthcheck)> {
+        let ValidatedCloudwatchLogs {
+            group_template,
+            stream_template,
+            batcher_settings,
+            headers,
+        } = validated.clone();
         let request_settings = self.request.tower.into_settings();
         let client = self.create_client(cx.proxy()).await?;
         let svc = ServiceBuilder::new()
@@ -224,7 +282,8 @@ impl SinkConfig for CloudwatchLogsSinkConfig {
             .service(CloudwatchLogsPartitionSvc::new(
                 self.clone(),
                 client.clone(),
-            )?);
+                headers.clone(),
+            ));
         let transformer = self.encoding.transformer();
         let serializer = self.encoding.build()?;
         let encoder = Encoder::<()>::new(serializer);
@@ -241,22 +300,6 @@ impl SinkConfig for CloudwatchLogsSinkConfig {
             service: svc,
         };
         Ok((VectorSink::from_event_streamsink(sink), healthcheck))
-    }
-
-    fn confinement_config(&self) -> Option<&crate::template::ConfinementConfig> {
-        Some(&self.confinement)
-    }
-
-    fn input(&self) -> Input {
-        let requirement =
-            schema::Requirement::empty().optional_meaning("timestamp", Kind::timestamp());
-
-        Input::new(self.encoding.config().input_type() & DataType::Log)
-            .with_schema_requirement(requirement)
-    }
-
-    fn acknowledgements(&self) -> &AcknowledgementsConfig {
-        &self.acknowledgements
     }
 }
 
@@ -299,12 +342,69 @@ impl SinkBatchSettings for CloudwatchLogsDefaultBatchSettings {
 
 #[cfg(test)]
 mod tests {
+    use crate::config::ValidatedSink;
     use crate::sinks::aws_cloudwatch_logs::config::CloudwatchLogsSinkConfig;
     use crate::template::{ConfinementConfig, Template};
+    use vector_lib::codecs::JsonSerializerConfig;
+
+    #[test]
+    fn prepares_valid_config() {
+        let mut config = super::default_config(JsonSerializerConfig::default().into());
+        config.group_name = "group-{{ file }}".try_into().unwrap();
+        config.stream_name = "stream".try_into().unwrap();
+
+        let validated = config.validate().expect("preparation should succeed");
+        assert_eq!(validated.group_template.to_string(), "group-{{ file }}");
+        assert_eq!(validated.stream_template.to_string(), "stream");
+        assert_eq!(validated.batcher_settings.item_limit, 10_000);
+    }
 
     #[test]
     fn test_generate_config() {
         crate::test_util::test_generate_config::<CloudwatchLogsSinkConfig>();
+    }
+
+    #[test]
+    fn validate_rejects_invalid_header_name() {
+        let mut config = super::default_config(JsonSerializerConfig::default().into());
+        config.group_name = "group".try_into().unwrap();
+        config.stream_name = "stream".try_into().unwrap();
+        config
+            .request
+            .headers
+            .insert("invalid header name".to_string(), "value".to_string());
+
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_invalid_header_value() {
+        let mut config = super::default_config(JsonSerializerConfig::default().into());
+        config.group_name = "group".try_into().unwrap();
+        config.stream_name = "stream".try_into().unwrap();
+        config.request.headers.insert(
+            "valid-header".to_string(),
+            "value\nwith newline".to_string(),
+        );
+
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn validate_retains_valid_headers() {
+        let mut config = super::default_config(JsonSerializerConfig::default().into());
+        config.group_name = "group".try_into().unwrap();
+        config.stream_name = "stream".try_into().unwrap();
+        config
+            .request
+            .headers
+            .insert("x-custom-header".to_string(), "custom-value".to_string());
+
+        let validated = config.validate().expect("preparation should succeed");
+        assert_eq!(validated.headers.len(), 1);
+        let (name, value) = validated.headers.iter().next().unwrap();
+        assert_eq!(name.inner(), "x-custom-header");
+        assert_eq!(value, "custom-value");
     }
 
     #[test]

--- a/src/sinks/aws_cloudwatch_logs/request.rs
+++ b/src/sinks/aws_cloudwatch_logs/request.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashMap,
+    collections::{BTreeMap, HashMap},
     future::Future,
     pin::Pin,
     task::{Context, Poll, ready},
@@ -18,11 +18,13 @@ use aws_sdk_cloudwatchlogs::{
 };
 use aws_smithy_runtime_api::client::{orchestrator::HttpResponse, result::SdkError};
 use futures::{FutureExt, future::BoxFuture};
-use http::{HeaderValue, header::HeaderName};
-use indexmap::IndexMap;
+use http::HeaderValue;
 use tokio::sync::oneshot;
 
-use crate::sinks::aws_cloudwatch_logs::{config::Retention, service::CloudwatchError};
+use crate::sinks::{
+    aws_cloudwatch_logs::{config::Retention, service::CloudwatchError},
+    util::http::OrderedHeaderName,
+};
 
 pub struct CloudwatchFuture {
     client: Client,
@@ -38,7 +40,7 @@ struct Client {
     client: CloudwatchLogsClient,
     stream_name: String,
     group_name: String,
-    headers: IndexMap<HeaderName, HeaderValue>,
+    headers: BTreeMap<OrderedHeaderName, HeaderValue>,
     retention_days: u32,
     kms_key: Option<String>,
     tags: Option<HashMap<String, String>>,
@@ -59,7 +61,7 @@ impl CloudwatchFuture {
     #[allow(clippy::too_many_arguments)]
     pub(super) fn new(
         client: CloudwatchLogsClient,
-        headers: IndexMap<HeaderName, HeaderValue>,
+        headers: BTreeMap<OrderedHeaderName, HeaderValue>,
         stream_name: String,
         group_name: String,
         create_missing_group: bool,
@@ -267,7 +269,8 @@ impl Client {
                 .customize()
                 .mutate_request(move |req| {
                     for (header, value) in headers.iter() {
-                        req.headers_mut().insert(header.clone(), value.clone());
+                        req.headers_mut()
+                            .insert(header.inner().clone(), value.clone());
                     }
                 })
                 .send()

--- a/src/sinks/aws_cloudwatch_logs/service.rs
+++ b/src/sinks/aws_cloudwatch_logs/service.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashMap,
+    collections::{BTreeMap, HashMap},
     fmt,
     task::{Context, Poll, ready},
 };
@@ -17,12 +17,7 @@ use aws_smithy_runtime_api::client::{orchestrator::HttpResponse, result::SdkErro
 use chrono::Duration;
 use futures::{FutureExt, future::BoxFuture};
 use futures_util::TryFutureExt;
-use http::{
-    HeaderValue,
-    header::{HeaderName, InvalidHeaderName, InvalidHeaderValue},
-};
-use indexmap::IndexMap;
-use snafu::{ResultExt, Snafu};
+use http::HeaderValue;
 use tokio::sync::oneshot;
 use tower::{
     Service, ServiceBuilder, ServiceExt,
@@ -45,7 +40,9 @@ use crate::sinks::{
         retry::CloudwatchRetryLogic,
         sink::BatchCloudwatchRequest,
     },
-    util::{EncodedLength, TowerRequestSettings, retries::FibonacciRetryPolicy},
+    util::{
+        EncodedLength, TowerRequestSettings, http::OrderedHeaderName, retries::FibonacciRetryPolicy,
+    },
 };
 
 type Svc = Buffer<
@@ -133,40 +130,21 @@ impl DriverResponse for CloudwatchResponse {
     }
 }
 
-#[derive(Snafu, Debug)]
-enum HeaderError {
-    #[snafu(display("invalid header name {source}"))]
-    InvalidName { source: InvalidHeaderName },
-    #[snafu(display("invalid header value {source}"))]
-    InvalidValue { source: InvalidHeaderValue },
-}
-
 impl CloudwatchLogsPartitionSvc {
     pub fn new(
         config: CloudwatchLogsSinkConfig,
         client: CloudwatchLogsClient,
-    ) -> crate::Result<Self> {
+        headers: BTreeMap<OrderedHeaderName, HeaderValue>,
+    ) -> Self {
         let request_settings = config.request.tower.into_settings();
 
-        let headers = config
-            .request
-            .headers
-            .iter()
-            .map(|(name, value)| {
-                Ok((
-                    HeaderName::from_bytes(name.as_bytes()).context(InvalidNameSnafu {})?,
-                    HeaderValue::from_str(value.as_str()).context(InvalidValueSnafu {})?,
-                ))
-            })
-            .collect::<Result<IndexMap<_, _>, HeaderError>>()?;
-
-        Ok(Self {
+        Self {
             config,
             clients: HashMap::new(),
             request_settings,
             client,
             headers,
-        })
+        }
     }
 }
 
@@ -236,7 +214,7 @@ impl CloudwatchLogsSvc {
         config: CloudwatchLogsSinkConfig,
         key: &CloudwatchKey,
         client: CloudwatchLogsClient,
-        headers: IndexMap<HeaderName, HeaderValue>,
+        headers: BTreeMap<OrderedHeaderName, HeaderValue>,
     ) -> Self {
         let group_name = key.group.clone();
         let stream_name = key.stream.clone();
@@ -347,7 +325,7 @@ impl Service<Vec<InputLogEvent>> for CloudwatchLogsSvc {
 
 pub struct CloudwatchLogsSvc {
     client: CloudwatchLogsClient,
-    headers: IndexMap<HeaderName, HeaderValue>,
+    headers: BTreeMap<OrderedHeaderName, HeaderValue>,
     stream_name: String,
     group_name: String,
     create_missing_group: bool,
@@ -368,7 +346,7 @@ impl EncodedLength for InputLogEvent {
 #[derive(Clone)]
 pub struct CloudwatchLogsPartitionSvc {
     config: CloudwatchLogsSinkConfig,
-    headers: IndexMap<HeaderName, HeaderValue>,
+    headers: BTreeMap<OrderedHeaderName, HeaderValue>,
     clients: HashMap<CloudwatchKey, Svc>,
     request_settings: TowerRequestSettings,
     client: CloudwatchLogsClient,

--- a/src/sinks/aws_cloudwatch_metrics/integration_tests.rs
+++ b/src/sinks/aws_cloudwatch_metrics/integration_tests.rs
@@ -38,7 +38,8 @@ async fn cloudwatch_metrics_put_data() {
     let cx = SinkContext::default();
     let config = config();
     let client = config.create_client(&cx.globals.proxy).await.unwrap();
-    let sink = CloudWatchMetricsSvc::new(config, client).unwrap();
+    let validated = config.validate().unwrap();
+    let sink = CloudWatchMetricsSvc::new(config, client, &validated).unwrap();
 
     let mut events = Vec::new();
 
@@ -97,7 +98,8 @@ async fn cloudwatch_metrics_namespace_partitioning() {
     let cx = SinkContext::default();
     let config = config();
     let client = config.create_client(&cx.globals.proxy).await.unwrap();
-    let sink = CloudWatchMetricsSvc::new(config, client).unwrap();
+    let validated = config.validate().unwrap();
+    let sink = CloudWatchMetricsSvc::new(config, client, &validated).unwrap();
 
     let mut events = Vec::new();
 

--- a/src/sinks/aws_cloudwatch_metrics/mod.rs
+++ b/src/sinks/aws_cloudwatch_metrics/mod.rs
@@ -3,7 +3,10 @@ mod integration_tests;
 #[cfg(test)]
 mod tests;
 
-use std::task::{Context, Poll};
+use std::{
+    fmt,
+    task::{Context, Poll},
+};
 
 use aws_config::Region;
 use aws_sdk_cloudwatch::{
@@ -26,7 +29,10 @@ use crate::{
     aws::{
         ClientBuilder, RegionOrEndpoint, auth::AwsAuthentication, create_client, is_retriable_error,
     },
-    config::{AcknowledgementsConfig, Input, ProxyConfig, SinkConfig, SinkContext},
+    config::{
+        AcknowledgementsConfig, DynValidatedSink, Input, ProxyConfig, SinkConfig, SinkContext,
+        ValidatedSink,
+    },
     event::{
         Event,
         metric::{Metric, MetricTags, MetricValue},
@@ -34,7 +40,7 @@ use crate::{
     sinks::util::{
         Compression, EncodedEvent, PartitionBuffer, PartitionInnerBuffer, SinkBatchSettings,
         TowerRequestConfig,
-        batch::BatchConfig,
+        batch::{BatchConfig, BatchSettings},
         buffer::metrics::{MetricNormalize, MetricNormalizer, MetricSet, MetricsBuffer},
         retries::RetryLogic,
     },
@@ -140,22 +146,57 @@ impl ClientBuilder for CloudwatchMetricsClientBuilder {
 #[async_trait::async_trait]
 #[typetag::serde(name = "aws_cloudwatch_metrics")]
 impl SinkConfig for CloudWatchMetricsSinkConfig {
-    async fn build(
-        &self,
-        cx: SinkContext,
-    ) -> crate::Result<(super::VectorSink, super::Healthcheck)> {
-        let client = self.create_client(&cx.proxy).await?;
-        let healthcheck = self.clone().healthcheck(client.clone()).boxed();
-        let sink = CloudWatchMetricsSvc::new(self.clone(), client)?;
-        Ok((sink, healthcheck))
-    }
-
     fn input(&self) -> Input {
         Input::metric()
     }
 
     fn acknowledgements(&self) -> &AcknowledgementsConfig {
         &self.acknowledgements
+    }
+
+    fn as_dyn_validated(&self) -> Option<&dyn DynValidatedSink> {
+        Some(self)
+    }
+}
+
+pub struct ValidatedCloudWatchMetrics {
+    batch: BatchSettings<MetricsBuffer>,
+    storage_resolution: IndexMap<String, i32>,
+}
+
+impl fmt::Debug for ValidatedCloudWatchMetrics {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ValidatedCloudWatchMetrics")
+            .field("batch_size_bytes", &self.batch.size.bytes)
+            .field("batch_size_events", &self.batch.size.events)
+            .field("batch_timeout", &self.batch.timeout)
+            .field("storage_resolution", &self.storage_resolution)
+            .finish()
+    }
+}
+
+#[async_trait::async_trait]
+impl ValidatedSink for CloudWatchMetricsSinkConfig {
+    type Validated = ValidatedCloudWatchMetrics;
+
+    fn validate(&self) -> crate::Result<ValidatedCloudWatchMetrics> {
+        let batch = self.batch.into_batch_settings()?;
+        let storage_resolution = validate_storage_resolutions(self.storage_resolution.clone())?;
+        Ok(ValidatedCloudWatchMetrics {
+            batch,
+            storage_resolution,
+        })
+    }
+
+    async fn build(
+        &self,
+        validated: &ValidatedCloudWatchMetrics,
+        cx: SinkContext,
+    ) -> crate::Result<(super::VectorSink, super::Healthcheck)> {
+        let client = self.create_client(&cx.proxy).await?;
+        let healthcheck = self.clone().healthcheck(client.clone()).boxed();
+        let sink = CloudWatchMetricsSvc::new(self.clone(), client, validated)?;
+        Ok((sink, healthcheck))
     }
 }
 
@@ -240,14 +281,15 @@ impl CloudWatchMetricsSvc {
     pub fn new(
         config: CloudWatchMetricsSinkConfig,
         client: CloudwatchClient,
+        validated: &ValidatedCloudWatchMetrics,
     ) -> crate::Result<VectorSink> {
         let default_namespace = config.default_namespace.clone();
-        let batch = config.batch.into_batch_settings()?;
+        let batch = &validated.batch;
         let request_settings = config.request.into_settings();
 
         let service = CloudWatchMetricsSvc {
             client,
-            storage_resolution: validate_storage_resolutions(config.storage_resolution)?,
+            storage_resolution: validated.storage_resolution.clone(),
         };
         let buffer = PartitionBuffer::new(MetricsBuffer::new(batch.size));
         let mut normalizer = MetricNormalizer::<AwsCloudwatchMetricNormalize>::default();

--- a/src/sinks/aws_cloudwatch_metrics/tests.rs
+++ b/src/sinks/aws_cloudwatch_metrics/tests.rs
@@ -19,6 +19,14 @@ fn generate_config() {
     crate::test_util::test_generate_config::<CloudWatchMetricsSinkConfig>();
 }
 
+#[test]
+fn prepares_valid_config() {
+    let config = config();
+    let validated = config.validate().expect("preparation should succeed");
+    assert_eq!(validated.storage_resolution.get("bytes_out"), Some(&1));
+    assert_eq!(validated.batch.size.events, 20);
+}
+
 fn config() -> CloudWatchMetricsSinkConfig {
     CloudWatchMetricsSinkConfig {
         default_namespace: "vector".into(),

--- a/src/sinks/aws_kinesis/firehose/config.rs
+++ b/src/sinks/aws_kinesis/firehose/config.rs
@@ -5,6 +5,7 @@ use aws_smithy_runtime_api::client::{orchestrator::HttpResponse, result::SdkErro
 use futures::FutureExt;
 use snafu::Snafu;
 use vector_lib::configurable::configurable_component;
+use vector_lib::stream::BatcherSettings;
 
 use super::{
     KinesisClient, KinesisError, KinesisRecord, KinesisResponse, KinesisSinkBaseConfig, build_sink,
@@ -13,7 +14,10 @@ use super::{
 };
 use crate::{
     aws::{ClientBuilder, create_client, is_retriable_error},
-    config::{AcknowledgementsConfig, GenerateConfig, Input, ProxyConfig, SinkConfig, SinkContext},
+    config::{
+        AcknowledgementsConfig, DynValidatedSink, GenerateConfig, Input, ProxyConfig, SinkConfig,
+        SinkContext, ValidatedSink,
+    },
     sinks::{
         Healthcheck, VectorSink,
         util::{
@@ -118,16 +122,46 @@ impl KinesisFirehoseSinkConfig {
 #[async_trait::async_trait]
 #[typetag::serde(name = "aws_kinesis_firehose")]
 impl SinkConfig for KinesisFirehoseSinkConfig {
-    async fn build(&self, cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
-        let client = self.create_client(&cx.proxy).await?;
-        let healthcheck = self.clone().healthcheck(client.clone()).boxed();
+    fn input(&self) -> Input {
+        self.base.input()
+    }
 
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        self.base.acknowledgements()
+    }
+
+    fn as_dyn_validated(&self) -> Option<&dyn DynValidatedSink> {
+        Some(self)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ValidatedKinesisFirehose {
+    batch_settings: BatcherSettings,
+}
+
+#[async_trait::async_trait]
+impl ValidatedSink for KinesisFirehoseSinkConfig {
+    type Validated = ValidatedKinesisFirehose;
+
+    fn validate(&self) -> crate::Result<ValidatedKinesisFirehose> {
         let batch_settings = self
             .batch
             .validate()?
             .limit_max_bytes(MAX_PAYLOAD_SIZE)?
             .limit_max_events(MAX_PAYLOAD_EVENTS)?
             .into_batcher_settings()?;
+
+        Ok(ValidatedKinesisFirehose { batch_settings })
+    }
+
+    async fn build(
+        &self,
+        validated: &ValidatedKinesisFirehose,
+        cx: SinkContext,
+    ) -> crate::Result<(VectorSink, Healthcheck)> {
+        let client = self.create_client(&cx.proxy).await?;
+        let healthcheck = self.clone().healthcheck(client.clone()).boxed();
 
         let sink = build_sink::<
             KinesisFirehoseClient,
@@ -138,7 +172,7 @@ impl SinkConfig for KinesisFirehoseSinkConfig {
         >(
             &self.base,
             self.base.partition_key_field.clone(),
-            batch_settings,
+            validated.batch_settings,
             KinesisFirehoseClient { client },
             KinesisRetryLogic {
                 retry_partial: self.base.request_retry_partial,
@@ -146,14 +180,6 @@ impl SinkConfig for KinesisFirehoseSinkConfig {
         )?;
 
         Ok((sink, healthcheck))
-    }
-
-    fn input(&self) -> Input {
-        self.base.input()
-    }
-
-    fn acknowledgements(&self) -> &AcknowledgementsConfig {
-        self.base.acknowledgements()
     }
 }
 
@@ -197,5 +223,36 @@ impl RetryLogic for KinesisRetryLogic {
         } else {
             RetryAction::Successful
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_produces_batch_settings() {
+        let config = KinesisFirehoseSinkConfig {
+            batch: BatchConfig::<KinesisFirehoseDefaultBatchSettings>::default(),
+            base: KinesisSinkBaseConfig {
+                stream_name: String::from("test"),
+                region: crate::aws::RegionOrEndpoint::with_both(
+                    "us-east-1",
+                    "http://localhost:4566",
+                ),
+                encoding: vector_lib::codecs::JsonSerializerConfig::default().into(),
+                compression: crate::sinks::util::Compression::None,
+                request: Default::default(),
+                tls: None,
+                auth: Default::default(),
+                request_retry_partial: false,
+                acknowledgements: Default::default(),
+                partition_key_field: None,
+            },
+        };
+
+        let validated = config.validate().expect("validation should succeed");
+        assert_eq!(validated.batch_settings.item_limit, MAX_PAYLOAD_EVENTS);
+        assert_eq!(validated.batch_settings.size_limit, MAX_PAYLOAD_SIZE);
     }
 }

--- a/src/sinks/aws_kinesis/streams/config.rs
+++ b/src/sinks/aws_kinesis/streams/config.rs
@@ -13,7 +13,10 @@ use super::{
 };
 use crate::{
     aws::{ClientBuilder, create_client, is_retriable_error},
-    config::{AcknowledgementsConfig, Input, ProxyConfig, SinkConfig, SinkContext},
+    config::{
+        AcknowledgementsConfig, DynValidatedSink, Input, ProxyConfig, SinkConfig, SinkContext,
+        ValidatedSink,
+    },
     sinks::{
         Healthcheck, VectorSink,
         prelude::*,
@@ -117,16 +120,46 @@ impl KinesisStreamsSinkConfig {
 #[async_trait::async_trait]
 #[typetag::serde(name = "aws_kinesis_streams")]
 impl SinkConfig for KinesisStreamsSinkConfig {
-    async fn build(&self, cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
-        let client = self.create_client(&cx.proxy).await?;
-        let healthcheck = self.clone().healthcheck(client.clone()).boxed();
+    fn input(&self) -> Input {
+        self.base.input()
+    }
 
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        self.base.acknowledgements()
+    }
+
+    fn as_dyn_validated(&self) -> Option<&dyn DynValidatedSink> {
+        Some(self)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ValidatedKinesisStreams {
+    batch_settings: BatcherSettings,
+}
+
+#[async_trait::async_trait]
+impl ValidatedSink for KinesisStreamsSinkConfig {
+    type Validated = ValidatedKinesisStreams;
+
+    fn validate(&self) -> crate::Result<ValidatedKinesisStreams> {
         let batch_settings = self
             .batch
             .validate()?
             .limit_max_bytes(MAX_PAYLOAD_SIZE)?
             .limit_max_events(MAX_PAYLOAD_EVENTS)?
             .into_batcher_settings()?;
+
+        Ok(ValidatedKinesisStreams { batch_settings })
+    }
+
+    async fn build(
+        &self,
+        validated: &ValidatedKinesisStreams,
+        cx: SinkContext,
+    ) -> crate::Result<(VectorSink, Healthcheck)> {
+        let client = self.create_client(&cx.proxy).await?;
+        let healthcheck = self.clone().healthcheck(client.clone()).boxed();
 
         let sink = build_sink::<
             KinesisStreamClient,
@@ -137,7 +170,7 @@ impl SinkConfig for KinesisStreamsSinkConfig {
         >(
             &self.base,
             self.base.partition_key_field.clone(),
-            batch_settings,
+            validated.batch_settings,
             KinesisStreamClient { client },
             KinesisRetryLogic {
                 retry_partial: self.base.request_retry_partial,
@@ -145,14 +178,6 @@ impl SinkConfig for KinesisStreamsSinkConfig {
         )?;
 
         Ok((sink, healthcheck))
-    }
-
-    fn input(&self) -> Input {
-        self.base.input()
-    }
-
-    fn acknowledgements(&self) -> &AcknowledgementsConfig {
-        self.base.acknowledgements()
     }
 }
 
@@ -221,10 +246,36 @@ impl RetryLogic for KinesisRetryLogic {
 
 #[cfg(test)]
 mod tests {
-    use super::KinesisStreamsSinkConfig;
+    use super::*;
 
     #[test]
     fn generate_config() {
         crate::test_util::test_generate_config::<KinesisStreamsSinkConfig>();
+    }
+
+    #[test]
+    fn validate_produces_batch_settings() {
+        let config = KinesisStreamsSinkConfig {
+            batch: BatchConfig::<KinesisDefaultBatchSettings>::default(),
+            base: KinesisSinkBaseConfig {
+                stream_name: String::from("test"),
+                region: crate::aws::RegionOrEndpoint::with_both(
+                    "us-east-1",
+                    "http://localhost:4566",
+                ),
+                encoding: vector_lib::codecs::JsonSerializerConfig::default().into(),
+                compression: Compression::None,
+                request: Default::default(),
+                tls: None,
+                auth: Default::default(),
+                request_retry_partial: false,
+                acknowledgements: Default::default(),
+                partition_key_field: None,
+            },
+        };
+
+        let validated = config.validate().expect("validation should succeed");
+        assert_eq!(validated.batch_settings.item_limit, MAX_PAYLOAD_EVENTS);
+        assert_eq!(validated.batch_settings.size_limit, MAX_PAYLOAD_SIZE);
     }
 }

--- a/src/sinks/aws_s3/config.rs
+++ b/src/sinks/aws_s3/config.rs
@@ -12,13 +12,17 @@ use vector_lib::{
     },
     configurable::configurable_component,
     sink::VectorSink,
+    stream::BatcherSettings,
 };
 
 use super::sink::S3RequestOptions;
 use crate::{
     aws::{AwsAuthentication, RegionOrEndpoint},
     codecs::{Encoder, EncodingConfigWithFraming, SinkType},
-    config::{AcknowledgementsConfig, GenerateConfig, Input, ProxyConfig, SinkConfig, SinkContext},
+    config::{
+        AcknowledgementsConfig, DynValidatedSink, GenerateConfig, Input, ProxyConfig, SinkConfig,
+        SinkContext, ValidatedSink,
+    },
     sinks::{
         Healthcheck,
         s3_common::{
@@ -33,7 +37,7 @@ use crate::{
             TowerRequestConfig, timezone_to_offset,
         },
     },
-    template::{ConfinementConfig, Template},
+    template::{ConfinedTemplate, ConfinementConfig, Template},
     tls::TlsConfig,
 };
 
@@ -228,13 +232,6 @@ impl GenerateConfig for S3SinkConfig {
 #[async_trait::async_trait]
 #[typetag::serde(name = "aws_s3")]
 impl SinkConfig for S3SinkConfig {
-    async fn build(&self, cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
-        let service = self.create_service(&cx.proxy).await?;
-        let healthcheck = self.build_healthcheck(service.client())?;
-        let sink = self.build_processor(service, cx)?;
-        Ok((sink, healthcheck))
-    }
-
     fn confinement_config(&self) -> Option<&crate::template::ConfinementConfig> {
         Some(&self.confinement)
     }
@@ -252,6 +249,59 @@ impl SinkConfig for S3SinkConfig {
     fn acknowledgements(&self) -> &AcknowledgementsConfig {
         &self.acknowledgements
     }
+
+    fn as_dyn_validated(&self) -> Option<&dyn DynValidatedSink> {
+        Some(self)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ValidatedAwsS3 {
+    batch_settings: BatcherSettings,
+    key_prefix: ConfinedTemplate,
+    ssekms_key_id: Option<ConfinedTemplate>,
+}
+
+#[async_trait::async_trait]
+impl ValidatedSink for S3SinkConfig {
+    type Validated = ValidatedAwsS3;
+
+    fn validate(&self) -> crate::Result<ValidatedAwsS3> {
+        let batch_settings = self.batch.into_batcher_settings()?;
+
+        let key_prefix = Template::try_from(self.key_prefix.clone())?.confine(
+            &self.confinement,
+            Self::NAME,
+            "key_prefix",
+        )?;
+
+        let ssekms_key_id = self
+            .options
+            .ssekms_key_id
+            .as_ref()
+            .cloned()
+            .map(|ssekms_key_id| Template::try_from(ssekms_key_id.as_str()))
+            .transpose()?
+            .map(|t| t.confine(&self.confinement, Self::NAME, "ssekms_key_id"))
+            .transpose()?;
+
+        Ok(ValidatedAwsS3 {
+            batch_settings,
+            key_prefix,
+            ssekms_key_id,
+        })
+    }
+
+    async fn build(
+        &self,
+        validated: &ValidatedAwsS3,
+        cx: SinkContext,
+    ) -> crate::Result<(VectorSink, Healthcheck)> {
+        let service = self.create_service(&cx.proxy).await?;
+        let healthcheck = self.build_healthcheck(service.client())?;
+        let sink = self.build_processor(service, cx, validated)?;
+        Ok((sink, healthcheck))
+    }
 }
 
 impl S3SinkConfig {
@@ -259,6 +309,7 @@ impl S3SinkConfig {
         &self,
         service: S3Service,
         cx: SinkContext,
+        validated: &ValidatedAwsS3,
     ) -> crate::Result<VectorSink> {
         // Build our S3 client/service, which is what we'll ultimately feed
         // requests into in order to ship files to S3.  We build this here in
@@ -276,20 +327,13 @@ impl S3SinkConfig {
             .and_then(timezone_to_offset);
 
         // Configure our partitioning/batching.
-        let batch_settings = self.batch.into_batcher_settings()?;
+        let batch_settings = validated.batch_settings;
 
-        let key_prefix = Template::try_from(self.key_prefix.clone())?.with_tz_offset(offset);
-        let key_prefix = key_prefix.confine(&self.confinement, Self::NAME, "key_prefix")?;
-
-        let ssekms_key_id = self
-            .options
+        let key_prefix = validated.key_prefix.clone().with_tz_offset(offset);
+        let ssekms_key_id = validated
             .ssekms_key_id
-            .as_ref()
-            .cloned()
-            .map(|ssekms_key_id| Template::try_from(ssekms_key_id.as_str()))
-            .transpose()?
-            .map(|t| t.confine(&self.confinement, Self::NAME, "ssekms_key_id"))
-            .transpose()?;
+            .clone()
+            .map(|t| t.with_tz_offset(offset));
 
         let partitioner = S3KeyPartitioner::new(key_prefix, ssekms_key_id, None);
 
@@ -381,7 +425,23 @@ impl S3SinkConfig {
 #[cfg(test)]
 mod tests {
     use super::S3SinkConfig;
+    use crate::config::ValidatedSink;
     use crate::template::{ConfinementConfig, Template};
+
+    #[test]
+    fn prepares_valid_config() {
+        let config: S3SinkConfig = serde_yaml::from_str(indoc::indoc! {r#"
+            bucket: test-bucket
+            compression: none
+            encoding:
+              codec: text
+        "#})
+        .unwrap();
+
+        let validated = config.validate().expect("preparation should succeed");
+        assert_eq!(validated.key_prefix.to_string(), "date=%F");
+        assert!(validated.ssekms_key_id.is_none());
+    }
 
     #[test]
     fn generate_config() {

--- a/src/sinks/aws_s3/integration_tests.rs
+++ b/src/sinks/aws_s3/integration_tests.rs
@@ -13,7 +13,7 @@ use super::config::S3BatchEncoding;
 use crate::{
     aws::{AwsAuthentication, RegionOrEndpoint, create_client},
     common::s3::S3ClientBuilder,
-    config::{Config, SinkContext},
+    config::{Config, SinkContext, ValidatedSink},
     sinks::{
         aws_s3::config::default_filename_time_format,
         s3_common::config::{S3Options, S3ServerSideEncryption},
@@ -69,7 +69,8 @@ async fn s3_insert_message_into_with_flat_key_prefix() {
     };
     let prefix = config.key_prefix.clone();
     let service = config.create_service(&cx.globals.proxy).await.unwrap();
-    let sink = config.build_processor(service, cx).unwrap();
+    let validated = config.validate().unwrap();
+    let sink = config.build_processor(service, cx, &validated).unwrap();
 
     let (lines, events, receiver) = make_events_batch(100, 10);
     run_and_assert_sink_compliance(sink, events, &AWS_SINK_TAGS).await;
@@ -105,7 +106,8 @@ async fn s3_insert_message_into_with_folder_key_prefix() {
     };
     let prefix = config.key_prefix.clone();
     let service = config.create_service(&cx.globals.proxy).await.unwrap();
-    let sink = config.build_processor(service, cx).unwrap();
+    let validated = config.validate().unwrap();
+    let sink = config.build_processor(service, cx, &validated).unwrap();
 
     let (lines, events, receiver) = make_events_batch(100, 10);
     run_and_assert_sink_compliance(sink, events, &AWS_SINK_TAGS).await;
@@ -147,7 +149,8 @@ async fn s3_insert_message_into_with_ssekms_key_id() {
     let prefix = config.key_prefix.clone();
 
     let service = config.create_service(&cx.globals.proxy).await.unwrap();
-    let sink = config.build_processor(service, cx).unwrap();
+    let validated = config.validate().unwrap();
+    let sink = config.build_processor(service, cx, &validated).unwrap();
 
     let (lines, events, receiver) = make_events_batch(100, 10);
     run_and_assert_sink_compliance(sink, events, &AWS_SINK_TAGS).await;
@@ -185,7 +188,8 @@ async fn s3_rotate_files_after_the_buffer_size_is_reached() {
     };
     let prefix = config.key_prefix.clone();
     let service = config.create_service(&cx.globals.proxy).await.unwrap();
-    let sink = config.build_processor(service, cx).unwrap();
+    let validated = config.validate().unwrap();
+    let sink = config.build_processor(service, cx, &validated).unwrap();
 
     let (lines, _events) = random_lines_with_stream(100, 30, None);
 
@@ -244,7 +248,8 @@ async fn s3_gzip() {
 
     let prefix = config.key_prefix.clone();
     let service = config.create_service(&cx.globals.proxy).await.unwrap();
-    let sink = config.build_processor(service, cx).unwrap();
+    let validated = config.validate().unwrap();
+    let sink = config.build_processor(service, cx, &validated).unwrap();
 
     let (lines, events, receiver) = make_events_batch(100, batch_size * batch_multiplier);
     run_and_assert_sink_compliance(sink, events, &AWS_SINK_TAGS).await;
@@ -289,7 +294,8 @@ async fn s3_zstd() {
 
     let prefix = config.key_prefix.clone();
     let service = config.create_service(&cx.globals.proxy).await.unwrap();
-    let sink = config.build_processor(service, cx).unwrap();
+    let validated = config.validate().unwrap();
+    let sink = config.build_processor(service, cx, &validated).unwrap();
 
     let (lines, events, receiver) = make_events_batch(100, batch_size * batch_multiplier);
     run_and_assert_sink_compliance(sink, events, &AWS_SINK_TAGS).await;
@@ -351,7 +357,8 @@ async fn s3_insert_message_into_object_lock() {
     let config = config(&bucket, 1000000, 5.0);
     let prefix = config.key_prefix.clone();
     let service = config.create_service(&cx.globals.proxy).await.unwrap();
-    let sink = config.build_processor(service, cx).unwrap();
+    let validated = config.validate().unwrap();
+    let sink = config.build_processor(service, cx, &validated).unwrap();
 
     let (lines, events, receiver) = make_events_batch(100, 10);
     run_and_assert_sink_compliance(sink, events, &AWS_SINK_TAGS).await;
@@ -384,7 +391,8 @@ async fn acknowledges_failures() {
     };
     let prefix = config.key_prefix.clone();
     let service = config.create_service(&cx.globals.proxy).await.unwrap();
-    let sink = config.build_processor(service, cx).unwrap();
+    let validated = config.validate().unwrap();
+    let sink = config.build_processor(service, cx, &validated).unwrap();
 
     let (_lines, events, receiver) = make_events_batch(1, 1);
     run_and_assert_sink_error(sink, events, &COMPONENT_ERROR_TAGS).await;
@@ -439,7 +447,8 @@ async fn s3_flush_on_exhaustion() {
     let config = config(&bucket, 10, 10.0);
     let prefix = config.key_prefix.clone();
     let service = config.create_service(&cx.globals.proxy).await.unwrap();
-    let sink = config.build_processor(service, cx).unwrap();
+    let validated = config.validate().unwrap();
+    let sink = config.build_processor(service, cx, &validated).unwrap();
 
     let (lines, _events) = random_lines_with_stream(100, 2, None); // only generate two events (less than batch size)
 
@@ -508,7 +517,8 @@ async fn s3_parquet_insert_message() {
 
     let prefix = config.key_prefix.clone();
     let service = config.create_service(&cx.globals.proxy).await.unwrap();
-    let sink = config.build_processor(service, cx).unwrap();
+    let validated = config.validate().unwrap();
+    let sink = config.build_processor(service, cx, &validated).unwrap();
 
     let (batch_notifier, receiver) = BatchNotifier::new_with_receiver();
     let events: Vec<Event> = (0..10)

--- a/src/sinks/aws_s_s/config.rs
+++ b/src/sinks/aws_s_s/config.rs
@@ -33,8 +33,6 @@ pub(super) struct BaseSSSinkConfig {
     /// The tag that specifies that a message belongs to a specific message group.
     ///
     /// Can be applied only to FIFO queues.
-    #[configurable(metadata(docs::examples = "vector"))]
-    #[configurable(metadata(docs::examples = "vector-%Y-%m-%d"))]
     pub(super) message_group_id: Option<String>,
 
     /// The message deduplication ID value to allow AWS to identify duplicate messages.
@@ -43,7 +41,6 @@ pub(super) struct BaseSSSinkConfig {
     /// documentation][deduplication_id_docs] for more about how AWS does message deduplication.
     ///
     /// [deduplication_id_docs]: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/using-messagededuplicationid-property.html
-    #[configurable(metadata(docs::examples = "{{ transaction_id }}"))]
     pub(super) message_deduplication_id: Option<String>,
 
     #[configurable(derived)]

--- a/src/sinks/aws_s_s/sns/config.rs
+++ b/src/sinks/aws_s_s/sns/config.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use aws_sdk_sns::Client as SnsClient;
 use vector_lib::configurable::configurable_component;
 
@@ -8,9 +10,10 @@ use super::{
 use crate::{
     aws::{ClientBuilder, RegionOrEndpoint, create_client},
     config::{
-        AcknowledgementsConfig, DataType, GenerateConfig, Input, ProxyConfig, SinkConfig,
-        SinkContext,
+        AcknowledgementsConfig, DataType, DynValidatedSink, GenerateConfig, Input, ProxyConfig,
+        SinkConfig, SinkContext, ValidatedSink,
     },
+    template::UnconfinedTemplate,
 };
 
 /// Configuration for the `aws_sns` sink.
@@ -24,6 +27,9 @@ pub(super) struct SnsSinkConfig {
     /// The ARN of the Amazon SNS topic to which messages are sent.
     #[configurable(validation(format = "uri"))]
     #[configurable(metadata(docs::examples = "arn:aws:sns:us-east-2:123456789012:MyTopic"))]
+    #[configurable(metadata(
+        docs::examples = "arn:aws:sns:us-east-2:123456789012:FifoTopic.fifo"
+    ))]
     pub(super) topic_arn: String,
 
     #[serde(flatten)]
@@ -63,44 +69,68 @@ impl SnsSinkConfig {
 #[async_trait::async_trait]
 #[typetag::serde(name = "aws_sns")]
 impl SinkConfig for SnsSinkConfig {
-    async fn build(
-        &self,
-        cx: SinkContext,
-    ) -> crate::Result<(crate::sinks::VectorSink, crate::sinks::Healthcheck)> {
-        let client = self.create_client(&cx.proxy).await?;
-
-        let publisher = SnsMessagePublisher::new(client.clone(), self.topic_arn.clone());
-
-        let healthcheck = Box::pin(healthcheck(client.clone(), self.topic_arn.clone()));
-
-        let message_group_id = message_group_id(
-            self.base_config.message_group_id.clone(),
-            self.topic_arn.ends_with(".fifo"),
-        );
-        let message_deduplication_id =
-            message_deduplication_id(self.base_config.message_deduplication_id.clone());
-
-        let sink = SSSink::new(
-            SSRequestBuilder::new(
-                message_group_id?,
-                message_deduplication_id?,
-                self.base_config.encoding.clone(),
-            )?,
-            self.base_config.request,
-            publisher,
-        )?;
-        Ok((
-            crate::sinks::VectorSink::from_event_streamsink(sink),
-            healthcheck,
-        ))
-    }
-
     fn input(&self) -> Input {
         Input::new(self.base_config.encoding.config().input_type() & DataType::Log)
     }
 
     fn acknowledgements(&self) -> &AcknowledgementsConfig {
         &self.base_config.acknowledgements
+    }
+
+    fn as_dyn_validated(&self) -> Option<&dyn DynValidatedSink> {
+        Some(self)
+    }
+}
+
+#[derive(Clone)]
+pub struct ValidatedSnsSink {
+    message_group_id: Option<UnconfinedTemplate>,
+    message_deduplication_id: Option<UnconfinedTemplate>,
+}
+
+impl fmt::Debug for ValidatedSnsSink {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ValidatedSnsSink").finish_non_exhaustive()
+    }
+}
+
+#[async_trait::async_trait]
+impl ValidatedSink for SnsSinkConfig {
+    type Validated = ValidatedSnsSink;
+
+    fn validate(&self) -> crate::Result<ValidatedSnsSink> {
+        let message_group_id = message_group_id(
+            self.base_config.message_group_id.clone(),
+            self.topic_arn.ends_with(".fifo"),
+        )?;
+        let message_deduplication_id =
+            message_deduplication_id(self.base_config.message_deduplication_id.clone())?;
+
+        Ok(ValidatedSnsSink {
+            message_group_id,
+            message_deduplication_id,
+        })
+    }
+
+    async fn build(
+        &self,
+        validated: &ValidatedSnsSink,
+        cx: SinkContext,
+    ) -> crate::Result<(crate::sinks::VectorSink, crate::sinks::Healthcheck)> {
+        let client = self.create_client(&cx.proxy).await?;
+        let publisher = SnsMessagePublisher::new(client.clone(), self.topic_arn.clone());
+        let healthcheck = Box::pin(healthcheck(client.clone(), self.topic_arn.clone()));
+
+        let request_builder = SSRequestBuilder::new(
+            validated.message_group_id.clone(),
+            validated.message_deduplication_id.clone(),
+            self.base_config.encoding.clone(),
+        )?;
+        let sink = SSSink::new(request_builder, self.base_config.request, publisher)?;
+        Ok((
+            crate::sinks::VectorSink::from_event_streamsink(sink),
+            healthcheck,
+        ))
     }
 }
 
@@ -122,4 +152,43 @@ pub(super) async fn healthcheck(client: SnsClient, topic_arn: String) -> crate::
         .await
         .map(|_| ())
         .map_err(Into::into)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vector_lib::codecs::TextSerializerConfig;
+
+    fn test_config(topic_arn: &str) -> SnsSinkConfig {
+        SnsSinkConfig {
+            region: RegionOrEndpoint::with_both("us-east-1", "http://localhost:4566"),
+            topic_arn: topic_arn.to_string(),
+            base_config: BaseSSSinkConfig {
+                encoding: TextSerializerConfig::default().into(),
+                message_group_id: None,
+                message_deduplication_id: None,
+                request: Default::default(),
+                tls: Default::default(),
+                assume_role: None,
+                auth: Default::default(),
+                acknowledgements: Default::default(),
+            },
+        }
+    }
+
+    #[test]
+    fn validate_rejects_fifo_without_message_group_id() {
+        let config = test_config("arn:aws:sns:us-east-2:123456789012:MyTopic.fifo");
+        let err = config.validate().unwrap_err().to_string();
+        assert!(
+            err.contains("message_group_id"),
+            "expected error to mention message_group_id, got: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_produces_validated_state() {
+        let config = test_config("arn:aws:sns:us-east-2:123456789012:MyTopic");
+        config.validate().expect("validation should succeed");
+    }
 }

--- a/src/sinks/aws_s_s/sqs/config.rs
+++ b/src/sinks/aws_s_s/sqs/config.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use aws_sdk_sqs::Client as SqsClient;
 use vector_lib::configurable::configurable_component;
 
@@ -9,9 +11,10 @@ use crate::{
     aws::{RegionOrEndpoint, create_client},
     common::sqs::SqsClientBuilder,
     config::{
-        AcknowledgementsConfig, DataType, GenerateConfig, Input, ProxyConfig, SinkConfig,
-        SinkContext,
+        AcknowledgementsConfig, DataType, DynValidatedSink, GenerateConfig, Input, ProxyConfig,
+        SinkConfig, SinkContext, ValidatedSink,
     },
+    template::UnconfinedTemplate,
 };
 
 /// Configuration for the `aws_sqs` sink.
@@ -66,43 +69,68 @@ impl SqsSinkConfig {
 #[async_trait::async_trait]
 #[typetag::serde(name = "aws_sqs")]
 impl SinkConfig for SqsSinkConfig {
-    async fn build(
-        &self,
-        cx: SinkContext,
-    ) -> crate::Result<(crate::sinks::VectorSink, crate::sinks::Healthcheck)> {
-        let client = self.create_client(&cx.proxy).await?;
-
-        let publisher = SqsMessagePublisher::new(client.clone(), self.queue_url.clone());
-
-        let healthcheck = Box::pin(healthcheck(client.clone(), self.queue_url.clone()));
-        let message_group_id = message_group_id(
-            self.base_config.message_group_id.clone(),
-            self.queue_url.ends_with(".fifo"),
-        );
-        let message_deduplication_id =
-            message_deduplication_id(self.base_config.message_deduplication_id.clone());
-
-        let sink = SSSink::new(
-            SSRequestBuilder::new(
-                message_group_id?,
-                message_deduplication_id?,
-                self.base_config.encoding.clone(),
-            )?,
-            self.base_config.request,
-            publisher,
-        )?;
-        Ok((
-            crate::sinks::VectorSink::from_event_streamsink(sink),
-            healthcheck,
-        ))
-    }
-
     fn input(&self) -> Input {
         Input::new(self.base_config.encoding.config().input_type() & DataType::Log)
     }
 
     fn acknowledgements(&self) -> &AcknowledgementsConfig {
         &self.base_config.acknowledgements
+    }
+
+    fn as_dyn_validated(&self) -> Option<&dyn DynValidatedSink> {
+        Some(self)
+    }
+}
+
+#[derive(Clone)]
+pub struct ValidatedSqsSink {
+    message_group_id: Option<UnconfinedTemplate>,
+    message_deduplication_id: Option<UnconfinedTemplate>,
+}
+
+impl fmt::Debug for ValidatedSqsSink {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ValidatedSqsSink").finish_non_exhaustive()
+    }
+}
+
+#[async_trait::async_trait]
+impl ValidatedSink for SqsSinkConfig {
+    type Validated = ValidatedSqsSink;
+
+    fn validate(&self) -> crate::Result<ValidatedSqsSink> {
+        let message_group_id = message_group_id(
+            self.base_config.message_group_id.clone(),
+            self.queue_url.ends_with(".fifo"),
+        )?;
+        let message_deduplication_id =
+            message_deduplication_id(self.base_config.message_deduplication_id.clone())?;
+
+        Ok(ValidatedSqsSink {
+            message_group_id,
+            message_deduplication_id,
+        })
+    }
+
+    async fn build(
+        &self,
+        validated: &ValidatedSqsSink,
+        cx: SinkContext,
+    ) -> crate::Result<(crate::sinks::VectorSink, crate::sinks::Healthcheck)> {
+        let client = self.create_client(&cx.proxy).await?;
+        let publisher = SqsMessagePublisher::new(client.clone(), self.queue_url.clone());
+        let healthcheck = Box::pin(healthcheck(client.clone(), self.queue_url.clone()));
+
+        let request_builder = SSRequestBuilder::new(
+            validated.message_group_id.clone(),
+            validated.message_deduplication_id.clone(),
+            self.base_config.encoding.clone(),
+        )?;
+        let sink = SSSink::new(request_builder, self.base_config.request, publisher)?;
+        Ok((
+            crate::sinks::VectorSink::from_event_streamsink(sink),
+            healthcheck,
+        ))
     }
 }
 
@@ -114,4 +142,43 @@ pub(super) async fn healthcheck(client: SqsClient, queue_url: String) -> crate::
         .await
         .map(|_| ())
         .map_err(Into::into)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vector_lib::codecs::TextSerializerConfig;
+
+    fn test_config(queue_url: &str) -> SqsSinkConfig {
+        SqsSinkConfig {
+            region: RegionOrEndpoint::with_both("us-east-1", "http://localhost:4566"),
+            queue_url: queue_url.to_string(),
+            base_config: BaseSSSinkConfig {
+                encoding: TextSerializerConfig::default().into(),
+                message_group_id: None,
+                message_deduplication_id: None,
+                request: Default::default(),
+                tls: Default::default(),
+                assume_role: None,
+                auth: Default::default(),
+                acknowledgements: Default::default(),
+            },
+        }
+    }
+
+    #[test]
+    fn validate_rejects_fifo_without_message_group_id() {
+        let config = test_config("https://sqs.us-east-2.amazonaws.com/123456789012/MyQueue.fifo");
+        let err = config.validate().unwrap_err().to_string();
+        assert!(
+            err.contains("message_group_id"),
+            "expected error to mention message_group_id, got: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_produces_validated_state() {
+        let config = test_config("https://sqs.us-east-2.amazonaws.com/123456789012/MyQueue");
+        config.validate().expect("validation should succeed");
+    }
 }

--- a/website/cue/reference/components/sinks/generated/aws_cloudwatch_logs.cue
+++ b/website/cue/reference/components/sinks/generated/aws_cloudwatch_logs.cue
@@ -709,7 +709,7 @@ generated: components: sinks: aws_cloudwatch_logs: configuration: {
 			"""
 		required: true
 		type: string: {
-			examples: ["group-name", "{{ file }}"]
+			examples: ["group-name", "group-{{ file }}"]
 			syntax: "template"
 		}
 	}
@@ -957,7 +957,7 @@ generated: components: sinks: aws_cloudwatch_logs: configuration: {
 			"""
 		required: true
 		type: string: {
-			examples: ["{{ host }}", "%Y-%m-%d", "stream-name"]
+			examples: ["stream-{{ host }}", "%Y-%m-%d", "stream-name"]
 			syntax: "template"
 		}
 	}

--- a/website/cue/reference/components/sinks/generated/aws_sns.cue
+++ b/website/cue/reference/components/sinks/generated/aws_sns.cue
@@ -605,7 +605,7 @@ generated: components: sinks: aws_sns: configuration: {
 			[deduplication_id_docs]: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/using-messagededuplicationid-property.html
 			"""
 		required: false
-		type: string: examples: ["{{ transaction_id }}"]
+		type: string: {}
 	}
 	message_group_id: {
 		description: """
@@ -614,7 +614,7 @@ generated: components: sinks: aws_sns: configuration: {
 			Can be applied only to FIFO queues.
 			"""
 		required: false
-		type: string: examples: ["vector", "vector-%Y-%m-%d"]
+		type: string: {}
 	}
 	region: {
 		description: """
@@ -908,6 +908,6 @@ generated: components: sinks: aws_sns: configuration: {
 	topic_arn: {
 		description: "The ARN of the Amazon SNS topic to which messages are sent."
 		required:    true
-		type: string: examples: ["arn:aws:sns:us-east-2:123456789012:MyTopic"]
+		type: string: examples: ["arn:aws:sns:us-east-2:123456789012:MyTopic", "arn:aws:sns:us-east-2:123456789012:FifoTopic.fifo"]
 	}
 }

--- a/website/cue/reference/components/sinks/generated/aws_sqs.cue
+++ b/website/cue/reference/components/sinks/generated/aws_sqs.cue
@@ -605,7 +605,7 @@ generated: components: sinks: aws_sqs: configuration: {
 			[deduplication_id_docs]: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/using-messagededuplicationid-property.html
 			"""
 		required: false
-		type: string: examples: ["{{ transaction_id }}"]
+		type: string: {}
 	}
 	message_group_id: {
 		description: """
@@ -614,7 +614,7 @@ generated: components: sinks: aws_sqs: configuration: {
 			Can be applied only to FIFO queues.
 			"""
 		required: false
-		type: string: examples: ["vector", "vector-%Y-%m-%d"]
+		type: string: {}
 	}
 	queue_url: {
 		description: "The URL of the Amazon SQS queue to which messages are sent."

--- a/website/generated/example-configs/sinks/aws_cloudwatch_logs/advanced.yaml
+++ b/website/generated/example-configs/sinks/aws_cloudwatch_logs/advanced.yaml
@@ -12,4 +12,4 @@ sinks:
     endpoint: http://127.0.0.0:5000/path/to/service
     group_name: group-name
     region: us-east-1
-    stream_name: "{{ host }}"
+    stream_name: stream-{{ host }}

--- a/website/generated/example-configs/sinks/aws_cloudwatch_logs/minimal.yaml
+++ b/website/generated/example-configs/sinks/aws_cloudwatch_logs/minimal.yaml
@@ -6,4 +6,4 @@ sinks:
     encoding:
       codec: json
     group_name: group-name
-    stream_name: "{{ host }}"
+    stream_name: stream-{{ host }}

--- a/website/generated/example-configs/sinks/aws_sns/advanced.yaml
+++ b/website/generated/example-configs/sinks/aws_sns/advanced.yaml
@@ -6,7 +6,5 @@ sinks:
     encoding:
       codec: json
     endpoint: http://127.0.0.0:5000/path/to/service
-    message_deduplication_id: "{{ transaction_id }}"
-    message_group_id: vector
     region: us-east-1
     topic_arn: arn:aws:sns:us-east-2:123456789012:MyTopic

--- a/website/generated/example-configs/sinks/aws_sqs/advanced.yaml
+++ b/website/generated/example-configs/sinks/aws_sqs/advanced.yaml
@@ -6,7 +6,5 @@ sinks:
     encoding:
       codec: json
     endpoint: http://127.0.0.0:5000/path/to/service
-    message_deduplication_id: "{{ transaction_id }}"
-    message_group_id: vector
     queue_url: https://sqs.us-east-2.amazonaws.com/123456789012/MyQueue
     region: us-east-1


### PR DESCRIPTION
## Summary
Refactor AWS sinks to validate config up front via the validated-config pattern, including header validation, and make ssekms_key_id respect the configured timezone.

### References
NA

## Vector configuration
NA

## How did you test this PR?
NA

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## Contributor Guidelines

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them. To catch issues early, add a `pre-push` hook ([template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push)) or run the following locally before pushing:
  - `make fmt`
  - `make check-clippy` (auto-fix with `make clippy-fix`)
  - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details on the [dd-rust-license-tool](https://crates.io/crates/dd-rust-license-tool).