### PR TITLE
chore(ci): bump cue to v0.17.1

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -193,8 +193,8 @@ runs:
         echo "Installing cue"
         TEMP=$(mktemp -d)
         curl \
-          -L https://github.com/cue-lang/cue/releases/download/v0.16.1/cue_v0.16.1_linux_amd64.tar.gz \
-          -o "${TEMP}/cue_v0.16.1_linux_amd64.tar.gz"
+          -L https://github.com/cue-lang/cue/releases/download/v0.17.1/cue_v0.17.1_linux_amd64.tar.gz \
+          -o "${TEMP}/cue_v0.17.1_linux_amd64.tar.gz"
         tar \
           -xvf "${TEMP}/cue_v0.16.1_linux_amd64.tar.gz" \
           -C "${TEMP}"

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -196,7 +196,7 @@ runs:
           -L https://github.com/cue-lang/cue/releases/download/v0.17.1/cue_v0.17.1_linux_amd64.tar.gz \
           -o "${TEMP}/cue_v0.17.1_linux_amd64.tar.gz"
         tar \
-          -xvf "${TEMP}/cue_v0.16.1_linux_amd64.tar.gz" \
+          -xvf "${TEMP}/cue_v0.17.1_linux_amd64.tar.gz" \
           -C "${TEMP}"
         sudo cp "${TEMP}/cue" /usr/bin/cue
         rm -rf "$TEMP"

--- a/website/Dockerfile
+++ b/website/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:bookworm-slim
 
 ARG HUGO_VERSION=0.154.5
-ARG CUE_VERSION=0.16.1
+ARG CUE_VERSION=0.17.1
 ARG NODE_VERSION=24
 
 ENV PATH="/root/.cargo/bin:/root/.local/bin:${PATH}"

