### PR TITLE
fix(topology): remove metrics for retired components

### DIFF
--- a/changelog.d/remove_retired_component_metrics.fix.md
+++ b/changelog.d/remove_retired_component_metrics.fix.md
@@ -1,0 +1,3 @@
+Stop emitting internal metrics for components removed during a successful topology reload.
+
+authors: Jansen-w

--- a/lib/vector-core/src/metrics/mod.rs
+++ b/lib/vector-core/src/metrics/mod.rs
@@ -137,6 +137,13 @@ impl Controller {
         self.recorder.with_registry(Registry::clear);
     }
 
+    /// Remove all metrics associated with a component that is no longer active.
+    pub fn remove_component_metrics(&self, component_id: &str, component_kind: &str) {
+        self.recorder.with_registry(|registry| {
+            registry.remove_component_metrics(component_id, component_kind);
+        });
+    }
+
     /// Get a handle to the globally registered controller, if it's initialized.
     ///
     /// # Errors
@@ -205,8 +212,8 @@ impl Controller {
 mod tests {
     use strum::IntoEnumIterator;
     use vector_common::{
-        counter, gauge,
-        internal_event::{CounterName, GaugeName},
+        counter, gauge, histogram,
+        internal_event::{CounterName, GaugeName, HistogramName},
     };
 
     use super::*;
@@ -269,6 +276,86 @@ mod tests {
         assert_eq!(controller.capture_metrics().len(), 4);
         gauge.set(1.0);
         assert_eq!(controller.capture_metrics().len(), 4);
+    }
+
+    #[test]
+    fn removes_component_metrics() {
+        let controller = init_metrics();
+        let counter_name = CounterName::iter().next().unwrap();
+        let gauge_name = GaugeName::iter().next().unwrap();
+        let histogram_name = HistogramName::iter().next().unwrap();
+
+        let removed_counter =
+            counter!(counter_name, "component_id" => "removed", "component_kind" => "transform");
+        removed_counter.increment(1);
+        gauge!(gauge_name, "component_id" => "removed", "component_kind" => "transform").set(2.0);
+        histogram!(histogram_name, "component_id" => "removed", "component_kind" => "transform")
+            .record(3.0);
+
+        counter!(counter_name, "component_id" => "live", "component_kind" => "transform")
+            .increment(1);
+        gauge!(gauge_name, "component_id" => "live", "component_kind" => "transform").set(2.0);
+        histogram!(histogram_name, "component_id" => "live", "component_kind" => "transform")
+            .record(3.0);
+        counter!(counter_name, "component_id" => "removed", "component_kind" => "source")
+            .increment(1);
+        counter!(counter_name, "component_id" => "removed.child", "component_kind" => "transform")
+            .increment(1);
+        counter!(counter_name).increment(1);
+
+        assert_eq!(
+            controller
+                .capture_metrics()
+                .iter()
+                .filter(
+                    |metric| metric.tags().and_then(|tags| tags.get("component_id"))
+                        == Some("removed")
+                )
+                .count(),
+            4
+        );
+
+        controller.remove_component_metrics("removed", "transform");
+        removed_counter.increment(1);
+
+        let metrics = controller.capture_metrics();
+        assert!(!metrics.iter().any(|metric| {
+            metric.tags().and_then(|tags| tags.get("component_id")) == Some("removed")
+                && metric.tags().and_then(|tags| tags.get("component_kind")) == Some("transform")
+        }));
+        assert!(metrics.iter().any(|metric| {
+            metric.tags().and_then(|tags| tags.get("component_id")) == Some("removed")
+                && metric.tags().and_then(|tags| tags.get("component_kind")) == Some("source")
+        }));
+        assert!(
+            metrics.iter().any(
+                |metric| metric.tags().and_then(|tags| tags.get("component_id")) == Some("live")
+            )
+        );
+        assert!(metrics.iter().any(
+            |metric| metric.tags().and_then(|tags| tags.get("component_id"))
+                == Some("removed.child")
+        ));
+        assert!(metrics.iter().any(|metric| metric.tags().is_none()));
+    }
+
+    #[test]
+    fn removes_component_metric_recency() {
+        let controller = init_metrics();
+        controller
+            .set_expiry(Some(IDLE_TIMEOUT), Vec::new())
+            .unwrap();
+        let name = CounterName::iter().next().unwrap();
+
+        counter!(name, "component_id" => "recreated", "component_kind" => "transform").increment(1);
+        controller.capture_metrics();
+        controller.remove_component_metrics("recreated", "transform");
+        std::thread::sleep(Duration::from_secs_f64(IDLE_TIMEOUT * 2.0));
+
+        counter!(name, "component_id" => "recreated", "component_kind" => "transform").increment(1);
+        assert!(controller.capture_metrics().iter().any(|metric| {
+            metric.tags().and_then(|tags| tags.get("component_id")) == Some("recreated")
+        }));
     }
 
     #[test]

--- a/lib/vector-core/src/metrics/recency.rs
+++ b/lib/vector-core/src/metrics/recency.rs
@@ -48,7 +48,7 @@
 //! not, and thus whether it should actually be deleted.
 
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     sync::{
         Arc,
         atomic::{AtomicUsize, Ordering},
@@ -303,6 +303,14 @@ where
             global_idle_timeout,
             per_set_timeouts: Mutex::new(PerSetTimeout::new(per_set_timeouts)),
         }
+    }
+
+    pub(super) fn remove_keys(&self, keys: &HashSet<K>) {
+        self.inner.lock().1.retain(|key, _| !keys.contains(key));
+        self.per_set_timeouts
+            .lock()
+            .per_key_timeouts
+            .retain(|key, _| !keys.contains(key));
     }
 
     /// Checks if the given counter should be stored, based on its known recency.

--- a/lib/vector-core/src/metrics/recorder.rs
+++ b/lib/vector-core/src/metrics/recorder.rs
@@ -1,5 +1,6 @@
 use std::{
     cell::OnceCell,
+    collections::HashSet,
     sync::{Arc, RwLock, atomic::Ordering},
     time::Duration,
 };
@@ -34,6 +35,41 @@ impl Registry {
 
     pub(super) fn clear(&self) {
         self.registry.clear();
+    }
+
+    pub(super) fn remove_component_metrics(&self, component_id: &str, component_kind: &str) {
+        let mut removed = HashSet::new();
+        let mut retain = |key: &Key| {
+            let belongs_to_component =
+                Self::belongs_to_component(key, component_id, component_kind);
+            if belongs_to_component {
+                removed.insert(key.clone());
+            }
+            !belongs_to_component
+        };
+
+        self.registry.retain_counters(|key, _| retain(key));
+        self.registry.retain_gauges(|key, _| retain(key));
+        self.registry.retain_histograms(|key, _| retain(key));
+
+        if let Some(recency) = self
+            .recency
+            .read()
+            .expect("Failed to acquire read lock on recency map")
+            .as_ref()
+        {
+            recency.remove_keys(&removed);
+        }
+    }
+
+    fn belongs_to_component(key: &Key, component_id: &str, component_kind: &str) -> bool {
+        let mut id_matches = false;
+        let mut kind_matches = false;
+        for label in key.labels() {
+            id_matches |= label.key() == "component_id" && label.value() == component_id;
+            kind_matches |= label.key() == "component_kind" && label.value() == component_kind;
+        }
+        id_matches && kind_matches
     }
 
     pub(super) fn set_expiry(

--- a/src/config/diff.rs
+++ b/src/config/diff.rs
@@ -65,6 +65,36 @@ impl ConfigDiff {
             || self.sinks.is_removed(key)
             || self.enrichment_tables.is_removed(key)
     }
+
+    /// Returns components removed from the resulting topology.
+    pub fn removed_components(&self) -> HashSet<(&ComponentKey, &'static str)> {
+        self.sources
+            .to_remove
+            .iter()
+            .map(|key| (key, "source"))
+            .chain(
+                self.transforms
+                    .to_remove
+                    .iter()
+                    .map(|key| (key, "transform")),
+            )
+            .chain(self.sinks.to_remove.iter().map(|key| (key, "sink")))
+            .chain(
+                self.enrichment_tables
+                    .sources
+                    .to_remove
+                    .iter()
+                    .map(|key| (key, "source")),
+            )
+            .chain(
+                self.enrichment_tables
+                    .sinks
+                    .to_remove
+                    .iter()
+                    .map(|key| (key, "sink")),
+            )
+            .collect()
+    }
 }
 
 #[derive(Debug)]

--- a/src/topology/running.rs
+++ b/src/topology/running.rs
@@ -347,6 +347,11 @@ impl RunningTopology {
                 self.spawn_diff(&diff, new_pieces);
                 self.config = new_config;
                 self.refresh_confinement_gauges();
+                let metrics = crate::metrics::Controller::get()
+                    .expect("Metrics must be initialized before reloading the topology");
+                for (key, kind) in diff.removed_components() {
+                    metrics.remove_component_metrics(key.id(), kind);
+                }
 
                 info!("New configuration loaded successfully.");
 

--- a/src/topology/test/mod.rs
+++ b/src/topology/test/mod.rs
@@ -14,6 +14,7 @@ use tokio::{
 use vector_lib::{
     buffers::{BufferConfig, BufferType, WhenFull},
     config::{ComponentKey, OutputId},
+    metrics::Controller,
     source_sender::SourceSenderItem,
 };
 
@@ -417,6 +418,57 @@ async fn topology_remove_one_transform() {
     let res2 = h_out2.await.unwrap();
     assert_eq!(vec!["this transformed"], res1);
     assert_eq!(Vec::<String>::new(), res2);
+}
+
+#[tokio::test]
+async fn topology_removes_metrics_for_removed_component() {
+    trace_init();
+
+    let (_input, source) = basic_source();
+    let mut config = Config::builder();
+    config.add_source("metric_cleanup_input", source);
+    config.add_transform(
+        "metric_cleanup_transform",
+        &["metric_cleanup_input"],
+        basic_transform(" transformed", 0.0),
+    );
+    config.add_sink(
+        "metric_cleanup_output",
+        &["metric_cleanup_transform"],
+        basic_sink(10).1,
+    );
+
+    let (mut topology, _) = start_topology(config.build().unwrap(), false).await;
+    let metrics = Controller::get().unwrap();
+    let belongs_to_removed_component = |metric: &crate::event::Metric| {
+        metric.tags().and_then(|tags| tags.get("component_id")) == Some("metric_cleanup_transform")
+    };
+    assert!(
+        metrics
+            .capture_metrics()
+            .iter()
+            .any(belongs_to_removed_component)
+    );
+
+    let mut config = Config::builder();
+    config.add_source("metric_cleanup_input", basic_source().1);
+    config.add_sink(
+        "metric_cleanup_output",
+        &["metric_cleanup_input"],
+        basic_sink(10).1,
+    );
+    topology
+        .reload_config_and_respawn(config.build().unwrap(), Default::default())
+        .await
+        .unwrap();
+
+    assert!(
+        !metrics
+            .capture_metrics()
+            .iter()
+            .any(belongs_to_removed_component)
+    );
+    topology.stop().await;
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Remove component-scoped internal metrics after a component is removed by a successful topology reload. Registry cleanup matches both `component_id` and `component_kind`, removes counters, gauges, and histograms, and clears their metric-recency bookkeeping so a later component with the same identity starts cleanly.

Cleanup runs only after the replacement topology is installed, preserving metrics when a reload fails and the previous topology is restored.

### References

None.

## Vector configuration

No new configuration is required. The regression test reloads a basic source-transform-sink topology after removing the transform.

## How did you test this PR?

- `cargo test -p vector-core metrics::tests --no-default-features`
- `cargo test -p vector --lib topology_removes_metrics_for_removed_component`
- `cargo test -p vector --lib topology_remove_one_transform`
- `cargo clippy -p vector-core --lib --tests --no-default-features -- -D warnings`
- `cargo clippy -p vector --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo vdev check changelog-fragments`

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [x] Yes. A changelog fragment is included.
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.