### PR TITLE
ci(release): publish Vector artifacts to COSE bucket

### DIFF
--- a/.github/workflows/ci-review-trigger.yml
+++ b/.github/workflows/ci-review-trigger.yml
@@ -252,6 +252,7 @@ jobs:
     permissions:
       contents: write
       packages: write
+      id-token: write # Required by the reusable publish workflow
     uses: ./.github/workflows/publish.yml
     with:
       git_ref: ${{ github.event.review.commit_id }}

--- a/.github/workflows/custom_builds.yml
+++ b/.github/workflows/custom_builds.yml
@@ -11,6 +11,7 @@ jobs:
     permissions:
       contents: write # Required to create/update releases and tags
       packages: write # Required to push container images to GHCR
+      id-token: write # Required to publish release artifacts with AWS OIDC
     uses: ./.github/workflows/publish.yml
     with:
       git_ref: ${{ github.ref }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,6 +13,7 @@ jobs:
     permissions:
       contents: write # Required to create/update releases and tags
       packages: write # Required to push container images to GHCR
+      id-token: write # Required to publish release artifacts with AWS OIDC
     uses: ./.github/workflows/publish.yml
     with:
       git_ref: ${{ github.ref }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -485,6 +485,9 @@ jobs:
     if: ${{ !inputs.skip_publish }}
     runs-on: ubuntu-24.04
     timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write
     needs:
       - generate-publish-metadata
       - build-linux-gnu-native
@@ -506,6 +509,11 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           vdev: true
+      - name: Configure credentials for COSE release artifacts
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        with:
+          role-to-assume: arn:aws:iam::486234852809:role/vector-release-publisher-github-actions
+          aws-region: us-east-1
       - name: Download all package artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -514,8 +522,8 @@ jobs:
           merge-multiple: true
       - name: Publish artifacts to S3
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.CI_AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.CI_AWS_SECRET_ACCESS_KEY }}
+          LEGACY_AWS_ACCESS_KEY_ID: ${{ secrets.CI_AWS_ACCESS_KEY_ID }}
+          LEGACY_AWS_SECRET_ACCESS_KEY: ${{ secrets.CI_AWS_SECRET_ACCESS_KEY }}
         run: make release-s3
 
   publish-github:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ jobs:
     permissions:
       contents: write # Required to create/update releases and tags
       packages: write # Required to push container images to GHCR
+      id-token: write # Required to publish release artifacts with AWS OIDC
     uses: ./.github/workflows/publish.yml
     with:
       git_ref: ${{ github.ref }}

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -50,7 +50,7 @@ experimental or breaking changes.
 
 ### Nightly channel
 
-Releases will appear in our [nightly artifact list] every night.
+Nightly releases are published every night.
 
 ## Downloading
 
@@ -95,7 +95,6 @@ Otherwise, the stable release is your best bet.
 [chat]: https://chat.vector.dev
 [package manager]: https://vector.dev/docs/setup/installation/package-managers/
 [download page]: https://vector.dev/download/
-[nightly artifact list]: https://dd-cose-releases.s3.amazonaws.com/vector/nightly/
 [@vectordotdev]: https://twitter.com/vectordotdev
 [GitHub repository]: https://github.com/vectordotdev/vector
 [GitHub subscription docs]: https://docs.github.com/en/github/managing-subscriptions-and-notifications-on-github/managing-subscriptions-for-activity-on-github/viewing-your-subscriptions

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -95,7 +95,7 @@ Otherwise, the stable release is your best bet.
 [chat]: https://chat.vector.dev
 [package manager]: https://vector.dev/docs/setup/installation/package-managers/
 [download page]: https://vector.dev/download/
-[nightly artifact list]: https://packages.timber.io/vector/nightly/
+[nightly artifact list]: https://dd-cose-releases.s3.amazonaws.com/vector/nightly/
 [@vectordotdev]: https://twitter.com/vectordotdev
 [GitHub repository]: https://github.com/vectordotdev/vector
 [GitHub subscription docs]: https://docs.github.com/en/github/managing-subscriptions-and-notifications-on-github/managing-subscriptions-for-activity-on-github/viewing-your-subscriptions

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -130,7 +130,7 @@ here. Each minor release bump will include an upgrade guide in the
 [`internal_metrics` source]: https://vector.dev/docs/reference/configuration/sources/internal_metrics/
 [`lua` transform]: https://vector.dev/docs/reference/configuration/transforms/lua/
 [`master` branch]: https://github.com/vectordotdev/vector/tree/master
