### PR TITLE
fix(sinks): separate Datadog validation from runtime construction

### DIFF
--- a/changelog.d/26145_datadog_endpoint_uri_compatibility.fix.md
+++ b/changelog.d/26145_datadog_endpoint_uri_compatibility.fix.md
@@ -1,0 +1,9 @@
+Datadog sink custom endpoints without a scheme now default to `https://`. Query parameters are
+removed when Vector appends its Datadog API path; endpoint query parameters are not supported for
+configuring Datadog API requests.
+
+When migrating a configuration that relies on endpoint query parameters, remove the query string
+and use the Datadog sink's supported request settings or headers instead. Specify `http://` or
+`https://` explicitly when the endpoint must use a particular scheme.
+
+authors: kurochan

--- a/changelog.d/26145_datadog_traces_apm_flusher_lifecycle.fix.md
+++ b/changelog.d/26145_datadog_traces_apm_flusher_lifecycle.fix.md
@@ -1,0 +1,6 @@
+Prevent the `datadog_traces` sink from starting its APM statistics flusher while the sink is being
+built. The flusher now follows the sink lifecycle, avoiding leaked background tasks during
+configuration validation or a rolled-back reload. Shutdown waits only a bounded time for the final
+APM statistics flush when the endpoint is unreachable.
+
+authors: kurochan

--- a/changelog.d/26145_macos_tls_native_roots_panic.fix.md
+++ b/changelog.d/26145_macos_tls_native_roots_panic.fix.md
@@ -1,0 +1,5 @@
+Prevent configuration validation from panicking on macOS when a restricted environment has no
+available Keychain. Vector avoids loading platform root certificates when TLS certificate
+verification is disabled, unless a client identity requires native certificate-chain support.
+
+authors: kurochan

--- a/lib/vector-core/src/tls/settings.rs
+++ b/lib/vector-core/src/tls/settings.rs
@@ -302,25 +302,17 @@ impl TlsSettings {
                 }
             }
         }
-        if self.authorities.is_empty() {
+        if self.should_load_native_roots(for_server) {
             debug!("Fetching system root certs.");
 
             cfg_if! {
                 if #[cfg(windows)] {
-                    load_windows_certs(context).unwrap();
+                    load_windows_certs(context)?;
                 } else if #[cfg(target_os = "macos")] {
-                    cfg_if! { // Panic in release builds, warn in debug builds.
-                        if #[cfg(debug_assertions)] {
-                            if let Err(error) = load_mac_certs(context) {
-                                warn!("Failed to load macOS certs: {error}");
-                            }
-                        } else {
-                            load_mac_certs(context).unwrap();
-                        }
-                    }
+                    load_mac_certs(context)?;
                 }
             }
-        } else {
+        } else if !self.authorities.is_empty() {
             let mut store = X509StoreBuilder::new().context(NewStoreBuilderSnafu)?;
             for authority in &self.authorities {
                 store
@@ -350,6 +342,11 @@ impl TlsSettings {
         }
 
         Ok(())
+    }
+
+    fn should_load_native_roots(&self, for_server: bool) -> bool {
+        self.authorities.is_empty()
+            && (self.verify_certificate || (!for_server && self.identity.is_some()))
     }
 
     /// Apply per-connection TLS settings.
@@ -837,6 +834,37 @@ mod test {
         let settings = TlsSettings::from_options(None).expect("Failed to generate null settings");
         assert!(settings.identity.is_none());
         assert_eq!(settings.authorities.len(), 0);
+    }
+
+    #[test]
+    fn apply_context_skips_system_roots_when_verification_is_disabled() {
+        use openssl::ssl::SslMethod;
+
+        let settings = TlsSettings::from_options(Some(&TlsConfig {
+            verify_certificate: Some(false),
+            ..Default::default()
+        }))
+        .expect("Failed to generate TLS settings");
+        let mut context = SslContextBuilder::new(SslMethod::tls()).unwrap();
+
+        // In particular, this must not access the macOS keychain or Windows certificate store.
+        settings
+            .apply_context(&mut context)
+            .expect("TLS context setup should not load native roots when verification is off");
+    }
+
+    #[test]
+    fn client_identity_loads_system_roots_when_verification_is_disabled() {
+        let settings = TlsSettings::from_options(Some(&TlsConfig {
+            verify_certificate: Some(false),
+            crt_file: Some(TEST_PEM_CLIENT_CRT_PATH.into()),
+            key_file: Some(TEST_PEM_CLIENT_KEY_PATH.into()),
+            ..Default::default()
+        }))
+        .expect("Failed to load client identity");
+
+        // Avoid native certificate-store access in this unit test.
+        assert!(settings.should_load_native_roots(false));
     }
 
     #[test]

--- a/src/sinks/datadog/events/config.rs
+++ b/src/sinks/datadog/events/config.rs
@@ -1,7 +1,7 @@
 use http::Uri;
 use indoc::indoc;
 use tower::ServiceBuilder;
-use vector_lib::{config::proxy::ProxyConfig, configurable::configurable_component, schema};
+use vector_lib::{configurable::configurable_component, schema};
 use vrl::value::Kind;
 
 use super::{
@@ -23,7 +23,6 @@ use crate::{
             http::{HttpStatusRetryLogic, RetryStrategy},
         },
     },
-    tls::MaybeTlsSettings,
 };
 
 /// Configuration for the `datadog_events` sink.
@@ -64,12 +63,6 @@ impl DatadogEventsConfig {
             .into_uri())
     }
 
