### PR TITLE
feat(datadog sinks): validate config at compile time

### DIFF
--- a/src/sinks/datadog/events/config.rs
+++ b/src/sinks/datadog/events/config.rs
@@ -19,7 +19,7 @@ use crate::{
         Healthcheck, VectorSink,
         datadog::{DatadogCommonConfig, LocalDatadogCommonConfig},
         util::{
-            ServiceBuilderExt, TowerRequestConfig, TowerRequestSettings,
+            HttpEndpoint, ServiceBuilderExt, TowerRequestConfig, TowerRequestSettings,
             http::{HttpStatusRetryLogic, RetryStrategy},
         },
     },
@@ -59,10 +59,9 @@ impl DatadogEventsConfig {
     /// Resolve the events API endpoint URI from the given endpoint/site.
     fn events_endpoint(endpoint: Option<&str>, site: &str) -> crate::Result<Uri> {
         let base = datadog::get_api_base_endpoint(endpoint, site);
-        [&base, "/api/v1/events"]
-            .join("")
-            .parse()
-            .map_err(Into::into)
+        Ok(HttpEndpoint::parse(&base)?
+            .append_path("/api/v1/events")?
+            .into_uri())
     }
 
     fn build_client(&self, proxy: &ProxyConfig) -> crate::Result<HttpClient> {
@@ -200,7 +199,7 @@ mod tests {
     }
 
     #[test]
-    fn validate_rejects_endpoint_without_scheme() {
+    fn validate_accepts_endpoint_without_scheme() {
         let config = DatadogEventsConfig {
             dd_common: LocalDatadogCommonConfig::new(
                 Some("localhost:8080".to_string()),
@@ -209,6 +208,14 @@ mod tests {
             ),
             ..Default::default()
         };
-        assert!(config.validate().is_err());
+        config.validate().expect("validation should succeed");
+        // A missing scheme is defaulted to https, matching the shared Datadog
+        // endpoint contract used by the healthcheck and other Datadog sinks.
+        assert_eq!(
+            DatadogEventsConfig::events_endpoint(Some("localhost:8080"), datadog::DD_US_SITE)
+                .expect("endpoint should parse")
+                .to_string(),
+            "https://localhost:8080/api/v1/events"
+        );
     }
 }

--- a/src/sinks/datadog/events/config.rs
+++ b/src/sinks/datadog/events/config.rs
@@ -1,3 +1,4 @@
+use http::Uri;
 use indoc::indoc;
 use tower::ServiceBuilder;
 use vector_lib::{config::proxy::ProxyConfig, configurable::configurable_component, schema};
@@ -9,13 +10,16 @@ use super::{
 };
 use crate::{
     common::datadog,
-    config::{AcknowledgementsConfig, GenerateConfig, Input, SinkConfig, SinkContext},
+    config::{
+        AcknowledgementsConfig, DynValidatedSink, GenerateConfig, Input, SinkConfig, SinkContext,
+        ValidatedSink,
+    },
     http::HttpClient,
     sinks::{
         Healthcheck, VectorSink,
         datadog::{DatadogCommonConfig, LocalDatadogCommonConfig},
         util::{
-            ServiceBuilderExt, TowerRequestConfig,
+            ServiceBuilderExt, TowerRequestConfig, TowerRequestSettings,
             http::{HttpStatusRetryLogic, RetryStrategy},
         },
     },
@@ -52,6 +56,15 @@ impl GenerateConfig for DatadogEventsConfig {
 }
 
 impl DatadogEventsConfig {
+    /// Resolve the events API endpoint URI from the given endpoint/site.
+    fn events_endpoint(endpoint: Option<&str>, site: &str) -> crate::Result<Uri> {
+        let base = datadog::get_api_base_endpoint(endpoint, site);
+        [&base, "/api/v1/events"]
+            .join("")
+            .parse()
+            .map_err(Into::into)
+    }
+
     fn build_client(&self, proxy: &ProxyConfig) -> crate::Result<HttpClient> {
         let tls = MaybeTlsSettings::from_config(self.dd_common.tls.as_ref(), false)?;
         let client = HttpClient::new(tls, proxy)?;
@@ -62,15 +75,13 @@ impl DatadogEventsConfig {
         &self,
         dd_common: &DatadogCommonConfig,
         client: HttpClient,
+        validated: &ValidatedEvents,
+        endpoint: Uri,
     ) -> crate::Result<VectorSink> {
-        let service = DatadogEventsService::new(
-            dd_common.get_api_endpoint("/api/v1/events")?,
-            dd_common.default_api_key.clone(),
-            client,
-        );
+        let service =
+            DatadogEventsService::new(endpoint, dd_common.default_api_key.clone(), client);
 
-        let request_opts = self.request;
-        let request_settings = request_opts.into_settings();
+        let request_settings = validated.request_settings.clone();
         let retry_logic = HttpStatusRetryLogic::new(
             |req: &DatadogEventsResponse| req.http_status,
             self.retry_strategy.clone(),
@@ -89,16 +100,6 @@ impl DatadogEventsConfig {
 #[async_trait::async_trait]
 #[typetag::serde(name = "datadog_events")]
 impl SinkConfig for DatadogEventsConfig {
-    async fn build(&self, cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
-        let client = self.build_client(cx.proxy())?;
-        let global = cx.extra_context.get_or_default::<datadog::Options>();
-        let dd_common = self.dd_common.with_globals(global)?;
-        let healthcheck = dd_common.build_healthcheck(client.clone())?;
-        let sink = self.build_sink(&dd_common, client)?;
-
-        Ok((sink, healthcheck))
-    }
-
     fn input(&self) -> Input {
         let requirement = schema::Requirement::empty()
             .required_meaning("message", Kind::bytes())
@@ -111,14 +112,103 @@ impl SinkConfig for DatadogEventsConfig {
     fn acknowledgements(&self) -> &AcknowledgementsConfig {
         &self.dd_common.acknowledgements
     }
+
+    fn as_dyn_validated(&self) -> Option<&dyn DynValidatedSink> {
+        Some(self)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ValidatedEvents {
+    request_settings: TowerRequestSettings,
+}
+
+#[async_trait::async_trait]
+impl ValidatedSink for DatadogEventsConfig {
+    type Validated = ValidatedEvents;
+
+    fn validate(&self) -> crate::Result<ValidatedEvents> {
+        let site = self
+            .dd_common
+            .site
+            .clone()
+            .unwrap_or_else(|| datadog::DD_US_SITE.to_owned());
+        let uri = Self::events_endpoint(self.dd_common.endpoint.as_deref(), &site)?;
+        if !matches!(uri.scheme_str(), Some("http" | "https")) || uri.authority().is_none() {
+            return Err("Datadog Events endpoint must be an absolute http(s) URL".into());
+        }
+        let request_settings = self.request.into_settings();
+        Ok(ValidatedEvents { request_settings })
+    }
+
+    async fn build(
+        &self,
+        validated: &ValidatedEvents,
+        cx: SinkContext,
+    ) -> crate::Result<(VectorSink, Healthcheck)> {
+        let client = self.build_client(cx.proxy())?;
+        let global = cx.extra_context.get_or_default::<datadog::Options>();
+        let dd_common = self.dd_common.with_globals(global)?;
+        let healthcheck = dd_common.build_healthcheck(client.clone())?;
+        let endpoint = Self::events_endpoint(dd_common.endpoint.as_deref(), &dd_common.site)?;
+        let sink = self.build_sink(&dd_common, client, validated, endpoint)?;
+
+        Ok((sink, healthcheck))
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::sinks::datadog::events::config::DatadogEventsConfig;
+    use super::*;
 
     #[test]
     fn generate_config() {
         crate::test_util::test_generate_config::<DatadogEventsConfig>();
+    }
+
+    #[test]
+    fn validate_produces_usable_state() {
+        let config = DatadogEventsConfig {
+            dd_common: LocalDatadogCommonConfig::new(
+                Some("http://127.0.0.1:8080".to_string()),
+                None,
+                None,
+            ),
+            ..Default::default()
+        };
+        config.validate().expect("validation should succeed");
+        // The delivery endpoint is derived at build time after globals; the
+        // pure endpoint resolution still produces the expected events URI.
+        assert_eq!(
+            DatadogEventsConfig::events_endpoint(
+                Some("http://127.0.0.1:8080"),
+                datadog::DD_US_SITE,
+            )
+            .expect("endpoint should parse")
+            .to_string(),
+            "http://127.0.0.1:8080/api/v1/events"
+        );
+    }
+
+    #[test]
+    fn validate_rejects_malformed_endpoint() {
+        let config = DatadogEventsConfig {
+            dd_common: LocalDatadogCommonConfig::new(Some("not a uri".to_string()), None, None),
+            ..Default::default()
+        };
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_endpoint_without_scheme() {
+        let config = DatadogEventsConfig {
+            dd_common: LocalDatadogCommonConfig::new(
+                Some("localhost:8080".to_string()),
+                None,
+                None,
+            ),
+            ..Default::default()
+        };
+        assert!(config.validate().is_err());
     }
 }

--- a/src/sinks/datadog/logs/config.rs
+++ b/src/sinks/datadog/logs/config.rs
@@ -10,6 +10,7 @@ use vrl::value::Kind;
 use hyper::{Body, client::connect::Connect};
 
 use super::{service::LogApiRetry, sink::LogSinkBuilder};
+use crate::config::{DynValidatedSink, ValidatedSink};
 use crate::{
     common::datadog,
     http::HttpClient,
@@ -17,7 +18,10 @@ use crate::{
     sinks::{
         datadog::{DatadogCommonConfig, LocalDatadogCommonConfig, logs::service::LogApiService},
         prelude::*,
-        util::{HttpEndpoint, http::RequestConfig},
+        util::{
+            HttpEndpoint,
+            http::{RequestConfig, validate_headers},
+        },
     },
     tls::{MaybeTlsSettings, TlsEnableableConfig},
 };
@@ -93,13 +97,18 @@ impl GenerateConfig for DatadogLogsConfig {
 impl DatadogLogsConfig {
     // TODO: We should probably hoist this type of base URI generation so that all DD sinks can
     // utilize it, since it all follows the same pattern.
-    fn get_uri(&self, dd_common: &DatadogCommonConfig) -> crate::Result<HttpEndpoint> {
-        let base_url = dd_common
-            .endpoint
-            .clone()
-            .unwrap_or_else(|| format!("https://http-intake.logs.{}", dd_common.site));
+    /// Resolve the logs API endpoint from the given endpoint/site.
+    fn logs_endpoint(endpoint: Option<&str>, site: &str) -> crate::Result<HttpEndpoint> {
+        let base_url = endpoint.map_or_else(
+            || format!("https://http-intake.logs.{site}"),
+            |endpoint| endpoint.to_string(),
+        );
 
         Ok(HttpEndpoint::parse(&base_url)?.append_path("/api/v2/logs")?)
+    }
+
+    fn get_uri(&self, dd_common: &DatadogCommonConfig) -> crate::Result<HttpEndpoint> {
+        Self::logs_endpoint(dd_common.endpoint.as_deref(), &dd_common.site)
     }
 
     pub fn build_processor<C>(
@@ -107,21 +116,13 @@ impl DatadogLogsConfig {
         dd_common: &DatadogCommonConfig,
         client: HttpClient<Body, C>,
         dd_evp_origin: String,
+        batch: BatcherSettings,
     ) -> crate::Result<VectorSink>
     where
         C: Connect + Clone + Send + Sync + 'static,
     {
         let default_api_key: Arc<str> = Arc::from(dd_common.default_api_key.inner());
         let request_limits = self.request.tower.into_settings();
-
-        // We forcefully cap the provided batch configuration to the size/log line limits imposed by
-        // the Datadog Logs API, but we still allow them to be lowered if need be.
-        let batch = self
-            .batch
-            .validate()?
-            .limit_max_bytes(BATCH_GOAL_BYTES)?
-            .limit_max_events(BATCH_MAX_EVENTS)?
-            .into_batcher_settings()?;
 
         let headers = {
             let mut request_headers = self.request.headers.clone();
@@ -187,18 +188,6 @@ impl DatadogLogsConfig {
 #[async_trait::async_trait]
 #[typetag::serde(name = "datadog_logs")]
 impl SinkConfig for DatadogLogsConfig {
-    async fn build(&self, cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
-        let client = self.create_client(&cx.proxy)?;
-        let global = cx.extra_context.get_or_default::<datadog::Options>();
-        let dd_common = self.local_dd_common.with_globals(global)?;
-
-        let healthcheck = dd_common.build_healthcheck(client.clone())?;
-
-        let sink = self.build_processor(&dd_common, client, cx.app_name_slug)?;
-
-        Ok((sink, healthcheck))
-    }
-
     fn input(&self) -> Input {
         let requirement = schema::Requirement::empty()
             .optional_meaning(meaning::MESSAGE, Kind::bytes())
@@ -215,6 +204,63 @@ impl SinkConfig for DatadogLogsConfig {
     fn acknowledgements(&self) -> &AcknowledgementsConfig {
         &self.local_dd_common.acknowledgements
     }
+
+    fn as_dyn_validated(&self) -> Option<&dyn DynValidatedSink> {
+        Some(self)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ValidatedLogs {
+    batch: BatcherSettings,
+}
+
+#[async_trait::async_trait]
+impl ValidatedSink for DatadogLogsConfig {
+    type Validated = ValidatedLogs;
+
+    fn validate(&self) -> crate::Result<ValidatedLogs> {
+        let site = self
+            .local_dd_common
+            .site
+            .clone()
+            .unwrap_or_else(|| datadog::DD_US_SITE.to_owned());
+        Self::logs_endpoint(self.local_dd_common.endpoint.as_deref(), &site)?;
+
+        let request_headers = {
+            let mut request_headers = self.request.headers.clone();
+            if self.conforms_as_agent {
+                request_headers.insert(String::from("DD-PROTOCOL"), String::from("agent-json"));
+            }
+            request_headers
+        };
+        validate_headers(&request_headers)?;
+
+        let batch = self
+            .batch
+            .validate()?
+            .limit_max_bytes(BATCH_GOAL_BYTES)?
+            .limit_max_events(BATCH_MAX_EVENTS)?
+            .into_batcher_settings()?;
+
+        Ok(ValidatedLogs { batch })
+    }
+
+    async fn build(
+        &self,
+        validated: &ValidatedLogs,
+        cx: SinkContext,
+    ) -> crate::Result<(VectorSink, Healthcheck)> {
+        let client = self.create_client(&cx.proxy)?;
+        let global = cx.extra_context.get_or_default::<datadog::Options>();
+        let dd_common = self.local_dd_common.with_globals(global)?;
+
+        let healthcheck = dd_common.build_healthcheck(client.clone())?;
+
+        let sink = self.build_processor(&dd_common, client, cx.app_name_slug, validated.batch)?;
+
+        Ok((sink, healthcheck))
+    }
 }
 
 #[cfg(test)]
@@ -226,11 +272,97 @@ mod test {
     };
 
     use super::*;
-    use crate::{codecs::EncodingConfigWithFraming, components::validation::prelude::*};
+    use crate::{
+        assert_downcast_matches, codecs::EncodingConfigWithFraming,
+        components::validation::prelude::*, config::ValidatedSink,
+        sinks::util::http::HeaderValidationError,
+    };
 
     #[test]
     fn generate_config() {
         crate::test_util::test_generate_config::<DatadogLogsConfig>();
+    }
+
+    #[test]
+    fn validate_produces_usable_batch_settings() {
+        let config = DatadogLogsConfig::default();
+        let validated = config.validate().expect("validation should succeed");
+        assert_eq!(validated.batch.size_limit, BATCH_GOAL_BYTES);
+        assert_eq!(validated.batch.item_limit, BATCH_MAX_EVENTS);
+    }
+
+    #[test]
+    fn validate_rejects_malformed_endpoint() {
+        let config = DatadogLogsConfig {
+            local_dd_common: LocalDatadogCommonConfig::new(
+                Some("not a uri".to_string()),
+                None,
+                None,
+            ),
+            ..Default::default()
+        };
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn validate_defaults_missing_scheme_to_https() {
+        let config = DatadogLogsConfig {
+            local_dd_common: LocalDatadogCommonConfig::new(
+                Some("localhost:8080".to_string()),
+                None,
+                None,
+            ),
+            ..Default::default()
+        };
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn validate_accepts_valid_headers() {
+        let config = indoc::indoc! {r#"
+            default_api_key: "test_key"
+            request:
+              headers:
+                Auth: "token:thing_and-stuff"
+                X-Custom-Nonsense: "_%_{}_-_&_._`_|_~_!_#_&_$_"
+        "#};
+        let config: DatadogLogsConfig = serde_yaml::from_str(config).unwrap();
+
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn validate_catches_bad_header_names() {
+        let config = indoc::indoc! {r#"
+            default_api_key: "test_key"
+            request:
+              headers:
+                "\x01": "bad"
+        "#};
+        let config: DatadogLogsConfig = serde_yaml::from_str(config).unwrap();
+
+        assert_downcast_matches!(
+            config.validate().unwrap_err(),
+            HeaderValidationError,
+            HeaderValidationError::InvalidHeaderName { .. }
+        );
+    }
+
+    #[test]
+    fn validate_catches_bad_header_values() {
+        let config = indoc::indoc! {r#"
+            default_api_key: "test_key"
+            request:
+              headers:
+                "X-Custom-Nonsense": "a\nb"
+        "#};
+        let config: DatadogLogsConfig = serde_yaml::from_str(config).unwrap();
+
+        assert_downcast_matches!(
+            config.validate().unwrap_err(),
+            HeaderValidationError,
+            HeaderValidationError::InvalidHeaderValue { .. }
+        );
     }
 
     #[test]

--- a/src/sinks/datadog/metrics/config.rs
+++ b/src/sinks/datadog/metrics/config.rs
@@ -10,7 +10,9 @@ use super::{
 };
 use crate::{
     common::datadog,
-    config::{AcknowledgementsConfig, Input, SinkConfig, SinkContext},
+    config::{
+        AcknowledgementsConfig, DynValidatedSink, Input, SinkConfig, SinkContext, ValidatedSink,
+    },
     http::HttpClient,
     sinks::{
         Healthcheck, VectorSink,
@@ -197,22 +199,64 @@ impl_generate_config_from_default!(DatadogMetricsConfig);
 #[async_trait::async_trait]
 #[typetag::serde(name = "datadog_metrics")]
 impl SinkConfig for DatadogMetricsConfig {
-    async fn build(&self, cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
-        let client = self.build_client(&cx.proxy)?;
-        let global = cx.extra_context.get_or_default::<datadog::Options>();
-        let dd_common = self.local_dd_common.with_globals(global)?;
-        let healthcheck = dd_common.build_healthcheck(client.clone())?;
-        let sink = self.build_sink(&dd_common, client)?;
-
-        Ok((sink, healthcheck))
-    }
-
     fn input(&self) -> Input {
         Input::metric()
     }
 
     fn acknowledgements(&self) -> &AcknowledgementsConfig {
         &self.local_dd_common.acknowledgements
+    }
+
+    fn as_dyn_validated(&self) -> Option<&dyn DynValidatedSink> {
+        Some(self)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ValidatedMetrics {
+    batcher_settings: BatcherSettings,
+    sketches_batcher_settings: BatcherSettings,
+}
+
+#[async_trait::async_trait]
+impl ValidatedSink for DatadogMetricsConfig {
+    type Validated = ValidatedMetrics;
+
+    fn validate(&self) -> crate::Result<ValidatedMetrics> {
+        let (batcher_settings, sketches_batcher_settings) =
+            resolve_endpoint_batch_settings(self.batch, self.series_api_version)?;
+
+        let site = self
+            .local_dd_common
+            .site
+            .clone()
+            .unwrap_or_else(|| datadog::DD_US_SITE.to_owned());
+        let base = Self::metrics_base_endpoint(self.local_dd_common.endpoint.as_deref(), &site);
+        HttpEndpoint::parse(&base)?;
+
+        Ok(ValidatedMetrics {
+            batcher_settings,
+            sketches_batcher_settings,
+        })
+    }
+
+    async fn build(
+        &self,
+        validated: &ValidatedMetrics,
+        cx: SinkContext,
+    ) -> crate::Result<(VectorSink, Healthcheck)> {
+        let client = self.build_client(&cx.proxy)?;
+        let global = cx.extra_context.get_or_default::<datadog::Options>();
+        let dd_common = self.local_dd_common.with_globals(global)?;
+        let healthcheck = dd_common.build_healthcheck(client.clone())?;
+        let sink = self.build_sink(
+            &dd_common,
+            client,
+            validated.batcher_settings,
+            validated.sketches_batcher_settings,
+        )?;
+
+        Ok((sink, healthcheck))
     }
 }
 
@@ -225,15 +269,14 @@ impl DatadogMetricsConfig {
     /// doing something wrong, for understanding issues from the API side.
     ///
     /// The `endpoint` configuration field will be used here if it is present.
-    fn get_base_agent_endpoint(&self, dd_common: &DatadogCommonConfig) -> String {
-        dd_common.endpoint.clone().unwrap_or_else(|| {
-            let version = str::replace(crate::built_info::PKG_VERSION, ".", "-");
-            format!(
-                "https://{}-vector.agent.{}",
-                version,
-                dd_common.site.as_str()
-            )
-        })
+    fn metrics_base_endpoint(endpoint: Option<&str>, site: &str) -> String {
+        endpoint.map_or_else(
+            || {
+                let version = str::replace(crate::built_info::PKG_VERSION, ".", "-");
+                format!("https://{version}-vector.agent.{site}")
+            },
+            |endpoint| endpoint.to_string(),
+        )
     }
 
     /// Generates the `DatadogMetricsEndpointConfiguration`, used for mapping endpoints to their URI.
@@ -241,7 +284,7 @@ impl DatadogMetricsConfig {
         &self,
         dd_common: &DatadogCommonConfig,
     ) -> crate::Result<DatadogMetricsEndpointConfiguration> {
-        let base_uri = self.get_base_agent_endpoint(dd_common);
+        let base_uri = Self::metrics_base_endpoint(dd_common.endpoint.as_deref(), &dd_common.site);
 
         let series_endpoint = build_uri(&base_uri, self.series_api_version.get_path())?;
         let sketches_endpoint = build_uri(&base_uri, SKETCHES_PATH)?;
@@ -273,10 +316,9 @@ impl DatadogMetricsConfig {
         &self,
         dd_common: &DatadogCommonConfig,
         client: HttpClient,
+        batcher_settings: BatcherSettings,
+        sketches_batcher_settings: BatcherSettings,
     ) -> crate::Result<VectorSink> {
-        let (batcher_settings, sketches_batcher_settings) =
-            resolve_endpoint_batch_settings(self.batch, self.series_api_version)?;
-
         // TODO: revisit our concurrency and batching defaults
         let request_limits = self.request.into_settings();
 
@@ -294,9 +336,12 @@ impl DatadogMetricsConfig {
             self.series_api_version,
         );
 
-        let protocol = HttpEndpoint::parse(&self.get_base_agent_endpoint(dd_common))?
-            .protocol()
-            .to_string();
+        let protocol = HttpEndpoint::parse(&Self::metrics_base_endpoint(
+            dd_common.endpoint.as_deref(),
+            &dd_common.site,
+        ))?
+        .protocol()
+        .to_string();
         let sink = DatadogMetricsSink::new(
             service,
             request_builder,
@@ -339,10 +384,45 @@ fn build_uri(host: &str, endpoint: &str) -> crate::Result<HttpEndpoint> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::ValidatedSink;
 
     #[test]
     fn generate_config() {
         crate::test_util::test_generate_config::<DatadogMetricsConfig>();
+    }
+
+    #[test]
+    fn validate_produces_endpoint_specific_batch_settings() {
+        let config = DatadogMetricsConfig::default();
+        let validated = config.validate().expect("validation should succeed");
+        assert_eq!(validated.batcher_settings.size_limit, 5_242_880); // 5 MiB — Series v2 limit
+        assert_eq!(validated.sketches_batcher_settings.size_limit, 62_914_560); // 60 MiB — Sketches limit
+    }
+
+    #[test]
+    fn validate_rejects_malformed_endpoint() {
+        let config = DatadogMetricsConfig {
+            local_dd_common: LocalDatadogCommonConfig::new(
+                Some("not a uri".to_string()),
+                None,
+                None,
+            ),
+            ..Default::default()
+        };
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_non_http_scheme() {
+        let config = DatadogMetricsConfig {
+            local_dd_common: LocalDatadogCommonConfig::new(
+                Some("ftp://localhost:8080".to_string()),
+                None,
+                None,
+            ),
+            ..Default::default()
+        };
+        assert!(config.validate().is_err());
     }
 
     // When max_bytes is unset, each endpoint gets its own API payload limit.

--- a/src/sinks/datadog/traces/config.rs
+++ b/src/sinks/datadog/traces/config.rs
@@ -6,6 +6,7 @@ use tower::ServiceBuilder;
 use vector_lib::{
     config::{AcknowledgementsConfig, proxy::ProxyConfig},
     configurable::configurable_component,
+    stream::BatcherSettings,
 };
 
 use super::{
@@ -14,7 +15,7 @@ use super::{
 };
 use crate::{
     common::datadog,
-    config::{GenerateConfig, Input, SinkConfig, SinkContext},
+    config::{DynValidatedSink, GenerateConfig, Input, SinkConfig, SinkContext, ValidatedSink},
     http::HttpClient,
     sinks::{
         Healthcheck, VectorSink,
@@ -106,18 +107,18 @@ impl DatadogTracesEndpointConfiguration {
 }
 
 impl DatadogTracesConfig {
-    fn get_base_uri(&self, dd_common: &DatadogCommonConfig) -> String {
-        dd_common
-            .endpoint
-            .clone()
-            .unwrap_or_else(|| format!("https://trace.agent.{}", dd_common.site))
+    fn traces_base_endpoint(endpoint: Option<&str>, site: &str) -> String {
+        endpoint.map_or_else(
+            || format!("https://trace.agent.{site}"),
+            |endpoint| endpoint.to_string(),
+        )
     }
 
     fn generate_traces_endpoint_configuration(
         &self,
         dd_common: &DatadogCommonConfig,
     ) -> crate::Result<DatadogTracesEndpointConfiguration> {
-        let base_uri = self.get_base_uri(dd_common);
+        let base_uri = Self::traces_base_endpoint(dd_common.endpoint.as_deref(), &dd_common.site);
         let traces_endpoint = build_uri(&base_uri, "/api/v0.2/traces")?;
         let stats_endpoint = build_uri(&base_uri, "/api/v0.2/stats")?;
 
@@ -131,17 +132,11 @@ impl DatadogTracesConfig {
         &self,
         dd_common: &DatadogCommonConfig,
         client: HttpClient,
+        batcher_settings: BatcherSettings,
     ) -> crate::Result<VectorSink> {
         let default_api_key: Arc<str> = Arc::from(dd_common.default_api_key.inner());
         let request_limits = self.request.into_settings();
         let endpoints = self.generate_traces_endpoint_configuration(dd_common)?;
-
-        let batcher_settings = self
-            .batch
-            .validate()?
-            .limit_max_bytes(BATCH_GOAL_BYTES)?
-            .limit_max_events(BATCH_MAX_EVENTS)?
-            .into_batcher_settings()?;
 
         let service = ServiceBuilder::new()
             .settings(request_limits, TraceApiRetry)
@@ -207,22 +202,59 @@ impl DatadogTracesConfig {
 #[async_trait::async_trait]
 #[typetag::serde(name = "datadog_traces")]
 impl SinkConfig for DatadogTracesConfig {
-    async fn build(&self, cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
-        let client = self.build_client(&cx.proxy)?;
-        let global = cx.extra_context.get_or_default::<datadog::Options>();
-        let dd_common = self.local_dd_common.with_globals(global)?;
-        let healthcheck = dd_common.build_healthcheck(client.clone())?;
-        let sink = self.build_sink(&dd_common, client)?;
-
-        Ok((sink, healthcheck))
-    }
-
     fn input(&self) -> Input {
         Input::trace()
     }
 
     fn acknowledgements(&self) -> &AcknowledgementsConfig {
         &self.local_dd_common.acknowledgements
+    }
+
+    fn as_dyn_validated(&self) -> Option<&dyn DynValidatedSink> {
+        Some(self)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ValidatedTraces {
+    batcher_settings: BatcherSettings,
+}
+
+#[async_trait::async_trait]
+impl ValidatedSink for DatadogTracesConfig {
+    type Validated = ValidatedTraces;
+
+    fn validate(&self) -> crate::Result<ValidatedTraces> {
+        let batcher_settings = self
+            .batch
+            .validate()?
+            .limit_max_bytes(BATCH_GOAL_BYTES)?
+            .limit_max_events(BATCH_MAX_EVENTS)?
+            .into_batcher_settings()?;
+
+        let site = self
+            .local_dd_common
+            .site
+            .clone()
+            .unwrap_or_else(|| datadog::DD_US_SITE.to_owned());
+        let base = Self::traces_base_endpoint(self.local_dd_common.endpoint.as_deref(), &site);
+        HttpEndpoint::parse(&base)?;
+
+        Ok(ValidatedTraces { batcher_settings })
+    }
+
+    async fn build(
+        &self,
+        validated: &ValidatedTraces,
+        cx: SinkContext,
+    ) -> crate::Result<(VectorSink, Healthcheck)> {
+        let client = self.build_client(&cx.proxy)?;
+        let global = cx.extra_context.get_or_default::<datadog::Options>();
+        let dd_common = self.local_dd_common.with_globals(global)?;
+        let healthcheck = dd_common.build_healthcheck(client.clone())?;
+        let sink = self.build_sink(&dd_common, client, validated.batcher_settings)?;
+
+        Ok((sink, healthcheck))
     }
 }
 
@@ -232,10 +264,45 @@ fn build_uri(host: &str, endpoint: &str) -> crate::Result<HttpEndpoint> {
 
 #[cfg(test)]
 mod test {
-    use super::DatadogTracesConfig;
+    use super::{BATCH_GOAL_BYTES, BATCH_MAX_EVENTS, DatadogTracesConfig};
+    use crate::{config::ValidatedSink, sinks::datadog::LocalDatadogCommonConfig};
 
     #[test]
     fn generate_config() {
         crate::test_util::test_generate_config::<DatadogTracesConfig>();
+    }
+
+    #[test]
+    fn validate_produces_usable_batch_settings() {
+        let config = DatadogTracesConfig::default();
+        let validated = config.validate().expect("validation should succeed");
+        assert_eq!(validated.batcher_settings.size_limit, BATCH_GOAL_BYTES);
+        assert_eq!(validated.batcher_settings.item_limit, BATCH_MAX_EVENTS);
+    }
+
+    #[test]
+    fn validate_rejects_malformed_endpoint() {
+        let config = DatadogTracesConfig {
+            local_dd_common: LocalDatadogCommonConfig::new(
+                Some("not a uri".to_string()),
+                None,
+                None,
+            ),
+            ..Default::default()
+        };
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_non_http_scheme() {
+        let config = DatadogTracesConfig {
+            local_dd_common: LocalDatadogCommonConfig::new(
+                Some("ftp://localhost:8080".to_string()),
+                None,
+                None,
+            ),
+            ..Default::default()
+        };
+        assert!(config.validate().is_err());
     }
 }


### PR DESCRIPTION
## Summary
Migrate the `datadog_events`, `datadog_logs`, `datadog_metrics`, and `datadog_traces` sinks to the validated config lifecycle: structural validation now runs at config-compile time and the validated state is retained for build.

### References
Related: #26048

## Vector configuration
NA

## How did you test this PR?
- `make check-clippy` with `sinks-datadog_events,sinks-datadog_logs,sinks-datadog_metrics,sinks-datadog_traces` features
- `make test` with the same features, `SCOPE="-E 'test(datadog)'"` (119 passed)

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## Contributor Guidelines

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them. To catch issues early, add a `pre-push` hook ([template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push)) or run the following locally before pushing:
  - `make fmt`
  - `make check-clippy` (auto-fix with `make clippy-fix`)
  - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details on the [dd-rust-license-tool](https://crates.io/crates/dd-rust-license-tool).
