### PR TITLE
feat(splunk_hec+humio sinks): validate config at compile time

### DIFF
--- a/src/sinks/humio/logs.rs
+++ b/src/sinks/humio/logs.rs
@@ -8,7 +8,10 @@ use vector_lib::{
 use super::config_host_key_target_path;
 use crate::{
     codecs::EncodingConfig,
-    config::{AcknowledgementsConfig, DataType, GenerateConfig, Input, SinkConfig, SinkContext},
+    config::{
+        AcknowledgementsConfig, DataType, DynValidatedSink, GenerateConfig, Input, SinkConfig,
+        SinkContext, ValidatedSink,
+    },
     sinks::{
         Healthcheck, VectorSink,
         splunk_hec::{
@@ -17,7 +20,7 @@ use crate::{
                 acknowledgements::HecClientAcknowledgementsConfig,
                 config_timestamp_key_target_path,
             },
-            logs::config::HecLogsSinkConfig,
+            logs::config::{HecLogsSinkConfig, ValidatedHecLogsSink},
         },
         util::{BatchConfig, Compression, HttpEndpoint, TowerRequestConfig},
     },
@@ -67,7 +70,7 @@ pub struct HumioLogsConfig {
     #[configurable(metadata(
         docs::examples = "json",
         docs::examples = "none",
-        docs::examples = "{{ event_type }}"
+        docs::examples = "event_type-{{ event_type }}"
     ))]
     pub event_type: Option<Template>,
 
@@ -100,7 +103,10 @@ pub struct HumioLogsConfig {
     ///
     /// [humio_data_format]: https://docs.humio.com/integrations/data-shippers/hec/#format-of-data
     #[serde(default)]
-    #[configurable(metadata(docs::examples = "{{ host }}", docs::examples = "custom_index"))]
+    #[configurable(metadata(
+        docs::examples = "index-{{ host }}",
+        docs::examples = "custom_index"
+    ))]
     pub index: Option<Template>,
 
     #[configurable(derived)]
