### PR TITLE
feat(gcp sinks): validate config at compile time

### DIFF
--- a/src/sinks/gcp/cloud_storage.rs
+++ b/src/sinks/gcp/cloud_storage.rs
@@ -13,11 +13,15 @@ use vector_lib::{
     configurable::configurable_component,
     event::{EventFinalizers, Finalizable},
     request_metadata::RequestMetadata,
+    stream::BatcherSettings,
 };
 
 use crate::{
     codecs::{Encoder, EncodingConfigWithFraming, SinkType, Transformer},
-    config::{AcknowledgementsConfig, DataType, GenerateConfig, Input, SinkConfig, SinkContext},
+    config::{
+        AcknowledgementsConfig, DataType, DynValidatedSink, GenerateConfig, Input, SinkConfig,
+        SinkContext, ValidatedSink,
+    },
     event::Event,
     gcp::{GcpAuthConfig, GcpAuthenticator, Scope},
     http::{HttpClient, get_http_scheme_from_uri},
@@ -39,7 +43,7 @@ use crate::{
             request_builder::EncodeResult, service::TowerRequestConfigDefaults, timezone_to_offset,
         },
     },
-    template::{ConfinementConfig, Template, TemplateParseError},
+    template::{ConfinedTemplate, ConfinementConfig, Template, TemplateParseError},
     tls::{TlsConfig, TlsSettings},
 };
 
