### PR TITLE
feat(doris sink): validate config at compile time

### DIFF
--- a/src/sinks/doris/common.rs
+++ b/src/sinks/doris/common.rs
@@ -21,7 +21,7 @@ pub struct DorisCommon {
 }
 
 impl DorisCommon {
-    pub async fn parse_config(config: &DorisConfig, endpoint: &UriSerde) -> crate::Result<Self> {
+    pub fn parse_config(config: &DorisConfig, endpoint: &UriSerde) -> crate::Result<Self> {
         if endpoint.uri.host().is_none() {
             return Err(
                 format!("Invalid host: {}, host must include hostname", endpoint.uri).into(),
@@ -50,10 +50,10 @@ impl DorisCommon {
             tls_settings,
         })
     }
-    pub async fn parse_many(config: &DorisConfig) -> crate::Result<Vec<Self>> {
+    pub fn parse_many(config: &DorisConfig) -> crate::Result<Vec<Self>> {
         let mut commons = Vec::new();
         for endpoint in config.endpoints.iter() {
-            commons.push(Self::parse_config(config, endpoint).await?);
+            commons.push(Self::parse_config(config, endpoint)?);
         }
         Ok(commons)
     }

--- a/src/sinks/doris/config.rs
+++ b/src/sinks/doris/config.rs
@@ -4,14 +4,18 @@ use super::sink::DorisSink;
 
 use crate::{
     codecs::EncodingConfigWithFraming,
-    http::{Auth, HttpClient},
+    config::{DynValidatedSink, ValidatedSink},
+    http::{Auth, HttpClient, MaybeAuth},
     sinks::{
         doris::{
             client::DorisSinkClient, common::DorisCommon, health::DorisHealthLogic,
             retry::DorisRetryLogic, service::DorisService,
         },
         prelude::*,
-        util::{RealtimeSizeBasedDefaultBatchSettings, UriSerde, service::HealthConfig},
+        util::{
+            RealtimeSizeBasedDefaultBatchSettings, TowerRequestSettings, UriSerde,
+            service::HealthConfig,
+        },
     },
     template::ConfinementConfig,
 };
@@ -29,8 +33,8 @@ pub struct DorisConfig {
     ///
     /// The endpoint must contain an HTTP scheme, and may specify a
     /// hostname or IP address and port.
-    #[serde(default)]
     #[configurable(metadata(docs::examples = "http://127.0.0.1:8030"))]
+    #[configurable(metadata(docs::required = true))]
     pub endpoints: Vec<UriSerde>,
 
     /// The database that contains the table data will be inserted into.
@@ -149,21 +153,98 @@ impl_generate_config_from_default!(DorisConfig);
 #[async_trait::async_trait]
 #[typetag::serde(name = "doris")]
 impl SinkConfig for DorisConfig {
-    async fn build(&self, cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
-        let endpoints = self.endpoints.clone();
+    fn confinement_config(&self) -> Option<&crate::template::ConfinementConfig> {
+        Some(&self.confinement)
+    }
 
-        if endpoints.is_empty() {
+    fn input(&self) -> Input {
+        Input::log()
+    }
+
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &self.acknowledgements
+    }
+
+    fn as_dyn_validated(&self) -> Option<&dyn DynValidatedSink> {
+        Some(self)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ValidatedDoris {
+    request_settings: TowerRequestSettings,
+    health_config: HealthConfig,
+    batch_settings: BatcherSettings,
+    database: ConfinedTemplate,
+    table: ConfinedTemplate,
+}
+
+#[async_trait::async_trait]
+impl ValidatedSink for DorisConfig {
+    type Validated = ValidatedDoris;
+
+    fn validate(&self) -> crate::Result<ValidatedDoris> {
+        if self.endpoints.is_empty() {
             return Err("No endpoints configured.'.".into());
         }
-        let commons = DorisCommon::parse_many(self).await?;
-        let common = commons[0].clone();
+        // Pure endpoint checks only — `DorisCommon`/TLS loading reads
+        // certificate files from disk, so it is deferred to `build` to keep
+        // `vector validate --no-environment` filesystem-free.
+        for endpoint in &self.endpoints {
+            if !matches!(endpoint.uri.scheme_str(), Some("http" | "https")) {
+                return Err(format!(
+                    "Invalid scheme: {}, endpoint must use http or https",
+                    endpoint.uri
+                )
+                .into());
+            }
+            if endpoint.uri.host().is_none() {
+                return Err(
+                    format!("Invalid host: {}, host must include hostname", endpoint.uri).into(),
+                );
+            }
+            self.auth.choose_one(&endpoint.auth)?;
+        }
+        let request_settings = self.request.into_settings();
+        let health_config = self.endpoint_health.clone().unwrap_or_default();
+        let batch_settings = self.batch.into_batcher_settings()?;
+        let database = self
+            .database
+            .clone()
+            .confine(&self.confinement, Self::NAME, "database")?;
+        let table = self
+            .table
+            .clone()
+            .confine(&self.confinement, Self::NAME, "table")?;
+
+        Ok(ValidatedDoris {
+            request_settings,
+            health_config,
+            batch_settings,
+            database,
+            table,
+        })
+    }
+
+    async fn build(
+        &self,
+        validated: &ValidatedDoris,
+        cx: SinkContext,
+    ) -> crate::Result<(VectorSink, Healthcheck)> {
+        let ValidatedDoris {
+            request_settings,
+            health_config,
+            batch_settings,
+            database,
+            table,
+        } = validated.clone();
+        // `DorisCommon` parsing performs environment-dependent work (TLS
+        // certificate loading from disk), so it happens here at build time
+        // rather than during `validate`.
+        let commons = DorisCommon::parse_many(self)?;
+        let common = &commons[0];
 
         let client = HttpClient::new(common.tls_settings.clone(), &cx.proxy)?;
-
-        // Setup retry logic using the configured request settings
-        let request_settings = self.request.into_settings();
-
-        let health_config = self.endpoint_health.clone().unwrap_or_default();
 
         let services_futures = commons
             .iter()
@@ -215,8 +296,14 @@ impl SinkConfig for DorisConfig {
             1, // Buffer bound is hardcoded to 1 for sinks
         );
 
-        // Create DorisSink with the configured service
-        let sink = DorisSink::new(service, self, &common)?;
+        // Create DorisSink with the pre-validated settings
+        let sink = DorisSink::new(
+            service,
+            batch_settings,
+            database,
+            table,
+            common.request_builder.clone(),
+        );
 
         let sink = VectorSink::from_event_streamsink(sink);
 
@@ -235,25 +322,13 @@ impl SinkConfig for DorisConfig {
         };
 
         // Use the previously saved client for health check, no need to create a new instance
-        let healthcheck = futures::future::select_ok(commons.into_iter().map(move |common| {
+        let healthcheck = futures::future::select_ok(commons.iter().cloned().map(move |common| {
             let client = Arc::clone(&healthcheck_doris_client);
             async move { common.healthcheck(client).await }.boxed()
         }))
         .map_ok(|((), _)| ())
         .boxed();
         Ok((sink, healthcheck))
-    }
-
-    fn confinement_config(&self) -> Option<&crate::template::ConfinementConfig> {
-        Some(&self.confinement)
-    }
-
-    fn input(&self) -> Input {
-        Input::log()
-    }
-
-    fn acknowledgements(&self) -> &AcknowledgementsConfig {
-        &self.acknowledgements
     }
 }
 
@@ -264,6 +339,74 @@ mod tests {
     #[test]
     fn generate_config() {
         crate::test_util::test_generate_config::<DorisConfig>();
+    }
+
+    #[test]
+    fn validate_produces_usable_values() {
+        use crate::config::ValidatedSink;
+        let config = DorisConfig {
+            endpoints: vec![
+                "http://127.0.0.1:8030"
+                    .parse::<http::Uri>()
+                    .unwrap()
+                    .try_into()
+                    .unwrap(),
+            ],
+            database: Template::try_from("mydatabase").unwrap(),
+            table: Template::try_from("mytable").unwrap(),
+            ..Default::default()
+        };
+        let validated = config.validate().expect("validation should succeed");
+        assert_eq!(validated.database.to_string(), "mydatabase");
+        assert_eq!(validated.table.to_string(), "mytable");
+    }
+
+    #[test]
+    fn validate_rejects_auth_conflict_with_endpoint_credentials() {
+        use crate::config::ValidatedSink;
+        let config = DorisConfig {
+            endpoints: vec![
+                "http://user:pass@127.0.0.1:8030"
+                    .parse::<http::Uri>()
+                    .unwrap()
+                    .try_into()
+                    .unwrap(),
+            ],
+            database: Template::try_from("mydatabase").unwrap(),
+            table: Template::try_from("mytable").unwrap(),
+            auth: Some(crate::http::Auth::Basic {
+                user: "config_user".to_string(),
+                password: vector_common::sensitive_string::SensitiveString::from(
+                    "config_pass".to_string(),
+                ),
+            }),
+            ..Default::default()
+        };
+        assert!(
+            config.validate().is_err(),
+            "top-level auth combined with endpoint-embedded credentials must be rejected"
+        );
+    }
+
+    #[test]
+    fn validate_rejects_non_http_scheme() {
+        use crate::config::ValidatedSink;
+        let config = DorisConfig {
+            endpoints: vec![
+                "ftp://doris.example.com:8030"
+                    .parse::<http::Uri>()
+                    .unwrap()
+                    .try_into()
+                    .unwrap(),
+            ],
+            database: Template::try_from("mydatabase").unwrap(),
+            table: Template::try_from("mytable").unwrap(),
+            ..Default::default()
+        };
+        assert!(
+            config.validate().is_err(),
+            "a non-http endpoint scheme must be rejected during validation"
+        );
     }
 
     #[test]

--- a/src/sinks/doris/sink.rs
+++ b/src/sinks/doris/sink.rs
@@ -1,7 +1,5 @@
 use crate::sinks::{
-    doris::{DorisConfig, common::DorisCommon, request_builder::DorisRequestBuilder},
-    prelude::*,
-    util::http::HttpRequest,
+    doris::request_builder::DorisRequestBuilder, prelude::*, util::http::HttpRequest,
 };
 
 pub struct DorisSink<S> {
@@ -19,25 +17,26 @@ where
     S::Response: DriverResponse + Send + 'static,
     S::Error: std::fmt::Debug + Into<crate::Error> + Send,
 {
-    pub fn new(service: S, config: &DorisConfig, common: &DorisCommon) -> crate::Result<Self> {
-        let batch_settings = config.batch.into_batcher_settings()?;
-        let database =
-            config
-                .database
-                .clone()
-                .confine(&config.confinement, DorisConfig::NAME, "database")?;
-        let table =
-            config
-                .table
-                .clone()
-                .confine(&config.confinement, DorisConfig::NAME, "table")?;
-        Ok(DorisSink {
+    /// Creates a new `DorisSink` from pre-validated values.
+    ///
+    /// Batch settings and confined templates are computed during the
+    /// `ValidatedSink::validate` phase and passed in here, so `build` does not
+    /// recompute them.
+    #[allow(clippy::missing_const_for_fn)]
+    pub fn new(
+        service: S,
+        batch_settings: BatcherSettings,
+        database: ConfinedTemplate,
+        table: ConfinedTemplate,
+        request_builder: DorisRequestBuilder,
+    ) -> Self {
+        DorisSink {
             batch_settings,
             service,
-            request_builder: common.request_builder.clone(),
+            request_builder,
             database,
             table,
-        })
+        }
     }
 
     async fn run_inner(self: Box<Self>, input: BoxStream<'_, Event>) -> Result<(), ()> {

--- a/src/sinks/doris/sink.rs
+++ b/src/sinks/doris/sink.rs
@@ -17,13 +17,7 @@ where
     S::Response: DriverResponse + Send + 'static,
     S::Error: std::fmt::Debug + Into<crate::Error> + Send,
 {
-    /// Creates a new `DorisSink` from pre-validated values.
-    ///
-    /// Batch settings and confined templates are computed during the
-    /// `ValidatedSink::validate` phase and passed in here, so `build` does not
-    /// recompute them.
-    #[allow(clippy::missing_const_for_fn)]
-    pub fn new(
+    pub const fn new(
         service: S,
         batch_settings: BatcherSettings,
         database: ConfinedTemplate,

--- a/website/cue/reference/components/sinks/generated/doris.cue
+++ b/website/cue/reference/components/sinks/generated/doris.cue
@@ -767,11 +767,8 @@ generated: components: sinks: doris: configuration: {
 			The endpoint must contain an HTTP scheme, and may specify a
 			hostname or IP address and port.
 			"""
-		required: false
-		type: array: {
-			default: []
-			items: type: string: examples: ["http://127.0.0.1:8030"]
-		}
+		required: true
+		type: array: items: type: string: examples: ["http://127.0.0.1:8030"]
 	}
 	framing: {
 		description: "Framing configuration."
@@ -870,7 +867,7 @@ generated: components: sinks: doris: configuration: {
 		type: string: {
 			default: "vector"
 			examples: [
-				"vector",
+				"vector"
 			]
 		}
 	}

--- a/website/cue/reference/components/sinks/generated/doris.cue
+++ b/website/cue/reference/components/sinks/generated/doris.cue
@@ -867,7 +867,7 @@ generated: components: sinks: doris: configuration: {
 		type: string: {
 			default: "vector"
 			examples: [
-				"vector"
+				"vector",
 			]
 		}
 	}

--- a/website/generated/example-configs/sinks/doris/minimal.yaml
+++ b/website/generated/example-configs/sinks/doris/minimal.yaml
@@ -6,4 +6,6 @@ sinks:
     database: mydatabase
     encoding:
       codec: json
+    endpoints:
+      - http://127.0.0.1:8030
     table: mytable


### PR DESCRIPTION
## Summary
Migrate the `doris` sink to the validated config lifecycle: structural validation now runs at config-compile time and the validated state is retained for build.

### References
Related: #26048

## Vector configuration
NA

## How did you test this PR?
- `make check-clippy` with `sinks-doris` feature
- `make test` with the same feature, `SCOPE="-E 'test(doris)'"` (8 passed)
- `make generate-docs` (regenerated `doris` docs)

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## Contributor Guidelines

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them. To catch issues early, add a `pre-push` hook ([template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push)) or run the following locally before pushing:
  - `make fmt`
  - `make check-clippy` (auto-fix with `make clippy-fix`)
  - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details on the [dd-rust-license-tool](https://crates.io/crates/dd-rust-license-tool).