--- a/website/cue/reference/components/sinks/generated/aws_s3.cue
+++ b/website/cue/reference/components/sinks/generated/aws_s3.cue
@@ -385,7 +385,7 @@ generated: components: sinks: aws_s3: configuration: {
 			"""
 		required: false
 		type: string: examples: [
-			"gzip",
+			"gzip"
 		]
 	}
 	content_type: {
@@ -884,7 +884,7 @@ generated: components: sinks: aws_s3: configuration: {
 			"""
 		required: false
 		type: string: examples: [
-			"json",
+			"json"
 		]
 	}
 	filename_time_format: {

--- a/website/cue/reference/components/sinks/generated/blackhole.cue
+++ b/website/cue/reference/components/sinks/generated/blackhole.cue
@@ -37,7 +37,7 @@ generated: components: sinks: blackhole: configuration: {
 		type: uint: {
 			default: 0
 			examples: [
-				10,
+				10
 			]
 			unit: "seconds"
 		}
@@ -50,7 +50,7 @@ generated: components: sinks: blackhole: configuration: {
 			"""
 		required: false
 		type: uint: examples: [
-			1000,
+			1000
 		]
 	}
 }

--- a/website/cue/reference/components/sinks/generated/doris.cue
+++ b/website/cue/reference/components/sinks/generated/doris.cue
@@ -870,7 +870,7 @@ generated: components: sinks: doris: configuration: {
 		type: string: {
 			default: "vector"
 			examples: [
-				"vector",
+				"vector"
 			]
 		}
 	}

--- a/website/cue/reference/components/sinks/generated/file.cue
+++ b/website/cue/reference/components/sinks/generated/file.cue
@@ -596,7 +596,7 @@ generated: components: sinks: file: configuration: {
 		type: uint: {
 			default: 30
 			examples: [
-				600,
+				600
 			]
 			unit: "seconds"
 		}

--- a/website/cue/reference/components/sinks/generated/greptimedb.cue
+++ b/website/cue/reference/components/sinks/generated/greptimedb.cue
@@ -75,7 +75,7 @@ generated: components: sinks: greptimedb: configuration: {
 		type: string: {
 			default: "public"
 			examples: [
-				"public",
+				"public"
 			]
 		}
 	}

--- a/website/cue/reference/components/sinks/generated/greptimedb_logs.cue
+++ b/website/cue/reference/components/sinks/generated/greptimedb_logs.cue
@@ -124,7 +124,7 @@ generated: components: sinks: greptimedb_logs: configuration: {
 		type: string: {
 			default: "public"
 			examples: [
-				"public",
+				"public"
 			]
 			syntax: "template"
 		}

--- a/website/cue/reference/components/sinks/generated/greptimedb_metrics.cue
+++ b/website/cue/reference/components/sinks/generated/greptimedb_metrics.cue
@@ -75,7 +75,7 @@ generated: components: sinks: greptimedb_metrics: configuration: {
 		type: string: {
 			default: "public"
 			examples: [
-				"public",
+				"public"
 			]
 		}
 	}

--- a/website/cue/reference/components/sinks/generated/http.cue
+++ b/website/cue/reference/components/sinks/generated/http.cue
@@ -845,7 +845,7 @@ generated: components: sinks: http: configuration: {
 		type: string: {
 			default: ""
 			examples: [
-				"}",
+				"}"
 			]
 		}
 	}

--- a/website/cue/reference/components/sinks/generated/influxdb_logs.cue
+++ b/website/cue/reference/components/sinks/generated/influxdb_logs.cue
@@ -80,7 +80,7 @@ generated: components: sinks: influxdb_logs: configuration: {
 		relevant_when: "version = \"1\""
 		required:      false
 		type: string: examples: [
-			"any",
+			"any"
 		]
 	}
 	database: {
@@ -153,7 +153,7 @@ generated: components: sinks: influxdb_logs: configuration: {
 			"""
 		required: false
 		type: string: examples: [
-			"text",
+			"text"
 		]
 	}
 	org: {
@@ -167,7 +167,7 @@ generated: components: sinks: influxdb_logs: configuration: {
 		required:      false
 		required_when: "version = \"2\""
 		type: string: examples: [
-			"my-org",
+			"my-org"
 		]
 	}
 	password: {
@@ -384,7 +384,7 @@ generated: components: sinks: influxdb_logs: configuration: {
 			"""
 		required: false
 		type: string: examples: [
-			"source",
+			"source"
 		]
 	}
 	tags: {
@@ -517,7 +517,7 @@ generated: components: sinks: influxdb_logs: configuration: {
 		relevant_when: "version = \"1\""
 		required:      false
 		type: string: examples: [
-			"todd",
+			"todd"
 		]
 	}
 	version: {

--- a/website/cue/reference/components/sinks/generated/influxdb_metrics.cue
+++ b/website/cue/reference/components/sinks/generated/influxdb_metrics.cue
@@ -80,7 +80,7 @@ generated: components: sinks: influxdb_metrics: configuration: {
 		relevant_when: "version = \"1\""
 		required:      false
 		type: string: examples: [
-			"any",
+			"any"
 		]
 	}
 	database: {
@@ -124,7 +124,7 @@ generated: components: sinks: influxdb_metrics: configuration: {
 		required:      false
 		required_when: "version = \"2\""
 		type: string: examples: [
-			"my-org",
+			"my-org"
 		]
 	}
 	password: {
@@ -472,7 +472,7 @@ generated: components: sinks: influxdb_metrics: configuration: {
 		relevant_when: "version = \"1\""
 		required:      false
 		type: string: examples: [
-			"todd",
+			"todd"
 		]
 	}
 	version: {

--- a/website/cue/reference/components/sinks/generated/mezmo.cue
+++ b/website/cue/reference/components/sinks/generated/mezmo.cue
@@ -70,7 +70,7 @@ generated: components: sinks: mezmo: configuration: {
 		type: string: {
 			default: "vector"
 			examples: [
-				"my-app",
+				"my-app"
 			]
 		}
 	}

--- a/website/cue/reference/components/sinks/generated/nats.cue
+++ b/website/cue/reference/components/sinks/generated/nats.cue
@@ -123,7 +123,7 @@ generated: components: sinks: nats: configuration: {
 		type: string: {
 			default: "vector"
 			examples: [
-				"foo",
+				"foo"
 			]
 		}
 	}

--- a/website/cue/reference/components/sinks/generated/socket.cue
+++ b/website/cue/reference/components/sinks/generated/socket.cue
@@ -593,7 +593,7 @@ generated: components: sinks: socket: configuration: {
 		required:      false
 		type: uint: {
 			examples: [
-				65536,
+				65536
 			]
 			unit: "bytes"
 		}

--- a/website/cue/reference/components/sinks/generated/statsd.cue
+++ b/website/cue/reference/components/sinks/generated/statsd.cue
@@ -122,7 +122,7 @@ generated: components: sinks: statsd: configuration: {
 		required: false
 		type: uint: {
 			examples: [
-				65536,
+				65536
 			]
 			unit: "bytes"
 		}

--- a/website/cue/reference/components/sinks/generated/websocket.cue
+++ b/website/cue/reference/components/sinks/generated/websocket.cue
@@ -661,7 +661,7 @@ generated: components: sinks: websocket: configuration: {
 		required: false
 		type: uint: {
 			examples: [
-				30,
+				30
 			]
 			unit: "seconds"
 		}
@@ -677,7 +677,7 @@ generated: components: sinks: websocket: configuration: {
 		required: false
 		type: uint: {
 			examples: [
-				5,
+				5
 			]
 			unit: "seconds"
 		}

--- a/website/cue/reference/components/sources/generated/amqp.cue
+++ b/website/cue/reference/components/sources/generated/amqp.cue
@@ -616,7 +616,7 @@ generated: components: sources: amqp: configuration: {
 			"""
 		required: false
 		type: uint: examples: [
-			100,
+			100
 		]
 	}
 	queue: {

--- a/website/cue/reference/components/sources/generated/file.cue
+++ b/website/cue/reference/components/sources/generated/file.cue
@@ -83,7 +83,7 @@ generated: components: sources: file: configuration: {
 		type: string: {
 			default: "file"
 			examples: [
-				"path",
+				"path"
 			]
 		}
 	}
@@ -197,7 +197,7 @@ generated: components: sources: file: configuration: {
 		required:    false
 		type: uint: {
 			examples: [
-				600,
+				600
 			]
 			unit: "seconds"
 		}
@@ -227,7 +227,7 @@ generated: components: sources: file: configuration: {
 		type: string: {
 			default: "\n"
 			examples: [
-				"\r\n",
+				"\r\n"
 			]
 		}
 	}
@@ -337,7 +337,7 @@ generated: components: sources: file: configuration: {
 			"""
 		required: false
 		type: string: examples: [
-			"offset",
+			"offset"
 		]
 	}
 	oldest_first: {

--- a/website/cue/reference/components/sources/generated/file_descriptor.cue
+++ b/website/cue/reference/components/sources/generated/file_descriptor.cue
@@ -319,7 +319,7 @@ generated: components: sources: file_descriptor: configuration: {
 		description: "The file descriptor number to read from."
 		required:    true
 		type: uint: examples: [
-			10,
+			10
 		]
 	}
 	framing: {

--- a/website/cue/reference/components/sources/generated/fluent.cue
+++ b/website/cue/reference/components/sources/generated/fluent.cue
@@ -84,7 +84,7 @@ generated: components: sources: fluent: configuration: {
 		required:      false
 		type: uint: {
 			examples: [
-				65536,
+				65536
 			]
 			unit: "bytes"
 		}

--- a/website/cue/reference/components/sources/generated/http.cue
+++ b/website/cue/reference/components/sources/generated/http.cue
@@ -736,7 +736,7 @@ generated: components: sources: http: configuration: {
 		type: uint: {
 			default: 200
 			examples: [
-				202,
+				202
 			]
 		}
 	}

--- a/website/cue/reference/components/sources/generated/http_server.cue
+++ b/website/cue/reference/components/sources/generated/http_server.cue
@@ -736,7 +736,7 @@ generated: components: sources: http_server: configuration: {
 		type: uint: {
 			default: 200
 			examples: [
-				202,
+				202
 			]
 		}
 	}

--- a/website/cue/reference/components/sources/generated/kafka.cue
+++ b/website/cue/reference/components/sources/generated/kafka.cue
@@ -746,7 +746,7 @@ generated: components: sources: kafka: configuration: {
 		type: string: {
 			default: "offset"
 			examples: [
-				"offset",
+				"offset"
 			]
 		}
 	}
@@ -936,7 +936,7 @@ generated: components: sources: kafka: configuration: {
 		type: string: {
 			default: "topic"
 			examples: [
-				"topic",
+				"topic"
 			]
 		}
 	}

--- a/website/cue/reference/components/sources/generated/kubernetes_logs.cue
+++ b/website/cue/reference/components/sources/generated/kubernetes_logs.cue
@@ -128,7 +128,7 @@ generated: components: sources: kubernetes_logs: configuration: {
 		required:    false
 		type: uint: {
 			examples: [
-				600,
+				600
 			]
 			unit: "seconds"
 		}
@@ -138,7 +138,7 @@ generated: components: sources: kubernetes_logs: configuration: {
 		required:    false
 		type: array: {
 			default: [
-				"**/*",
+				"**/*"
 			]
 			items: type: string: examples: ["**/include/**"]
 		}

--- a/website/cue/reference/components/sources/generated/logstash.cue
+++ b/website/cue/reference/components/sources/generated/logstash.cue
@@ -56,7 +56,7 @@ generated: components: sources: logstash: configuration: {
 		required:    false
 		type: uint: {
 			examples: [
-				65536,
+				65536
 			]
 			unit: "bytes"
 		}

--- a/website/cue/reference/components/sources/generated/mqtt.cue
+++ b/website/cue/reference/components/sources/generated/mqtt.cue
@@ -700,7 +700,7 @@ generated: components: sources: mqtt: configuration: {
 		type: string: {
 			default: "topic"
 			examples: [
-				"topic",
+				"topic"
 			]
 		}
 	}

--- a/website/cue/reference/components/sources/generated/nats.cue
+++ b/website/cue/reference/components/sources/generated/nats.cue
@@ -95,7 +95,7 @@ generated: components: sources: nats: configuration: {
 			"""
 		required: true
 		type: string: examples: [
-			"vector",
+			"vector"
 		]
 	}
 	decoding: {

--- a/website/cue/reference/components/sources/generated/redis.cue
+++ b/website/cue/reference/components/sources/generated/redis.cue
@@ -568,7 +568,7 @@ generated: components: sources: redis: configuration: {
 		description: "The Redis key to read messages from."
 		required:    true
 		type: string: examples: [
-			"vector",
+			"vector"
 		]
 	}
 	list: {

--- a/website/cue/reference/components/sources/generated/websocket.cue
+++ b/website/cue/reference/components/sources/generated/websocket.cue
@@ -186,7 +186,7 @@ generated: components: sources: websocket: configuration: {
 		type: uint: {
 			default: 30
 			examples: [
-				10,
+				10
 			]
 			unit: "seconds"
 		}
@@ -744,7 +744,7 @@ generated: components: sources: websocket: configuration: {
 		type: uint: {
 			default: 2
 			examples: [
-				5,
+				5
 			]
 			unit: "seconds"
 		}
@@ -763,7 +763,7 @@ generated: components: sources: websocket: configuration: {
 		required: false
 		type: uint: {
 			examples: [
-				30,
+				30
 			]
 			unit: "seconds"
 		}
@@ -787,7 +787,7 @@ generated: components: sources: websocket: configuration: {
 		required: false
 		type: uint: {
 			examples: [
-				5,
+				5
 			]
 			unit: "seconds"
 		}

--- a/website/cue/reference/components/transforms/generated/sample.cue
+++ b/website/cue/reference/components/transforms/generated/sample.cue
@@ -82,7 +82,7 @@ generated: components: transforms: sample: configuration: {
 		required_one_of: ["rate", "ratio"]
 		required_one_of_group: "sampling_strategy"
 		type: float: examples: [
-			0.13,
+			0.13
 		]
 	}
 	ratio_field: {


### PR DESCRIPTION
## Summary
Bump the CUE version used by CI and the website Dockerfile from v0.16.1 to v0.17.1, and regenerate the component docs to match the new formatter output.

CUE v0.17 ships the `formatv2` rewritten formatter (now default for `cue fmt`), which drops trailing commas in single-element lists. The committed generated docs were produced with v0.16.1, so they no longer match what `cue fmt` v0.17.1 produces. This PR regenerates them so `check-docs` and `check-generated-docs` stay green after the bump.

### References
NA

## Vector configuration
NA

## How did you test this PR?
- `make check-docs` (passes with cue v0.17.1)
- `make check-generated-docs` (passes, 248 examples validated)

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## Contributor Guidelines

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them. To catch issues early, add a `pre-push` hook ([template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push)) or run the following locally before pushing:
  - `make fmt`
  - `make check-clippy` (auto-fix with `make clippy-fix`)
  - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details on the [dd-rust-license-tool](https://crates.io/crates/dd-rust-license-tool).
