### PR TITLE
enhancement(acknowledgements): support best-effort sink branches

### DIFF
--- a/changelog.d/selective_sink_acknowledgements.enhancement.md
+++ b/changelog.d/selective_sink_acknowledgements.enhancement.md
@@ -1,0 +1,4 @@
+Allow sinks with explicitly disabled acknowledgements to operate as best-effort branches that do
+not delay or affect upstream source acknowledgements.
+
+authors: Jansen-w

--- a/lib/vector-core/src/config/mod.rs
+++ b/lib/vector-core/src/config/mod.rs
@@ -379,6 +379,10 @@ impl AcknowledgementsConfig {
     pub fn enabled(&self) -> bool {
         self.enabled.unwrap_or(false)
     }
+
+    pub fn explicitly_disabled(&self) -> bool {
+        self.enabled == Some(false)
+    }
 }
 
 impl From<Option<bool>> for AcknowledgementsConfig {

--- a/lib/vector-core/src/fanout.rs
+++ b/lib/vector-core/src/fanout.rs
@@ -9,12 +9,22 @@ use vector_buffers::topology::channel::BufferSender;
 
 use crate::{
     config::ComponentKey,
-    event::{EventArray, EventContainer},
+    event::{EventArray, EventContainer, Finalizable},
 };
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AcknowledgementRequirement {
+    Required,
+    BestEffort,
+}
 
 pub enum ControlMessage {
     /// Adds a new sink to the fanout.
-    Add(ComponentKey, BufferSender<EventArray>),
+    Add(
+        ComponentKey,
+        BufferSender<EventArray>,
+        AcknowledgementRequirement,
+    ),
 
     /// Removes a sink from the fanout.
     Remove(ComponentKey),
@@ -26,17 +36,23 @@ pub enum ControlMessage {
     Pause(ComponentKey),
 
     /// Replaces a paused sink with its new sender.
-    Replace(ComponentKey, BufferSender<EventArray>),
+    Replace(
+        ComponentKey,
+        BufferSender<EventArray>,
+        AcknowledgementRequirement,
+    ),
 }
 
 impl fmt::Debug for ControlMessage {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "ControlMessage::")?;
         match self {
-            Self::Add(id, _) => write!(f, "Add({id:?})"),
+            Self::Add(id, _, requirement) => write!(f, "Add({id:?}, {requirement:?})"),
             Self::Remove(id) => write!(f, "Remove({id:?})"),
             Self::Pause(id) => write!(f, "Pause({id:?})"),
-            Self::Replace(id, _) => write!(f, "Replace({id:?})"),
+            Self::Replace(id, _, requirement) => {
+                write!(f, "Replace({id:?}, {requirement:?})")
+            }
         }
     }
 }
