### PR TITLE
enhancement(ci): cache libsasl2 packages to avoid flaky apt

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -219,6 +219,10 @@ runs:
 
         DEBS_DIR=/tmp/libsasl2-debs
 
+        apt_get_with_timeout() {
+          timeout 30m sudo apt-get "$@"
+        }
+
         # Install the cached .deb files, skipping any package that is already
         # satisfied at an equal or newer version.
         install_from_cache() {
@@ -242,15 +246,15 @@ runs:
           if ! install_from_cache; then
             echo "Cached packages could not be installed, falling back to apt"
             echo "::warning::Cached libsasl2 packages could not be installed. Refresh the cache by running the 'Refresh libsasl2 cache' workflow manually, or wait for the weekly scheduled refresh."
-            timeout 30m sudo apt-get update
-            timeout 30m sudo apt-get install -f -y libsasl2-dev
+            apt_get_with_timeout update
+            apt_get_with_timeout install -f -y libsasl2-dev
           fi
         else
           echo "Installing libsasl2 from apt"
-          timeout 30m sudo apt-get update
+          apt_get_with_timeout update
           TMP_DEBS=$(mktemp -d)
           cd "$TMP_DEBS"
-          timeout 30m apt-get download libsasl2-dev libsasl2-2 libsasl2-modules-db libdb5.3t64
+          apt_get_with_timeout download libsasl2-dev libsasl2-2 libsasl2-modules-db libdb5.3t64
           mkdir -p "$DEBS_DIR"
           cp "$TMP_DEBS"/*.deb "$DEBS_DIR"/
           rm -rf "$TMP_DEBS"

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -201,10 +201,60 @@ runs:
         sudo cp "${TEMP}/cue" /usr/bin/cue
         rm -rf "$TEMP"
 
+    - name: Cache libsasl2 packages
+      if: ${{ inputs.libsasl2 == 'true' }}
+      id: cache-libsasl2
+      uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+      with:
+        path: /tmp/libsasl2-debs
+        key: ${{ runner.os }}-libsasl2-${{ hashFiles('.github/actions/setup/action.yml') }}
+        restore-keys: |
+          ${{ runner.os }}-libsasl2-
+
     - name: Install libsasl2
       if: ${{ inputs.libsasl2 == 'true' }}
       shell: bash
-      run: timeout 30m sudo apt-get update && timeout 30m sudo apt-get install -y libsasl2-dev
+      run: |
+        set -euo pipefail
+
+        DEBS_DIR=/tmp/libsasl2-debs
+
+        # Install the cached .deb files, skipping any package that is already
+        # satisfied at an equal or newer version.
+        install_from_cache() {
+          local debs=()
+          local pkg ver installed
+          for deb in "$DEBS_DIR"/*.deb; do
+            pkg=$(dpkg-deb -f "$deb" Package)
+            ver=$(dpkg-deb -f "$deb" Version)
+            installed=$(dpkg-query -W -f='${Version}' "$pkg" 2>/dev/null || true)
+            if [[ -z "$installed" ]] || ! dpkg --compare-versions "$installed" ge "$ver"; then
+              debs+=("$deb")
+            fi
+          done
+          if [[ ${#debs[@]} -gt 0 ]]; then
+            sudo dpkg -i "${debs[@]}"
+          fi
+        }
+
+        if compgen -G "$DEBS_DIR"/*.deb > /dev/null; then
+          echo "Installing libsasl2 from cached packages"
+          if ! install_from_cache; then
+            echo "Cached packages could not be installed, falling back to apt"
+            timeout 30m sudo apt-get update
+            timeout 30m sudo apt-get install -f -y libsasl2-dev
+          fi
+        else
+          echo "Installing libsasl2 from apt"
+          timeout 30m sudo apt-get update
+          TMP_DEBS=$(mktemp -d)
+          cd "$TMP_DEBS"
+          timeout 30m apt-get download libsasl2-dev libsasl2-2 libsasl2-modules-db libdb5.3t64
+          mkdir -p "$DEBS_DIR"
+          cp "$TMP_DEBS"/*.deb "$DEBS_DIR"/
+          rm -rf "$TMP_DEBS"
+          install_from_cache
+        fi
 
     - name: Cache cargo binaries
       id: cache-cargo-binaries

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -241,6 +241,7 @@ runs:
           echo "Installing libsasl2 from cached packages"
           if ! install_from_cache; then
             echo "Cached packages could not be installed, falling back to apt"
+            echo "::warning::Cached libsasl2 packages could not be installed. Refresh the cache by running the 'Refresh libsasl2 cache' workflow manually, or wait for the weekly scheduled refresh."
             timeout 30m sudo apt-get update
             timeout 30m sudo apt-get install -f -y libsasl2-dev
           fi

--- a/.github/workflows/refresh-libsasl2-cache.yml
+++ b/.github/workflows/refresh-libsasl2-cache.yml
@@ -1,0 +1,37 @@
+name: Refresh libsasl2 cache
+
+# Refreshes the cached libsasl2 .deb packages consumed by the setup action so
+# CI does not depend on a stale cache or a flaky `apt-get update`. Deletes the
+# cached packages and re-warms them via the setup action. Runs weekly and can
+# be triggered manually when a `dpkg` failure is reported in CI.
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 5 * * 1" # 05:00 UTC every Monday
+
+permissions:
+  actions: write # Required to delete the stale libsasl2 cache
+  contents: read # Required to checkout code
+
+concurrency:
+  group: refresh-libsasl2-cache
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    name: Refresh libsasl2 cache
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      # Delete every cached libsasl2 entry so the setup action below misses the
+      # cache, downloads fresh packages, and saves them under the stable key.
+      - name: Delete stale libsasl2 cache
+        run: gh api --method DELETE repos/${{ github.repository }}/actions/caches -f key="Linux-libsasl2-"
+
+      - uses: ./.github/actions/setup
+        with:
+          mold: false
+          libsasl2: true

--- a/.github/workflows/refresh-libsasl2-cache.yml
+++ b/.github/workflows/refresh-libsasl2-cache.yml
@@ -28,10 +28,18 @@ jobs:
 
       # Delete every cached libsasl2 entry so the setup action below misses the
       # cache, downloads fresh packages, and saves them under the stable key.
+      # The list endpoint supports prefix filtering; delete each matching cache
+      # by ID rather than relying on the delete-by-key endpoint's match semantics.
       - name: Delete stale libsasl2 cache
-        run: gh api --method DELETE repos/${{ github.repository }}/actions/caches -f key="Linux-libsasl2-"
+        run: |
+          set -euo pipefail
+          ids=$(gh api --method GET "repos/${{ github.repository }}/actions/caches" -f key="Linux-libsasl2-" -f per_page=100 --jq '.actions_caches[].id')
+          for id in $ids; do
+            gh api --method DELETE "repos/${{ github.repository }}/actions/caches/$id"
+          done
 
       - uses: ./.github/actions/setup
         with:
           mold: false
+          vdev: false
           libsasl2: true


### PR DESCRIPTION
## Summary
Cache the libsasl2 .deb packages in the CI setup action so installing them no longer depends on a flaky `apt-get update`. On cache hit, installs via `dpkg -i` from the cached packages; on miss, downloads the full dependency closure via `apt-get download`.

### References
NA

## Vector configuration
NA

## How did you test this PR?
Verified the install logic in an Ubuntu 24.04 container (cache-miss, cache-hit offline, version-guard idempotency) and end-to-end on real GitHub runners in vectordotdev/ci-sandbox (cache miss -> save, cache hit -> restore, key rotation -> restore-keys fallback).

Also re-ran clippy to grab a cached version of libsasl2. Run: https://github.com/vectordotdev/vector/actions/runs/32284131167/job/96197673338?pr=26156


## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## Contributor Guidelines

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them. To catch issues early, add a `pre-push` hook ([template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push)) or run the following locally before pushing:
  - `make fmt`
  - `make check-clippy` (auto-fix with `make clippy-fix`)
  - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details on the [dd-rust-license-tool](https://crates.io/crates/dd-rust-license-tool).