@@ -262,22 +266,6 @@ impl GenerateConfig for GcsSinkConfig {
 #[async_trait::async_trait]
 #[typetag::serde(name = "gcp_cloud_storage")]
 impl SinkConfig for GcsSinkConfig {
-    async fn build(&self, cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
-        let auth = self.auth.build(Scope::DevStorageReadWrite).await?;
-        let base_url = self.endpoint.append_path(&format!("{}/", self.bucket))?;
-        let tls = TlsSettings::from_options(self.tls.as_ref())?;
-        let client = HttpClient::new(tls, cx.proxy())?;
-        let healthcheck = build_healthcheck(
-            self.bucket.clone(),
-            client.clone(),
-            base_url.clone(),
-            auth.clone(),
-        )?;
-        auth.spawn_regenerate_token();
-        let sink = self.build_sink(client, base_url, auth, cx)?;
-        Ok((sink, healthcheck))
-    }
-
     fn confinement_config(&self) -> Option<&crate::template::ConfinementConfig> {
         Some(&self.confinement)
     }
@@ -289,6 +277,55 @@ impl SinkConfig for GcsSinkConfig {
     fn acknowledgements(&self) -> &AcknowledgementsConfig {
         &self.acknowledgements
     }
+
+    fn as_dyn_validated(&self) -> Option<&dyn DynValidatedSink> {
+        Some(self)
+    }
+}
+
+#[async_trait::async_trait]
+impl ValidatedSink for GcsSinkConfig {
+    type Validated = ValidatedGcsSink;
+
+    fn validate(&self) -> crate::Result<ValidatedGcsSink> {
+        let base_url = self.endpoint.append_path(&format!("{}/", self.bucket))?;
+        let batch_settings = self.batch.into_batcher_settings()?;
+        let key_prefix_template = self.key_prefix_template()?;
+
+        Ok(ValidatedGcsSink {
+            base_url,
+            batch_settings,
+            key_prefix_template,
+        })
+    }
+
+    async fn build(
+        &self,
+        validated: &ValidatedGcsSink,
+        cx: SinkContext,
+    ) -> crate::Result<(VectorSink, Healthcheck)> {
+        let ValidatedGcsSink { base_url, .. } = validated;
+
+        let auth = self.auth.build(Scope::DevStorageReadWrite).await?;
+        let tls = TlsSettings::from_options(self.tls.as_ref())?;
+        let client = HttpClient::new(tls, cx.proxy())?;
+        let healthcheck = build_healthcheck(
+            self.bucket.clone(),
+            client.clone(),
+            base_url.clone(),
+            auth.clone(),
+        )?;
+        auth.spawn_regenerate_token();
+        let sink = self.build_sink(client, base_url.clone(), auth, cx, validated)?;
+        Ok((sink, healthcheck))
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ValidatedGcsSink {
+    base_url: HttpEndpoint,
+    batch_settings: BatcherSettings,
+    key_prefix_template: ConfinedTemplate,
 }
 
 impl GcsSinkConfig {
@@ -298,12 +335,11 @@ impl GcsSinkConfig {
         base_url: HttpEndpoint,
         auth: GcpAuthenticator,
         cx: SinkContext,
+        validated: &ValidatedGcsSink,
     ) -> crate::Result<VectorSink> {
         let request = self.request.into_settings();
 
-        let batch_settings = self.batch.into_batcher_settings()?;
-
-        let partitioner = self.key_partitioner()?;
+        let partitioner = KeyPartitioner::new(validated.key_prefix_template.clone(), None);
 
         let protocol = get_http_scheme_from_uri(base_url.as_uri());
 
@@ -313,16 +349,27 @@ impl GcsSinkConfig {
 
         let request_settings = RequestSettings::new(self, cx)?;
 
-        let sink = GcsSink::new(svc, request_settings, partitioner, batch_settings, protocol);
+        let sink = GcsSink::new(
+            svc,
+            request_settings,
+            partitioner,
+            validated.batch_settings,
+            protocol,
+        );
 
         Ok(VectorSink::from_event_streamsink(sink))
     }
 
+    #[cfg(test)]
     fn key_partitioner(&self) -> crate::Result<KeyPartitioner> {
+        let tpl = self.key_prefix_template()?;
+        Ok(KeyPartitioner::new(tpl, None))
+    }
+
+    fn key_prefix_template(&self) -> crate::Result<ConfinedTemplate> {
         let tpl = Template::try_from(self.key_prefix.as_deref().unwrap_or("date=%F/"))
             .context(KeyPrefixTemplateSnafu)?;
-        let tpl = tpl.confine(&self.confinement, Self::NAME, "key_prefix")?;
-        Ok(KeyPartitioner::new(tpl, None))
+        tpl.confine(&self.confinement, Self::NAME, "key_prefix")
     }
 }
 
@@ -518,6 +565,25 @@ mod tests {
         crate::test_util::test_generate_config::<GcsSinkConfig>();
     }
 
+    #[test]
+    fn validate_produces_usable_values() {
+        use crate::config::ValidatedSink;
+
+        let config = GcsSinkConfig {
+            bucket: "my-bucket".into(),
+            key_prefix: Some("date=%F/".into()),
+            endpoint: HttpEndpoint::parse("https://storage.googleapis.com")
+                .expect("valid endpoint"),
+            ..default_config((None::<FramingConfig>, TextSerializerConfig::default()).into())
+        };
+        let validated = config.validate().expect("validation should succeed");
+        assert_eq!(
+            validated.base_url.to_string(),
+            "https://storage.googleapis.com/my-bucket/"
+        );
+        assert_eq!(validated.key_prefix_template.to_string(), "date=%F/");
+    }
+
     #[tokio::test]
     async fn component_spec_compliance() {
         let mock_endpoint = spawn_blackhole_http_server(always_200_response).await;
@@ -528,14 +594,18 @@ mod tests {
         let client =
             HttpClient::new(tls, context.proxy()).expect("should not fail to create HTTP client");
 
-        let config =
-            default_config((None::<FramingConfig>, JsonSerializerConfig::default()).into());
+        let config = GcsSinkConfig {
+            endpoint: HttpEndpoint::parse(&mock_endpoint.to_string()).expect("valid mock endpoint"),
+            ..default_config((None::<FramingConfig>, JsonSerializerConfig::default()).into())
+        };
+        let validated = config.validate().expect("validation should succeed");
         let sink = config
             .build_sink(
                 client,
                 HttpEndpoint::parse(&mock_endpoint.to_string()).expect("valid mock endpoint"),
                 GcpAuthenticator::None,
                 context,
+                &validated,
             )
             .expect("failed to build sink");
 

--- a/src/sinks/gcp/pubsub.rs
+++ b/src/sinks/gcp/pubsub.rs
@@ -11,7 +11,10 @@ use vector_lib::configurable::configurable_component;
 
 use crate::{
     codecs::{Encoder, EncodingConfig, Transformer},
-    config::{AcknowledgementsConfig, GenerateConfig, Input, SinkConfig, SinkContext},
+    config::{
+        AcknowledgementsConfig, DynValidatedSink, GenerateConfig, Input, SinkConfig, SinkContext,
+        ValidatedSink,
+    },
     event::Event,
     gcp::{GcpAuthConfig, GcpAuthenticator, PUBSUB_URL, Scope},
     http::HttpClient,
@@ -19,8 +22,8 @@ use crate::{
         Healthcheck, VectorSink,
         gcs_common::config::healthcheck_response,
         util::{
-            BatchConfig, BoxedRawValue, HttpEndpoint, JsonArrayBuffer, SinkBatchSettings,
-            TowerRequestConfig,
+            BatchConfig, BatchSettings, BoxedRawValue, HttpEndpoint, JsonArrayBuffer,
+            SinkBatchSettings, TowerRequestConfig,
             http::{BatchedHttpSink, HttpEventEncoder, HttpSink},
         },
     },
@@ -118,13 +121,68 @@ impl GenerateConfig for PubsubConfig {
 #[async_trait::async_trait]
 #[typetag::serde(name = "gcp_pubsub")]
 impl SinkConfig for PubsubConfig {
-    async fn build(&self, cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
-        let sink = PubsubSink::from_config(self).await?;
+    fn input(&self) -> Input {
+        Input::new(self.encoding.config().input_type())
+    }
+
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &self.acknowledgements
+    }
+
+    fn as_dyn_validated(&self) -> Option<&dyn DynValidatedSink> {
+        Some(self)
+    }
+}
+
+#[async_trait::async_trait]
+impl ValidatedSink for PubsubConfig {
+    type Validated = ValidatedPubsub;
+
+    fn validate(&self) -> crate::Result<ValidatedPubsub> {
+        let uri_base = self.endpoint.append_path(&format!(
+            "/v1/projects/{}/topics/{}",
+            self.project, self.topic,
+        ))?;
+
         let batch_settings = self
             .batch
             .validate()?
             .limit_max_bytes(MAX_BATCH_PAYLOAD_SIZE)?
             .into_batch_settings()?;
+
+        let transformer = self.encoding.transformer();
+
+        Ok(ValidatedPubsub {
+            uri_base,
+            batch_settings,
+            transformer,
+        })
+    }
+
+    async fn build(
+        &self,
+        validated: &ValidatedPubsub,
+        cx: SinkContext,
+    ) -> crate::Result<(VectorSink, Healthcheck)> {
+        let ValidatedPubsub {
+            uri_base,
+            batch_settings,
+            transformer,
+        } = validated.clone();
+
+        // We only need to load the credentials if we are not targeting an emulator.
+        let auth = self.auth.build(Scope::PubSub).await?;
+
+        let serializer = self.encoding.build()?;
+        let encoder = Encoder::<()>::new(serializer);
+
+        let sink = PubsubSink {
+            auth,
+            uri_base,
+            transformer,
+            encoder,
+        };
+
         let request_settings = self.request.into_settings();
         let tls_settings = TlsSettings::from_options(self.tls.as_ref())?;
         let client = HttpClient::new(tls_settings, cx.proxy())?;
@@ -144,14 +202,13 @@ impl SinkConfig for PubsubConfig {
         #[allow(deprecated)]
         Ok((VectorSink::from_event_sink(sink), healthcheck))
     }
+}
 
-    fn input(&self) -> Input {
-        Input::new(self.encoding.config().input_type())
-    }
-
-    fn acknowledgements(&self) -> &AcknowledgementsConfig {
-        &self.acknowledgements
-    }
+#[derive(Clone, Debug)]
+pub struct ValidatedPubsub {
+    uri_base: HttpEndpoint,
+    batch_settings: BatchSettings<JsonArrayBuffer>,
+    transformer: Transformer,
 }
 
 struct PubsubSink {
@@ -162,27 +219,6 @@ struct PubsubSink {
 }
 
 impl PubsubSink {
-    async fn from_config(config: &PubsubConfig) -> crate::Result<Self> {
-        // We only need to load the credentials if we are not targeting an emulator.
-        let auth = config.auth.build(Scope::PubSub).await?;
-
-        let uri_base = config.endpoint.clone().append_path(&format!(
-            "/v1/projects/{}/topics/{}",
-            config.project, config.topic,
-        ))?;
-
-        let transformer = config.encoding.transformer();
-        let serializer = config.encoding.build()?;
-        let encoder = Encoder::<()>::new(serializer);
-
-        Ok(Self {
-            auth,
-            uri_base,
-            transformer,
-            encoder,
-        })
-    }
-
     fn uri(&self, suffix: &str) -> crate::Result<Uri> {
         // The suffix is a Google API method (for example `:publish`) that
         // attaches directly to the topic path without a separator.
@@ -254,6 +290,25 @@ mod tests {
         crate::test_util::test_generate_config::<PubsubConfig>();
     }
 
+    #[test]
+    fn validate_produces_usable_values() {
+        use crate::config::ValidatedSink;
+
+        let config: PubsubConfig = serde_yaml::from_str(indoc! {r#"
+                project: project
+                topic: topic
+                encoding:
+                  codec: json
+            "#})
+        .unwrap();
+
+        let validated = config.validate().expect("validation should succeed");
+        assert_eq!(
+            validated.uri_base.to_string(),
+            "https://pubsub.googleapis.com/v1/projects/project/topics/topic"
+        );
+    }
+
     #[tokio::test]
     async fn fails_missing_creds() {
         let config: PubsubConfig = serde_yaml::from_str(indoc! {r#"
@@ -263,7 +318,10 @@ mod tests {
                   codec: json
             "#})
         .unwrap();
-        if config.build(SinkContext::default()).await.is_ok() {
+        if SinkConfig::build(&config, SinkContext::default())
+            .await
+            .is_ok()
+        {
             panic!("config.build failed to error");
         }
     }
@@ -312,7 +370,9 @@ mod integration_tests {
 
     async fn config_build(topic: &str) -> (VectorSink, crate::sinks::Healthcheck) {
         let cx = SinkContext::default();
-        config(topic).build(cx).await.expect("Building sink failed")
+        SinkConfig::build(&config(topic), cx)
+            .await
+            .expect("Building sink failed")
     }
 
     #[tokio::test]

--- a/src/sinks/gcp/stackdriver/logs/config.rs
+++ b/src/sinks/gcp/stackdriver/logs/config.rs
@@ -17,6 +17,7 @@ use super::{
     sink::StackdriverLogsSink,
 };
 use crate::{
+    config::{DynValidatedSink, ValidatedSink},
     gcp::{GcpAuthConfig, GcpAuthenticator, Scope},
     http::HttpClient,
     schema,
@@ -198,7 +199,10 @@ pub(super) struct StackdriverLabelConfig {
 fn labels_examples() -> HashMap<String, String> {
     let mut example = HashMap::new();
     example.insert("label_1".to_string(), "value_1".to_string());
-    example.insert("label_2".to_string(), "{{ template_value_2 }}".to_string());
+    example.insert(
+        "label_2".to_string(),
+        "label-{{ template_value_2 }}".to_string(),
+    );
     example
 }
 
@@ -241,7 +245,7 @@ pub(super) struct StackdriverResource {
 fn label_examples() -> HashMap<String, String> {
     let mut example = HashMap::new();
     example.insert("instanceId".to_string(), "Twilight".to_string());
-    example.insert("zone".to_string(), "{{ zone }}".to_string());
+    example.insert("zone".to_string(), "zone-{{ zone }}".to_string());
     example
 }
 
@@ -250,7 +254,31 @@ impl_generate_config_from_default!(StackdriverConfig);
 #[async_trait::async_trait]
 #[typetag::serde(name = "gcp_stackdriver_logs")]
 impl SinkConfig for StackdriverConfig {
-    async fn build(&self, cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
+    fn confinement_config(&self) -> Option<&crate::template::ConfinementConfig> {
+        Some(&self.confinement)
+    }
+
+    fn input(&self) -> Input {
+        let requirement =
+            schema::Requirement::empty().required_meaning("timestamp", Kind::timestamp());
+
+        Input::log().with_schema_requirement(requirement)
+    }
+
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &self.acknowledgements
+    }
+
+    fn as_dyn_validated(&self) -> Option<&dyn DynValidatedSink> {
+        Some(self)
+    }
+}
+
+#[async_trait::async_trait]
+impl ValidatedSink for StackdriverConfig {
+    type Validated = ValidatedStackdriverLogs;
+
+    fn validate(&self) -> crate::Result<ValidatedStackdriverLogs> {
         let log_id = self
             .log_id
             .clone()
@@ -289,18 +317,14 @@ impl SinkConfig for StackdriverConfig {
                 .collect::<crate::Result<_>>()?,
         };
 
-        let auth = self.auth.build(Scope::LoggingWrite).await?;
-
-        let request_builder = StackdriverLogsRequestBuilder {
-            encoder: StackdriverLogsEncoder::new(
-                self.encoding.clone(),
-                log_id,
-                self.log_name.clone(),
-                label_config,
-                resource,
-                self.severity_key.clone(),
-            ),
-        };
+        let encoder = StackdriverLogsEncoder::new(
+            self.encoding.clone(),
+            log_id,
+            self.log_name.clone(),
+            label_config,
+            resource,
+            self.severity_key.clone(),
+        );
 
         let batch_settings = self
             .batch
@@ -308,15 +332,35 @@ impl SinkConfig for StackdriverConfig {
             .limit_max_bytes(MAX_BATCH_PAYLOAD_SIZE)?
             .into_batcher_settings()?;
 
+        Ok(ValidatedStackdriverLogs {
+            encoder,
+            batch_settings,
+        })
+    }
+
+    async fn build(
+        &self,
+        validated: &ValidatedStackdriverLogs,
+        cx: SinkContext,
+    ) -> crate::Result<(VectorSink, Healthcheck)> {
+        let ValidatedStackdriverLogs {
+            encoder,
+            batch_settings,
+        } = validated;
+
+        let auth = self.auth.build(Scope::LoggingWrite).await?;
+
+        let request_builder = StackdriverLogsRequestBuilder {
+            encoder: encoder.clone(),
+        };
+
         let request_limits = self.request.into_settings();
 
         let tls_settings = TlsSettings::from_options(self.tls.as_ref())?;
         let client = HttpClient::new(tls_settings, cx.proxy())?;
 
-        let uri = self.endpoint.clone().into_uri();
-
         let stackdriver_logs_service_request_builder = StackdriverLogsServiceRequestBuilder {
-            uri: uri.clone(),
+            uri: self.endpoint.as_uri().clone(),
             auth: auth.clone(),
         };
 
@@ -329,28 +373,19 @@ impl SinkConfig for StackdriverConfig {
             )
             .service(service);
 
-        let sink = StackdriverLogsSink::new(service, batch_settings, request_builder);
+        let sink = StackdriverLogsSink::new(service, *batch_settings, request_builder);
 
-        let healthcheck = healthcheck(client, auth.clone(), uri).boxed();
+        let healthcheck = healthcheck(client, auth.clone(), self.endpoint.as_uri().clone()).boxed();
 
         auth.spawn_regenerate_token();
         Ok((VectorSink::from_event_streamsink(sink), healthcheck))
     }
+}
 
-    fn confinement_config(&self) -> Option<&crate::template::ConfinementConfig> {
-        Some(&self.confinement)
-    }
-
-    fn input(&self) -> Input {
-        let requirement =
-            schema::Requirement::empty().required_meaning("timestamp", Kind::timestamp());
-
-        Input::log().with_schema_requirement(requirement)
-    }
-
-    fn acknowledgements(&self) -> &AcknowledgementsConfig {
-        &self.acknowledgements
-    }
+#[derive(Clone, Debug)]
+pub struct ValidatedStackdriverLogs {
+    encoder: StackdriverLogsEncoder,
+    batch_settings: BatcherSettings,
 }
 
 async fn healthcheck(client: HttpClient, auth: GcpAuthenticator, uri: Uri) -> crate::Result<()> {
@@ -375,7 +410,10 @@ async fn healthcheck(client: HttpClient, auth: GcpAuthenticator, uri: Uri) -> cr
 
 #[cfg(test)]
 mod tests {
+    use crate::config::ValidatedSink;
     use crate::template::{ConfinementConfig, Template};
+
+    use super::*;
 
     #[test]
     fn confinement_rejects_unconfined_log_id() {
@@ -401,5 +439,19 @@ mod tests {
         let config = ConfinementConfig::default();
         let result = template.confine(&config, "gcp_stackdriver_logs", "log_id");
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn validate_produces_usable_values() {
+        let config = StackdriverConfig {
+            log_id: "events-{{ env }}".try_into().unwrap(),
+            endpoint: default_endpoint(),
+            ..Default::default()
+        };
+        config.validate().expect("validation should succeed");
+        assert_eq!(
+            config.endpoint.to_string(),
+            "https://logging.googleapis.com/v2/entries:write"
+        );
     }
 }

--- a/src/sinks/gcp/stackdriver/metrics/config.rs
+++ b/src/sinks/gcp/stackdriver/metrics/config.rs
@@ -8,6 +8,7 @@ use super::{
     sink::StackdriverMetricsSink,
 };
 use crate::{
+    config::{DynValidatedSink, ValidatedSink},
     gcp::{GcpAuthConfig, GcpAuthenticator},
     http::HttpClient,
     sinks::{
@@ -101,15 +102,52 @@ impl_generate_config_from_default!(StackdriverConfig);
 #[async_trait::async_trait]
 #[typetag::serde(name = "gcp_stackdriver_metrics")]
 impl SinkConfig for StackdriverConfig {
-    async fn build(&self, cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
+    fn input(&self) -> Input {
+        Input::metric()
+    }
+
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &self.acknowledgements
+    }
+
+    fn as_dyn_validated(&self) -> Option<&dyn DynValidatedSink> {
+        Some(self)
+    }
+}
+
+#[async_trait::async_trait]
+impl ValidatedSink for StackdriverConfig {
+    type Validated = ValidatedStackdriverMetrics;
+
+    fn validate(&self) -> crate::Result<ValidatedStackdriverMetrics> {
+        let batch_settings = self.batch.validate()?.into_batcher_settings()?;
+
+        let uri = self
+            .endpoint
+            .append_path(&format!("/v3/projects/{}/timeSeries", self.project_id))?;
+
+        Ok(ValidatedStackdriverMetrics {
+            batch_settings,
+            uri,
+        })
+    }
+
+    async fn build(
+        &self,
+        validated: &ValidatedStackdriverMetrics,
+        cx: SinkContext,
+    ) -> crate::Result<(VectorSink, Healthcheck)> {
+        let ValidatedStackdriverMetrics {
+            batch_settings,
+            uri,
+        } = validated.clone();
+
         let auth = self.auth.build(Scope::MonitoringWrite).await?;
 
         let healthcheck = healthcheck().boxed();
         let started = chrono::Utc::now();
         let tls_settings = TlsSettings::from_options(self.tls.as_ref())?;
         let client = HttpClient::new(tls_settings, cx.proxy())?;
-
-        let batch_settings = self.batch.validate()?.into_batcher_settings()?;
 
         let request_builder = StackdriverMetricsRequestBuilder {
             encoder: StackdriverMetricsEncoder {
@@ -121,15 +159,12 @@ impl SinkConfig for StackdriverConfig {
 
         let request_limits = self.request.into_settings();
 
-        let uri = self
-            .endpoint
-            .append_path(&format!("/v3/projects/{}/timeSeries", self.project_id))?
-            .into_uri();
-
         auth.spawn_regenerate_token();
 
-        let stackdriver_metrics_service_request_builder =
-            StackdriverMetricsServiceRequestBuilder { uri, auth };
+        let stackdriver_metrics_service_request_builder = StackdriverMetricsServiceRequestBuilder {
+            uri: uri.into_uri(),
+            auth,
+        };
 
         let service = HttpService::new(client, stackdriver_metrics_service_request_builder);
 
@@ -144,13 +179,31 @@ impl SinkConfig for StackdriverConfig {
 
         Ok((VectorSink::from_event_streamsink(sink), healthcheck))
     }
+}
 
-    fn input(&self) -> Input {
-        Input::metric()
-    }
+#[derive(Clone, Debug)]
+pub struct ValidatedStackdriverMetrics {
+    batch_settings: BatcherSettings,
+    uri: HttpEndpoint,
+}
 
-    fn acknowledgements(&self) -> &AcknowledgementsConfig {
-        &self.acknowledgements
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::ValidatedSink;
+
+    #[test]
+    fn validate_produces_usable_values() {
+        let config = StackdriverConfig {
+            project_id: "test-project".into(),
+            endpoint: default_endpoint(),
+            ..Default::default()
+        };
+        let validated = config.validate().expect("validation should succeed");
+        assert_eq!(
+            validated.uri.to_string(),
+            "https://monitoring.googleapis.com/v3/projects/test-project/timeSeries"
+        );
     }
 }
 

--- a/src/sinks/gcp_chronicle/chronicle_unstructured.rs
+++ b/src/sinks/gcp_chronicle/chronicle_unstructured.rs
@@ -24,12 +24,13 @@ use vector_lib::{
     event::{Event, EventFinalizers, Finalizable},
     request_metadata::{GroupedCountByteSize, MetaDescriptive, RequestMetadata},
     sink::VectorSink,
+    stream::BatcherSettings,
 };
 use vrl::value::Kind;
 
 use crate::{
     codecs::{self, EncodingConfig},
-    config::{GenerateConfig, SinkConfig, SinkContext},
+    config::{DynValidatedSink, GenerateConfig, SinkConfig, SinkContext, ValidatedSink},
     gcp::{GcpAuthConfig, GcpAuthenticator},
     http::HttpClient,
     schema,
@@ -45,7 +46,8 @@ use crate::{
             service::GcsResponse,
         },
         util::{
-            BatchConfig, Compression, RequestBuilder, SinkBatchSettings, TowerRequestConfig,
+            BatchConfig, Compression, HttpEndpoint, RequestBuilder, SinkBatchSettings,
+            TowerRequestConfig,
             encoding::{Encoder, as_tracked_write},
             metadata::RequestMetadataBuilder,
             request_builder::EncodeResult,
@@ -180,13 +182,15 @@ impl TowerRequestConfigDefaults for ChronicleUnstructuredTowerRequestConfigDefau
 pub struct ChronicleUnstructuredConfig {
     /// The endpoint to send data to.
     #[configurable(metadata(
-        docs::examples = "127.0.0.1:8080",
-        docs::examples = "example.com:12345"
+        docs::examples = "http://127.0.0.1:8080",
+        docs::examples = "http://example.com:12345"
     ))]
-    pub endpoint: Option<String>,
+    #[configurable(required_one_of = "region_or_endpoint")]
+    pub endpoint: Option<HttpEndpoint>,
 
     /// The GCP region to use.
     #[configurable(derived)]
+    #[configurable(required_one_of = "region_or_endpoint")]
     pub region: Option<Region>,
 
     /// The Unique identifier (UUID) corresponding to the Chronicle instance.
@@ -263,6 +267,7 @@ impl GenerateConfig for ChronicleUnstructuredConfig {
             credentials_path: /path/to/credentials.json
             customer_id: customer_id
             namespace: namespace
+            region: asia
             compression: gzip
             log_type: log_type
             fallback_log_type: VECTOR_DEV
@@ -302,24 +307,6 @@ pub enum ChronicleError {
 #[async_trait::async_trait]
 #[typetag::serde(name = "gcp_chronicle_unstructured")]
 impl SinkConfig for ChronicleUnstructuredConfig {
-    async fn build(&self, cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
-        let creds = self.auth.build(Scope::MalachiteIngestion).await?;
-
-        let tls = TlsSettings::from_options(self.tls.as_ref())?;
-        let client = HttpClient::new(tls, cx.proxy())?;
-
-        let endpoint = self.create_endpoint("v2/unstructuredlogentries:batchCreate")?;
-
-        // For the healthcheck we see if we can fetch the list of available log types.
-        let healthcheck_endpoint = self.create_endpoint("v2/logtypes")?;
-
-        let healthcheck = build_healthcheck(client.clone(), &healthcheck_endpoint, creds.clone())?;
-        creds.spawn_regenerate_token();
-        let sink = self.build_sink(client, endpoint, creds)?;
-
-        Ok((sink, healthcheck))
-    }
-
     fn input(&self) -> Input {
         let requirement =
             schema::Requirement::empty().required_meaning("timestamp", Kind::timestamp());
@@ -330,6 +317,62 @@ impl SinkConfig for ChronicleUnstructuredConfig {
     fn acknowledgements(&self) -> &AcknowledgementsConfig {
         &self.acknowledgements
     }
+
+    fn as_dyn_validated(&self) -> Option<&dyn DynValidatedSink> {
+        Some(self)
+    }
+}
+
+#[async_trait::async_trait]
+impl ValidatedSink for ChronicleUnstructuredConfig {
+    type Validated = ValidatedChronicleUnstructured;
+
+    fn validate(&self) -> crate::Result<ValidatedChronicleUnstructured> {
+        let endpoint = self.create_endpoint("v2/unstructuredlogentries:batchCreate")?;
+        endpoint.parse::<Uri>()?;
+
+        // For the healthcheck we see if we can fetch the list of available log types.
+        let healthcheck_endpoint = self.create_endpoint("v2/logtypes")?;
+        healthcheck_endpoint.parse::<Uri>()?;
+
+        let batch_settings = self.batch.into_batcher_settings()?;
+
+        Ok(ValidatedChronicleUnstructured {
+            endpoint,
+            healthcheck_endpoint,
+            batch_settings,
+        })
+    }
+
+    async fn build(
+        &self,
+        validated: &ValidatedChronicleUnstructured,
+        cx: SinkContext,
+    ) -> crate::Result<(VectorSink, Healthcheck)> {
+        let ValidatedChronicleUnstructured {
+            endpoint,
+            healthcheck_endpoint,
+            ..
+        } = validated;
+
+        let creds = self.auth.build(Scope::MalachiteIngestion).await?;
+
+        let tls = TlsSettings::from_options(self.tls.as_ref())?;
+        let client = HttpClient::new(tls, cx.proxy())?;
+
+        let healthcheck = build_healthcheck(client.clone(), healthcheck_endpoint, creds.clone())?;
+        creds.spawn_regenerate_token();
+        let sink = self.build_sink(client, endpoint.clone(), creds, validated)?;
+
+        Ok((sink, healthcheck))
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ValidatedChronicleUnstructured {
+    endpoint: String,
+    healthcheck_endpoint: String,
+    batch_settings: BatcherSettings,
 }
 
 impl ChronicleUnstructuredConfig {
@@ -338,12 +381,11 @@ impl ChronicleUnstructuredConfig {
         client: HttpClient,
         base_url: String,
         creds: GcpAuthenticator,
+        validated: &ValidatedChronicleUnstructured,
     ) -> crate::Result<VectorSink> {
         use crate::sinks::util::service::ServiceBuilderExt;
 
         let request = self.request.into_settings();
-
-        let batch_settings = self.batch.into_batcher_settings()?;
 
         let partitioner = self.partitioner()?;
 
@@ -351,9 +393,14 @@ impl ChronicleUnstructuredConfig {
             .settings(request, GcsRetryLogic::default())
             .service(ChronicleService::new(client, base_url, creds));
 
-        let request_settings = ChronicleRequestBuilder::new(self)?;
-
-        let sink = ChronicleSink::new(svc, request_settings, partitioner, batch_settings, "http");
+        let request_builder = ChronicleRequestBuilder::new(self)?;
+        let sink = ChronicleSink::new(
+            svc,
+            request_builder,
+            partitioner,
+            validated.batch_settings,
+            "http",
+        );
 
         Ok(VectorSink::from_event_streamsink(sink))
     }
@@ -370,8 +417,8 @@ impl ChronicleUnstructuredConfig {
         Ok(format!(
             "{}/{}",
             match (&self.endpoint, self.region) {
-                (Some(endpoint), None) => endpoint.trim_end_matches('/'),
-                (None, Some(region)) => region.endpoint(),
+                (Some(endpoint), None) => endpoint.to_string().trim_end_matches('/').to_string(),
+                (None, Some(region)) => region.endpoint().to_string(),
                 (Some(_), Some(_)) => return Err(ChronicleError::BothRegionAndEndpoint),
                 (None, None) => return Err(ChronicleError::RegionOrEndpoint),
             },
@@ -723,6 +770,89 @@ mod unit_tests {
             creds_path, log_type
         ))
         .unwrap();
-        assert!(config.build(cx).await.is_err());
+        assert!(SinkConfig::build(&config, cx).await.is_err());
+    }
+
+    #[test]
+    fn deserialization_rejects_malformed_endpoint() {
+        // The `HttpEndpoint` config field rejects a malformed endpoint at
+        // config load time, so deserialization fails.
+        let result: Result<ChronicleUnstructuredConfig, _> = serde_yaml::from_str(indoc! {r#"
+            endpoint: "not a uri"
+            customer_id: test-customer
+            log_type: "WINDOWS_DNS"
+            encoding:
+              codec: text
+        "#});
+        assert!(
+            result.is_err(),
+            "config load should reject a malformed endpoint"
+        );
+    }
+
+    #[test]
+    fn deserialization_rejects_non_http_endpoint() {
+        // The `HttpEndpoint` config field rejects a non-http(s) endpoint at
+        // config load time, so deserialization fails.
+        let result: Result<ChronicleUnstructuredConfig, _> = serde_yaml::from_str(indoc! {r#"
+            endpoint: "ftp://example.com"
+            customer_id: test-customer
+            log_type: "WINDOWS_DNS"
+            encoding:
+              codec: text
+        "#});
+        assert!(
+            result.is_err(),
+            "config load should reject a non-http endpoint"
+        );
+    }
+
+    #[test]
+    fn relative_endpoint_becomes_absolute_https() {
+        use crate::config::ValidatedSink;
+
+        // A missing scheme is defaulted to https by `HttpEndpoint`.
+        let config: ChronicleUnstructuredConfig = serde_yaml::from_str(indoc! {r#"
+            endpoint: "chronicle.example.com:8080"
+            customer_id: test-customer
+            log_type: "WINDOWS_DNS"
+            encoding:
+              codec: text
+        "#})
+        .unwrap();
+
+        let validated = config.validate().expect("validation should succeed");
+        assert_eq!(
+            validated.endpoint,
+            "https://chronicle.example.com:8080/v2/unstructuredlogentries:batchCreate"
+        );
+        assert_eq!(
+            validated.healthcheck_endpoint,
+            "https://chronicle.example.com:8080/v2/logtypes"
+        );
+    }
+
+    #[test]
+    fn validate_produces_usable_values() {
+        use crate::config::ValidatedSink;
+
+        let config: ChronicleUnstructuredConfig = serde_yaml::from_str(indoc! {r#"
+            endpoint: "http://127.0.0.1:8080"
+            customer_id: test-customer
+            log_type: "WINDOWS_DNS"
+            encoding:
+              codec: text
+        "#})
+        .unwrap();
+
+        let validated = config.validate().expect("validation should succeed");
+        assert_eq!(
+            validated.endpoint,
+            "http://127.0.0.1:8080/v2/unstructuredlogentries:batchCreate"
+        );
+        assert_eq!(
+            validated.healthcheck_endpoint,
+            "http://127.0.0.1:8080/v2/logtypes"
+        );
     }
 }

--- a/website/cue/reference/components/sinks/gcp_stackdriver_logs.cue
+++ b/website/cue/reference/components/sinks/gcp_stackdriver_logs.cue
@@ -67,7 +67,7 @@ components: sinks: gcp_stackdriver_logs: {
 		resource: type: object: examples: [{
 			type:       "gce_instance"
 			instanceId: "Twilight"
-			zone:       "{{ zone }}"
+			zone:       "zone-{{ zone }}"
 		}]
 		project_id: type: string: examples: ["my-project"]
 		log_id: type: string: examples: ["my-log"]

--- a/website/cue/reference/components/sinks/generated/gcp_chronicle_unstructured.cue
+++ b/website/cue/reference/components/sinks/generated/gcp_chronicle_unstructured.cue
@@ -557,9 +557,17 @@ generated: components: sinks: gcp_chronicle_unstructured: configuration: {
 		}
 	}
 	endpoint: {
-		description: "The endpoint to send data to."
-		required:    false
-		type: string: examples: ["127.0.0.1:8080", "example.com:12345"]
+		description: """
+			An absolute http(s) URL.
+
+			The endpoint to send data to.
+
+			Exactly one of `endpoint` or `region` must be set.
+			"""
+		required: false
+		required_one_of: ["endpoint", "region"]
+		required_one_of_group: "region_or_endpoint"
+		type: string: examples: ["http://127.0.0.1:8080", "http://example.com:12345"]
 	}
 	fallback_log_type: {
 		description: "The default `log_type` to attach to events if the template in `log_type` cannot be resolved."
@@ -605,8 +613,14 @@ generated: components: sinks: gcp_chronicle_unstructured: configuration: {
 		}
 	}
 	region: {
-		description: "The GCP region to use."
-		required:    false
+		description: """
+			The GCP region to use.
+
+			Exactly one of `endpoint` or `region` must be set.
+			"""
+		required: false
+		required_one_of: ["endpoint", "region"]
+		required_one_of_group: "region_or_endpoint"
 		type: string: enum: {
 			asia:      "APAC region (this is the same as the Singapore region endpoint retained for backwards compatibility)"
 			canada:    "Canada Region"

--- a/website/cue/reference/components/sinks/generated/gcp_stackdriver_logs.cue
+++ b/website/cue/reference/components/sinks/generated/gcp_stackdriver_logs.cue
@@ -163,7 +163,7 @@ generated: components: sinks: gcp_stackdriver_logs: configuration: {
 		type: object: {
 			examples: [{
 				label_1: "value_1"
-				label_2: "{{ template_value_2 }}"
+				label_2: "label-{{ template_value_2 }}"
 			}]
 			options: "*": {
 				description: "A key, value pair that describes a log entry."
@@ -412,7 +412,7 @@ generated: components: sinks: gcp_stackdriver_logs: configuration: {
 		type: object: {
 			examples: [{
 				instanceId: "Twilight"
-				zone:       "{{ zone }}"
+				zone:       "zone-{{ zone }}"
 			}]
 			options: {
 				"*": {

--- a/website/generated/example-configs/sinks/gcp_chronicle_unstructured/advanced.yaml
+++ b/website/generated/example-configs/sinks/gcp_chronicle_unstructured/advanced.yaml
@@ -7,11 +7,10 @@ sinks:
     customer_id: c8c65bfa-5f2c-42d4-9189-64bb7b939f2c
     encoding:
       codec: json
-    endpoint: 127.0.0.1:8080
+    endpoint: http://127.0.0.1:8080
     fallback_log_type: VECTOR_DEV
     labels:
       source: vector
       tenant: marketing
     log_type: WINDOWS_DNS
     namespace: production
-    region: asia

--- a/website/generated/example-configs/sinks/gcp_chronicle_unstructured/minimal.yaml
+++ b/website/generated/example-configs/sinks/gcp_chronicle_unstructured/minimal.yaml
@@ -6,4 +6,5 @@ sinks:
     customer_id: c8c65bfa-5f2c-42d4-9189-64bb7b939f2c
     encoding:
       codec: json
+    endpoint: http://127.0.0.1:8080
     log_type: WINDOWS_DNS

--- a/website/generated/example-configs/sinks/gcp_stackdriver_logs/advanced.yaml
+++ b/website/generated/example-configs/sinks/gcp_stackdriver_logs/advanced.yaml
@@ -6,12 +6,12 @@ sinks:
     dangerously_allow_unconfined_template_resolution: false
     labels:
       label_1: value_1
-      label_2: "{{ template_value_2 }}"
+      label_2: label-{{ template_value_2 }}
     labels_key: logging.googleapis.com/labels
     log_id: my-log
     project_id: my-project
     resource:
       instanceId: Twilight
-      zone: "{{ zone }}"
+      zone: zone-{{ zone }}
       type: gce_instance
     severity_key: severity

--- a/website/generated/example-configs/sinks/gcp_stackdriver_logs/minimal.yaml
+++ b/website/generated/example-configs/sinks/gcp_stackdriver_logs/minimal.yaml
@@ -7,5 +7,5 @@ sinks:
     project_id: my-project
     resource:
       instanceId: Twilight
-      zone: "{{ zone }}"
+      zone: zone-{{ zone }}
       type: gce_instance


### PR DESCRIPTION
## Summary
Migrate the `gcp_cloud_storage`, `gcp_pubsub`, `gcp_stackdriver_logs`, `gcp_stackdriver_metrics`, and `gcp_chronicle_unstructured` sinks to the validated config lifecycle: structural validation now runs at config-compile time and the validated state is retained for build.

### References
Related: #26048

## Vector configuration
NA

## How did you test this PR?
- `make check-clippy` with `sinks-gcp` feature
- `make test` with the same feature, `SCOPE="-E 'test(gcp) or test(cloud_storage) or test(pubsub) or test(stackdriver) or test(chronicle)'"` (50 passed)

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## Contributor Guidelines

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them. To catch issues early, add a `pre-push` hook ([template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push)) or run the following locally before pushing:
  - `make fmt`
  - `make check-clippy` (auto-fix with `make clippy-fix`)
  - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details on the [dd-rust-license-tool](https://crates.io/crates/dd-rust-license-tool).
