### PR TITLE
feat(databricks_zerobus sink): validate config at compile time

### DIFF
--- a/src/sinks/databricks_zerobus/config.rs
+++ b/src/sinks/databricks_zerobus/config.rs
@@ -3,10 +3,15 @@
 use vector_lib::configurable::configurable_component;
 use vector_lib::sensitive_string::SensitiveString;
 
-use crate::config::{AcknowledgementsConfig, GenerateConfig, Input, SinkConfig, SinkContext};
+use crate::config::{
+    AcknowledgementsConfig, DynValidatedSink, GenerateConfig, Input, SinkConfig, SinkContext,
+    ValidatedSink,
+};
 use crate::sinks::{
     prelude::*,
-    util::{BatchConfig, RealtimeSizeBasedDefaultBatchSettings},
+    util::{
+        BatchConfig, HttpEndpoint, RealtimeSizeBasedDefaultBatchSettings, TowerRequestSettings,
+    },
 };
 
 use super::{error::ZerobusSinkError, service::ZerobusService, sink::ZerobusSink};
@@ -126,7 +131,7 @@ pub struct ZerobusSinkConfig {
     #[configurable(metadata(
         docs::examples = "https://6543210987654321.zerobus.us-east-1.cloud.databricks.com"
     ))]
-    pub ingestion_endpoint: String,
+    pub ingestion_endpoint: HttpEndpoint,
 
     /// The Unity Catalog table name to write to.
     ///