@@ -70,11 +86,26 @@ impl Fanout {
     ///
     /// Function will panic if a sink with the same ID is already present.
     pub fn add(&mut self, id: ComponentKey, sink: BufferSender<EventArray>) {
+        self.add_with_requirement(id, sink, AcknowledgementRequirement::Required);
+    }
+
+    /// Add a new output with its acknowledgement requirement.
+    ///
+    /// # Panics
+    ///
+    /// Function will panic if an output with the same ID is already present.
+    pub fn add_with_requirement(
+        &mut self,
+        id: ComponentKey,
+        sink: BufferSender<EventArray>,
+        requirement: AcknowledgementRequirement,
+    ) {
         assert!(
             !self.senders.contains_key(&id),
             "Adding duplicate output id to fanout: {id}"
         );
-        self.senders.insert(id, Some(Sender::new(sink)));
+        self.senders
+            .insert(id, Some(Sender::new(sink, requirement)));
     }
 
     fn remove(&mut self, id: &ComponentKey) {
@@ -84,14 +115,19 @@ impl Fanout {
         );
     }
 
-    fn replace(&mut self, id: &ComponentKey, sink: BufferSender<EventArray>) {
+    fn replace(
+        &mut self,
+        id: &ComponentKey,
+        sink: BufferSender<EventArray>,
+        requirement: AcknowledgementRequirement,
+    ) {
         match self.senders.get_mut(id) {
             Some(sender) => {
                 // While a sink must be _known_ to be replaced, it must also be empty (previously
                 // paused or consumed when the `SendGroup` was created), otherwise an invalid
                 // sequence of control operations has been applied.
                 assert!(
-                    sender.replace(Sender::new(sink)).is_none(),
+                    sender.replace(Sender::new(sink, requirement)).is_none(),
                     "Replacing existing sink is not valid: {id}"
                 );
             }
@@ -134,10 +170,14 @@ impl Fanout {
         trace!("Processing control message outside of send: {:?}", message);
 
         match message {
-            ControlMessage::Add(id, sink) => self.add(id, sink),
+            ControlMessage::Add(id, sink, requirement) => {
+                self.add_with_requirement(id, sink, requirement);
+            }
             ControlMessage::Remove(id) => self.remove(&id),
             ControlMessage::Pause(id) => self.pause(&id),
-            ControlMessage::Replace(id, sink) => self.replace(&id, sink),
+            ControlMessage::Replace(id, sink, requirement) => {
+                self.replace(&id, sink, requirement);
+            }
         }
     }
 
@@ -277,8 +317,8 @@ impl Fanout {
                     // During a send operation, control messages must be applied via the
                     // `SendGroup`, since it has exclusive access to the senders.
                     match maybe_msg {
-                        Some(ControlMessage::Add(id, sink)) => {
-                            send_group.add(id, sink);
+                        Some(ControlMessage::Add(id, sink, requirement)) => {
+                            send_group.add(id, sink, requirement);
                         },
                         Some(ControlMessage::Remove(id)) => {
                             send_group.remove(&id);
@@ -286,8 +326,8 @@ impl Fanout {
                         Some(ControlMessage::Pause(id)) => {
                             send_group.pause(&id);
                         },
-                        Some(ControlMessage::Replace(id, sink)) => {
-                            send_group.replace(&id, Sender::new(sink));
+                        Some(ControlMessage::Replace(id, sink, requirement)) => {
+                            send_group.replace(&id, Sender::new(sink, requirement));
                         },
                         None => {
                             // Control channel is closed, which means Vector is shutting down.
@@ -337,11 +377,20 @@ impl<'a> SendGroup<'a> {
                 .expect("sender must be present to initialize SendGroup");
 
             // First, arm each sender with the item to actually send.
-            if i == last_sender_idx {
-                sender.input = events.take();
+            let mut input = if i == last_sender_idx {
+                events
+                    .take()
+                    .expect("events must be present for last sender")
             } else {
-                sender.input.clone_from(&events);
+                events
+                    .as_ref()
+                    .expect("events must be present before last sender")
+                    .clone()
+            };
+            if sender.requirement == AcknowledgementRequirement::BestEffort {
+                drop(input.take_finalizers());
             }
+            sender.input = Some(input);
             sender.send_reference = send_reference;
 
             // Now generate a send for that sender which we'll drive to completion.
@@ -377,12 +426,17 @@ impl<'a> SendGroup<'a> {
     }
 
     #[allow(clippy::needless_pass_by_value)]
-    fn add(&mut self, id: ComponentKey, sink: BufferSender<EventArray>) {
+    fn add(
+        &mut self,
+        id: ComponentKey,
+        sink: BufferSender<EventArray>,
+        requirement: AcknowledgementRequirement,
+    ) {
         // When we're in the middle of a send, we can only keep track of the new sink, but can't
         // actually send to it, as we don't have the item to send... so only add it to `senders`.
         assert!(
             self.senders
-                .insert(id.clone(), Some(Sender::new(sink)))
+                .insert(id.clone(), Some(Sender::new(sink, requirement)))
                 .is_none(),
             "Adding duplicate output id to fanout: {id}"
         );
@@ -478,14 +532,16 @@ impl<'a> SendGroup<'a> {
 
 struct Sender {
     inner: BufferSender<EventArray>,
+    requirement: AcknowledgementRequirement,
     input: Option<EventArray>,
     send_reference: Option<Instant>,
 }
 
 impl Sender {
-    fn new(inner: BufferSender<EventArray>) -> Self {
+    fn new(inner: BufferSender<EventArray>, requirement: AcknowledgementRequirement) -> Self {
         Self {
             inner,
+            requirement,
             input: None,
             send_reference: None,
         }
@@ -508,6 +564,7 @@ mod tests {
 
     use futures::poll;
     use tokio::sync::mpsc::UnboundedSender;
+    use tokio::sync::oneshot::error::TryRecvError;
     use tokio_test::{assert_pending, assert_ready, task::spawn};
     use tracing::Span;
     use vector_buffers::{
@@ -519,10 +576,13 @@ mod tests {
     };
     use vrl::{event_path, value::Value};
 
-    use super::{ControlMessage, Fanout};
+    use super::{AcknowledgementRequirement, ControlMessage, Fanout};
     use crate::{
         config::ComponentKey,
-        event::{Event, EventArray, EventContainer, LogEvent},
+        event::{
+            BatchNotifier, BatchStatus, Event, EventArray, EventContainer, EventFinalizer,
+            EventStatus, Finalizable, LogEvent,
+        },
         test_util::{collect_ready, collect_ready_events},
     };
 
@@ -606,6 +666,7 @@ mod tests {
             .send(ControlMessage::Replace(
                 ComponentKey::from(sender_id.to_string()),
                 sender,
+                AcknowledgementRequirement::Required,
             ))
             .expect("sending control message should not fail");
 
@@ -639,6 +700,7 @@ mod tests {
             .send(ControlMessage::Replace(
                 ComponentKey::from(sender_id.to_string()),
                 sender,
+                AcknowledgementRequirement::Required,
             ))
             .expect("sending control message should not fail");
     }
@@ -673,6 +735,50 @@ mod tests {
                 std::slice::from_ref(&events)
             );
         }
+    }
+
+    #[tokio::test]
+    async fn best_effort_branch_does_not_participate_in_acknowledgements() {
+        let (mut fanout, _) = Fanout::new(ComponentKey::from("test_upstream"));
+        let (required_sender, mut required_receiver) = build_sender_pair(1);
+        let (best_effort_sender, mut best_effort_receiver) = build_sender_pair(1);
+        fanout.add_with_requirement(
+            ComponentKey::from("required"),
+            required_sender,
+            AcknowledgementRequirement::Required,
+        );
+        fanout.add_with_requirement(
+            ComponentKey::from("best_effort"),
+            best_effort_sender,
+            AcknowledgementRequirement::BestEffort,
+        );
+
+        let (batch, mut receiver) = BatchNotifier::new_with_receiver();
+        let mut events = make_event_array(1);
+        let EventArray::Logs(logs) = &mut events else {
+            panic!("test events must be logs");
+        };
+        logs[0].add_finalizer(EventFinalizer::new(batch.clone()));
+        drop(batch);
+
+        fanout.send(events, None).await.expect("send must succeed");
+
+        let mut best_effort = best_effort_receiver
+            .next()
+            .await
+            .expect("best-effort branch must receive events");
+        assert!(best_effort.take_finalizers().is_empty());
+        drop(best_effort);
+        assert!(matches!(receiver.try_recv(), Err(TryRecvError::Empty)));
+
+        let mut required = required_receiver
+            .next()
+            .await
+            .expect("required branch must receive events");
+        let finalizers = required.take_finalizers();
+        finalizers.update_status(EventStatus::Delivered);
+        drop(finalizers);
+        assert_eq!(receiver.await, BatchStatus::Delivered);
     }
 
     #[tokio::test]

--- a/lib/vector-tap/src/controller.rs
+++ b/lib/vector-tap/src/controller.rs
@@ -378,8 +378,11 @@ async fn tap_handler(
                             // as a previous, and we are not getting involved in config diffing at
                             // this point.
                             let sink_id = Uuid::new_v4().to_string();
-                            match control_tx
-                                .send(fanout::ControlMessage::Add(ComponentKey::from(sink_id.as_str()), tap_buffer_tx))
+                            match control_tx.send(fanout::ControlMessage::Add(
+                                ComponentKey::from(sink_id.as_str()),
+                                tap_buffer_tx,
+                                fanout::AcknowledgementRequirement::BestEffort,
+                            ))
                             {
                                 Ok(_) => {
                                     debug!(

--- a/src/config/builder.rs
+++ b/src/config/builder.rs
@@ -94,6 +94,8 @@ impl From<Config> for ConfigBuilder {
             sources,
             sinks,
             transforms,
+            acknowledgement_required: _,
+            acknowledgement_best_effort: _,
             tests,
             secret,
             graceful_shutdown_duration,

--- a/src/config/compiler.rs
+++ b/src/config/compiler.rs
@@ -138,6 +138,8 @@ pub fn compile(mut builder: ConfigBuilder) -> Result<(Config, Vec<String>), Vec<
             sources,
             sinks,
             transforms,
+            acknowledgement_required: Default::default(),
+            acknowledgement_best_effort: Default::default(),
             tests,
             secret,
             graceful_shutdown_duration,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -154,6 +154,10 @@ pub struct Config {
     sources: IndexMap<ComponentKey, SourceOuter>,
     sinks: IndexMap<ComponentKey, SinkOuter<OutputId>>,
     transforms: IndexMap<ComponentKey, TransformOuter<OutputId>>,
+    #[serde(skip)]
+    acknowledgement_required: HashSet<ComponentKey>,
+    #[serde(skip)]
+    acknowledgement_best_effort: HashSet<ComponentKey>,
     pub enrichment_tables: IndexMap<ComponentKey, EnrichmentTableOuter<OutputId>>,
     tests: Vec<TestDefinition>,
     secret: IndexMap<ComponentKey, SecretBackends>,
@@ -211,8 +215,16 @@ impl Config {
             .or_else(|| self.enrichment_tables.get(id).map(|s| &s.inputs[..]))
     }
 
+    pub fn acknowledgement_required(&self, id: &ComponentKey) -> bool {
+        self.acknowledgement_required.contains(id)
+    }
+
+    pub fn acknowledgement_best_effort(&self, id: &ComponentKey) -> bool {
+        self.acknowledgement_best_effort.contains(id) && !self.acknowledgement_required.contains(id)
+    }
+
     pub fn propagate_acknowledgements(&mut self) -> Result<(), Vec<String>> {
-        let inputs: Vec<_> = self
+        let enabled_sinks: Vec<_> = self
             .sinks
             .iter()
             .filter(|(_, sink)| {
@@ -221,19 +233,22 @@ impl Config {
                     .merge_default(&self.global.acknowledgements)
                     .enabled()
             })
-            .flat_map(|(name, sink)| {
-                sink.inputs
-                    .iter()
-                    .map(|input| (name.clone(), input.clone()))
-            })
+            .map(|(name, sink)| (name.clone(), sink.inputs.clone()))
             .collect();
-        self.propagate_acks_rec(inputs);
-        Ok(())
-    }
 
-    fn propagate_acks_rec(&mut self, sink_inputs: Vec<(ComponentKey, OutputId)>) {
-        for (sink, input) in sink_inputs {
+        self.acknowledgement_required.clear();
+        let mut pending = Vec::new();
+        for (sink, inputs) in enabled_sinks {
+            self.acknowledgement_required.insert(sink.clone());
+            pending.extend(inputs.into_iter().map(|input| (sink.clone(), input)));
+        }
+
+        while let Some((sink, input)) = pending.pop() {
             let component = &input.component;
+            if !self.acknowledgement_required.insert(component.clone()) {
+                continue;
+            }
+
             if let Some(source) = self.sources.get_mut(component) {
                 if source.inner.can_acknowledge() {
                     source.sink_acknowledgements = true;
@@ -245,14 +260,36 @@ impl Config {
                     );
                 }
             } else if let Some(transform) = self.transforms.get(component) {
-                let inputs = transform
-                    .inputs
-                    .iter()
-                    .map(|input| (sink.clone(), input.clone()))
-                    .collect();
-                self.propagate_acks_rec(inputs);
+                pending.extend(
+                    transform
+                        .inputs
+                        .iter()
+                        .map(|input| (sink.clone(), input.clone())),
+                );
             }
         }
+
+        self.acknowledgement_best_effort.clear();
+        let mut pending: Vec<_> = self
+            .sinks
+            .iter()
+            .filter(|(_, sink)| sink.inner.acknowledgements().explicitly_disabled())
+            .flat_map(|(sink, config)| {
+                self.acknowledgement_best_effort.insert(sink.clone());
+                config.inputs.iter().cloned()
+            })
+            .collect();
+        while let Some(input) = pending.pop() {
+            let component = &input.component;
+            if !self.acknowledgement_best_effort.insert(component.clone()) {
+                continue;
+            }
+            if let Some(transform) = self.transforms.get(component) {
+                pending.extend(transform.inputs.iter().cloned());
+            }
+        }
+
+        Ok(())
     }
 
     pub fn transform_keys_with_external_files(&self) -> HashSet<ComponentKey> {
@@ -1206,6 +1243,12 @@ mod acknowledgements_tests {
                     encoding.codec = "text"
                     path = "/path/to/out2"
                     acknowledgements = true
+                [sinks.out2_optional]
+                    type = "file"
+                    inputs = ["in2"]
+                    encoding.codec = "text"
+                    path = "/path/to/out2_optional"
+                    acknowledgements = false
                 [sinks.out3]
                     type = "file"
                     inputs = ["parse3"]
@@ -1230,6 +1273,12 @@ mod acknowledgements_tests {
         assert!(!get("in1").sink_acknowledgements);
         assert!(get("in2").sink_acknowledgements);
         assert!(get("in3").sink_acknowledgements);
+
+        assert!(config.acknowledgement_required(&ComponentKey::from("out2")));
+        assert!(config.acknowledgement_required(&ComponentKey::from("in2")));
+        assert!(!config.acknowledgement_required(&ComponentKey::from("out2_optional")));
+        assert!(config.acknowledgement_best_effort(&ComponentKey::from("out2_optional")));
+        assert!(!config.acknowledgement_required(&ComponentKey::from("out1")));
     }
 }
 

--- a/src/topology/builder.rs
+++ b/src/topology/builder.rs
@@ -190,8 +190,25 @@ impl<'a> Builder<'a> {
             // readonly.
             enrichment_tables.finish_load();
 
+            let acknowledgement_requirements = self
+                .config
+                .transforms()
+                .map(|(key, _)| key)
+                .chain(self.config.sinks().map(|(key, _)| key))
+                .chain(self.config.enrichment_tables().map(|(key, _)| key))
+                .map(|key| {
+                    let requirement = if self.config.acknowledgement_best_effort(key) {
+                        fanout::AcknowledgementRequirement::BestEffort
+                    } else {
+                        fanout::AcknowledgementRequirement::Required
+                    };
+                    (key.clone(), requirement)
+                })
+                .collect();
+
             Ok(TopologyPieces {
                 inputs: self.inputs,
+                acknowledgement_requirements,
                 outputs: Self::finalize_outputs(self.outputs),
                 tasks: self.tasks,
                 source_tasks,
@@ -1110,6 +1127,8 @@ pub async fn reload_enrichment_tables(config: &Config) {
 
 pub struct TopologyPieces {
     pub(super) inputs: HashMap<ComponentKey, (BufferSender<EventArray>, Inputs<OutputId>)>,
+    pub(super) acknowledgement_requirements:
+        HashMap<ComponentKey, fanout::AcknowledgementRequirement>,
     pub(crate) outputs: HashMap<ComponentKey, HashMap<Option<String>, fanout::ControlChannel>>,
     pub(super) tasks: HashMap<ComponentKey, Task>,
     pub(crate) source_tasks: HashMap<ComponentKey, Task>,

--- a/src/topology/running.rs
+++ b/src/topology/running.rs
@@ -24,7 +24,7 @@ use vector_lib::{
 use super::{
     BuiltBuffer, TaskHandle, TaskResult,
     builder::{self, TopologyPieces, TopologyPiecesBuilder, reload_enrichment_tables},
-    fanout::{ControlChannel, ControlMessage},
+    fanout::{AcknowledgementRequirement, ControlChannel, ControlMessage},
     handle_errors, retain, take_healthchecks,
     task::{Task, TaskOutput},
 };
@@ -881,7 +881,7 @@ impl RunningTopology {
         // Instead of propagating connections forward -- B reconnecting A forcefully -- we only
         // connect components backwards i.e. transforms to sources/transforms, and sinks to
         // sources/transforms, to ensure we're connecting components in order.
-        self.reattach_severed_inputs(diff);
+        self.reattach_severed_inputs(diff, &new_pieces.acknowledgement_requirements);
 
         // Broadcast any topology changes to subscribers.
         if !self.watch.0.is_closed() {
@@ -965,6 +965,11 @@ impl RunningTopology {
         diff: &ConfigDiff,
         new_pieces: &mut builder::TopologyPieces,
     ) {
+        let acknowledgement_requirement = new_pieces
+            .acknowledgement_requirements
+            .get(key)
+            .copied()
+            .unwrap_or(AcknowledgementRequirement::Required);
         let (tx, inputs) = new_pieces.inputs.remove(key).unwrap();
 
         let old_inputs = self
@@ -987,7 +992,11 @@ impl RunningTopology {
                 // output for the first time, since there's nothing to actually replace at this point.
                 debug!(component_id = %key, fanout_id = %input, "Adding component input to fanout.");
 
-                _ = output.send(ControlMessage::Add(key.clone(), tx.clone()));
+                _ = output.send(ControlMessage::Add(
+                    key.clone(),
+                    tx.clone(),
+                    acknowledgement_requirement,
+                ));
             } else {
                 // We know that if this component is connected to a given input, and neither
                 // components were changed, then the output must still exist, which means we paused
@@ -995,7 +1004,11 @@ impl RunningTopology {
                 // now:
                 debug!(component_id = %key, fanout_id = %input, "Replacing component input in fanout.");
 
-                _ = output.send(ControlMessage::Replace(key.clone(), tx.clone()));
+                _ = output.send(ControlMessage::Replace(
+                    key.clone(),
+                    tx.clone(),
+                    acknowledgement_requirement,
+                ));
             }
         }
 
@@ -1052,7 +1065,11 @@ impl RunningTopology {
         }
     }
 
-    fn reattach_severed_inputs(&mut self, diff: &ConfigDiff) {
+    fn reattach_severed_inputs(
+        &mut self,
+        diff: &ConfigDiff,
+        acknowledgement_requirements: &HashMap<ComponentKey, AcknowledgementRequirement>,
+    ) {
         let unchanged_transforms = self
             .config
             .transforms()
@@ -1064,7 +1081,15 @@ impl RunningTopology {
 
                 let input = self.inputs.get(transform_key).cloned().unwrap();
                 let output = self.outputs.get_mut(&output_id).unwrap();
-                _ = output.send(ControlMessage::Add(transform_key.clone(), input));
+                let requirement = acknowledgement_requirements
+                    .get(transform_key)
+                    .copied()
+                    .unwrap_or(AcknowledgementRequirement::Required);
+                _ = output.send(ControlMessage::Add(
+                    transform_key.clone(),
+                    input,
+                    requirement,
+                ));
             }
         }
 
@@ -1087,7 +1112,11 @@ impl RunningTopology {
 
                 let input = self.inputs.get(sink_key).cloned().unwrap();
                 let output = self.outputs.get_mut(&output_id).unwrap();
-                _ = output.send(ControlMessage::Add(sink_key.clone(), input));
+                let requirement = acknowledgement_requirements
+                    .get(sink_key)
+                    .copied()
+                    .unwrap_or(AcknowledgementRequirement::Required);
+                _ = output.send(ControlMessage::Add(sink_key.clone(), input, requirement));
             }
         }
     }

--- a/src/topology/test/end_to_end.rs
+++ b/src/topology/test/end_to_end.rs
@@ -146,6 +146,86 @@ uri = "http://{address2}/"
 }
 
 #[tokio::test]
+async fn best_effort_sink_does_not_delay_source_acknowledgement() {
+    test_util::trace_init();
+
+    let (_source_guard, source_address) = test_util::addr::next_addr();
+    let (_required_guard, required_address) = test_util::addr::next_addr();
+    let (_best_effort_guard, best_effort_address) = test_util::addr::next_addr();
+    let config = config::load_from_str(
+        &format!(
+            r#"
+[sources.in]
+type = "http"
+address = "{source_address}"
+
+[sinks.required]
+type = "http"
+inputs = ["in"]
+encoding.codec = "json"
+uri = "http://{required_address}/"
+acknowledgements.enabled = true
+
+[sinks.best_effort]
+type = "http"
+inputs = ["in"]
+encoding.codec = "json"
+uri = "http://{best_effort_address}/"
+acknowledgements.enabled = false
+"#,
+        ),
+        Format::Toml,
+    )
+    .unwrap();
+    let diff = ConfigDiff::initial(&config);
+    let pieces = TopologyPiecesBuilder::new(&config, &diff)
+        .build_or_log_errors()
+        .await
+        .unwrap();
+    let (_topology, _) = RunningTopology::start_validated(config, diff, pieces)
+        .await
+        .unwrap();
+
+    test_util::wait_for_tcp(source_address).await;
+
+    let required_mutex = Arc::new(Mutex::new(()));
+    let required_pause = required_mutex.lock().await;
+    let mut required_rx = http_server(
+        required_address,
+        Arc::clone(&required_mutex),
+        StatusCode::OK,
+    )
+    .await;
+    let best_effort_mutex = Arc::new(Mutex::new(()));
+    let best_effort_pause = best_effort_mutex.lock().await;
+    let mut best_effort_rx = http_server(
+        best_effort_address,
+        Arc::clone(&best_effort_mutex),
+        StatusCode::INTERNAL_SERVER_ERROR,
+    )
+    .await;
+
+    let (_response_ready, sender) = http_client(source_address, "test");
+    timeout(Duration::from_secs(4), required_rx.recv())
+        .await
+        .expect("Timed out waiting for required sink")
+        .expect("Required sink did not receive event");
+    timeout(Duration::from_secs(4), best_effort_rx.recv())
+        .await
+        .expect("Timed out waiting for best-effort sink")
+        .expect("Best-effort sink did not receive event");
+
+    drop(required_pause);
+    let result = timeout(Duration::from_secs(1), sender)
+        .await
+        .expect("Best-effort sink delayed source acknowledgement")
+        .expect("Error receiving result from tokio task");
+    assert_eq!(result.status(), StatusCode::OK);
+
+    drop(best_effort_pause);
+}
+
+#[tokio::test]
 async fn http_to_http_delivered() {
     http_to_http(StatusCode::OK, StatusCode::OK).await;
 }


### PR DESCRIPTION
## Summary

This draft explores selective sink participation in end-to-end acknowledgements. A sink with `acknowledgements.enabled: false` becomes a best-effort branch: it still receives events, but its event copies do not retain source finalizers and therefore cannot delay or affect the upstream acknowledgement result.

The implementation:

- computes required and explicitly best-effort reachability during configuration compilation
- carries the resulting requirement on fanout connections
- removes source finalizers from best-effort event copies before they enter sink buffers
- preserves existing behavior for sinks whose acknowledgement setting is unspecified
- treats tap outputs as best effort

### Known prototype limitations

- acknowledgement requirement changes during topology reload do not yet rebuild affected sources or reconnect every unchanged upstream edge
- best-effort branches still participate in fanout backpressure while their buffers accept events
- memory and disk buffer lifecycle coverage needs to be expanded before this is ready for production

### References

None.

## Vector configuration

```yaml
sources:
  input:
    type: http_server
    address: 0.0.0.0:8080

sinks:
  required:
    type: http
    inputs: [input]
    uri: https://required.example.com/events
    acknowledgements:
      enabled: true
    encoding:
      codec: json

  best_effort:
    type: http
    inputs: [input]
    uri: https://best-effort.example.com/events
    acknowledgements:
      enabled: false
    encoding:
      codec: json
```

## How did you test this PR?

- `cargo test -p vector-core fanout::tests --lib`
- `cargo test -p vector --features sources-file,sinks-file config::acknowledgements_tests::propagates_settings --lib`
- `cargo test -p vector --features sources-http_server,sinks-http topology::test::end_to_end --lib`
- `cargo check -p vector --lib`
- `cargo clippy -p vector-core --tests -- -D warnings`
- `cargo clippy -p vector --lib --features sources-http_server,sinks-http,sources-file,sinks-file -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo vdev check changelog-fragments`

The end-to-end test blocks a failing best-effort HTTP sink and verifies that the HTTP source responds successfully as soon as the required sink succeeds.

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [x] Yes. A changelog fragment is included.
- [ ] No.