-[nightly artifact list]: https://packages.timber.io/vector/nightly/
+[nightly artifact list]: https://dd-cose-releases.s3.amazonaws.com/vector/nightly/
 [package manager]: https://vector.dev/docs/setup/installation/package-managers/
 [release notes]: https://vector.dev/releases/
 [release policy]: https://github.com/vectordotdev/vector/blob/master/RELEASES.md

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -130,7 +130,6 @@ here. Each minor release bump will include an upgrade guide in the
 [`internal_metrics` source]: https://vector.dev/docs/reference/configuration/sources/internal_metrics/
 [`lua` transform]: https://vector.dev/docs/reference/configuration/transforms/lua/
 [`master` branch]: https://github.com/vectordotdev/vector/tree/master
-[nightly artifact list]: https://dd-cose-releases.s3.amazonaws.com/vector/nightly/
 [package manager]: https://vector.dev/docs/setup/installation/package-managers/
 [release notes]: https://vector.dev/releases/
 [release policy]: https://github.com/vectordotdev/vector/blob/master/RELEASES.md

--- a/scripts/release-s3.sh
+++ b/scripts/release-s3.sh
@@ -142,7 +142,6 @@ if [[ "$CHANNEL" == "nightly" ]]; then
 
   # Add "latest" nightly files
   echo "Uploading all artifacts to s3://$COSE_BUCKET/vector/nightly/latest"
-  cose_aws s3 rm --recursive "s3://$COSE_BUCKET/vector/nightly/latest"
   s3_copy cose_aws "$td_nightly" "s3://$COSE_BUCKET/vector/nightly/latest" --recursive
   echo "Uploaded archives"
 