@@ -193,8 +198,10 @@ pub struct ZerobusSinkConfig {
 impl GenerateConfig for ZerobusSinkConfig {
     fn generate_config() -> serde_json::Value {
         serde_json::to_value(Self {
-            ingestion_endpoint: "https://1234567890123456.zerobus.us-west-2.cloud.databricks.com"
-                .to_string(),
+            ingestion_endpoint: HttpEndpoint::parse(
+                "https://1234567890123456.zerobus.us-west-2.cloud.databricks.com",
+            )
+            .expect("valid example ingestion endpoint"),
             table_name: "main.default.logs".to_string(),
             unity_catalog_endpoint: "https://dbc-a1b2c3d4-e5f6.cloud.databricks.com".to_string(),
             auth: DatabricksAuthentication::OAuth {
@@ -214,15 +221,56 @@ impl GenerateConfig for ZerobusSinkConfig {
 #[async_trait::async_trait]
 #[typetag::serde(name = "databricks_zerobus")]
 impl SinkConfig for ZerobusSinkConfig {
-    async fn build(&self, cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
+    fn input(&self) -> Input {
+        Input::log()
+    }
+
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &self.acknowledgements
+    }
+
+    fn as_dyn_validated(&self) -> Option<&dyn DynValidatedSink> {
+        Some(self)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ValidatedZerobus {
+    batch_settings: BatcherSettings,
+    request_limits: TowerRequestSettings,
+}
+
+#[async_trait::async_trait]
+impl ValidatedSink for ZerobusSinkConfig {
+    type Validated = ValidatedZerobus;
+
+    fn validate(&self) -> crate::Result<ValidatedZerobus> {
+        // Pure structural validation (no network/filesystem/async).
         self.validate()?;
 
-        let service = ZerobusService::new(self.clone(), cx.proxy()).await?;
-        let healthcheck_service = service.clone();
+        let batch_settings = self.batch.into_batcher_settings()?;
 
         let request_limits = self.request.into_settings();
 
-        let sink = ZerobusSink::new(service, request_limits, self.batch)?;
+        Ok(ValidatedZerobus {
+            batch_settings,
+            request_limits,
+        })
+    }
+
+    async fn build(
+        &self,
+        validated: &ValidatedZerobus,
+        cx: SinkContext,
+    ) -> crate::Result<(VectorSink, Healthcheck)> {
+        let service = ZerobusService::new(self.clone(), cx.proxy()).await?;
+        let healthcheck_service = service.clone();
+
+        let sink = ZerobusSink::new(
+            service,
+            validated.request_limits.clone(),
+            validated.batch_settings,
+        );
 
         let healthcheck = async move {
             healthcheck_service
@@ -236,23 +284,13 @@ impl SinkConfig for ZerobusSinkConfig {
             Box::pin(healthcheck),
         ))
     }
-
-    fn input(&self) -> Input {
-        Input::log()
-    }
-
-    fn acknowledgements(&self) -> &AcknowledgementsConfig {
-        &self.acknowledgements
-    }
 }
 
 impl ZerobusSinkConfig {
     pub fn validate(&self) -> Result<(), ZerobusSinkError> {
-        if self.ingestion_endpoint.is_empty() {
-            return Err(ZerobusSinkError::ConfigError {
-                message: "ingestion_endpoint cannot be empty".to_string(),
-            });
-        }
+        // `ingestion_endpoint` is an `HttpEndpoint`: deserialization already
+        // guarantees it is an absolute http(s) URL with a host and valid port,
+        // so no further validation is needed here.
 
         if self.table_name.is_empty() {
             return Err(ZerobusSinkError::ConfigError {
@@ -271,6 +309,24 @@ impl ZerobusSinkConfig {
         if self.unity_catalog_endpoint.is_empty() {
             return Err(ZerobusSinkError::ConfigError {
                 message: "unity_catalog_endpoint cannot be empty".to_string(),
+            });
+        }
+
+        // The build-time healthcheck resolves `{endpoint}/oidc/v1/token` and
+        // `{endpoint}/api/2.1/unity-catalog/tables/{name}` as `http::Uri`s, so the
+        // endpoint must be an absolute http(s) URL. Validate here (pure, env-free)
+        // so `vector validate --no-environment` catches misconfigurations at
+        // validate time instead of deferring to the healthcheck at build.
+        let uri = self
+            .unity_catalog_endpoint
+            .parse::<http::Uri>()
+            .map_err(|e| ZerobusSinkError::ConfigError {
+                message: format!("Invalid Unity Catalog endpoint URL: {}", e),
+            })?;
+        if !matches!(uri.scheme_str(), Some("http" | "https")) || uri.authority().is_none() {
+            return Err(ZerobusSinkError::ConfigError {
+                message: "Databricks Unity Catalog endpoint must be an absolute http(s) URL"
+                    .to_string(),
             });
         }
 
@@ -339,7 +395,7 @@ mod tests {
 
     fn create_test_config() -> ZerobusSinkConfig {
         ZerobusSinkConfig {
-            ingestion_endpoint: "https://test.databricks.com".to_string(),
+            ingestion_endpoint: HttpEndpoint::parse("https://test.databricks.com").unwrap(),
             table_name: "test.default.logs".to_string(),
             unity_catalog_endpoint: "https://test-workspace.databricks.com".to_string(),
             auth: DatabricksAuthentication::OAuth {
@@ -355,27 +411,81 @@ mod tests {
     }
 
     #[test]
+    fn validate_produces_request_limits_and_batch() {
+        use crate::config::ValidatedSink;
+        let config = create_test_config();
+        // The inherent `validate` (structural checks) shadows the trait method in
+        // method-call syntax, so call the trait method via UFCS.
+        let validated = <ZerobusSinkConfig as ValidatedSink>::validate(&config)
+            .expect("validation should succeed");
+        // Default request settings resolve to an unbounded concurrency.
+        assert_eq!(validated.request_limits.concurrency, None);
+        assert!(validated.request_limits.timeout.as_secs() > 0);
+        // Default batch settings resolve to the 10MB size limit.
+        assert_eq!(validated.batch_settings.size_limit, 10_000_000);
+    }
+
+    #[test]
+    fn validate_rejects_invalid_batch_settings() {
+        use crate::config::ValidatedSink;
+        // `batch.max_events = 0` is a pure config error that `vector validate
+        // --no-environment` must catch rather than deferring to build.
+        let mut config = create_test_config();
+        config.batch.max_events = Some(0);
+        assert!(
+            <ZerobusSinkConfig as ValidatedSink>::validate(&config).is_err(),
+            "max_events = 0 should fail validation"
+        );
+
+        // Same for a non-positive timeout.
+        let mut config = create_test_config();
+        config.batch.timeout_secs = Some(0.0);
+        assert!(
+            <ZerobusSinkConfig as ValidatedSink>::validate(&config).is_err(),
+            "timeout_secs <= 0 should fail validation"
+        );
+    }
+
+    #[test]
     fn test_config_validation_success() {
         let config = create_test_config();
         assert!(config.validate().is_ok());
     }
 
     #[test]
-    fn test_config_validation_empty_endpoint() {
-        let mut config = create_test_config();
-        config.ingestion_endpoint = "".to_string();
+    fn test_config_validation_rejects_non_http_ingestion_endpoint() {
+        // `ingestion_endpoint` is an `HttpEndpoint`, so a non-http scheme is
+        // rejected at deserialization time rather than at validate time.
+        let config = r#"
+ingestion_endpoint: "ftp://test.databricks.com"
+table_name: "test.default.logs"
+unity_catalog_endpoint: "https://test-workspace.databricks.com"
+auth:
+  strategy: oauth
+  client_id: "test-client-id"
+  client_secret: "test-client-secret"
+"#;
+        let result: Result<ZerobusSinkConfig, _> = serde_yaml::from_str(config);
+        assert!(
+            result.is_err(),
+            "non-http ingestion_endpoint should fail deserialization"
+        );
 
-        let result = config.validate();
-        assert!(result.is_err());
-
-        if let Err(crate::sinks::databricks_zerobus::error::ZerobusSinkError::ConfigError {
-            message,
-        }) = result
-        {
-            assert!(message.contains("ingestion_endpoint cannot be empty"));
-        } else {
-            panic!("Expected ConfigError for empty ingestion_endpoint");
-        }
+        // The same holds for a relative endpoint with no host.
+        let config = r#"
+ingestion_endpoint: "/some/path"
+table_name: "test.default.logs"
+unity_catalog_endpoint: "https://test-workspace.databricks.com"
+auth:
+  strategy: oauth
+  client_id: "test-client-id"
+  client_secret: "test-client-secret"
+"#;
+        let result: Result<ZerobusSinkConfig, _> = serde_yaml::from_str(config);
+        assert!(
+            result.is_err(),
+            "host-less ingestion_endpoint should fail deserialization"
+        );
     }
 
     #[test]
@@ -453,6 +563,49 @@ mod tests {
             assert!(message.contains("unity_catalog_endpoint cannot be empty"));
         } else {
             panic!("Expected ConfigError for empty unity_catalog_endpoint");
+        }
+    }
+
+    #[test]
+    fn test_config_validation_invalid_unity_catalog_endpoint_uri() {
+        let mut config = create_test_config();
+        config.unity_catalog_endpoint = "not a uri".to_string();
+
+        let result = config.validate();
+        assert!(result.is_err());
+
+        if let Err(crate::sinks::databricks_zerobus::error::ZerobusSinkError::ConfigError {
+            message,
+        }) = result
+        {
+            assert!(message.contains("Invalid Unity Catalog endpoint URL"));
+        } else {
+            panic!("Expected ConfigError for malformed unity_catalog_endpoint");
+        }
+    }
+
+    #[test]
+    fn test_config_validation_unity_catalog_endpoint_requires_scheme_and_authority() {
+        // The healthcheck builds absolute http(s) URLs from this value, so a
+        // relative path (no scheme/authority) or a non-http scheme must be
+        // rejected at validate time.
+        for bad in [
+            "my-unity-catalog",
+            "//workspace.databricks.com",
+            "ftp://workspace.databricks.com",
+        ] {
+            let mut config = create_test_config();
+            config.unity_catalog_endpoint = bad.to_string();
+            let result = config.validate();
+            assert!(result.is_err(), "expected error for endpoint={bad:?}");
+            if let Err(crate::sinks::databricks_zerobus::error::ZerobusSinkError::ConfigError {
+                message,
+            }) = result
+            {
+                assert!(message.contains("absolute http(s) URL"));
+            } else {
+                panic!("Expected ConfigError for endpoint={bad:?}");
+            }
         }
     }
 

--- a/src/sinks/databricks_zerobus/config.rs
+++ b/src/sinks/databricks_zerobus/config.rs
@@ -155,7 +155,7 @@ pub struct ZerobusSinkConfig {
     /// [zerobus_endpoint]: https://docs.databricks.com/aws/en/ingestion/zerobus-ingest#get-your-workspace-url-and-zerobus-ingest-endpoint
     #[configurable(metadata(docs::examples = "https://dbc-a1b2c3d4-e5f6.cloud.databricks.com"))]
     #[configurable(metadata(docs::examples = "https://dbc-f6e5d4c3-b2a1.cloud.databricks.com"))]
-    pub unity_catalog_endpoint: String,
+    pub unity_catalog_endpoint: HttpEndpoint,
 
     /// Databricks authentication configuration.
     ///
@@ -203,7 +203,10 @@ impl GenerateConfig for ZerobusSinkConfig {
             )
             .expect("valid example ingestion endpoint"),
             table_name: "main.default.logs".to_string(),
-            unity_catalog_endpoint: "https://dbc-a1b2c3d4-e5f6.cloud.databricks.com".to_string(),
+            unity_catalog_endpoint: HttpEndpoint::parse(
+                "https://dbc-a1b2c3d4-e5f6.cloud.databricks.com",
+            )
+            .expect("valid example unity catalog endpoint"),
             auth: DatabricksAuthentication::OAuth {
                 client_id: SensitiveString::from("${DATABRICKS_CLIENT_ID}".to_string()),
                 client_secret: SensitiveString::from("${DATABRICKS_CLIENT_SECRET}".to_string()),
@@ -306,29 +309,11 @@ impl ZerobusSinkConfig {
             });
         }
 
-        if self.unity_catalog_endpoint.is_empty() {
-            return Err(ZerobusSinkError::ConfigError {
-                message: "unity_catalog_endpoint cannot be empty".to_string(),
-            });
-        }
-
-        // The build-time healthcheck resolves `{endpoint}/oidc/v1/token` and
-        // `{endpoint}/api/2.1/unity-catalog/tables/{name}` as `http::Uri`s, so the
-        // endpoint must be an absolute http(s) URL. Validate here (pure, env-free)
-        // so `vector validate --no-environment` catches misconfigurations at
-        // validate time instead of deferring to the healthcheck at build.
-        let uri = self
-            .unity_catalog_endpoint
-            .parse::<http::Uri>()
-            .map_err(|e| ZerobusSinkError::ConfigError {
-                message: format!("Invalid Unity Catalog endpoint URL: {}", e),
-            })?;
-        if !matches!(uri.scheme_str(), Some("http" | "https")) || uri.authority().is_none() {
-            return Err(ZerobusSinkError::ConfigError {
-                message: "Databricks Unity Catalog endpoint must be an absolute http(s) URL"
-                    .to_string(),
-            });
-        }
+        // `unity_catalog_endpoint` is an `HttpEndpoint`: deserialization already
+        // guarantees it is an absolute http(s) URL with a nonempty host and a
+        // valid numeric port (the healthcheck builds `{endpoint}/oidc/v1/token`
+        // and `{endpoint}/api/2.1/unity-catalog/tables/{name}` from it), so no
+        // further validation is needed here.
 
         // Validate authentication credentials
         match &self.auth {
@@ -397,7 +382,8 @@ mod tests {
         ZerobusSinkConfig {
             ingestion_endpoint: HttpEndpoint::parse("https://test.databricks.com").unwrap(),
             table_name: "test.default.logs".to_string(),
-            unity_catalog_endpoint: "https://test-workspace.databricks.com".to_string(),
+            unity_catalog_endpoint: HttpEndpoint::parse("https://test-workspace.databricks.com")
+                .unwrap(),
             auth: DatabricksAuthentication::OAuth {
                 client_id: SensitiveString::from("test-client-id".to_string()),
                 client_secret: SensitiveString::from("test-client-secret".to_string()),
@@ -549,63 +535,36 @@ auth:
     }
 
     #[test]
-    fn test_config_validation_empty_unity_catalog_endpoint() {
-        let mut config = create_test_config();
-        config.unity_catalog_endpoint = "".to_string();
-
-        let result = config.validate();
-        assert!(result.is_err());
-
-        if let Err(crate::sinks::databricks_zerobus::error::ZerobusSinkError::ConfigError {
-            message,
-        }) = result
-        {
-            assert!(message.contains("unity_catalog_endpoint cannot be empty"));
-        } else {
-            panic!("Expected ConfigError for empty unity_catalog_endpoint");
-        }
-    }
-
-    #[test]
-    fn test_config_validation_invalid_unity_catalog_endpoint_uri() {
-        let mut config = create_test_config();
-        config.unity_catalog_endpoint = "not a uri".to_string();
-
-        let result = config.validate();
-        assert!(result.is_err());
-
-        if let Err(crate::sinks::databricks_zerobus::error::ZerobusSinkError::ConfigError {
-            message,
-        }) = result
-        {
-            assert!(message.contains("Invalid Unity Catalog endpoint URL"));
-        } else {
-            panic!("Expected ConfigError for malformed unity_catalog_endpoint");
-        }
-    }
-
-    #[test]
-    fn test_config_validation_unity_catalog_endpoint_requires_scheme_and_authority() {
-        // The healthcheck builds absolute http(s) URLs from this value, so a
-        // relative path (no scheme/authority) or a non-http scheme must be
-        // rejected at validate time.
+    fn test_config_rejects_invalid_unity_catalog_endpoint() {
+        // `unity_catalog_endpoint` is an `HttpEndpoint`, so a malformed endpoint
+        // is rejected at deserialization time (config load) rather than at
+        // validate time. `http::Uri` alone would accept an empty host
+        // (`http://:8080`) and a non-numeric port (`http://localhost:notaport`),
+        // both of which `HttpEndpoint` rejects.
         for bad in [
-            "my-unity-catalog",
+            "",
+            "not a uri",
             "//workspace.databricks.com",
             "ftp://workspace.databricks.com",
+            "http://:8080",
+            "http://localhost:notaport",
         ] {
-            let mut config = create_test_config();
-            config.unity_catalog_endpoint = bad.to_string();
-            let result = config.validate();
-            assert!(result.is_err(), "expected error for endpoint={bad:?}");
-            if let Err(crate::sinks::databricks_zerobus::error::ZerobusSinkError::ConfigError {
-                message,
-            }) = result
-            {
-                assert!(message.contains("absolute http(s) URL"));
-            } else {
-                panic!("Expected ConfigError for endpoint={bad:?}");
-            }
+            let config = format!(
+                r#"
+ingestion_endpoint: "https://test.databricks.com"
+table_name: "test.default.logs"
+unity_catalog_endpoint: {bad:?}
+auth:
+  strategy: oauth
+  client_id: "test-client-id"
+  client_secret: "test-client-secret"
+"#
+            );
+            let result: Result<ZerobusSinkConfig, _> = serde_yaml::from_str(&config);
+            assert!(
+                result.is_err(),
+                "expected deserialization error for endpoint={bad:?}"
+            );
         }
     }
 

--- a/src/sinks/databricks_zerobus/service.rs
+++ b/src/sinks/databricks_zerobus/service.rs
@@ -318,7 +318,7 @@ impl ZerobusService {
     ) -> Result<Self, ZerobusSinkError> {
         let mut builder = ZerobusSdk::builder()
             .endpoint(config.ingestion_endpoint.to_string())
-            .unity_catalog_url(&config.unity_catalog_endpoint)
+            .unity_catalog_url(config.unity_catalog_endpoint.to_string())
             .application_name(config.user_agent_suffix());
         builder = builder.connector_factory(build_connector_factory(proxy)?);
         let sdk = builder.build().map_err(|e| ZerobusSinkError::ConfigError {
@@ -352,7 +352,7 @@ impl ZerobusService {
         let (client_id, client_secret) = config.auth.credentials();
 
         let table_schema = unity_catalog_schema::fetch_table_schema(
-            &config.unity_catalog_endpoint,
+            &config.unity_catalog_endpoint.to_string(),
             &config.table_name,
             client_id,
             client_secret,
@@ -587,7 +587,7 @@ impl ZerobusService {
 
         let sdk = ZerobusSdk::builder()
             .endpoint(config.ingestion_endpoint.to_string())
-            .unity_catalog_url(&config.unity_catalog_endpoint)
+            .unity_catalog_url(config.unity_catalog_endpoint.to_string())
             .build()
             .map_err(|e| ZerobusSinkError::ConfigError {
                 message: format!("Failed to create Zerobus SDK: {}", e),
@@ -711,7 +711,7 @@ mod tests {
         ZerobusSinkConfig {
             ingestion_endpoint: HttpEndpoint::parse("https://127.0.0.1:1").unwrap(),
             table_name: "test.default.logs".to_string(),
-            unity_catalog_endpoint: "https://127.0.0.1:1".to_string(),
+            unity_catalog_endpoint: HttpEndpoint::parse("https://127.0.0.1:1").unwrap(),
             auth: DatabricksAuthentication::OAuth {
                 client_id: SensitiveString::from("id".to_string()),
                 client_secret: SensitiveString::from("secret".to_string()),

--- a/src/sinks/databricks_zerobus/service.rs
+++ b/src/sinks/databricks_zerobus/service.rs
@@ -317,7 +317,7 @@ impl ZerobusService {
         proxy: &ProxyConfig,
     ) -> Result<Self, ZerobusSinkError> {
         let mut builder = ZerobusSdk::builder()
-            .endpoint(&config.ingestion_endpoint)
+            .endpoint(config.ingestion_endpoint.to_string())
             .unity_catalog_url(&config.unity_catalog_endpoint)
             .application_name(config.user_agent_suffix());
         builder = builder.connector_factory(build_connector_factory(proxy)?);
@@ -586,7 +586,7 @@ impl ZerobusService {
         config.validate()?;
 
         let sdk = ZerobusSdk::builder()
-            .endpoint(&config.ingestion_endpoint)
+            .endpoint(config.ingestion_endpoint.to_string())
             .unity_catalog_url(&config.unity_catalog_endpoint)
             .build()
             .map_err(|e| ZerobusSinkError::ConfigError {
@@ -703,12 +703,13 @@ mod tests {
     use crate::sinks::databricks_zerobus::config::{
         DatabricksAuthentication, ZerobusStreamOptions,
     };
+    use crate::sinks::util::HttpEndpoint;
     use databricks_zerobus_ingest_sdk::ZerobusError;
     use vector_lib::sensitive_string::SensitiveString;
 
     fn test_config() -> ZerobusSinkConfig {
         ZerobusSinkConfig {
-            ingestion_endpoint: "https://127.0.0.1:1".to_string(),
+            ingestion_endpoint: HttpEndpoint::parse("https://127.0.0.1:1").unwrap(),
             table_name: "test.default.logs".to_string(),
             unity_catalog_endpoint: "https://127.0.0.1:1".to_string(),
             auth: DatabricksAuthentication::OAuth {

--- a/src/sinks/databricks_zerobus/sink.rs
+++ b/src/sinks/databricks_zerobus/sink.rs
@@ -9,8 +9,8 @@ use futures::stream::BoxStream;
 use vector_lib::finalization::Finalizable;
 
 use crate::sinks::prelude::*;
+use crate::sinks::util::TowerRequestSettings;
 use crate::sinks::util::metadata::RequestMetadataBuilder;
-use crate::sinks::util::{RealtimeSizeBasedDefaultBatchSettings, TowerRequestSettings};
 
 use super::service::{
     RetryableErrorAsErroredLayer, ZerobusRequest, ZerobusRetryLogic, ZerobusService,
@@ -24,18 +24,16 @@ pub struct ZerobusSink {
 }
 
 impl ZerobusSink {
-    pub fn new(
+    pub const fn new(
         service: ZerobusService,
         request_limits: TowerRequestSettings,
-        batch_config: BatchConfig<RealtimeSizeBasedDefaultBatchSettings>,
-    ) -> Result<Self, crate::Error> {
-        let batch_settings = batch_config.into_batcher_settings()?;
-
-        Ok(Self {
+        batch_settings: BatcherSettings,
+    ) -> Self {
+        Self {
             service,
             request_limits,
             batch_settings,
-        })
+        }
     }
 
     async fn run_inner(self: Box<Self>, input: BoxStream<'_, Event>) -> Result<(), ()> {


### PR DESCRIPTION
## Summary
Migrate the `databricks_zerobus` sink to the validated config lifecycle: structural validation now runs at config-compile time and the validated state is retained for build.

### References
Related: #26048

## Vector configuration
NA

## How did you test this PR?
- `make check-clippy` with `sinks-databricks-zerobus` feature
- `make test` with the same feature, `SCOPE="-E 'test(zerobus)'"` (43 passed)
- `make generate-docs` (no doc changes required)

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## Contributor Guidelines

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them. To catch issues early, add a `pre-push` hook ([template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push)) or run the following locally before pushing:
  - `make fmt`
  - `make check-clippy` (auto-fix with `make clippy-fix`)
  - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details on the [dd-rust-license-tool](https://crates.io/crates/dd-rust-license-tool).
