### PR TITLE
feat(greptimedb sinks): validate config at compile time

### DIFF
--- a/src/sinks/greptimedb/logs/config.rs
+++ b/src/sinks/greptimedb/logs/config.rs
@@ -7,6 +7,7 @@ use vector_lib::{
 };
 
 use crate::{
+    config::{DynValidatedSink, ValidatedSink},
     http::{Auth, HttpClient},
     sinks::{
         greptimedb::{
@@ -20,7 +21,7 @@ use crate::{
             },
         },
         prelude::*,
-        util::http::HttpService,
+        util::{HttpEndpoint, http::HttpService},
     },
     template::ConfinementConfig,
 };
@@ -29,15 +30,22 @@ fn extra_params_examples() -> HashMap<String, String> {
     HashMap::<_, _>::from_iter([("source".to_owned(), "vector".to_owned())])
 }
 
+fn default_endpoint() -> HttpEndpoint {
+    HttpEndpoint::parse("http://localhost:4000")
+        .expect("static default endpoint should be a valid http(s) URL")
+}
+
 /// Configuration for the `greptimedb_logs` sink.
 #[configurable_component(sink("greptimedb_logs", "Ingest logs data into GreptimeDB."))]
-#[derive(Clone, Debug, Default, Derivative)]
+#[derive(Clone, Debug, Derivative)]
+#[derivative(Default)]
 #[serde(deny_unknown_fields)]
 pub struct GreptimeDBLogsConfig {
     /// The endpoint of the GreptimeDB server.
     #[serde(alias = "host")]
+    #[derivative(Default(value = "default_endpoint()"))]
     #[configurable(metadata(docs::examples = "http://localhost:4000"))]
-    pub endpoint: String,
+    pub endpoint: HttpEndpoint,
 
     /// The table that data is inserted into.
     #[configurable(metadata(docs::examples = "mytable"))]
@@ -134,7 +142,38 @@ impl_generate_config_from_default!(GreptimeDBLogsConfig);
 #[async_trait::async_trait]
 #[typetag::serde(name = "greptimedb_logs")]
 impl SinkConfig for GreptimeDBLogsConfig {
-    async fn build(&self, cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
+    fn confinement_config(&self) -> Option<&crate::template::ConfinementConfig> {
+        Some(&self.confinement)
+    }
+
+    fn input(&self) -> Input {
+        Input::log()
+    }
+
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &self.acknowledgements
+    }
+
+    fn as_dyn_validated(&self) -> Option<&dyn DynValidatedSink> {
+        Some(self)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ValidatedGreptimeDBLogs {
+    confined_table: ConfinedTemplate,
+    confined_dbname: ConfinedTemplate,
+    confined_pipeline_name: ConfinedTemplate,
+    confined_pipeline_version: Option<ConfinedTemplate>,
+    auth: Option<Auth>,
+    batch_settings: BatcherSettings,
+}
+
+#[async_trait::async_trait]
+impl ValidatedSink for GreptimeDBLogsConfig {
+    type Validated = ValidatedGreptimeDBLogs;
+
+    fn validate(&self) -> crate::Result<ValidatedGreptimeDBLogs> {
         let confined_table = self
             .table
             .clone()
@@ -152,8 +191,6 @@ impl SinkConfig for GreptimeDBLogsConfig {
             .clone()
             .map(|t| t.confine(&self.confinement, Self::NAME, "pipeline_version"))
             .transpose()?;
-        let tls_settings = TlsSettings::from_options(self.tls.as_ref())?;
-        let client = HttpClient::new(tls_settings, &cx.proxy)?;
 
         let auth = match (self.username.clone(), self.password.clone()) {
             (Some(username), Some(password)) => Some(Auth::Basic {
@@ -162,8 +199,38 @@ impl SinkConfig for GreptimeDBLogsConfig {
             }),
             _ => None,
         };
+
+        let batch_settings = self.batch.into_batcher_settings()?;
+
+        Ok(ValidatedGreptimeDBLogs {
+            confined_table,
+            confined_dbname,
+            confined_pipeline_name,
+            confined_pipeline_version,
+            auth,
+            batch_settings,
+        })
+    }
+
+    async fn build(
+        &self,
+        validated: &ValidatedGreptimeDBLogs,
+        cx: SinkContext,
+    ) -> crate::Result<(VectorSink, Healthcheck)> {
+        let ValidatedGreptimeDBLogs {
+            confined_table,
+            confined_dbname,
+            confined_pipeline_name,
+            confined_pipeline_version,
+            auth,
+            batch_settings,
+        } = validated;
+
+        let tls_settings = TlsSettings::from_options(self.tls.as_ref())?;
+        let client = HttpClient::new(tls_settings, &cx.proxy)?;
+
         let request_builder = GreptimeDBLogsHttpRequestBuilder {
-            endpoint: self.endpoint.clone(),
+            endpoint: self.endpoint.to_string(),
             auth: auth.clone(),
             encoder: (
                 self.encoding.clone(),
@@ -187,14 +254,14 @@ impl SinkConfig for GreptimeDBLogsConfig {
             .service(service);
 
         let logs_sink_setting = LogsSinkSetting {
-            dbname: confined_dbname,
-            table: confined_table,
-            pipeline_name: confined_pipeline_name,
-            pipeline_version: confined_pipeline_version,
+            dbname: confined_dbname.clone(),
+            table: confined_table.clone(),
+            pipeline_name: confined_pipeline_name.clone(),
+            pipeline_version: confined_pipeline_version.clone(),
         };
 
         let sink = GreptimeDBLogsHttpSink::new(
-            self.batch.into_batcher_settings()?,
+            *batch_settings,
             service,
             request_builder,
             logs_sink_setting,
@@ -202,28 +269,70 @@ impl SinkConfig for GreptimeDBLogsConfig {
 
         let healthcheck = Box::pin(http_healthcheck(
             client,
-            self.endpoint.clone(),
+            self.endpoint.to_string(),
             auth.clone(),
         ));
         Ok((VectorSink::from_event_streamsink(sink), healthcheck))
-    }
-
-    fn confinement_config(&self) -> Option<&crate::template::ConfinementConfig> {
-        Some(&self.confinement)
-    }
-
-    fn input(&self) -> Input {
-        Input::log()
-    }
-
-    fn acknowledgements(&self) -> &AcknowledgementsConfig {
-        &self.acknowledgements
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::template::{ConfinementConfig, Template};
+    use indoc::indoc;
+
+    use super::*;
+    use crate::{
+        config::ValidatedSink,
+        template::{ConfinementConfig, Template},
+    };
+
+    #[test]
+    fn prepares_valid_config() {
+        let config = GreptimeDBLogsConfig {
+            endpoint: HttpEndpoint::parse("http://localhost:4000").unwrap(),
+            table: "mytable".try_into().unwrap(),
+            dbname: "public".try_into().unwrap(),
+            pipeline_name: "greptime_identity".try_into().unwrap(),
+            ..Default::default()
+        };
+
+        let validated = config.validate().expect("preparation should succeed");
+        assert_eq!(validated.confined_table.to_string(), "mytable");
+        assert_eq!(validated.confined_dbname.to_string(), "public");
+        assert_eq!(
+            validated.confined_pipeline_name.to_string(),
+            "greptime_identity"
+        );
+        assert!(validated.auth.is_none());
+    }
+
+    #[test]
+    fn validate_rejects_malformed_endpoint() {
+        // `HttpEndpoint` rejects a malformed endpoint at load time, so
+        // deserialization fails.
+        let result: Result<GreptimeDBLogsConfig, _> = serde_yaml::from_str(indoc! {r#"
+            endpoint: "not a uri"
+            table: "mytable"
+        "#});
+        assert!(
+            result.is_err(),
+            "config load should reject a malformed endpoint"
+        );
+    }
+
+    #[test]
+    fn validate_rejects_non_http_endpoint() {
+        // `HttpEndpoint` only accepts absolute http(s) URLs, so an `ftp://`
+        // endpoint is rejected at load time.
+        let result: Result<GreptimeDBLogsConfig, _> = serde_yaml::from_str(indoc! {r#"
+            endpoint: "ftp://example.com"
+            table: "mytable"
+        "#});
+        assert!(
+            result.is_err(),
+            "config load should reject a non-http endpoint"
+        );
+    }
 
     #[test]
     fn confinement_rejects_unconfined_table() {

--- a/src/sinks/greptimedb/logs/config.rs
+++ b/src/sinks/greptimedb/logs/config.rs
@@ -230,7 +230,7 @@ impl ValidatedSink for GreptimeDBLogsConfig {
         let client = HttpClient::new(tls_settings, &cx.proxy)?;
 
         let request_builder = GreptimeDBLogsHttpRequestBuilder {
-            endpoint: self.endpoint.to_string(),
+            endpoint: self.endpoint.clone(),
             auth: auth.clone(),
             encoder: (
                 self.encoding.clone(),
@@ -269,7 +269,7 @@ impl ValidatedSink for GreptimeDBLogsConfig {
 
         let healthcheck = Box::pin(http_healthcheck(
             client,
-            self.endpoint.to_string(),
+            self.endpoint.clone(),
             auth.clone(),
         ));
         Ok((VectorSink::from_event_streamsink(sink), healthcheck))

--- a/src/sinks/greptimedb/logs/http_request_builder.rs
+++ b/src/sinks/greptimedb/logs/http_request_builder.rs
@@ -17,7 +17,10 @@ use crate::{
     sinks::{
         HTTPRequestBuilderSnafu, HealthcheckError,
         prelude::*,
-        util::http::{HttpRequest, HttpResponse, HttpRetryLogic, HttpServiceRequestBuilder},
+        util::{
+            HttpEndpoint,
+            http::{HttpRequest, HttpResponse, HttpRetryLogic, HttpServiceRequestBuilder},
+        },
     },
 };
 
@@ -113,7 +116,7 @@ impl Partitioner for KeyPartitioner {
 /// GreptimeDB logs HTTP request builder.
 #[derive(Debug, Clone)]
 pub(super) struct GreptimeDBLogsHttpRequestBuilder {
-    pub(super) endpoint: String,
+    pub(super) endpoint: HttpEndpoint,
     pub(super) auth: Option<Auth>,
     pub(super) encoder: (Transformer, Encoder<Framer>),
     pub(super) compression: Compression,
@@ -122,13 +125,16 @@ pub(super) struct GreptimeDBLogsHttpRequestBuilder {
 }
 
 fn prepare_log_ingester_url(
-    endpoint: &str,
+    endpoint: &HttpEndpoint,
     db: &str,
     table: &str,
     metadata: &PartitionKey,
     extra_params: &Option<HashMap<String, String>>,
 ) -> String {
-    let path = format!("{endpoint}/v1/events/logs");
+    let path = endpoint
+        .append_path("/v1/events/logs")
+        .expect("static log ingester path should be a valid URL")
+        .to_string();
     let mut url = url::Url::parse(&path).unwrap();
     let mut url_builder = url.query_pairs_mut();
     url_builder
@@ -156,13 +162,8 @@ impl HttpServiceRequestBuilder<PartitionKey> for GreptimeDBLogsHttpRequestBuilde
         let db = metadata.dbname.clone();
 
         // prepare url
-        let url = prepare_log_ingester_url(
-            self.endpoint.as_str(),
-            &db,
-            &table,
-            metadata,
-            &self.extra_params,
-        );
+        let url =
+            prepare_log_ingester_url(&self.endpoint, &db, &table, metadata, &self.extra_params);
 
         // prepare body
         let payload = request.take_payload();
@@ -242,10 +243,13 @@ impl RequestBuilder<(PartitionKey, Vec<Event>)> for GreptimeDBLogsHttpRequestBui
 
 pub(super) async fn http_healthcheck(
     client: HttpClient,
-    endpoint: String,
+    endpoint: HttpEndpoint,
     auth: Option<Auth>,
 ) -> crate::Result<()> {
-    let uri = format!("{endpoint}/health");
+    let uri = endpoint
+        .append_path("/health")
+        .expect("static health path should be a valid URL")
+        .to_string();
     let mut request = Request::get(uri).body(Body::empty())?;
 
     if let Some(auth) = auth {
@@ -286,7 +290,7 @@ mod tests {
 
     #[test]
     fn test_prepare_url() {
-        let endpoint = "http://localhost:8080";
+        let endpoint = HttpEndpoint::parse("http://localhost:8080").unwrap();
         let db = "test_db";
         let table = "test_table";
         let metadata = PartitionKey {
@@ -303,8 +307,13 @@ mod tests {
                 .collect(),
         );
 
-        let url = prepare_log_ingester_url(endpoint, db, table, &metadata, &extra_params);
+        let url = prepare_log_ingester_url(&endpoint, db, table, &metadata, &extra_params);
         let url = url::Url::parse(&url).unwrap();
+        assert_eq!(
+            url.path(),
+            "/v1/events/logs",
+            "log ingester path must not gain a double slash from the endpoint"
+        );
         let check = url.query_pairs().all(|(k, v)| match k.as_ref() {
             "db" => v == "test_db",
             "table" => v == "test_table",

--- a/src/sinks/greptimedb/metrics/config.rs
+++ b/src/sinks/greptimedb/metrics/config.rs
@@ -1,16 +1,19 @@
 use vector_lib::{configurable::configurable_component, sensitive_string::SensitiveString};
 
-use crate::sinks::{
-    greptimedb::{
-        GreptimeDBDefaultBatchSettings, GrpcCompression, default_dbname,
-        metrics::{
-            request::GreptimeDBGrpcRetryLogic,
-            request_builder::RequestBuilderOptions,
-            service::{GreptimeDBGrpcService, healthcheck},
-            sink,
+use crate::{
+    config::{DynValidatedSink, ValidatedSink},
+    sinks::{
+        greptimedb::{
+            GreptimeDBDefaultBatchSettings, GrpcCompression, default_dbname,
+            metrics::{
+                request::GreptimeDBGrpcRetryLogic,
+                request_builder::RequestBuilderOptions,
+                service::{GreptimeDBGrpcService, healthcheck},
+                sink,
+            },
         },
+        prelude::*,
     },
-    prelude::*,
 };
 
 /// Configuration for the `greptimedb` sink.
@@ -30,19 +33,36 @@ impl GenerateConfig for GreptimeDBConfig {
 #[async_trait::async_trait]
 #[typetag::serde(name = "greptimedb")]
 impl SinkConfig for GreptimeDBConfig {
-    async fn build(&self, cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
-        warn!(
-            "DEPRECATED: The `greptimedb` sink has been renamed. Please use `greptimedb_metrics` instead."
-        );
-        self.0.build(cx).await
-    }
-
     fn input(&self) -> Input {
         self.0.input()
     }
 
     fn acknowledgements(&self) -> &AcknowledgementsConfig {
         self.0.acknowledgements()
+    }
+
+    fn as_dyn_validated(&self) -> Option<&dyn DynValidatedSink> {
+        Some(self)
+    }
+}
+
+#[async_trait::async_trait]
+impl ValidatedSink for GreptimeDBConfig {
+    type Validated = ValidatedGreptimeDBMetrics;
+
+    fn validate(&self) -> crate::Result<ValidatedGreptimeDBMetrics> {
+        self.0.validate()
+    }
+
+    async fn build(
+        &self,
+        validated: &ValidatedGreptimeDBMetrics,
+        cx: SinkContext,
+    ) -> crate::Result<(VectorSink, Healthcheck)> {
+        warn!(
+            "DEPRECATED: The `greptimedb` sink has been renamed. Please use `greptimedb_metrics` instead."
+        );
+        ValidatedSink::build(&self.0, validated, cx).await
     }
 }
 
@@ -133,29 +153,78 @@ impl_generate_config_from_default!(GreptimeDBMetricsConfig);
 #[typetag::serde(name = "greptimedb_metrics")]
 #[async_trait::async_trait]
 impl SinkConfig for GreptimeDBMetricsConfig {
-    async fn build(&self, _cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
-        let request_settings = self.request.into_settings();
-        let service = ServiceBuilder::new()
-            .settings(request_settings, GreptimeDBGrpcRetryLogic)
-            .service(GreptimeDBGrpcService::try_new(self)?);
-        let sink = sink::GreptimeDBGrpcSink {
-            service,
-            batch_settings: self.batch.into_batcher_settings()?,
-            request_builder_options: RequestBuilderOptions {
-                use_new_naming: self.new_naming.unwrap_or(false),
-            },
-        };
-
-        let healthcheck = healthcheck(self)?;
-        Ok((VectorSink::from_event_streamsink(sink), healthcheck))
-    }
-
     fn input(&self) -> Input {
         Input::metric()
     }
 
     fn acknowledgements(&self) -> &AcknowledgementsConfig {
         &self.acknowledgements
+    }
+
+    fn as_dyn_validated(&self) -> Option<&dyn DynValidatedSink> {
+        Some(self)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ValidatedGreptimeDBMetrics {
+    batch_settings: BatcherSettings,
+    use_new_naming: bool,
+}
+
+/// Validate the all-or-none GreptimeDB TLS path requirement without touching the
+/// filesystem.
+///
+/// The greptimedb ingester requires all three TLS paths (`ca_file`, `crt_file`,
+/// `key_file`) to be set. Mirrors the check in `new_client_from_config`.
+pub(super) fn validate_tls_all_or_none(tls: &TlsConfig) -> crate::Result<()> {
+    if tls.ca_file.is_none() || tls.crt_file.is_none() || tls.key_file.is_none() {
+        return Err(
+            "GreptimeDB TLS requires ca_file, crt_file, and key_file to all be set.".into(),
+        );
+    }
+    Ok(())
+}
+
+#[async_trait::async_trait]
+impl ValidatedSink for GreptimeDBMetricsConfig {
+    type Validated = ValidatedGreptimeDBMetrics;
+
+    fn validate(&self) -> crate::Result<ValidatedGreptimeDBMetrics> {
+        let batch_settings = self.batch.into_batcher_settings()?;
+
+        if let Some(tls) = &self.tls {
+            validate_tls_all_or_none(tls)?;
+        }
+
+        Ok(ValidatedGreptimeDBMetrics {
+            batch_settings,
+            use_new_naming: self.new_naming.unwrap_or(false),
+        })
+    }
+
+    async fn build(
+        &self,
+        validated: &ValidatedGreptimeDBMetrics,
+        _cx: SinkContext,
+    ) -> crate::Result<(VectorSink, Healthcheck)> {
+        let ValidatedGreptimeDBMetrics {
+            batch_settings,
+            use_new_naming,
+        } = validated.clone();
+
+        let request_settings = self.request.into_settings();
+        let service = ServiceBuilder::new()
+            .settings(request_settings, GreptimeDBGrpcRetryLogic)
+            .service(GreptimeDBGrpcService::try_new(self)?);
+        let sink = sink::GreptimeDBGrpcSink {
+            service,
+            batch_settings,
+            request_builder_options: RequestBuilderOptions { use_new_naming },
+        };
+
+        let healthcheck = healthcheck(self)?;
+        Ok((VectorSink::from_event_streamsink(sink), healthcheck))
     }
 }
 
@@ -164,6 +233,7 @@ mod tests {
     use indoc::indoc;
 
     use super::*;
+    use crate::config::ValidatedSink;
 
     #[test]
     fn generate_config() {
@@ -178,5 +248,49 @@ mod tests {
         "#};
 
         serde_yaml::from_str::<GreptimeDBMetricsConfig>(config).unwrap();
+    }
+
+    #[test]
+    fn prepares_valid_config() {
+        let config = GreptimeDBMetricsConfig {
+            endpoint: "example.com:4001".to_string(),
+            ..Default::default()
+        };
+
+        let validated = config.validate().expect("preparation should succeed");
+        assert!(!validated.use_new_naming);
+    }
+
+    #[test]
+    fn validate_rejects_partial_tls() {
+        let config = indoc! {r#"
+            endpoint: "example.com:4001"
+            tls:
+                ca_file: "/path/to/ca.pem"
+                crt_file: "/path/to/crt.pem"
+        "#};
+
+        let config = serde_yaml::from_str::<GreptimeDBMetricsConfig>(config).unwrap();
+        assert!(
+            config.validate().is_err(),
+            "partial TLS should fail validation"
+        );
+    }
+
+    #[test]
+    fn validate_accepts_full_tls() {
+        let config = indoc! {r#"
+            endpoint: "example.com:4001"
+            tls:
+                ca_file: "/path/to/ca.pem"
+                crt_file: "/path/to/crt.pem"
+                key_file: "/path/to/key.pem"
+        "#};
+
+        let config = serde_yaml::from_str::<GreptimeDBMetricsConfig>(config).unwrap();
+        assert!(
+            config.validate().is_ok(),
+            "complete TLS should pass validation"
+        );
     }
 }

--- a/src/sinks/greptimedb/metrics/service.rs
+++ b/src/sinks/greptimedb/metrics/service.rs
@@ -14,7 +14,7 @@ use crate::sinks::{
     greptimedb::{
         GrpcCompression,
         metrics::{
-            config::GreptimeDBMetricsConfig,
+            config::{GreptimeDBMetricsConfig, validate_tls_all_or_none},
             request::{GreptimeDBGrpcBatchOutput, GreptimeDBGrpcRequest},
         },
     },
@@ -64,6 +64,7 @@ fn new_client_from_config(config: &GreptimeDBGrpcServiceConfig) -> crate::Result
 
         // The greptimedb ingester requires all three TLS paths (ca_file, crt_file,
         // key_file) to be set. Refuse a partial config rather than downgrading to plaintext.
+        validate_tls_all_or_none(tls_config)?;
         match (ca_file, crt_file, key_file) {
             (Some(ca), Some(crt), Some(key)) => {
                 channel_config.client_tls = Some(ClientTlsOption {
@@ -73,11 +74,7 @@ fn new_client_from_config(config: &GreptimeDBGrpcServiceConfig) -> crate::Result
                 });
                 ChannelManager::with_tls_config(channel_config).map_err(Box::new)?
             }
-            _ => {
-                return Err(
-                    "GreptimeDB TLS requires ca_file, crt_file, and key_file to all be set.".into(),
-                );
-            }
+            _ => unreachable!("TLS all-or-none validated by validate_tls_all_or_none"),
         }
     } else {
         ChannelManager::with_config(channel_config)


### PR DESCRIPTION
## Summary
Migrate the `greptimedb`, `greptimedb_logs`, and `greptimedb_metrics` sinks to the validated config lifecycle: structural validation now runs at config-compile time and the validated state is retained for build.

### References
Related: #26048

## Vector configuration
NA

## How did you test this PR?
- `make check-clippy` with `sinks-greptimedb_logs,sinks-greptimedb_metrics` features
- `make test` with the same features, `SCOPE="-E 'test(greptime)'"` (20 passed)
- `make generate-docs` (no doc changes required)

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## Contributor Guidelines

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them. To catch issues early, add a `pre-push` hook ([template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push)) or run the following locally before pushing:
  - `make fmt`
  - `make check-clippy` (auto-fix with `make clippy-fix`)
  - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details on the [dd-rust-license-tool](https://crates.io/crates/dd-rust-license-tool).