-    fn build_client(&self, proxy: &ProxyConfig) -> crate::Result<HttpClient> {
-        let tls = MaybeTlsSettings::from_config(self.dd_common.tls.as_ref(), false)?;
-        let client = HttpClient::new(tls, proxy)?;
-        Ok(client)
-    }
-
     fn build_sink(
         &self,
         dd_common: &DatadogCommonConfig,
@@ -80,14 +73,13 @@ impl DatadogEventsConfig {
         let service =
             DatadogEventsService::new(endpoint, dd_common.default_api_key.clone(), client);
 
-        let request_settings = validated.request_settings.clone();
         let retry_logic = HttpStatusRetryLogic::new(
             |req: &DatadogEventsResponse| req.http_status,
             self.retry_strategy.clone(),
         );
 
         let service = ServiceBuilder::new()
-            .settings(request_settings, retry_logic)
+            .settings(validated.request_settings.clone(), retry_logic)
             .service(service);
 
         let sink = DatadogEventsSink { service };
@@ -145,9 +137,9 @@ impl ValidatedSink for DatadogEventsConfig {
         validated: &ValidatedEvents,
         cx: SinkContext,
     ) -> crate::Result<(VectorSink, Healthcheck)> {
-        let client = self.build_client(cx.proxy())?;
-        let global = cx.extra_context.get_or_default::<datadog::Options>();
-        let dd_common = self.dd_common.with_globals(global)?;
+        let dd_common = self.dd_common.with_globals_from(&cx)?;
+        // Events defaults to HTTP; explicit TLS configuration overrides it.
+        let client = self.dd_common.build_client(cx.proxy(), false)?;
         let healthcheck = dd_common.build_healthcheck(client.clone())?;
         let endpoint = Self::events_endpoint(dd_common.endpoint.as_deref(), &dd_common.site)?;
         let sink = self.build_sink(&dd_common, client, validated, endpoint)?;

--- a/src/sinks/datadog/events/tests.rs
+++ b/src/sinks/datadog/events/tests.rs
@@ -10,15 +10,29 @@ use vrl::event_path;
 
 use super::*;
 use crate::{
-    config::SinkConfig,
+    config::{SinkConfig, SinkContext},
     event::EventArray,
-    sinks::util::test::{build_test_server_status, load_sink},
+    sinks::util::test::{build_test_server_status, load_sink, load_sink_with_context},
     test_util::{
         addr::next_addr,
         components::{self, COMPONENT_ERROR_TAGS, HTTP_SINK_TAGS},
         random_lines_with_stream,
     },
 };
+
+#[tokio::test]
+async fn pure_validation_does_not_load_tls_files_but_full_build_does() {
+    let config = indoc! {r#"
+        default_api_key = "local-key"
+        tls.enabled = true
+        tls.ca_file = "/definitely/missing/vector-datadog-ca.pem"
+    "#};
+    let (config, cx) =
+        load_sink_with_context::<DatadogEventsConfig>(config, SinkContext::default()).unwrap();
+
+    assert!(crate::config::ValidatedSink::validate(&config).is_ok());
+    assert!(config.build(cx).await.is_err());
+}
 
 fn random_events_with_stream(
     len: usize,

--- a/src/sinks/datadog/logs/config.rs
+++ b/src/sinks/datadog/logs/config.rs
@@ -1,29 +1,26 @@
-use std::sync::Arc;
+use std::{collections::BTreeMap, sync::Arc};
 
+use http::HeaderValue;
 use indoc::indoc;
 use tower::ServiceBuilder;
-use vector_lib::{
-    config::proxy::ProxyConfig, configurable::configurable_component, schema::meaning,
-};
+use vector_lib::{configurable::configurable_component, schema::meaning, stream::BatcherSettings};
 use vrl::value::Kind;
 
 use hyper::{Body, client::connect::Connect};
 
 use super::{service::LogApiRetry, sink::LogSinkBuilder};
-use crate::config::{DynValidatedSink, ValidatedSink};
 use crate::{
-    common::datadog,
+    config::{DynValidatedSink, ValidatedSink},
     http::HttpClient,
     schema,
     sinks::{
         datadog::{DatadogCommonConfig, LocalDatadogCommonConfig, logs::service::LogApiService},
         prelude::*,
         util::{
-            HttpEndpoint,
-            http::{RequestConfig, validate_headers},
+            HttpEndpoint, TowerRequestSettings,
+            http::{OrderedHeaderName, RequestConfig, validate_headers},
         },
     },
-    tls::{MaybeTlsSettings, TlsEnableableConfig},
 };
 
 // The Datadog API has a hard limit of 5MB for uncompressed payloads. Above this
@@ -81,6 +78,15 @@ pub struct DatadogLogsConfig {
     pub conforms_as_agent: bool,
 }
 
+#[derive(Clone, Debug)]
+pub struct ValidatedDatadogLogs {
+    batch: BatcherSettings,
+    compression: Compression,
+    headers: BTreeMap<OrderedHeaderName, HeaderValue>,
+    conforms_as_agent: bool,
+    request_settings: TowerRequestSettings,
+}
+
 const fn default_compression() -> Option<Compression> {
     Some(Compression::zstd_default())
 }
@@ -116,39 +122,21 @@ impl DatadogLogsConfig {
         dd_common: &DatadogCommonConfig,
         client: HttpClient<Body, C>,
         dd_evp_origin: String,
-        batch: BatcherSettings,
+        validated: &ValidatedDatadogLogs,
     ) -> crate::Result<VectorSink>
     where
         C: Connect + Clone + Send + Sync + 'static,
     {
         let default_api_key: Arc<str> = Arc::from(dd_common.default_api_key.inner());
-        let request_limits = self.request.tower.into_settings();
-
-        let headers = {
-            let mut request_headers = self.request.headers.clone();
-            if self.conforms_as_agent {
-                request_headers.insert(String::from("DD-PROTOCOL"), String::from("agent-json"));
-            }
-            request_headers
-        };
-
-        // conforms_as_agent is true if either the user supplied configuration parameter is enabled
-        // or the DD-PROTOCOL: agent-json header had already been manually set
-        let conforms_as_agent = if let Some(value) = headers.get("DD-PROTOCOL") {
-            value == "agent-json"
-        } else {
-            false
-        };
-
         let endpoint = self.get_uri(dd_common)?;
         let protocol = endpoint.protocol().to_string();
 
         let service = ServiceBuilder::new()
-            .settings(request_limits, LogApiRetry)
+            .settings(validated.request_settings.clone(), LogApiRetry)
             .service(LogApiService::new(
                 client,
                 endpoint.into_uri(),
-                headers,
+                validated.headers.clone(),
                 dd_evp_origin,
             )?);
 
@@ -158,30 +146,14 @@ impl DatadogLogsConfig {
             encoding,
             service,
             default_api_key,
-            batch,
+            validated.batch,
             protocol,
-            conforms_as_agent,
+            validated.conforms_as_agent,
         )
-        .compression(self.compression.or_else(default_compression).unwrap())
+        .compression(validated.compression)
         .build();
 
         Ok(VectorSink::from_event_streamsink(sink))
-    }
-
-    pub fn create_client(&self, proxy: &ProxyConfig) -> crate::Result<HttpClient> {
-        let default_tls_config;
-
-        let tls_settings = MaybeTlsSettings::from_config(
-            Some(match self.local_dd_common.tls.as_ref() {
-                Some(config) => config,
-                None => {
-                    default_tls_config = TlsEnableableConfig::enabled();
-                    &default_tls_config
-                }
-            }),
-            false,
-        )?;
-        Ok(HttpClient::new(tls_settings, proxy)?)
     }
 }
 
@@ -210,32 +182,13 @@ impl SinkConfig for DatadogLogsConfig {
     }
 }
 
-#[derive(Clone, Debug)]
-pub struct ValidatedLogs {
-    batch: BatcherSettings,
-}
-
 #[async_trait::async_trait]
 impl ValidatedSink for DatadogLogsConfig {
-    type Validated = ValidatedLogs;
+    type Validated = ValidatedDatadogLogs;
 
-    fn validate(&self) -> crate::Result<ValidatedLogs> {
-        let site = self
-            .local_dd_common
-            .site
-            .clone()
-            .unwrap_or_else(|| datadog::DD_US_SITE.to_owned());
-        Self::logs_endpoint(self.local_dd_common.endpoint.as_deref(), &site)?;
-
-        let request_headers = {
-            let mut request_headers = self.request.headers.clone();
-            if self.conforms_as_agent {
-                request_headers.insert(String::from("DD-PROTOCOL"), String::from("agent-json"));
-            }
-            request_headers
-        };
-        validate_headers(&request_headers)?;
-
+    fn validate(&self) -> crate::Result<Self::Validated> {
+        // We forcefully cap the provided batch configuration to the size/log line limits imposed by
+        // the Datadog Logs API, but we still allow them to be lowered if need be.
         let batch = self
             .batch
             .validate()?
@@ -243,21 +196,45 @@ impl ValidatedSink for DatadogLogsConfig {
             .limit_max_events(BATCH_MAX_EVENTS)?
             .into_batcher_settings()?;
 
-        Ok(ValidatedLogs { batch })
+        let mut configured_headers = self.request.headers.clone();
+        if self.conforms_as_agent {
+            configured_headers.insert(String::from("DD-PROTOCOL"), String::from("agent-json"));
+        }
+
+        // conforms_as_agent is true if either the user supplied configuration parameter is enabled
+        // or the DD-PROTOCOL: agent-json header had already been manually set
+        let conforms_as_agent = configured_headers
+            .get("DD-PROTOCOL")
+            .is_some_and(|value| value == "agent-json");
+        let headers = validate_headers(&configured_headers)?;
+
+        if self.local_dd_common.endpoint.is_some() {
+            self.local_dd_common
+                .validate_endpoint_with_path("/api/v2/logs")?;
+        } else if let Some(site) = self.local_dd_common.site.as_deref() {
+            Self::logs_endpoint(None, site)?;
+        }
+
+        let compression = self.compression.or_else(default_compression).unwrap();
+
+        Ok(ValidatedDatadogLogs {
+            batch,
+            compression,
+            headers,
+            conforms_as_agent,
+            request_settings: self.request.tower.into_settings(),
+        })
     }
 
     async fn build(
         &self,
-        validated: &ValidatedLogs,
+        validated: &Self::Validated,
         cx: SinkContext,
     ) -> crate::Result<(VectorSink, Healthcheck)> {
-        let client = self.create_client(&cx.proxy)?;
-        let global = cx.extra_context.get_or_default::<datadog::Options>();
-        let dd_common = self.local_dd_common.with_globals(global)?;
-
+        let dd_common = self.local_dd_common.with_globals_from(&cx)?;
+        let client = self.local_dd_common.build_client(&cx.proxy, true)?;
         let healthcheck = dd_common.build_healthcheck(client.clone())?;
-
-        let sink = self.build_processor(&dd_common, client, cx.app_name_slug, validated.batch)?;
+        let sink = self.build_processor(&dd_common, client, cx.app_name_slug, validated)?;
 
         Ok((sink, healthcheck))
     }
@@ -297,6 +274,19 @@ mod test {
             local_dd_common: LocalDatadogCommonConfig::new(
                 Some("not a uri".to_string()),
                 None,
+                None,
+            ),
+            ..Default::default()
+        };
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_malformed_local_site_without_endpoint() {
+        let config = DatadogLogsConfig {
+            local_dd_common: LocalDatadogCommonConfig::new(
+                None,
+                Some("bad site".to_string()),
                 None,
             ),
             ..Default::default()
@@ -439,6 +429,24 @@ mod test {
             config_gzip.compression,
             Some(Compression::Gzip(_))
         ));
+    }
+
+    #[test]
+    fn invalid_request_headers_are_rejected_during_structure_validation() {
+        let mut config = DatadogLogsConfig {
+            local_dd_common: LocalDatadogCommonConfig::new(
+                None,
+                None,
+                Some("test_key".to_string().into()),
+            ),
+            ..Default::default()
+        };
+        config
+            .request
+            .headers
+            .insert("invalid\nname".to_string(), "value".to_string());
+
+        assert!(crate::config::ValidatedSink::validate(&config).is_err());
     }
 
     impl ValidatableComponent for DatadogLogsConfig {

--- a/src/sinks/datadog/logs/service.rs
+++ b/src/sinks/datadog/logs/service.rs
@@ -111,11 +111,9 @@ where
     pub fn new(
         client: HttpClient<Body, C>,
         uri: Uri,
-        headers: BTreeMap<String, String>,
+        user_provided_headers: BTreeMap<OrderedHeaderName, HeaderValue>,
         dd_evp_origin: String,
     ) -> crate::Result<Self> {
-        let user_provided_headers = validate_headers(&headers)?;
-
         let dd_evp_headers: BTreeMap<String, String> = [
             ("DD-EVP-ORIGIN".to_string(), dd_evp_origin),
             ("DD-EVP-ORIGIN-VERSION".to_string(), crate::get_version()),

--- a/src/sinks/datadog/logs/tests.rs
+++ b/src/sinks/datadog/logs/tests.rs
@@ -483,6 +483,20 @@ async fn does_not_send_too_big_payloads() {
 }
 
 #[tokio::test]
+async fn pure_validation_does_not_load_tls_files_but_full_build_does() {
+    let config = indoc! {r#"
+        default_api_key = "local-key"
+        tls.enabled = true
+        tls.ca_file = "/definitely/missing/vector-datadog-ca.pem"
+    "#};
+    let (config, cx) =
+        load_sink_with_context::<DatadogLogsConfig>(config, SinkContext::default()).unwrap();
+
+    assert!(crate::config::ValidatedSink::validate(&config).is_ok());
+    assert!(config.build(cx).await.is_err());
+}
+
+#[tokio::test]
 async fn global_options() {
     let config = indoc! {r#"
             compression = "none"

--- a/src/sinks/datadog/metrics/config.rs
+++ b/src/sinks/datadog/metrics/config.rs
@@ -1,7 +1,5 @@
 use tower::ServiceBuilder;
-use vector_lib::{
-    config::proxy::ProxyConfig, configurable::configurable_component, stream::BatcherSettings,
-};
+use vector_lib::{configurable::configurable_component, stream::BatcherSettings};
 
 use super::{
     request_builder::DatadogMetricsRequestBuilder,
@@ -9,7 +7,6 @@ use super::{
     sink::DatadogMetricsSink,
 };
 use crate::{
-    common::datadog,
     config::{
         AcknowledgementsConfig, DynValidatedSink, Input, SinkConfig, SinkContext, ValidatedSink,
     },
@@ -19,10 +16,9 @@ use crate::{
         datadog::{DatadogCommonConfig, LocalDatadogCommonConfig},
         util::{
             HttpEndpoint, ServiceBuilderExt, SinkBatchSettings, TowerRequestConfig,
-            batch::BatchConfig,
+            TowerRequestSettings, batch::BatchConfig,
         },
     },
-    tls::{MaybeTlsSettings, TlsEnableableConfig},
 };
 #[derive(Clone, Copy, Debug, Default)]
 pub struct DatadogMetricsDefaultBatchSettings;
@@ -194,6 +190,13 @@ pub struct DatadogMetricsConfig {
     pub request: TowerRequestConfig,
 }
 
+#[derive(Clone, Debug)]
+pub struct ValidatedDatadogMetrics {
+    batcher_settings: BatcherSettings,
+    sketches_batcher_settings: BatcherSettings,
+    request_limits: TowerRequestSettings,
+}
+
 impl_generate_config_from_default!(DatadogMetricsConfig);
 
 #[async_trait::async_trait]
@@ -212,49 +215,37 @@ impl SinkConfig for DatadogMetricsConfig {
     }
 }
 
-#[derive(Clone, Debug)]
-pub struct ValidatedMetrics {
-    batcher_settings: BatcherSettings,
-    sketches_batcher_settings: BatcherSettings,
-}
-
 #[async_trait::async_trait]
 impl ValidatedSink for DatadogMetricsConfig {
-    type Validated = ValidatedMetrics;
+    type Validated = ValidatedDatadogMetrics;
 
-    fn validate(&self) -> crate::Result<ValidatedMetrics> {
+    fn validate(&self) -> crate::Result<Self::Validated> {
         let (batcher_settings, sketches_batcher_settings) =
             resolve_endpoint_batch_settings(self.batch, self.series_api_version)?;
+        let request_limits = self.request.into_settings();
 
-        let site = self
-            .local_dd_common
-            .site
-            .clone()
-            .unwrap_or_else(|| datadog::DD_US_SITE.to_owned());
-        let base = Self::metrics_base_endpoint(self.local_dd_common.endpoint.as_deref(), &site);
-        HttpEndpoint::parse(&base)?;
+        if self.local_dd_common.endpoint.is_some() {
+            self.local_dd_common.validate_endpoint()?;
+        } else if let Some(site) = self.local_dd_common.site.as_deref() {
+            HttpEndpoint::parse(&Self::metrics_base_endpoint(None, site))?;
+        }
 
-        Ok(ValidatedMetrics {
+        Ok(ValidatedDatadogMetrics {
             batcher_settings,
             sketches_batcher_settings,
+            request_limits,
         })
     }
 
     async fn build(
         &self,
-        validated: &ValidatedMetrics,
+        validated: &Self::Validated,
         cx: SinkContext,
     ) -> crate::Result<(VectorSink, Healthcheck)> {
-        let client = self.build_client(&cx.proxy)?;
-        let global = cx.extra_context.get_or_default::<datadog::Options>();
-        let dd_common = self.local_dd_common.with_globals(global)?;
+        let dd_common = self.local_dd_common.with_globals_from(&cx)?;
+        let client = self.local_dd_common.build_client(&cx.proxy, true)?;
         let healthcheck = dd_common.build_healthcheck(client.clone())?;
-        let sink = self.build_sink(
-            &dd_common,
-            client,
-            validated.batcher_settings,
-            validated.sketches_batcher_settings,
-        )?;
+        let sink = self.build_sink(&dd_common, client, validated)?;
 
         Ok((sink, healthcheck))
     }
@@ -295,36 +286,15 @@ impl DatadogMetricsConfig {
         ))
     }
 
-    fn build_client(&self, proxy: &ProxyConfig) -> crate::Result<HttpClient> {
-        let default_tls_config;
-
-        let tls_settings = MaybeTlsSettings::from_config(
-            Some(match self.local_dd_common.tls.as_ref() {
-                Some(config) => config,
-                None => {
-                    default_tls_config = TlsEnableableConfig::enabled();
-                    &default_tls_config
-                }
-            }),
-            false,
-        )?;
-        let client = HttpClient::new(tls_settings, proxy)?;
-        Ok(client)
-    }
-
     fn build_sink(
         &self,
         dd_common: &DatadogCommonConfig,
         client: HttpClient,
-        batcher_settings: BatcherSettings,
-        sketches_batcher_settings: BatcherSettings,
+        validated: &ValidatedDatadogMetrics,
     ) -> crate::Result<VectorSink> {
-        // TODO: revisit our concurrency and batching defaults
-        let request_limits = self.request.into_settings();
-
         let endpoint_configuration = self.generate_metrics_endpoint_configuration(dd_common)?;
         let service = ServiceBuilder::new()
-            .settings(request_limits, DatadogMetricsRetryLogic)
+            .settings(validated.request_limits.clone(), DatadogMetricsRetryLogic)
             .service(DatadogMetricsService::new(
                 client,
                 dd_common.default_api_key.inner(),
@@ -345,8 +315,8 @@ impl DatadogMetricsConfig {
         let sink = DatadogMetricsSink::new(
             service,
             request_builder,
-            batcher_settings,
-            sketches_batcher_settings,
+            validated.batcher_settings,
+            validated.sketches_batcher_settings,
             protocol,
             self.series_api_version,
         );
@@ -405,6 +375,19 @@ mod tests {
             local_dd_common: LocalDatadogCommonConfig::new(
                 Some("not a uri".to_string()),
                 None,
+                None,
+            ),
+            ..Default::default()
+        };
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_malformed_local_site_without_endpoint() {
+        let config = DatadogMetricsConfig {
+            local_dd_common: LocalDatadogCommonConfig::new(
+                None,
+                Some("bad site".to_string()),
                 None,
             ),
             ..Default::default()

--- a/src/sinks/datadog/metrics/tests.rs
+++ b/src/sinks/datadog/metrics/tests.rs
@@ -19,6 +19,20 @@ use crate::{
 };
 
 #[tokio::test]
+async fn pure_validation_does_not_load_tls_files_but_full_build_does() {
+    let config = indoc! {r#"
+        default_api_key = "local-key"
+        tls.enabled = true
+        tls.ca_file = "/definitely/missing/vector-datadog-ca.pem"
+    "#};
+    let (config, cx) =
+        load_sink_with_context::<DatadogMetricsConfig>(config, SinkContext::default()).unwrap();
+
+    assert!(crate::config::ValidatedSink::validate(&config).is_ok());
+    assert!(config.build(cx).await.is_err());
+}
+
+#[tokio::test]
 async fn global_options() {
     let config = "";
     let cx = SinkContext {

--- a/src/sinks/datadog/mod.rs
+++ b/src/sinks/datadog/mod.rs
@@ -3,8 +3,10 @@ use http::{Request, StatusCode, Uri};
 use hyper::{body::Body, client::connect::Connect};
 use snafu::Snafu;
 use vector_lib::{
-    config::AcknowledgementsConfig, configurable::configurable_component,
-    sensitive_string::SensitiveString, tls::TlsEnableableConfig,
+    config::{AcknowledgementsConfig, proxy::ProxyConfig},
+    configurable::configurable_component,
+    sensitive_string::SensitiveString,
+    tls::{MaybeTlsSettings, TlsEnableableConfig},
 };
 
 use super::Healthcheck;
@@ -102,6 +104,13 @@ impl LocalDatadogCommonConfig {
         }
     }
 
+    pub fn with_globals_from(
+        &self,
+        cx: &crate::config::SinkContext,
+    ) -> Result<DatadogCommonConfig, ConfigurationError> {
+        self.with_globals(cx.extra_context.get_or_default::<datadog::Options>())
+    }
+
     pub fn with_globals(
         &self,
         config: datadog::Options,
@@ -116,6 +125,36 @@ impl LocalDatadogCommonConfig {
                 .ok_or(ConfigurationError::ApiKeyRequired)?,
             acknowledgements: self.acknowledgements,
         })
+    }
+
+    pub fn validate_endpoint(&self) -> crate::Result<()> {
+        if let Some(endpoint) = &self.endpoint {
+            HttpEndpoint::parse(endpoint)?;
+        }
+
+        Ok(())
+    }
+
+    pub fn validate_endpoint_with_path(&self, path: &str) -> crate::Result<()> {
+        if let Some(endpoint) = &self.endpoint {
+            HttpEndpoint::parse(endpoint)?.append_path(path)?;
+        }
+
+        Ok(())
+    }
+
+    pub fn build_client(
+        &self,
+        proxy: &ProxyConfig,
+        default_tls: bool,
+    ) -> crate::Result<HttpClient> {
+        let tls = match (self.tls.as_ref(), default_tls) {
+            (Some(config), _) => MaybeTlsSettings::from_config(Some(config), false)?,
+            (None, true) => MaybeTlsSettings::enable_client()?,
+            (None, false) => MaybeTlsSettings::from_config(None, false)?,
+        };
+
+        Ok(HttpClient::new(tls, proxy)?)
     }
 }
 

--- a/src/sinks/datadog/traces/apm_stats/flusher.rs
+++ b/src/sinks/datadog/traces/apm_stats/flusher.rs
@@ -19,9 +19,9 @@ use crate::{
     sinks::util::{Compression, Compressor},
 };
 
-/// Flushes cached APM stats buckets to Datadog on a 10 second interval.
-/// When the sink signals this thread that it is shutting down, all remaining
-/// buckets are flush before the thread exits.
+/// Polls cached APM stats buckets and flushes them to Datadog on a 10 second interval.
+/// When the sink signals shutdown, all remaining buckets are force-flushed before this future
+/// acknowledges shutdown and completes.
 ///
 /// # arguments
 ///
@@ -30,7 +30,7 @@ use crate::{
 /// * `compression`              - Compression to use when creating the HTTP requests.
 /// * `endpoint_configuration`   - Endpoint configuration to use when creating the HTTP requests.
 /// * `aggregator`               - The Aggregator object containing cached stats buckets.
-pub async fn flush_apm_stats_thread(
+pub async fn flush_apm_stats(
     mut tripwire: Receiver<Sender<()>>,
     client: HttpClient,
     compression: Compression,
@@ -48,7 +48,7 @@ pub async fn flush_apm_stats_thread(
     let mut interval =
         tokio::time::interval(std::time::Duration::from_nanos(BUCKET_DURATION_NANOSECONDS));
 
-    debug!("Starting APM stats flushing thread.");
+    debug!("Starting APM stats flusher.");
 
     loop {
         tokio::select! {
@@ -61,10 +61,9 @@ pub async fn flush_apm_stats_thread(
             // sink has signaled us that the process is shutting down
             Ok(sink_shutdown_ack_sender) => {
 
-                debug!("APM stats flushing thread received exit condition. Flushing remaining stats before exiting.");
+                debug!("APM stats flusher received shutdown. Flushing remaining stats before completing.");
                 sender.flush_apm_stats(true).await;
 
-                // signal the sink (who tripped the tripwire), that we are done flushing
                 _ = sink_shutdown_ack_sender.send(());
                 break;
             }

--- a/src/sinks/datadog/traces/apm_stats/mod.rs
+++ b/src/sinks/datadog/traces/apm_stats/mod.rs
@@ -10,7 +10,7 @@ use std::sync::{Arc, Mutex};
 use serde::{Deserialize, Serialize};
 use vector_lib::event::TraceEvent;
 
-pub use self::{aggregation::Aggregator, flusher::flush_apm_stats_thread};
+pub use self::{aggregation::Aggregator, flusher::flush_apm_stats};
 pub(crate) use super::{
     config::{DatadogTracesEndpoint, DatadogTracesEndpointConfiguration},
     request_builder::{DDTracesMetadata, RequestBuilderError, build_request},

--- a/src/sinks/datadog/traces/config.rs
+++ b/src/sinks/datadog/traces/config.rs
@@ -1,20 +1,16 @@
 use std::sync::{Arc, Mutex};
 
+use futures_util::FutureExt;
 use indoc::indoc;
 use tokio::sync::oneshot::{Sender, channel};
 use tower::ServiceBuilder;
-use vector_lib::{
-    config::{AcknowledgementsConfig, proxy::ProxyConfig},
-    configurable::configurable_component,
-    stream::BatcherSettings,
-};
+use vector_lib::{config::AcknowledgementsConfig, configurable::configurable_component};
 
 use super::{
-    apm_stats::{Aggregator, flush_apm_stats_thread},
+    apm_stats::{Aggregator, flush_apm_stats},
     service::TraceApiRetry,
 };
 use crate::{
-    common::datadog,
     config::{DynValidatedSink, GenerateConfig, Input, SinkConfig, SinkContext, ValidatedSink},
     http::HttpClient,
     sinks::{
@@ -28,10 +24,9 @@ use crate::{
         },
         util::{
             BatchConfig, Compression, HttpEndpoint, SinkBatchSettings, TowerRequestConfig,
-            service::ServiceBuilderExt,
+            TowerRequestSettings, service::ServiceBuilderExt,
         },
     },
-    tls::{MaybeTlsSettings, TlsEnableableConfig},
 };
 
 // The Datadog API has a hard limit of 3.2MB for uncompressed payloads.
@@ -71,6 +66,12 @@ pub struct DatadogTracesConfig {
     #[configurable(derived)]
     #[serde(default)]
     pub request: TowerRequestConfig,
+}
+
+#[derive(Clone, Debug)]
+pub struct ValidatedDatadogTraces {
+    batcher_settings: vector_lib::stream::BatcherSettings,
+    request_limits: TowerRequestSettings,
 }
 
 impl GenerateConfig for DatadogTracesConfig {
@@ -132,14 +133,13 @@ impl DatadogTracesConfig {
         &self,
         dd_common: &DatadogCommonConfig,
         client: HttpClient,
-        batcher_settings: BatcherSettings,
+        validated: &ValidatedDatadogTraces,
     ) -> crate::Result<VectorSink> {
         let default_api_key: Arc<str> = Arc::from(dd_common.default_api_key.inner());
-        let request_limits = self.request.into_settings();
         let endpoints = self.generate_traces_endpoint_configuration(dd_common)?;
 
         let service = ServiceBuilder::new()
-            .settings(request_limits, TraceApiRetry)
+            .settings(validated.request_limits.clone(), TraceApiRetry)
             .service(TraceApiService::new(client.clone()));
 
         // Object responsible for caching/processing APM stats from incoming trace events.
@@ -157,45 +157,30 @@ impl DatadogTracesConfig {
         )?;
 
         // shutdown= Sender that the sink signals when input stream is exhausted.
-        // tripwire= Receiver that APM stats flush thread listens for exit signal on.
+        // tripwire= Receiver that the APM stats flusher listens for the exit signal on.
         let (shutdown, tripwire) = channel::<Sender<()>>();
 
-        let sink = TracesSink::new(
-            service,
-            request_builder,
-            batcher_settings,
-            shutdown,
-            endpoints.traces_endpoint.protocol().to_string(),
-        );
-
-        // Send the APM stats payloads independently of the sink framework.
-        // This is necessary to comply with what the APM stats backend of Datadog expects with
-        // respect to receiving stats payloads.
-        crate::spawn_in_current_span(flush_apm_stats_thread(
+        // Construct the APM stats flusher here; `TracesSink::run` drives it so build spawns no task.
+        let protocol = endpoints.traces_endpoint.protocol().to_string();
+        let flusher = flush_apm_stats(
             tripwire,
             client,
             compression,
             endpoints,
             Arc::clone(&apm_stats_aggregator),
-        ));
+        )
+        .boxed();
+
+        let sink = TracesSink::new(
+            service,
+            request_builder,
+            validated.batcher_settings,
+            shutdown,
+            protocol,
+            flusher,
+        );
 
         Ok(VectorSink::from_event_streamsink(sink))
-    }
-
-    pub fn build_client(&self, proxy: &ProxyConfig) -> crate::Result<HttpClient> {
-        let default_tls_config;
-
-        let tls_settings = MaybeTlsSettings::from_config(
-            Some(match self.local_dd_common.tls.as_ref() {
-                Some(config) => config,
-                None => {
-                    default_tls_config = TlsEnableableConfig::enabled();
-                    &default_tls_config
-                }
-            }),
-            false,
-        )?;
-        Ok(HttpClient::new(tls_settings, proxy)?)
     }
 }
 
@@ -215,16 +200,17 @@ impl SinkConfig for DatadogTracesConfig {
     }
 }
 
-#[derive(Clone, Debug)]
-pub struct ValidatedTraces {
-    batcher_settings: BatcherSettings,
-}
-
 #[async_trait::async_trait]
 impl ValidatedSink for DatadogTracesConfig {
-    type Validated = ValidatedTraces;
+    type Validated = ValidatedDatadogTraces;
 
-    fn validate(&self) -> crate::Result<ValidatedTraces> {
+    fn validate(&self) -> crate::Result<Self::Validated> {
+        if self.local_dd_common.endpoint.is_some() {
+            self.local_dd_common.validate_endpoint()?;
+        } else if let Some(site) = self.local_dd_common.site.as_deref() {
+            HttpEndpoint::parse(&Self::traces_base_endpoint(None, site))?;
+        }
+
         let batcher_settings = self
             .batch
             .validate()?
@@ -232,27 +218,21 @@ impl ValidatedSink for DatadogTracesConfig {
             .limit_max_events(BATCH_MAX_EVENTS)?
             .into_batcher_settings()?;
 
-        let site = self
-            .local_dd_common
-            .site
-            .clone()
-            .unwrap_or_else(|| datadog::DD_US_SITE.to_owned());
-        let base = Self::traces_base_endpoint(self.local_dd_common.endpoint.as_deref(), &site);
-        HttpEndpoint::parse(&base)?;
-
-        Ok(ValidatedTraces { batcher_settings })
+        Ok(ValidatedDatadogTraces {
+            batcher_settings,
+            request_limits: self.request.into_settings(),
+        })
     }
 
     async fn build(
         &self,
-        validated: &ValidatedTraces,
+        validated: &Self::Validated,
         cx: SinkContext,
     ) -> crate::Result<(VectorSink, Healthcheck)> {
-        let client = self.build_client(&cx.proxy)?;
-        let global = cx.extra_context.get_or_default::<datadog::Options>();
-        let dd_common = self.local_dd_common.with_globals(global)?;
+        let dd_common = self.local_dd_common.with_globals_from(&cx)?;
+        let client = self.local_dd_common.build_client(&cx.proxy, true)?;
         let healthcheck = dd_common.build_healthcheck(client.clone())?;
-        let sink = self.build_sink(&dd_common, client, validated.batcher_settings)?;
+        let sink = self.build_sink(&dd_common, client, validated)?;
 
         Ok((sink, healthcheck))
     }
@@ -286,6 +266,19 @@ mod test {
             local_dd_common: LocalDatadogCommonConfig::new(
                 Some("not a uri".to_string()),
                 None,
+                None,
+            ),
+            ..Default::default()
+        };
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_malformed_local_site_without_endpoint() {
+        let config = DatadogTracesConfig {
+            local_dd_common: LocalDatadogCommonConfig::new(
+                None,
+                Some("bad site".to_string()),
                 None,
             ),
             ..Default::default()

--- a/src/sinks/datadog/traces/request_builder.rs
+++ b/src/sinks/datadog/traces/request_builder.rs
@@ -115,7 +115,7 @@ impl IncrementalRequestBuilder<(PartitionKey, Vec<Event>)> for DatadogTracesRequ
             .collect::<Vec<TraceEvent>>();
 
         // Compute APM stats from the incoming events. The stats payloads are sent out
-        // separately from the sink framework, by the thread `flush_apm_stats_thread()`
+        // separately from the sink framework, by the flusher future `flush_apm_stats()`
         compute_apm_stats(&key, Arc::clone(&self.stats_aggregator), &trace_events);
 
         encode_traces(&key, trace_events, self.max_size)

--- a/src/sinks/datadog/traces/sink.rs
+++ b/src/sinks/datadog/traces/sink.rs
@@ -1,8 +1,9 @@
-use std::{fmt::Debug, sync::Arc};
+use std::{fmt::Debug, future::Future, sync::Arc, time::Duration};
 
 use async_trait::async_trait;
 use futures_util::{
     StreamExt,
+    future::BoxFuture,
     stream::{self, BoxStream},
 };
 use tokio::sync::oneshot::{Sender, channel};
@@ -79,6 +80,63 @@ pub struct TracesSink<S> {
     batch_settings: BatcherSettings,
     shutdown: Sender<Sender<()>>,
     protocol: String,
+    flusher: BoxFuture<'static, ()>,
+}
+
+const APM_FLUSH_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Runs the event driver and APM flusher with structured shutdown coordination.
+///
+/// Waits for the final flush acknowledgement even if the driver fails. Dropping this future drops
+/// both child futures. The acknowledgement confirms a flush attempt, not Datadog delivery.
+async fn run_driver_and_flusher<D, F>(
+    driver: D,
+    shutdown: Sender<Sender<()>>,
+    flusher: F,
+) -> Result<(), ()>
+where
+    D: Future<Output = Result<(), ()>>,
+    F: Future<Output = ()>,
+{
+    run_driver_and_flusher_with_timeout(driver, shutdown, flusher, APM_FLUSH_SHUTDOWN_TIMEOUT).await
+}
+
+async fn run_driver_and_flusher_with_timeout<D, F>(
+    driver: D,
+    shutdown: Sender<Sender<()>>,
+    flusher: F,
+    shutdown_timeout: Duration,
+) -> Result<(), ()>
+where
+    D: Future<Output = Result<(), ()>>,
+    F: Future<Output = ()>,
+{
+    tokio::pin!(driver);
+    tokio::pin!(flusher);
+
+    let driver_result = tokio::select! {
+        result = &mut driver => result,
+        () = &mut flusher => return Err(()),
+    };
+
+    let (sender, receiver) = channel();
+    _ = shutdown.send(sender);
+    tokio::pin!(receiver);
+
+    let ack_result = tokio::select! {
+        result = &mut receiver => result.map_err(|_| ()),
+        () = &mut flusher => (&mut receiver).await.map_err(|_| ()),
+        _ = tokio::time::sleep(shutdown_timeout) => {
+            warn!(
+                message = "Timed out waiting for the Datadog APM stats flusher during shutdown.",
+                timeout = ?shutdown_timeout,
+            );
+            Err(())
+        }
+    };
+
+    // Preserve the existing contract: a missing acknowledgement fails an otherwise successful driver.
+    driver_result.and(ack_result)
 }
 
 impl<S> TracesSink<S>
@@ -88,12 +146,13 @@ where
     S::Future: Send + 'static,
     S::Response: DriverResponse,
 {
-    pub const fn new(
+    pub fn new(
         service: S,
         request_builder: DatadogTracesRequestBuilder,
         batch_settings: BatcherSettings,
         shutdown: Sender<Sender<()>>,
         protocol: String,
+        flusher: BoxFuture<'static, ()>,
     ) -> Self {
         TracesSink {
             service,
@@ -101,49 +160,48 @@ where
             batch_settings,
             shutdown,
             protocol,
+            flusher,
         }
     }
 
     async fn run_inner(self: Box<Self>, input: BoxStream<'_, Event>) -> Result<(), ()> {
-        let batch_settings = self.batch_settings;
+        let TracesSink {
+            service,
+            request_builder,
+            batch_settings,
+            shutdown,
+            protocol,
+            flusher,
+        } = *self;
 
-        input
-            .batched_partitioned(EventPartitioner, batch_settings.timeout, |_| {
-                batch_settings.as_byte_size_config()
-            })
-            .incremental_request_builder(self.request_builder)
-            .flat_map(stream::iter)
-            .filter_map(|request| async move {
-                match request {
-                    Err(e) => {
-                        let (error_message, error_reason, dropped_events) = e.into_parts();
-                        emit!(DatadogTracesEncodingError {
-                            error_message,
-                            error_reason,
-                            dropped_events: dropped_events as usize,
-                        });
-                        None
+        let driver = async move {
+            input
+                .batched_partitioned(EventPartitioner, batch_settings.timeout, |_| {
+                    batch_settings.as_byte_size_config()
+                })
+                .incremental_request_builder(request_builder)
+                .flat_map(stream::iter)
+                .filter_map(|request| async move {
+                    match request {
+                        Err(e) => {
+                            let (error_message, error_reason, dropped_events) = e.into_parts();
+                            emit!(DatadogTracesEncodingError {
+                                error_message,
+                                error_reason,
+                                dropped_events: dropped_events as usize,
+                            });
+                            None
+                        }
+                        Ok(req) => Some(req),
                     }
-                    Ok(req) => Some(req),
-                }
-            })
-            .into_driver(self.service)
-            .protocol(self.protocol)
-            .run()
-            .await?;
+                })
+                .into_driver(service)
+                .protocol(protocol)
+                .run()
+                .await
+        };
 
-        // Create a channel for the stats flushing thread to communicate back that it has flushed
-        // remaining stats. This is necessary so that we do not terminate the process while the
-        // stats flushing thread is trying to complete the HTTP request.
-        let (sender, receiver) = channel();
-
-        // Signal the stats thread task to flush remaining payloads and shutdown.
-        _ = self.shutdown.send(sender);
-
-        // The stats flushing thread has until the component shutdown grace period to end
-        // gracefully. Otherwise the sink + stats flushing thread will be killed and an error
-        // reported upstream.
-        receiver.await.map_err(|_| ())
+        run_driver_and_flusher(driver, shutdown, flusher).await
     }
 }
 
@@ -157,5 +215,173 @@ where
 {
     async fn run(self: Box<Self>, input: BoxStream<'_, Event>) -> Result<(), ()> {
         self.run_inner(input).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        future::Future,
+        sync::{
+            Arc,
+            atomic::{AtomicBool, Ordering},
+        },
+        task::{Context, Poll},
+        time::Duration,
+    };
+
+    use futures_util::task::noop_waker_ref;
+    use tokio::sync::oneshot;
+
+    use super::{
+        APM_FLUSH_SHUTDOWN_TIMEOUT, run_driver_and_flusher, run_driver_and_flusher_with_timeout,
+    };
+
+    async fn run_coordination_case(driver_result: Result<(), ()>) -> (Result<(), ()>, bool) {
+        let (shutdown, shutdown_receiver) = oneshot::channel::<oneshot::Sender<()>>();
+        let (force_flush, force_flush_observed) = oneshot::channel();
+        let (allow_ack, allow_ack_receiver) = oneshot::channel();
+        let flusher = async move {
+            let ack = shutdown_receiver.await.expect("shutdown signal");
+            force_flush.send(()).expect("force flush marker receiver");
+            allow_ack_receiver.await.expect("ack release");
+            ack.send(()).expect("shutdown ack receiver");
+        };
+
+        let coordination = tokio::spawn(run_driver_and_flusher(
+            async move { driver_result },
+            shutdown,
+            flusher,
+        ));
+        let force_flush_observed = force_flush_observed.await.is_ok();
+        assert!(!coordination.is_finished());
+        allow_ack.send(()).expect("ack release receiver");
+
+        let result = coordination.await.expect("coordination task");
+        (result, force_flush_observed)
+    }
+
+    #[tokio::test]
+    async fn driver_error_waits_for_force_flush_and_ack() {
+        let (result, force_flush_observed) = run_coordination_case(Err(())).await;
+
+        assert_eq!(result, Err(()));
+        assert!(force_flush_observed);
+    }
+
+    #[tokio::test]
+    async fn normal_driver_waits_for_force_flush_and_ack() {
+        let (result, force_flush_observed) = run_coordination_case(Ok(())).await;
+
+        assert_eq!(result, Ok(()));
+        assert!(force_flush_observed);
+    }
+
+    #[tokio::test]
+    async fn missing_shutdown_ack_fails_coordination() {
+        let (shutdown, shutdown_receiver) = oneshot::channel::<oneshot::Sender<()>>();
+        let flusher = async move {
+            shutdown_receiver.await.expect("shutdown signal");
+        };
+
+        let result = run_driver_and_flusher_with_timeout(
+            async { Ok(()) },
+            shutdown,
+            flusher,
+            Duration::from_secs(1),
+        )
+        .await;
+
+        assert_eq!(result, Err(()));
+    }
+
+    struct DropFlag(Arc<AtomicBool>);
+
+    impl Drop for DropFlag {
+        fn drop(&mut self) {
+            self.0.store(true, Ordering::SeqCst);
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn shutdown_timeout_cancels_stuck_flusher_and_reports_coordination_failure() {
+        let (shutdown, shutdown_receiver) = oneshot::channel::<oneshot::Sender<()>>();
+        let (shutdown_observed, shutdown_observed_receiver) = oneshot::channel();
+        let flusher_dropped = Arc::new(AtomicBool::new(false));
+        let flusher_dropped_clone = Arc::clone(&flusher_dropped);
+        let flusher = async move {
+            let _drop_flag = DropFlag(flusher_dropped_clone);
+            let _ack = shutdown_receiver.await.expect("shutdown signal");
+            shutdown_observed
+                .send(())
+                .expect("shutdown observer receiver");
+            std::future::pending::<()>().await;
+        };
+
+        let coordination = tokio::spawn(run_driver_and_flusher_with_timeout(
+            async { Ok(()) },
+            shutdown,
+            flusher,
+            APM_FLUSH_SHUTDOWN_TIMEOUT,
+        ));
+
+        shutdown_observed_receiver
+            .await
+            .expect("flusher should observe shutdown");
+        tokio::time::advance(APM_FLUSH_SHUTDOWN_TIMEOUT + Duration::from_secs(1)).await;
+
+        assert_eq!(coordination.await.expect("coordination task"), Err(()));
+        assert!(flusher_dropped.load(Ordering::SeqCst));
+    }
+
+    struct PendingDriver(Arc<AtomicBool>);
+
+    impl Future for PendingDriver {
+        type Output = Result<(), ()>;
+
+        fn poll(self: std::pin::Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Self::Output> {
+            Poll::Pending
+        }
+    }
+
+    impl Drop for PendingDriver {
+        fn drop(&mut self) {
+            self.0.store(true, Ordering::SeqCst);
+        }
+    }
+
+    struct PendingFlusher(Arc<AtomicBool>);
+
+    impl Future for PendingFlusher {
+        type Output = ();
+
+        fn poll(self: std::pin::Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Self::Output> {
+            Poll::Pending
+        }
+    }
+
+    impl Drop for PendingFlusher {
+        fn drop(&mut self) {
+            self.0.store(true, Ordering::SeqCst);
+        }
+    }
+
+    #[test]
+    fn dropping_coordination_future_drops_child_futures() {
+        let (shutdown, _shutdown_receiver) = oneshot::channel();
+        let driver_dropped = Arc::new(AtomicBool::new(false));
+        let flusher_dropped = Arc::new(AtomicBool::new(false));
+        let mut coordination = Box::pin(run_driver_and_flusher(
+            PendingDriver(Arc::clone(&driver_dropped)),
+            shutdown,
+            PendingFlusher(Arc::clone(&flusher_dropped)),
+        ));
+        let mut context = Context::from_waker(noop_waker_ref());
+
+        assert!(coordination.as_mut().poll(&mut context).is_pending());
+        drop(coordination);
+
+        assert!(driver_dropped.load(Ordering::SeqCst));
+        assert!(flusher_dropped.load(Ordering::SeqCst));
     }
 }

--- a/src/sinks/datadog/traces/tests.rs
+++ b/src/sinks/datadog/traces/tests.rs
@@ -122,6 +122,42 @@ fn validate_simple_span(span: dd_proto::Span, resource: String) {
     assert_eq!(span.metrics["a_metric"], 0.577);
 }
 
+#[tokio::test(flavor = "current_thread")]
+async fn build_does_not_spawn_tasks() {
+    let config = indoc! {r#"
+        default_api_key = "atoken"
+        compression = "none"
+        endpoint = "http://127.0.0.1:1"
+        tls.enabled = false
+    "#};
+    let (config, cx) = load_sink::<DatadogTracesConfig>(config).unwrap();
+
+    let metrics = tokio::runtime::Handle::current().metrics();
+    let alive_before = metrics.num_alive_tasks();
+
+    // Building the sink must not spawn any background task; the APM stats flusher is
+    // driven by `TracesSink::run` instead, so a built-but-never-run sink (config
+    // validation, rolled-back reload) leaves nothing behind.
+    let built = config.build(cx).await.unwrap();
+    assert_eq!(metrics.num_alive_tasks(), alive_before);
+
+    drop(built);
+    assert_eq!(metrics.num_alive_tasks(), alive_before);
+}
+
+#[tokio::test]
+async fn pure_validation_does_not_load_tls_files_but_full_build_does() {
+    let config = indoc! {r#"
+        default_api_key = "local-key"
+        tls.enabled = true
+        tls.ca_file = "/definitely/missing/vector-datadog-ca.pem"
+    "#};
+    let (config, cx) = load_sink::<DatadogTracesConfig>(config).unwrap();
+
+    assert!(crate::config::ValidatedSink::validate(&config).is_ok());
+    assert!(config.build(cx).await.is_err());
+}
+
 #[tokio::test]
 async fn smoke() {
     let mut t = simple_trace_event("a_resource".to_string());


### PR DESCRIPTION
## Summary

Separate Datadog sink configuration validation from runtime construction.

In restricted environments such as CI, containers, and AI coding-agent sandboxes,
`vector validate --no-environment` is expected to validate structural configuration
without opening outbound connections or initializing runtime resources such as native
TLS trust stores.

Previously, Datadog sink validation could reach runtime client/TLS construction even
when no outbound request was made. In restricted sandbox environments, the macOS
Keychain may be unavailable; attempting to load native root certificates through it
caused validation to panic.

This PR makes the boundary explicit:

- Move configuration-only validation for the Datadog logs, metrics, events, and
  traces sinks into `ValidatedSink::validate`.
- Keep client, proxy, TLS, global Datadog option, and effective endpoint construction
  in the runtime build path.
- Move the APM stats flusher from a build-time detached task into the
  `TracesSink::run` lifecycle.
  - Request a final flush after both successful and failed trace drivers.
  - Bound shutdown acknowledgement waiting to 10 seconds so a stuck endpoint cannot
    delay shutdown indefinitely.
- Avoid unnecessary native certificate-store initialization when certificate
  verification is disabled.
- Consolidate shared Datadog endpoint, TLS, and client construction logic to reduce
  sink-specific validation/build drift.

Regular `vector validate` continues to build all sinks and remains the validation
mode for errors that require effective runtime construction. `--no-environment`
intentionally does not guarantee detection of every runtime construction error.

The APM flusher acknowledgement confirms that the final flush was attempted; it does
not guarantee that Datadog accepted the payload.

### References

N/A

## Vector configuration

No new user configuration was added. Unit tests cover the Datadog logs, metrics,
events, and traces sinks with their existing inline configurations and custom
endpoints.

## How did you test this PR?

- `cargo test -p vector --lib datadog`
- `cargo test -p vector-core tls::settings::test`
- `cargo test -p vector --lib sinks::datadog::traces::sink::tests`
- `cargo check -p vector --lib`
- `make check-clippy`
- `cargo fmt --all -- --check`
- `make check-changelog-fragments`

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [x] Yes. A changelog fragment will be added in a follow-up commit after the PR number is assigned.
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.