--- a/scripts/release-s3.sh
+++ b/scripts/release-s3.sh
@@ -53,11 +53,20 @@ publish_release_redirects() {
     local version_prefix="$3"
     local file
 
-    for file in $("$client" s3api list-objects-v2 --bucket "$bucket" --prefix "vector/$version_prefix/" --query 'Contents[*].Key' --output text | tr "\t" "\n" | grep "\-$VERSION_EXACT"); do
-        file=$(basename "$file")
-        # vector-$version-amd64.deb -> vector-amd64.deb
-        echo -n "" | s3_copy "$client" - "s3://$bucket/vector/$version_prefix/${file/-$VERSION_EXACT/}" --website-redirect "/vector/$version_prefix/$file"
-    done
+    if [[ "$client" == "legacy_aws" ]]; then
+        for file in $("$client" s3api list-objects-v2 --bucket "$bucket" --prefix "vector/$version_prefix/" --query 'Contents[*].Key' --output text | tr "\t" "\n" | grep "\-$VERSION_EXACT"); do
+            file=$(basename "$file")
+            # vector-$version-amd64.deb -> vector-amd64.deb
+            echo -n "" | s3_copy "$client" - "s3://$bucket/vector/$version_prefix/${file/-$VERSION_EXACT/}" --website-redirect "/vector/$version_prefix/$file"
+        done
+    else
+        find "$td" -maxdepth 1 -type f -print0 | while read -r -d $'\0' file; do
+            file_name=$(basename "$file")
+            # S3's REST endpoint does not follow website redirects, so COSE
+            # aliases are full copies of the corresponding release artifact.
+            s3_copy "$client" "$file" "s3://$bucket/vector/$version_prefix/${file_name/-$VERSION_EXACT/}"
+        done
+    fi
 }
 
 publish_release_artifacts() {
@@ -167,10 +176,10 @@ elif [[ "$CHANNEL" == "release" ]]; then
     file=$(basename "$file")
     # vector-$version-amd64.deb -> vector-latest-amd64.deb
     echo -n "" | s3_copy legacy_aws - "s3://$LEGACY_BUCKET/vector/latest/${file/$VERSION_EXACT/latest}" --website-redirect "/vector/latest/$file"
-    echo -n "" | s3_copy cose_aws - "s3://$COSE_BUCKET/vector/latest/${file/$VERSION_EXACT/latest}" --website-redirect "/vector/latest/$file"
+    s3_copy cose_aws "$td/$file" "s3://$COSE_BUCKET/vector/latest/${file/$VERSION_EXACT/latest}"
     # vector-$version-amd64.deb -> vector-amd64.deb
     echo -n "" | s3_copy legacy_aws - "s3://$LEGACY_BUCKET/vector/latest/${file/$VERSION_EXACT-/}" --website-redirect "/vector/latest/$file"
-    echo -n "" | s3_copy cose_aws - "s3://$COSE_BUCKET/vector/latest/${file/$VERSION_EXACT-/}" --website-redirect "/vector/latest/$file"
+    s3_copy cose_aws "$td/$file" "s3://$COSE_BUCKET/vector/latest/${file/$VERSION_EXACT-/}"
   done
   echo "Added latest symlinks"
 

--- a/scripts/release-s3.sh
+++ b/scripts/release-s3.sh
@@ -17,6 +17,68 @@ VERIFY_RETRIES="${VERIFY_RETRIES:-"2"}"
 
 export AWS_REGION=us-east-1
 
+LEGACY_BUCKET="packages.timber.io"
+COSE_BUCKET="dd-cose-releases"
+COSE_PUBLIC_URL="https://${COSE_BUCKET}.s3.amazonaws.com"
+
+# Stable releases are dual-published with legacy static credentials and the
+# COSE GitHub OIDC credentials configured by the publish workflow.
+legacy_aws() {
+    : "${LEGACY_AWS_ACCESS_KEY_ID:?LEGACY_AWS_ACCESS_KEY_ID is required for legacy stable releases}"
+    : "${LEGACY_AWS_SECRET_ACCESS_KEY:?LEGACY_AWS_SECRET_ACCESS_KEY is required for legacy stable releases}"
+    env -u AWS_SESSION_TOKEN -u AWS_SECURITY_TOKEN \
+        AWS_ACCESS_KEY_ID="$LEGACY_AWS_ACCESS_KEY_ID" \
+        AWS_SECRET_ACCESS_KEY="$LEGACY_AWS_SECRET_ACCESS_KEY" \
+        aws "$@"
+}
+
+cose_aws() {
+    aws "$@"
+}
+
+s3_copy() {
+    local client="$1"
+    shift
+
+    if [[ "$client" == "legacy_aws" ]]; then
+        "$client" s3 cp "$@" --sse --acl public-read
+    else
+        "$client" s3 cp "$@" --sse
+    fi
+}
+
+publish_release_redirects() {
+    local client="$1"
+    local bucket="$2"
+    local version_prefix="$3"
+    local file
+
+    for file in $("$client" s3api list-objects-v2 --bucket "$bucket" --prefix "vector/$version_prefix/" --query 'Contents[*].Key' --output text | tr "\t" "\n" | grep "\-$VERSION_EXACT"); do
+        file=$(basename "$file")
+        # vector-$version-amd64.deb -> vector-amd64.deb
+        echo -n "" | s3_copy "$client" - "s3://$bucket/vector/$version_prefix/${file/-$VERSION_EXACT/}" --website-redirect "/vector/$version_prefix/$file"
+    done
+}
+
+publish_release_artifacts() {
+    local client="$1"
+    local bucket="$2"
+    local version_prefix="$3"
+
+    echo "Uploading artifacts to s3://$bucket/vector/$version_prefix/"
+    s3_copy "$client" "$td" "s3://$bucket/vector/$version_prefix/" --recursive
+
+    if [[ "$version_prefix" == "${VERSION_MAJOR_X}" || "$version_prefix" == "${VERSION_MINOR_X}" || "$version_prefix" == "latest" ]] ; then
+        echo "Deleting old artifacts from s3://$bucket/vector/$version_prefix/"
+        "$client" s3 rm "s3://$bucket/vector/$version_prefix/" --recursive --exclude "*$VERSION_EXACT*"
+        echo "Deleted old versioned artifacts"
+    fi
+
+    echo "Redirecting old artifact names in s3://$bucket/vector/$version_prefix/"
+    publish_release_redirects "$client" "$bucket" "$version_prefix"
+    echo "Redirected old artifact names"
+}
+
 #
 # Setup
 #
@@ -65,27 +127,27 @@ verify_artifact() {
 
 if [[ "$CHANNEL" == "nightly" ]]; then
   # Add nightly files with the $DATE for posterity
-  echo "Uploading all artifacts to s3://packages.timber.io/vector/nightly/$DATE"
-  aws s3 cp "$td_nightly" "s3://packages.timber.io/vector/nightly/$DATE" --recursive --sse --acl public-read
+  echo "Uploading all artifacts to s3://$COSE_BUCKET/vector/nightly/$DATE"
+  s3_copy cose_aws "$td_nightly" "s3://$COSE_BUCKET/vector/nightly/$DATE" --recursive
   echo "Uploaded archives"
 
   # Add "latest" nightly files
-  echo "Uploading all artifacts to s3://packages.timber.io/vector/nightly/latest"
-  aws s3 rm --recursive "s3://packages.timber.io/vector/nightly/latest"
-  aws s3 cp "$td_nightly" "s3://packages.timber.io/vector/nightly/latest" --recursive --sse --acl public-read
+  echo "Uploading all artifacts to s3://$COSE_BUCKET/vector/nightly/latest"
+  cose_aws s3 rm --recursive "s3://$COSE_BUCKET/vector/nightly/latest"
+  s3_copy cose_aws "$td_nightly" "s3://$COSE_BUCKET/vector/nightly/latest" --recursive
   echo "Uploaded archives"
 
   # Verify that the files exist and can be downloaded
   echo "Waiting for $VERIFY_TIMEOUT seconds before running the verifications"
   sleep "$VERIFY_TIMEOUT"
   verify_artifact \
-    "https://packages.timber.io/vector/nightly/$DATE/vector-nightly-x86_64-unknown-linux-musl.tar.gz" \
+    "$COSE_PUBLIC_URL/vector/nightly/$DATE/vector-nightly-x86_64-unknown-linux-musl.tar.gz" \
     "$td_nightly/vector-nightly-x86_64-unknown-linux-musl.tar.gz"
   verify_artifact \
-    "https://packages.timber.io/vector/nightly/latest/vector-nightly-x86_64-unknown-linux-musl.tar.gz" \
+    "$COSE_PUBLIC_URL/vector/nightly/latest/vector-nightly-x86_64-unknown-linux-musl.tar.gz" \
     "$td_nightly/vector-nightly-x86_64-unknown-linux-musl.tar.gz"
   verify_artifact \
-    "https://packages.timber.io/vector/nightly/latest/vector-nightly-x86_64-unknown-linux-gnu.tar.gz" \
+    "$COSE_PUBLIC_URL/vector/nightly/latest/vector-nightly-x86_64-unknown-linux-gnu.tar.gz" \
     "$td_nightly/vector-nightly-x86_64-unknown-linux-gnu.tar.gz"
 
 elif [[ "$CHANNEL" == "release" ]]; then
@@ -96,33 +158,19 @@ elif [[ "$CHANNEL" == "release" ]]; then
   VERSION_MAJOR_X="$(echo "$VERSION" | sed 's/\.[0-9]*\.[0-9]*$/.X/g')"
 
   for i in "$VERSION_EXACT" "$VERSION_MINOR_X" "$VERSION_MAJOR_X" "latest"; do
-    # Upload the specific version
-    echo "Uploading artifacts to s3://packages.timber.io/vector/$i/"
-    aws s3 cp "$td" "s3://packages.timber.io/vector/$i/" --recursive --sse --acl public-read
-
-    if [[ "$i" == "${VERSION_MAJOR_X}" || "$i" == "${VERSION_MINOR_X}" || "$i" == "latest" ]] ; then
-      # Delete anything that isn't the current version
-      echo "Deleting old artifacts from s3://packages.timber.io/vector/$i/"
-      aws s3 rm "s3://packages.timber.io/vector/$i/" --recursive --exclude "*$VERSION_EXACT*"
-      echo "Deleted old versioned artifacts"
-    fi
-
-    echo "Redirecting old artifact names in s3://packages.timber.io/vector/$i/"
-    for file in $(aws s3api list-objects-v2 --bucket packages.timber.io --prefix "vector/$i/" --query 'Contents[*].Key' --output text  | tr "\t" "\n" | grep "\-$VERSION_EXACT"); do
-      file=$(basename "$file")
-      # vector-$version-amd64.deb -> vector-amd64.deb
-      echo -n "" | aws s3 cp - "s3://packages.timber.io/vector/$i/${file/-$VERSION_EXACT/}" --website-redirect "/vector/$i/$file" --acl public-read
-    done
-    echo "Redirected old artifact names"
+    publish_release_artifacts legacy_aws "$LEGACY_BUCKET" "$i"
+    publish_release_artifacts cose_aws "$COSE_BUCKET" "$i"
   done
 
   echo "Add latest symlinks"
   find "$td" -maxdepth 1 -type f -print0 | while read -r -d $'\0' file ; do
     file=$(basename "$file")
     # vector-$version-amd64.deb -> vector-latest-amd64.deb
-    echo -n "" | aws s3 cp - "s3://packages.timber.io/vector/latest/${file/$VERSION_EXACT/latest}" --website-redirect "/vector/latest/$file" --acl public-read
+    echo -n "" | s3_copy legacy_aws - "s3://$LEGACY_BUCKET/vector/latest/${file/$VERSION_EXACT/latest}" --website-redirect "/vector/latest/$file"
+    echo -n "" | s3_copy cose_aws - "s3://$COSE_BUCKET/vector/latest/${file/$VERSION_EXACT/latest}" --website-redirect "/vector/latest/$file"
     # vector-$version-amd64.deb -> vector-amd64.deb
-    echo -n "" | aws s3 cp - "s3://packages.timber.io/vector/latest/${file/$VERSION_EXACT-/}" --website-redirect "/vector/latest/$file" --acl public-read
+    echo -n "" | s3_copy legacy_aws - "s3://$LEGACY_BUCKET/vector/latest/${file/$VERSION_EXACT-/}" --website-redirect "/vector/latest/$file"
+    echo -n "" | s3_copy cose_aws - "s3://$COSE_BUCKET/vector/latest/${file/$VERSION_EXACT-/}" --website-redirect "/vector/latest/$file"
   done
   echo "Added latest symlinks"
 
@@ -133,23 +181,29 @@ elif [[ "$CHANNEL" == "release" ]]; then
     verify_artifact \
       "https://packages.timber.io/vector/$i/vector-$VERSION-x86_64-unknown-linux-musl.tar.gz" \
       "$td/vector-$VERSION-x86_64-unknown-linux-musl.tar.gz"
+    verify_artifact \
+      "$COSE_PUBLIC_URL/vector/$i/vector-$VERSION-x86_64-unknown-linux-musl.tar.gz" \
+      "$td/vector-$VERSION-x86_64-unknown-linux-musl.tar.gz"
   done
   verify_artifact \
     "https://packages.timber.io/vector/latest/vector-latest-x86_64-unknown-linux-gnu.tar.gz" \
+    "$td/vector-$VERSION-x86_64-unknown-linux-gnu.tar.gz"
+  verify_artifact \
+    "$COSE_PUBLIC_URL/vector/latest/vector-latest-x86_64-unknown-linux-gnu.tar.gz" \
     "$td/vector-$VERSION-x86_64-unknown-linux-gnu.tar.gz"
 
 elif [[ "$CHANNEL" == "custom" ]]; then
 
   # Add custom files
-  echo "Uploading all artifacts to s3://packages.timber.io/vector/custom"
-  aws s3 cp "$td" "s3://packages.timber.io/vector/custom/$VERSION" --recursive --sse --acl public-read
+  echo "Uploading all artifacts to s3://$COSE_BUCKET/vector/custom"
+  s3_copy cose_aws "$td" "s3://$COSE_BUCKET/vector/custom/$VERSION" --recursive
   echo "Uploaded archives"
 
   # Verify that the files exist and can be downloaded
   echo "Waiting for $VERIFY_TIMEOUT seconds before running the verifications"
   sleep "$VERIFY_TIMEOUT"
   verify_artifact \
-    "https://packages.timber.io/vector/custom/$VERSION/vector-$VERSION-x86_64-unknown-linux-gnu.tar.gz" \
+    "$COSE_PUBLIC_URL/vector/custom/$VERSION/vector-$VERSION-x86_64-unknown-linux-gnu.tar.gz" \
     "$td/vector-$VERSION-x86_64-unknown-linux-gnu.tar.gz"
 
 fi

--- a/website/content/en/docs/setup/installation/manual/from-archives.md
+++ b/website/content/en/docs/setup/installation/manual/from-archives.md
@@ -24,7 +24,7 @@ mkdir -p vector && \
 
 # Nightly
 mkdir -p vector && \
-  curl -sSfL --proto '=https' --tlsv1.2 https://packages.timber.io/vector/nightly/latest/vector-nightly-aarch64-unknown-linux-musl.tar.gz | \
+  curl -sSfL --proto '=https' --tlsv1.2 https://dd-cose-releases.s3.amazonaws.com/vector/nightly/latest/vector-nightly-aarch64-unknown-linux-musl.tar.gz | \
   tar xzf - -C vector --strip-components=2
 ```
 
@@ -59,7 +59,7 @@ mkdir -p vector && \
 
 # Nightly
 mkdir -p vector && \
-  curl -sSfL --proto '=https' --tlsv1.2 https://packages.timber.io/vector/nightly/latest/vector-nightly-armv7-unknown-linux-gnueabihf.tar.gz | \
+  curl -sSfL --proto '=https' --tlsv1.2 https://dd-cose-releases.s3.amazonaws.com/vector/nightly/latest/vector-nightly-armv7-unknown-linux-gnueabihf.tar.gz | \
   tar xzf - -C vector --strip-components=2
 ```
 
@@ -94,7 +94,7 @@ mkdir -p vector && \
 
 # Nightly
 mkdir -p vector && \
-  curl -sSfL --proto '=https' --tlsv1.2 https://packages.timber.io/vector/nightly/latest/vector-nightly-arm64-apple-darwin.tar.gz  | \
+  curl -sSfL --proto '=https' --tlsv1.2 https://dd-cose-releases.s3.amazonaws.com/vector/nightly/latest/vector-nightly-arm64-apple-darwin.tar.gz  | \
   tar xzf - -C vector --strip-components=2
 ```
 
@@ -127,7 +127,7 @@ powershell Invoke-WebRequest https://packages.timber.io/vector/{{< version >}}/v
 
 
 # Nightly
-powershell Invoke-WebRequest https://packages.timber.io/vector/0.12.X/vector-nightly-x86_64-pc-windows-msvc.zip -OutFile vector-nightly-x86_64-pc-windows-msvc.zip
+powershell Invoke-WebRequest https://dd-cose-releases.s3.amazonaws.com/vector/nightly/latest/vector-nightly-x86_64-pc-windows-msvc.zip -OutFile vector-nightly-x86_64-pc-windows-msvc.zip
 ```
 
 Extract files from the archive:
@@ -160,7 +160,7 @@ mkdir -p vector && \
 
 # Nightly
 mkdir -p vector && \
-  curl -sSfL --proto '=https' --tlsv1.2 https://packages.timber.io/vector/nightly/latest/vector-nightly-x86_64-unknown-linux-musl.tar.gz | \
+  curl -sSfL --proto '=https' --tlsv1.2 https://dd-cose-releases.s3.amazonaws.com/vector/nightly/latest/vector-nightly-x86_64-unknown-linux-musl.tar.gz | \
   tar xzf - -C vector --strip-components=2
 ```
 

--- a/website/cue/reference/urls.cue
+++ b/website/cue/reference/urls.cue
@@ -608,7 +608,7 @@ urls: {
 	vector_monitoring:                          "/docs/administration/monitoring"
 	vector_msi_source_files:                    "\(vector_repo)/tree/master/distribution/msi"
 	vector_new_relic_sink:                      "/docs/reference/configuration/sinks/new_relic/"
-	vector_nightly_builds:                      "https://packages.timber.io/vector/nightly/latest/"
+	vector_nightly_builds:                      "https://dd-cose-releases.s3.amazonaws.com/vector/nightly/latest/"
 	vector_nix_package:                         "\(github)/NixOS/nixpkgs/blob/master/pkgs/tools/misc/vector/default.nix"
 	vector_packages_root:                       "https://packages.timber.io"
 	vector_performance:                         "\(vector_repo)/#performance"

--- a/website/cue/reference/urls.cue
+++ b/website/cue/reference/urls.cue
@@ -608,7 +608,6 @@ urls: {
 	vector_monitoring:                          "/docs/administration/monitoring"
 	vector_msi_source_files:                    "\(vector_repo)/tree/master/distribution/msi"
 	vector_new_relic_sink:                      "/docs/reference/configuration/sinks/new_relic/"
-	vector_nightly_builds:                      "https://dd-cose-releases.s3.amazonaws.com/vector/nightly/latest/"
 	vector_nix_package:                         "\(github)/NixOS/nixpkgs/blob/master/pkgs/tools/misc/vector/default.nix"
 	vector_packages_root:                       "https://packages.timber.io"
 	vector_performance:                         "\(vector_repo)/#performance"

--- a/website/layouts/partials/download/download-matrix.html
+++ b/website/layouts/partials/download/download-matrix.html
@@ -63,11 +63,3 @@
   </div>
   {{ end }}
 </div>
-
-{{ $version = cond (eq $version "nightly") "nightly/latest" $version }}
-{{ $link := printf "%s/vector/%s" $packagesRoot $version }}
-<div class="mt-8">
-  <a href="{{ $link }}" class="text-sm dark:text-gray-300 hover:text-primary-dark dark:hover:text-secondary dark:text-primary text-secondary" rel="noopener" target="_blank">
-    browse all files...
-  </a>
-</div>

--- a/website/layouts/partials/download/download-matrix.html
+++ b/website/layouts/partials/download/download-matrix.html
@@ -1,5 +1,6 @@
 {{ $version := .version }}
 {{ $v1 := cond (eq $version "nightly") "nightly/latest" $version }}
+{{ $packagesRoot := cond (eq $version "nightly") "https://dd-cose-releases.s3.amazonaws.com" "https://packages.timber.io" }}
 {{ $host := site.Data.matrix.host }}
 {{ $matrix := site.Data.docs.administration.downloads }}
 <div class="flex flex-col space-y-4">
@@ -37,7 +38,7 @@
         {{ end }}
         {{ if $showOption }}
         {{ $vector := cond (eq $version "nightly") "vector/nightly" "vector" }}
-        {{ $url := .download_url | replaceRE "{v1}" $v1 | replaceRE "{v2}" $version }}
+        {{ $url := .download_url | replaceRE "https://packages\\.timber\\.io" $packagesRoot | replaceRE "{v1}" $v1 | replaceRE "{v2}" $version }}
 
         <a
           type="button"
@@ -64,7 +65,7 @@
 </div>
 
 {{ $version = cond (eq $version "nightly") "nightly/latest" $version }}
-{{ $link := printf "https://packages.timber.io/vector/%s" $version }}
+{{ $link := printf "%s/vector/%s" $packagesRoot $version }}
 <div class="mt-8">
   <a href="{{ $link }}" class="text-sm dark:text-gray-300 hover:text-primary-dark dark:hover:text-secondary dark:text-primary text-secondary" rel="noopener" target="_blank">
     browse all files...


### PR DESCRIPTION
## Summary

Publish Vector artifacts to the COSE-owned `dd-cose-releases` bucket using GitHub OIDC.

### Motivation

Vector release artifacts are moving from `packages.timber.io` to the COSE-managed public bucket. Future nightly and custom builds must publish only to the new bucket. Stable releases remain available from both buckets during the migration window.

### Changes

- Assume the least-privilege `vector-release-publisher-github-actions` role with GitHub OIDC.
- Publish nightly and custom artifacts to `dd-cose-releases/vector/` without public ACLs.
- Dual-publish stable releases to `packages.timber.io` and `dd-cose-releases` during the migration window.
- Verify downloads from the public S3 endpoint and isolate legacy static credentials from OIDC session credentials.

### References

Related: #26104

## Vector configuration

N/A

## How did you test this PR?

- `git diff --check`
- `bash -n scripts/release-s3.sh`
- `shellcheck scripts/release-s3.sh`
- Parsed the changed workflow YAML files.
- Simulated nightly, custom, and stable dual-publish commands with mocked AWS and download clients. Legacy commands retained `--acl public-read`; the new bucket never received it.
- Ran the `Custom Builds` workflow from this branch with publishing enabled: https://github.com/vectordotdev/vector/actions/runs/32316848983
  - The complete workflow and `Custom / Publish to S3` job succeeded using GitHub OIDC.
  - Published 19 artifacts (828.8 MiB) to `s3://dd-cose-releases/vector/custom/0.58.0.custom.9911185/`.
  - Listed the published objects using the human SSO operator role.
  - Verified that an uploaded archive is publicly downloadable from the S3 endpoint with HTTP 200.

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.