@@ -179,10 +185,6 @@ impl GenerateConfig for HumioLogsConfig {
 #[async_trait::async_trait]
 #[typetag::serde(name = "humio_logs")]
 impl SinkConfig for HumioLogsConfig {
-    async fn build(&self, cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
-        self.build_with_component_type(cx, Self::NAME)
-    }
-
     fn confinement_config(&self) -> Option<&crate::template::ConfinementConfig> {
         Some(&self.confinement)
     }
@@ -194,20 +196,58 @@ impl SinkConfig for HumioLogsConfig {
     fn acknowledgements(&self) -> &AcknowledgementsConfig {
         &self.acknowledgements
     }
+
+    fn as_dyn_validated(&self) -> Option<&dyn DynValidatedSink> {
+        Some(self)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ValidatedHumioLogs {
+    pub(super) hec: ValidatedHecLogsSink,
+}
+
+#[async_trait::async_trait]
+impl ValidatedSink for HumioLogsConfig {
+    type Validated = ValidatedHumioLogs;
+
+    fn validate(&self) -> crate::Result<ValidatedHumioLogs> {
+        self.validate_with_component_name(Self::NAME)
+    }
+
+    async fn build(
+        &self,
+        validated: &ValidatedHumioLogs,
+        cx: SinkContext,
+    ) -> crate::Result<(VectorSink, Healthcheck)> {
+        self.build_from_validated(cx, &validated.hec)
+    }
 }
 
 impl HumioLogsConfig {
-    /// Confinement + sink construction. `component_name` is threaded through so
+    /// Pure structural validation. `component_name` is threaded through so
     /// per-template security warnings carry the outer sink type — `humio_logs`
     /// when this is the top-level sink, `humio_metrics` when
-    /// [`HumioMetricsConfig::build`] delegates here.
-    pub(super) fn build_with_component_type(
+    /// [`HumioMetricsConfig`] delegates here.
+    pub(super) fn validate_with_component_name(
+        &self,
+        component_name: &'static str,
+    ) -> crate::Result<ValidatedHumioLogs> {
+        Ok(ValidatedHumioLogs {
+            hec: self
+                .build_hec_config()
+                .validate_with_component_name(component_name)?,
+        })
+    }
+
+    /// Build the sink from validated state, delegating to the underlying
+    /// Splunk HEC logs sink without redoing any pure validation.
+    pub(super) fn build_from_validated(
         &self,
         cx: SinkContext,
-        component_name: &'static str,
+        validated: &ValidatedHecLogsSink,
     ) -> crate::Result<(VectorSink, Healthcheck)> {
-        self.build_hec_config()
-            .build_with_component_type(cx, component_name)
+        self.build_hec_config().build_from_validated(cx, validated)
     }
 
     fn build_hec_config(&self) -> HecLogsSinkConfig {
@@ -244,6 +284,33 @@ mod tests {
     #[test]
     fn generate_config() {
         crate::test_util::test_generate_config::<HumioLogsConfig>();
+    }
+
+    #[test]
+    fn validate_rejects_unconfined_template() {
+        use crate::config::ValidatedSink;
+
+        let config = HumioLogsConfig {
+            token: "token".to_string().into(),
+            endpoint: default_endpoint(),
+            source: None,
+            encoding: JsonSerializerConfig::default().into(),
+            event_type: None,
+            host_key: config_host_key_target_path(),
+            indexed_fields: vec![],
+            index: Some("{{ index }}".try_into().unwrap()),
+            compression: Compression::default(),
+            request: TowerRequestConfig::default(),
+            batch: BatchConfig::default(),
+            tls: None,
+            timestamp_nanos_key: None,
+            acknowledgements: Default::default(),
+            timestamp_key: config_timestamp_key_target_path(),
+            confinement: Default::default(),
+        };
+
+        let result = config.validate();
+        assert!(result.is_err());
     }
 }
 
@@ -286,7 +353,7 @@ mod integration_tests {
 
         let config = config(&repo.default_ingest_token);
 
-        let (sink, _) = config.build(cx).await.unwrap();
+        let (sink, _) = SinkConfig::build(&config, cx).await.unwrap();
 
         let message = random_string(100);
         let host = "192.168.1.1".to_string();
@@ -331,7 +398,7 @@ mod integration_tests {
         let mut config = config(&repo.default_ingest_token);
         config.source = Template::try_from("/var/log/syslog".to_string()).ok();
 
-        let (sink, _) = config.build(cx).await.unwrap();
+        let (sink, _) = SinkConfig::build(&config, cx).await.unwrap();
 
         let message = random_string(100);
         let event = LogEvent::from(message.clone());
@@ -360,7 +427,9 @@ mod integration_tests {
             let mut config = config(&repo.default_ingest_token);
             config.event_type = Template::try_from("json".to_string()).ok();
 
-            let (sink, _) = config.build(SinkContext::default()).await.unwrap();
+            let (sink, _) = SinkConfig::build(&config, SinkContext::default())
+                .await
+                .unwrap();
 
             let message = random_string(100);
             let mut event = LogEvent::from(message.clone());
@@ -386,7 +455,9 @@ mod integration_tests {
         {
             let config = config(&repo.default_ingest_token);
 
-            let (sink, _) = config.build(SinkContext::default()).await.unwrap();
+            let (sink, _) = SinkConfig::build(&config, SinkContext::default())
+                .await
+                .unwrap();
 
             let message = random_string(100);
             let event = LogEvent::from(message.clone());

--- a/src/sinks/humio/metrics.rs
+++ b/src/sinks/humio/metrics.rs
@@ -17,12 +17,13 @@ use super::{
 };
 use crate::{
     config::{
-        AcknowledgementsConfig, GenerateConfig, Input, SinkConfig, SinkContext, TransformContext,
+        AcknowledgementsConfig, DynValidatedSink, GenerateConfig, Input, SinkConfig, SinkContext,
+        TransformContext, ValidatedSink,
     },
     event::{Event, EventArray, EventContainer},
     sinks::{
         Healthcheck, VectorSink,
-        splunk_hec::common::SplunkHecDefaultBatchSettings,
+        splunk_hec::{common::SplunkHecDefaultBatchSettings, logs::config::ValidatedHecLogsSink},
         util::{BatchConfig, Compression, HttpEndpoint, TowerRequestConfig},
     },
     template::Template,
@@ -80,7 +81,7 @@ pub struct HumioMetricsConfig {
     #[configurable(metadata(
         docs::examples = "json",
         docs::examples = "none",
-        docs::examples = "{{ event_type }}"
+        docs::examples = "event_type-{{ event_type }}"
     ))]
     event_type: Option<Template>,
 
@@ -113,7 +114,10 @@ pub struct HumioMetricsConfig {
     ///
     /// [humio_data_format]: https://docs.humio.com/integrations/data-shippers/hec/#format-of-data
     #[serde(default)]
-    #[configurable(metadata(docs::examples = "{{ host }}", docs::examples = "custom_index"))]
+    #[configurable(metadata(
+        docs::examples = "index-{{ host }}",
+        docs::examples = "custom_index"
+    ))]
     index: Option<Template>,
 
     #[configurable(derived)]
@@ -160,12 +164,65 @@ impl GenerateConfig for HumioMetricsConfig {
 #[async_trait::async_trait]
 #[typetag::serde(name = "humio_metrics")]
 impl SinkConfig for HumioMetricsConfig {
-    async fn build(&self, cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
+    fn confinement_config(&self) -> Option<&crate::template::ConfinementConfig> {
+        Some(&self.confinement)
+    }
+
+    fn input(&self) -> Input {
+        Input::metric()
+    }
+
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &self.acknowledgements
+    }
+
+    fn as_dyn_validated(&self) -> Option<&dyn DynValidatedSink> {
+        Some(self)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ValidatedHumioMetrics {
+    hec: ValidatedHecLogsSink,
+}
+
+#[async_trait::async_trait]
+impl ValidatedSink for HumioMetricsConfig {
+    type Validated = ValidatedHumioMetrics;
+
+    fn validate(&self) -> crate::Result<ValidatedHumioMetrics> {
+        let humio_logs = self.build_humio_logs_config();
+        let validated = humio_logs.validate_with_component_name(Self::NAME)?;
+        Ok(ValidatedHumioMetrics { hec: validated.hec })
+    }
+
+    async fn build(
+        &self,
+        validated: &ValidatedHumioMetrics,
+        cx: SinkContext,
+    ) -> crate::Result<(VectorSink, Healthcheck)> {
         let transform = self
             .transform
             .build_transform(&TransformContext::new_with_globals(cx.globals.clone()));
 
-        let sink = HumioLogsConfig {
+        let humio_logs = self.build_humio_logs_config();
+
+        // Route through the inner Humio helper threaded with our own component
+        // type, so per-template security warnings carry `humio_metrics` rather
+        // than the delegated `humio_logs`/`splunk_hec_logs`.
+        let (sink, healthcheck) = humio_logs.build_from_validated(cx, &validated.hec)?;
+
+        let sink = HumioMetricsSink {
+            inner: sink,
+            transform,
+        };
+        Ok((VectorSink::Stream(Box::new(sink)), healthcheck))
+    }
+}
+
+impl HumioMetricsConfig {
+    fn build_humio_logs_config(&self) -> HumioLogsConfig {
+        HumioLogsConfig {
             token: self.token.clone(),
             endpoint: self.endpoint.clone(),
             source: self.source.clone(),
@@ -189,30 +246,7 @@ impl SinkConfig for HumioMetricsConfig {
                 Some(lookup::owned_value_path!("timestamp")),
             ),
             confinement: self.confinement.clone(),
-        };
-
-        // Route through the inner Humio helper threaded with our own component
-        // type, so per-template security warnings carry `humio_metrics` rather
-        // than the delegated `humio_logs`/`splunk_hec_logs`.
-        let (sink, healthcheck) = sink.build_with_component_type(cx, Self::NAME)?;
-
-        let sink = HumioMetricsSink {
-            inner: sink,
-            transform,
-        };
-        Ok((VectorSink::Stream(Box::new(sink)), healthcheck))
-    }
-
-    fn confinement_config(&self) -> Option<&crate::template::ConfinementConfig> {
-        Some(&self.confinement)
-    }
-
-    fn input(&self) -> Input {
-        Input::metric()
-    }
-
-    fn acknowledgements(&self) -> &AcknowledgementsConfig {
-        &self.acknowledgements
+        }
     }
 }
 
@@ -266,6 +300,31 @@ mod tests {
     }
 
     #[test]
+    fn validate_rejects_unconfined_template() {
+        use crate::config::ValidatedSink;
+
+        let config = HumioMetricsConfig {
+            transform: MetricToLogConfig::default(),
+            token: "token".to_string().into(),
+            endpoint: default_endpoint(),
+            source: None,
+            event_type: None,
+            host_key: config_host_key(),
+            indexed_fields: vec![],
+            index: Some("{{ index }}".try_into().unwrap()),
+            compression: Compression::default(),
+            request: TowerRequestConfig::default(),
+            batch: BatchConfig::default(),
+            tls: None,
+            acknowledgements: Default::default(),
+            confinement: Default::default(),
+        };
+
+        let result = config.validate();
+        assert!(result.is_err());
+    }
+
+    #[test]
     fn test_endpoint_field() {
         let (config, _) = load_sink::<HumioMetricsConfig>(indoc! {r#"
             token = "atoken"
@@ -304,7 +363,7 @@ mod tests {
         // to our local server
         config.endpoint = HttpEndpoint::parse(&format!("http://{addr}")).unwrap();
 
-        let (sink, _) = config.build(cx).await.unwrap();
+        let (sink, _) = SinkConfig::build(&config, cx).await.unwrap();
 
         let (rx, _trigger, server) = build_test_server(addr);
         tokio::spawn(server);
@@ -370,7 +429,7 @@ mod tests {
         // to our local server
         config.endpoint = HttpEndpoint::parse(&format!("http://{addr}")).unwrap();
 
-        let (sink, _) = config.build(cx).await.unwrap();
+        let (sink, _) = SinkConfig::build(&config, cx).await.unwrap();
 
         let (rx, _trigger, server) = build_test_server(addr);
         tokio::spawn(server);

--- a/src/sinks/splunk_hec/logs/config.rs
+++ b/src/sinks/splunk_hec/logs/config.rs
@@ -8,6 +8,7 @@ use vector_lib::{
 
 use super::{encoder::HecLogsEncoder, request_builder::HecLogsRequestBuilder, sink::HecLogsSink};
 use crate::{
+    config::{DynValidatedSink, ValidatedSink},
     http::HttpClient,
     sinks::{
         prelude::*,
@@ -71,13 +72,19 @@ pub struct HecLogsSinkConfig {
     /// The name of the index to send events to.
     ///
     /// If not specified, the default index defined within Splunk is used.
-    #[configurable(metadata(docs::examples = "{{ host }}", docs::examples = "custom_index"))]
+    #[configurable(metadata(
+        docs::examples = "index-{{ host }}",
+        docs::examples = "custom_index"
+    ))]
     pub index: Option<Template>,
 
     /// The sourcetype of events sent to this sink.
     ///
     /// If unset, Splunk defaults to `httpevent`.
-    #[configurable(metadata(docs::examples = "{{ sourcetype }}", docs::examples = "_json",))]
+    #[configurable(metadata(
+        docs::examples = "sourcetype-{{ sourcetype }}",
+        docs::examples = "_json",
+    ))]
     pub sourcetype: Option<Template>,
 
     /// The source of events sent to this sink.
@@ -86,7 +93,7 @@ pub struct HecLogsSinkConfig {
     ///
     /// If unset, the Splunk collector sets it.
     #[configurable(metadata(
-        docs::examples = "{{ file }}",
+        docs::examples = "source-{{ file }}",
         docs::examples = "/var/log/syslog",
         docs::examples = "UDP:514"
     ))]
@@ -183,18 +190,19 @@ impl GenerateConfig for HecLogsSinkConfig {
 }
 
 impl HecLogsSinkConfig {
-    /// Confinement + sink construction. `component_name` is threaded into the
+    /// Pure structural validation. `component_name` is threaded into the
     /// per-template security warnings emitted from `Template::confine`, so
     /// wrapping sinks (Humio) see their own type in logs rather than the
     /// delegated `splunk_hec_logs`.
-    pub(crate) fn build_with_component_type(
+    pub(crate) fn validate_with_component_name(
         &self,
-        cx: SinkContext,
         component_name: &'static str,
-    ) -> crate::Result<(VectorSink, Healthcheck)> {
+    ) -> crate::Result<ValidatedHecLogsSink> {
         if self.auto_extract_timestamp.is_some() && self.endpoint_target == EndpointTarget::Raw {
             return Err("`auto_extract_timestamp` cannot be set for the `raw` endpoint.".into());
         }
+
+        // The endpoint is validated at config load as an absolute http(s) URL.
 
         let index = self
             .index
@@ -212,6 +220,24 @@ impl HecLogsSinkConfig {
             .map(|t| t.confine(&self.confinement, component_name, "sourcetype"))
             .transpose()?;
 
+        let batch_settings = self.batch.into_batcher_settings()?;
+
+        Ok(ValidatedHecLogsSink {
+            index,
+            source,
+            sourcetype,
+            batch_settings,
+        })
+    }
+
+    /// Build the sink from validated state. Only environment-dependent work
+    /// (client creation, healthcheck) happens here; the validated state is
+    /// consumed without recomputing any pure validation.
+    pub(crate) fn build_from_validated(
+        &self,
+        cx: SinkContext,
+        validated: &ValidatedHecLogsSink,
+    ) -> crate::Result<(VectorSink, Healthcheck)> {
         let client = create_client(self.tls.as_ref(), cx.proxy())?;
         let healthcheck = build_healthcheck(
             self.endpoint.clone().into(),
@@ -219,7 +245,7 @@ impl HecLogsSinkConfig {
             client.clone(),
         )
         .boxed();
-        let sink = self.build_processor(client, cx, sourcetype, source, index)?;
+        let sink = self.build_processor(client, cx, validated)?;
 
         Ok((sink, healthcheck))
     }
@@ -228,10 +254,6 @@ impl HecLogsSinkConfig {
 #[async_trait::async_trait]
 #[typetag::serde(name = "splunk_hec_logs")]
 impl SinkConfig for HecLogsSinkConfig {
-    async fn build(&self, cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
-        self.build_with_component_type(cx, Self::NAME)
-    }
-
     fn confinement_config(&self) -> Option<&crate::template::ConfinementConfig> {
         Some(&self.confinement)
     }
@@ -243,6 +265,35 @@ impl SinkConfig for HecLogsSinkConfig {
     fn acknowledgements(&self) -> &AcknowledgementsConfig {
         &self.acknowledgements.inner
     }
+
+    fn as_dyn_validated(&self) -> Option<&dyn DynValidatedSink> {
+        Some(self)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ValidatedHecLogsSink {
+    index: Option<ConfinedTemplate>,
+    source: Option<ConfinedTemplate>,
+    sourcetype: Option<ConfinedTemplate>,
+    batch_settings: BatcherSettings,
+}
+
+#[async_trait::async_trait]
+impl ValidatedSink for HecLogsSinkConfig {
+    type Validated = ValidatedHecLogsSink;
+
+    fn validate(&self) -> crate::Result<ValidatedHecLogsSink> {
+        self.validate_with_component_name(Self::NAME)
+    }
+
+    async fn build(
+        &self,
+        validated: &ValidatedHecLogsSink,
+        cx: SinkContext,
+    ) -> crate::Result<(VectorSink, Healthcheck)> {
+        self.build_from_validated(cx, validated)
+    }
 }
 
 impl HecLogsSinkConfig {
@@ -250,9 +301,7 @@ impl HecLogsSinkConfig {
         &self,
         client: HttpClient,
         _: SinkContext,
-        sourcetype: Option<ConfinedTemplate>,
-        source: Option<ConfinedTemplate>,
-        index: Option<ConfinedTemplate>,
+        validated: &ValidatedHecLogsSink,
     ) -> crate::Result<VectorSink> {
         let ack_client = if self.acknowledgements.indexer_acknowledgements_enabled {
             Some(client.clone())
@@ -262,10 +311,9 @@ impl HecLogsSinkConfig {
 
         let transformer = self.encoding.transformer();
         let serializer = self.encoding.build()?;
-        let encoder = Encoder::<()>::new(serializer);
         let encoder = HecLogsEncoder {
             transformer,
-            encoder,
+            encoder: Encoder::<()>::new(serializer),
             auto_extract_timestamp: self.auto_extract_timestamp.unwrap_or_default(),
         };
         let request_builder = HecLogsRequestBuilder {
@@ -296,15 +344,13 @@ impl HecLogsSinkConfig {
             self.acknowledgements.clone(),
         );
 
-        let batch_settings = self.batch.into_batcher_settings()?;
-
         let sink = HecLogsSink {
             service,
             request_builder,
-            batch_settings,
-            sourcetype,
-            source,
-            index,
+            batch_settings: validated.batch_settings,
+            sourcetype: validated.sourcetype.clone(),
+            source: validated.source.clone(),
+            index: validated.index.clone(),
             indexed_fields: self
                 .indexed_fields
                 .iter()
@@ -335,6 +381,40 @@ mod tests {
     #[test]
     fn generate_config() {
         crate::test_util::test_generate_config::<HecLogsSinkConfig>();
+    }
+
+    #[test]
+    fn validate_produces_usable_state() {
+        use crate::config::ValidatedSink;
+
+        let config = HecLogsSinkConfig {
+            default_token: "token".to_string().into(),
+            endpoint: HttpEndpoint::parse("http://localhost:8088").unwrap(),
+            host_key: None,
+            indexed_fields: vec![],
+            index: Some("custom_index".try_into().unwrap()),
+            sourcetype: None,
+            source: None,
+            encoding: JsonSerializerConfig::default().into(),
+            compression: Compression::default(),
+            batch: Default::default(),
+            request: Default::default(),
+            tls: None,
+            acknowledgements: Default::default(),
+            timestamp_nanos_key: None,
+            timestamp_key: None,
+            auto_extract_timestamp: None,
+            endpoint_target: EndpointTarget::Event,
+            confinement: Default::default(),
+        };
+
+        let validated = config.validate().expect("validation should succeed");
+        assert_eq!(
+            validated.index.as_ref().unwrap().to_string(),
+            "custom_index"
+        );
+        assert!(validated.source.is_none());
+        assert!(validated.sourcetype.is_none());
     }
 
     #[test]

--- a/src/sinks/splunk_hec/metrics/config.rs
+++ b/src/sinks/splunk_hec/metrics/config.rs
@@ -4,13 +4,16 @@ use futures_util::FutureExt;
 use tower::ServiceBuilder;
 use vector_lib::{
     configurable::configurable_component, lookup::lookup_v2::OptionalValuePath,
-    sensitive_string::SensitiveString, sink::VectorSink,
+    sensitive_string::SensitiveString, sink::VectorSink, stream::BatcherSettings,
 };
 
 use super::{request_builder::HecMetricsRequestBuilder, sink::HecMetricsSink};
 
 use crate::{
-    config::{AcknowledgementsConfig, GenerateConfig, Input, SinkConfig, SinkContext},
+    config::{
+        AcknowledgementsConfig, DynValidatedSink, GenerateConfig, Input, SinkConfig, SinkContext,
+        ValidatedSink,
+    },
     http::HttpClient,
     sinks::{
         Healthcheck,
@@ -79,13 +82,19 @@ pub struct HecMetricsSinkConfig {
     /// The name of the index where to send the events to.
     ///
     /// If not specified, the default index defined within Splunk is used.
-    #[configurable(metadata(docs::examples = "{{ host }}", docs::examples = "custom_index"))]
+    #[configurable(metadata(
+        docs::examples = "index-{{ host }}",
+        docs::examples = "custom_index"
+    ))]
     pub index: Option<Template>,
 
     /// The sourcetype of events sent to this sink.
     ///
     /// If unset, Splunk defaults to `httpevent`.
-    #[configurable(metadata(docs::examples = "{{ sourcetype }}", docs::examples = "_json",))]
+    #[configurable(metadata(
+        docs::examples = "sourcetype-{{ sourcetype }}",
+        docs::examples = "_json",
+    ))]
     pub sourcetype: Option<Template>,
 
     /// The source of events sent to this sink.
@@ -94,7 +103,7 @@ pub struct HecMetricsSinkConfig {
     ///
     /// If unset, the Splunk collector sets it.
     #[configurable(metadata(
-        docs::examples = "{{ file }}",
+        docs::examples = "source-{{ file }}",
         docs::examples = "/var/log/syslog",
         docs::examples = "UDP:514"
     ))]
@@ -148,7 +157,39 @@ impl GenerateConfig for HecMetricsSinkConfig {
 #[async_trait::async_trait]
 #[typetag::serde(name = "splunk_hec_metrics")]
 impl SinkConfig for HecMetricsSinkConfig {
-    async fn build(&self, cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
+    fn confinement_config(&self) -> Option<&crate::template::ConfinementConfig> {
+        Some(&self.confinement)
+    }
+
+    fn input(&self) -> Input {
+        Input::metric()
+    }
+
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &self.acknowledgements.inner
+    }
+
+    fn as_dyn_validated(&self) -> Option<&dyn DynValidatedSink> {
+        Some(self)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ValidatedHecMetricsSink {
+    index: Option<ConfinedTemplate>,
+    source: Option<ConfinedTemplate>,
+    sourcetype: Option<ConfinedTemplate>,
+    templated_field_keys: Box<[String]>,
+    batch_settings: BatcherSettings,
+}
+
+#[async_trait::async_trait]
+impl ValidatedSink for HecMetricsSinkConfig {
+    type Validated = ValidatedHecMetricsSink;
+
+    fn validate(&self) -> crate::Result<ValidatedHecMetricsSink> {
+        // The endpoint is validated at config load as an absolute http(s) URL.
+
         let templated_field_keys =
             compute_templated_field_keys(&self.index, &self.source, &self.sourcetype);
 
@@ -168,6 +209,22 @@ impl SinkConfig for HecMetricsSinkConfig {
             .map(|t| t.confine(&self.confinement, Self::NAME, "index"))
             .transpose()?;
 
+        let batch_settings = self.batch.into_batcher_settings()?;
+
+        Ok(ValidatedHecMetricsSink {
+            index: confined_index,
+            source: confined_source,
+            sourcetype: confined_sourcetype,
+            templated_field_keys,
+            batch_settings,
+        })
+    }
+
+    async fn build(
+        &self,
+        validated: &ValidatedHecMetricsSink,
+        cx: SinkContext,
+    ) -> crate::Result<(VectorSink, Healthcheck)> {
         let client = create_client(self.tls.as_ref(), cx.proxy())?;
         let healthcheck = build_healthcheck(
             self.endpoint.clone().into(),
@@ -175,27 +232,8 @@ impl SinkConfig for HecMetricsSinkConfig {
             client.clone(),
         )
         .boxed();
-        let sink = self.build_processor(
-            client,
-            cx,
-            confined_sourcetype,
-            confined_source,
-            confined_index,
-            templated_field_keys, // passed to encoder, not per-event metadata
-        )?;
+        let sink = self.build_processor(client, cx, validated)?;
         Ok((sink, healthcheck))
-    }
-
-    fn confinement_config(&self) -> Option<&crate::template::ConfinementConfig> {
-        Some(&self.confinement)
-    }
-
-    fn input(&self) -> Input {
-        Input::metric()
-    }
-
-    fn acknowledgements(&self) -> &AcknowledgementsConfig {
-        &self.acknowledgements.inner
     }
 }
 
@@ -218,10 +256,7 @@ impl HecMetricsSinkConfig {
         &self,
         client: HttpClient,
         _: SinkContext,
-        sourcetype: Option<ConfinedTemplate>,
-        source: Option<ConfinedTemplate>,
-        index: Option<ConfinedTemplate>,
-        templated_field_keys: Box<[String]>,
+        validated: &ValidatedHecMetricsSink,
     ) -> crate::Result<VectorSink> {
         let ack_client = if self.acknowledgements.indexer_acknowledgements_enabled {
             Some(client.clone())
@@ -229,7 +264,8 @@ impl HecMetricsSinkConfig {
             None
         };
 
-        let request_builder = HecMetricsRequestBuilder::new(self.compression, templated_field_keys);
+        let request_builder =
+            HecMetricsRequestBuilder::new(self.compression, validated.templated_field_keys.clone());
 
         let request_settings = self.request.into_settings();
         let http_request_builder = Arc::new(HttpRequestBuilder::new(
@@ -254,19 +290,50 @@ impl HecMetricsSinkConfig {
             self.acknowledgements.clone(),
         );
 
-        let batch_settings = self.batch.into_batcher_settings()?;
-
         let sink = HecMetricsSink {
             service,
-            batch_settings,
+            batch_settings: validated.batch_settings,
             request_builder,
-            sourcetype,
-            source,
-            index,
+            sourcetype: validated.sourcetype.clone(),
+            source: validated.source.clone(),
+            index: validated.index.clone(),
             host_key: self.host_key.path.clone(),
             default_namespace: self.default_namespace.clone(),
         };
 
         Ok(VectorSink::from_event_streamsink(sink))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::ValidatedSink;
+
+    #[test]
+    fn validate_produces_usable_state() {
+        let config = HecMetricsSinkConfig {
+            default_namespace: None,
+            default_token: "token".to_string().into(),
+            endpoint: HttpEndpoint::parse("http://localhost:8088").unwrap(),
+            host_key: config_host_key(),
+            index: Some("custom_index".try_into().unwrap()),
+            sourcetype: None,
+            source: None,
+            compression: Compression::default(),
+            batch: Default::default(),
+            request: Default::default(),
+            tls: None,
+            acknowledgements: Default::default(),
+            confinement: Default::default(),
+        };
+
+        let validated = config.validate().expect("validation should succeed");
+        assert_eq!(
+            validated.index.as_ref().unwrap().to_string(),
+            "custom_index"
+        );
+        assert!(validated.source.is_none());
+        assert!(validated.sourcetype.is_none());
     }
 }

--- a/src/sinks/splunk_hec/metrics/tests.rs
+++ b/src/sinks/splunk_hec/metrics/tests.rs
@@ -116,6 +116,30 @@ fn generate_config() {
 }
 
 #[test]
+fn validate_rejects_unconfined_template() {
+    use crate::config::ValidatedSink;
+
+    let config = HecMetricsSinkConfig {
+        default_token: "token".to_owned().into(),
+        endpoint: HttpEndpoint::parse("http://localhost:8088").unwrap(),
+        host_key: config_host_key(),
+        index: Some("{{ index }}".try_into().unwrap()),
+        sourcetype: None,
+        source: None,
+        compression: Compression::None,
+        batch: Default::default(),
+        request: Default::default(),
+        tls: None,
+        acknowledgements: Default::default(),
+        default_namespace: None,
+        confinement: Default::default(),
+    };
+
+    let result = config.validate();
+    assert!(result.is_err());
+}
+
+#[test]
 fn test_process_metric() {
     let sourcetype = Template::try_from("{{ tags.template_sourcetype }}".to_string()).ok();
     let source = Template::try_from("{{ tags.template_source }}".to_string()).ok();

--- a/website/cue/reference/components/sinks/generated/humio_logs.cue
+++ b/website/cue/reference/components/sinks/generated/humio_logs.cue
@@ -573,7 +573,7 @@ generated: components: sinks: humio_logs: configuration: {
 			"""
 		required: false
 		type: string: {
-			examples: ["json", "none", "{{ event_type }}"]
+			examples: ["json", "none", "event_type-{{ event_type }}"]
 			syntax: "template"
 		}
 	}
@@ -603,7 +603,7 @@ generated: components: sinks: humio_logs: configuration: {
 			"""
 		required: false
 		type: string: {
-			examples: ["{{ host }}", "custom_index"]
+			examples: ["index-{{ host }}", "custom_index"]
 			syntax: "template"
 		}
 	}

--- a/website/cue/reference/components/sinks/generated/humio_metrics.cue
+++ b/website/cue/reference/components/sinks/generated/humio_metrics.cue
@@ -132,7 +132,7 @@ generated: components: sinks: humio_metrics: configuration: {
 			"""
 		required: false
 		type: string: {
-			examples: ["json", "none", "{{ event_type }}"]
+			examples: ["json", "none", "event_type-{{ event_type }}"]
 			syntax: "template"
 		}
 	}
@@ -174,7 +174,7 @@ generated: components: sinks: humio_metrics: configuration: {
 			"""
 		required: false
 		type: string: {
-			examples: ["{{ host }}", "custom_index"]
+			examples: ["index-{{ host }}", "custom_index"]
 			syntax: "template"
 		}
 	}

--- a/website/cue/reference/components/sinks/generated/splunk_hec_logs.cue
+++ b/website/cue/reference/components/sinks/generated/splunk_hec_logs.cue
@@ -659,7 +659,7 @@ generated: components: sinks: splunk_hec_logs: configuration: {
 			"""
 		required: false
 		type: string: {
-			examples: ["{{ host }}", "custom_index"]
+			examples: ["index-{{ host }}", "custom_index"]
 			syntax: "template"
 		}
 	}
@@ -871,7 +871,7 @@ generated: components: sinks: splunk_hec_logs: configuration: {
 			"""
 		required: false
 		type: string: {
-			examples: ["{{ file }}", "/var/log/syslog", "UDP:514"]
+			examples: ["source-{{ file }}", "/var/log/syslog", "UDP:514"]
 			syntax: "template"
 		}
 	}
@@ -883,7 +883,7 @@ generated: components: sinks: splunk_hec_logs: configuration: {
 			"""
 		required: false
 		type: string: {
-			examples: ["{{ sourcetype }}", "_json"]
+			examples: ["sourcetype-{{ sourcetype }}", "_json"]
 			syntax: "template"
 		}
 	}

--- a/website/cue/reference/components/sinks/generated/splunk_hec_metrics.cue
+++ b/website/cue/reference/components/sinks/generated/splunk_hec_metrics.cue
@@ -186,7 +186,7 @@ generated: components: sinks: splunk_hec_metrics: configuration: {
 			"""
 		required: false
 		type: string: {
-			examples: ["{{ host }}", "custom_index"]
+			examples: ["index-{{ host }}", "custom_index"]
 			syntax: "template"
 		}
 	}
@@ -386,7 +386,7 @@ generated: components: sinks: splunk_hec_metrics: configuration: {
 			"""
 		required: false
 		type: string: {
-			examples: ["{{ file }}", "/var/log/syslog", "UDP:514"]
+			examples: ["source-{{ file }}", "/var/log/syslog", "UDP:514"]
 			syntax: "template"
 		}
 	}
@@ -398,7 +398,7 @@ generated: components: sinks: splunk_hec_metrics: configuration: {
 			"""
 		required: false
 		type: string: {
-			examples: ["{{ sourcetype }}", "_json"]
+			examples: ["sourcetype-{{ sourcetype }}", "_json"]
 			syntax: "template"
 		}
 	}

--- a/website/generated/example-configs/sinks/humio_logs/advanced.yaml
+++ b/website/generated/example-configs/sinks/humio_logs/advanced.yaml
@@ -10,7 +10,7 @@ sinks:
     endpoint: https://cloud.humio.com/
     event_type: json
     host_key: .host
-    index: "{{ host }}"
+    index: index-{{ host }}
     timestamp_key: .timestamp
     timestamp_nanos_key: "@timestamp.nanos"
     token: ${HUMIO_TOKEN}

--- a/website/generated/example-configs/sinks/humio_metrics/advanced.yaml
+++ b/website/generated/example-configs/sinks/humio_metrics/advanced.yaml
@@ -9,7 +9,7 @@ sinks:
     event_type: json
     host_key: host
     host_tag: host
-    index: "{{ host }}"
+    index: index-{{ host }}
     metric_tag_values: single
     timezone: local
     token: ${HUMIO_TOKEN}

--- a/website/generated/example-configs/sinks/splunk_hec_logs/advanced.yaml
+++ b/website/generated/example-configs/sinks/splunk_hec_logs/advanced.yaml
@@ -11,9 +11,9 @@ sinks:
       codec: json
     endpoint: https://http-inputs-hec.splunkcloud.com
     endpoint_target: event
-    index: "{{ host }}"
+    index: index-{{ host }}
     indexed_fields:
       - field1
-    source: "{{ file }}"
-    sourcetype: "{{ sourcetype }}"
+    source: source-{{ file }}
+    sourcetype: sourcetype-{{ sourcetype }}
     timestamp_key: timestamp

--- a/website/generated/example-configs/sinks/splunk_hec_metrics/advanced.yaml
+++ b/website/generated/example-configs/sinks/splunk_hec_metrics/advanced.yaml
@@ -9,6 +9,6 @@ sinks:
     default_token: ${SPLUNK_HEC_TOKEN}
     endpoint: https://http-inputs-hec.splunkcloud.com
     host_key: host
-    index: "{{ host }}"
-    source: "{{ file }}"
-    sourcetype: "{{ sourcetype }}"
+    index: index-{{ host }}
+    source: source-{{ file }}
+    sourcetype: sourcetype-{{ sourcetype }}


### PR DESCRIPTION
## Summary
Migrate the `splunk_hec_logs`, `splunk_hec_metrics`, `humio_logs`, and `humio_metrics` sinks to the validated config lifecycle: structural validation now runs at config-compile time and the validated state is retained for build.

### References
Related: #26048

## Vector configuration
NA

## How did you test this PR?
- `make check-clippy` with `sinks-splunk_hec,sinks-humio` features
- `make test` with the same features, `SCOPE="-E 'test(splunk) or test(humio)'"` (53 passed)
- `make generate-docs` (regenerated splunk_hec and humio docs)

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## Contributor Guidelines

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them. To catch issues early, add a `pre-push` hook ([template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push)) or run the following locally before pushing:
  - `make fmt`
  - `make check-clippy` (auto-fix with `make clippy-fix`)
  - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details on the [dd-rust-license-tool](https://crates.io/crates/dd-rust-license-tool).
