### PR TITLE
chore(release): omit stable latest from COSE

### DIFF
--- a/scripts/release-s3.sh
+++ b/scripts/release-s3.sh
@@ -175,21 +175,16 @@ elif [[ "$CHANNEL" == "release" ]]; then
     publish_release_artifacts legacy_aws "$LEGACY_BUCKET" "$i"
   done
 
-  # The COSE bucket exposes immutable exact releases and one floating stable
-  # channel. Only the mutable latest prefix is pruned when it is updated.
-  for i in "$VERSION_EXACT" "latest"; do
-    publish_release_artifacts cose_aws "$COSE_BUCKET" "$i"
-  done
+  # COSE exposes stable artifacts only under their immutable exact version.
+  publish_release_artifacts cose_aws "$COSE_BUCKET" "$VERSION_EXACT"
 
   echo "Add latest symlinks"
   find "$td" -maxdepth 1 -type f -print0 | while read -r -d $'\0' file ; do
     file=$(basename "$file")
     # vector-$version-amd64.deb -> vector-latest-amd64.deb
     echo -n "" | s3_copy legacy_aws - "s3://$LEGACY_BUCKET/vector/latest/${file/$VERSION_EXACT/latest}" --website-redirect "/vector/latest/$file"
-    s3_copy cose_aws "$td/$file" "s3://$COSE_BUCKET/vector/latest/${file/$VERSION_EXACT/latest}"
     # vector-$version-amd64.deb -> vector-amd64.deb
     echo -n "" | s3_copy legacy_aws - "s3://$LEGACY_BUCKET/vector/latest/${file/$VERSION_EXACT-/}" --website-redirect "/vector/latest/$file"
-    s3_copy cose_aws "$td/$file" "s3://$COSE_BUCKET/vector/latest/${file/$VERSION_EXACT-/}"
   done
   echo "Added latest symlinks"
 
@@ -201,16 +196,11 @@ elif [[ "$CHANNEL" == "release" ]]; then
       "https://packages.timber.io/vector/$i/vector-$VERSION-x86_64-unknown-linux-musl.tar.gz" \
       "$td/vector-$VERSION-x86_64-unknown-linux-musl.tar.gz"
   done
-  for i in "$VERSION_EXACT" "latest"; do
-    verify_artifact \
-      "$COSE_PUBLIC_URL/vector/$i/vector-$VERSION-x86_64-unknown-linux-musl.tar.gz" \
-      "$td/vector-$VERSION-x86_64-unknown-linux-musl.tar.gz"
-  done
+  verify_artifact \
+    "$COSE_PUBLIC_URL/vector/$VERSION_EXACT/vector-$VERSION-x86_64-unknown-linux-musl.tar.gz" \
+    "$td/vector-$VERSION-x86_64-unknown-linux-musl.tar.gz"
   verify_artifact \
     "https://packages.timber.io/vector/latest/vector-latest-x86_64-unknown-linux-gnu.tar.gz" \
-    "$td/vector-$VERSION-x86_64-unknown-linux-gnu.tar.gz"
-  verify_artifact \
-    "$COSE_PUBLIC_URL/vector/latest/vector-latest-x86_64-unknown-linux-gnu.tar.gz" \
     "$td/vector-$VERSION-x86_64-unknown-linux-gnu.tar.gz"
 
 elif [[ "$CHANNEL" == "custom" ]]; then


### PR DESCRIPTION
## Summary

### Motivation

Vector has not advertised the legacy stable `latest/` binary paths since 2019, and introducing them in COSE would create another mutable public interface to maintain. COSE stable downloads should remain limited to immutable, exact-version prefixes while the legacy bucket continues its existing compatibility behavior during dual publishing.

### Changes

- Publish stable COSE artifacts only under `vector/<version>/`.
- Stop creating and verifying stable aliases under COSE `vector/latest/`.
- Preserve legacy stable `latest/` aliases and COSE `vector/nightly/latest/` behavior.

### References

- Follow-up to #26163
- Related migration tracking: #26104

## Vector configuration

N/A

## How did you test this PR?

- Confirmed the stable release path publishes and verifies only the exact COSE version prefix.
- Confirmed legacy exact, `.X`, and `latest` publishing remains unchanged.
- Confirmed COSE nightly `latest` publishing remains unchanged.

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.
