### PR TITLE
feat(http, axiom, opentelemetry sinks): validate config at compile time

### DIFF
--- a/src/sinks/axiom/config.rs
+++ b/src/sinks/axiom/config.rs
@@ -38,10 +38,12 @@ pub struct UrlOrRegion {
     /// If a path is provided, the URL is used as-is.
     /// If no path (or only `/`) is provided, `/v1/datasets/{dataset}/ingest` is appended for backwards compatibility.
     /// This takes precedence over `region` if both are set (but both should not be set).
+    //
+    // No examples are rendered for this field: `url` and `region` are mutually
+    // exclusive but neither is required, and the example-config generator emits
+    // every field that has examples, which would produce an invalid config with
+    // both set.
     #[configurable(validation(format = "uri"))]
-    #[configurable(metadata(docs::examples = "https://api.eu.axiom.co"))]
-    #[configurable(metadata(docs::examples = "http://localhost:3400/ingest"))]
-    #[configurable(metadata(docs::examples = "${AXIOM_URL}"))]
     pub url: Option<String>,
 
     /// The Axiom regional edge domain to use for ingestion.
@@ -49,8 +51,8 @@ pub struct UrlOrRegion {
     /// Specify the domain name only (no scheme, no path).
     /// When set, data is sent to `https://{region}/v1/ingest/{dataset}`.
     /// Cannot be used together with `url`.
-    #[configurable(metadata(docs::examples = "${AXIOM_REGION}"))]
     #[configurable(metadata(docs::examples = "mumbai.axiom.co"))]
+    #[configurable(metadata(docs::examples = "${AXIOM_REGION}"))]
     #[configurable(metadata(docs::examples = "eu-central-1.aws.edge.axiom.co"))]
     pub region: Option<String>,
 }

--- a/src/sinks/axiom/config.rs
+++ b/src/sinks/axiom/config.rs
@@ -9,17 +9,20 @@ use vector_lib::{
 
 use crate::{
     codecs::{EncodingConfigWithFraming, Transformer},
-    config::{AcknowledgementsConfig, DataType, GenerateConfig, Input, SinkConfig, SinkContext},
+    config::{
+        AcknowledgementsConfig, DataType, DynValidatedSink, GenerateConfig, Input, SinkConfig,
+        SinkContext, ValidatedSink,
+    },
     http::Auth as HttpAuthConfig,
     sinks::{
         Healthcheck, VectorSink,
-        http::config::{HttpMethod, HttpSinkConfig},
+        http::config::{HttpMethod, HttpSinkConfig, ValidatedHttp},
         util::{
             BatchConfig, Compression, RealtimeSizeBasedDefaultBatchSettings,
             http::{RequestConfig, RetryStrategy},
         },
     },
-    template::ConfinementConfig,
+    template::{ConfinementConfig, Template},
     tls::TlsConfig,
 };
 
@@ -150,10 +153,71 @@ impl GenerateConfig for AxiomConfig {
 #[async_trait::async_trait]
 #[typetag::serde(name = "axiom")]
 impl SinkConfig for AxiomConfig {
-    async fn build(&self, cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
+    fn confinement_config(&self) -> Option<&crate::template::ConfinementConfig> {
+        Some(&self.confinement)
+    }
+
+    fn input(&self) -> Input {
+        Input::new(DataType::Metric | DataType::Log | DataType::Trace)
+    }
+
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &self.acknowledgements
+    }
+
+    fn as_dyn_validated(&self) -> Option<&dyn DynValidatedSink> {
+        Some(self)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ValidatedAxiom {
+    uri: Template,
+    http: ValidatedHttp,
+}
+
+#[async_trait::async_trait]
+impl ValidatedSink for AxiomConfig {
+    type Validated = ValidatedAxiom;
+
+    fn validate(&self) -> crate::Result<ValidatedAxiom> {
         // Validate that url and region are not both set
         self.endpoint.validate()?;
 
+        // Resolve and parse the ingest endpoint up front (pure, no I/O).
+        let uri: Template = self.build_endpoint().try_into()?;
+
+        // Construct and validate the derived HTTP config up front so
+        // `vector validate --no-environment` catches pure HTTP sink errors
+        // (invalid batch settings, invalid `X-Axiom-Org-Id` header value, ...)
+        // that the delegated HTTP sink would otherwise only reject at build.
+        let http_sink_config = self.http_sink_config(uri.clone())?;
+        let http = http_sink_config.validate()?;
+
+        Ok(ValidatedAxiom { uri, http })
+    }
+
+    async fn build(
+        &self,
+        validated: &ValidatedAxiom,
+        cx: SinkContext,
+    ) -> crate::Result<(VectorSink, Healthcheck)> {
+        // Route through the HTTP builder threaded with our own component type,
+        // so per-template security warnings carry `component_type=axiom` rather
+        // than `http`. The derived HTTP config was already constructed and
+        // validated during `validate`, so we build from the retained state.
+        let http_sink_config = self.http_sink_config(validated.uri.clone())?;
+        http_sink_config
+            .build_from_validated(&validated.http, cx, Self::NAME)
+            .await
+    }
+}
+
+impl AxiomConfig {
+    /// Build the derived HTTP sink configuration. The org-id header is added
+    /// here so the derived config (including the header value) is validated
+    /// during `validate`.
+    fn http_sink_config(&self, uri: Template) -> crate::Result<HttpSinkConfig> {
         let mut request = self.request.clone();
         if let Some(org_id) = &self.org_id {
             // NOTE: Only add the org id header if an org id is provided
@@ -168,8 +232,8 @@ impl SinkConfig for AxiomConfig {
         // to Axiom, whilst keeping the configuration simple and easy to use
         // and maintenance of the vector axiom sink to a minimum.
         //
-        let http_sink_config = HttpSinkConfig {
-            uri: self.build_endpoint().try_into()?,
+        Ok(HttpSinkConfig {
+            uri,
             compression: self.compression,
             auth: Some(HttpAuthConfig::Bearer {
                 token: self.token.clone(),
@@ -191,30 +255,9 @@ impl SinkConfig for AxiomConfig {
             payload_suffix: "".into(), // Always newline delimited JSON
             retry_strategy: self.retry_strategy.clone(),
             confinement: self.confinement.clone(),
-        };
-
-        // Route through the HTTP builder threaded with our own component type,
-        // so per-template security warnings carry `component_type=axiom` rather
-        // than `http`.
-        http_sink_config
-            .build_with_component_type(cx, Self::NAME)
-            .await
+        })
     }
 
-    fn confinement_config(&self) -> Option<&crate::template::ConfinementConfig> {
-        Some(&self.confinement)
-    }
-
-    fn input(&self) -> Input {
-        Input::new(DataType::Metric | DataType::Log | DataType::Trace)
-    }
-
-    fn acknowledgements(&self) -> &AcknowledgementsConfig {
-        &self.acknowledgements
-    }
-}
-
-impl AxiomConfig {
     fn build_endpoint(&self) -> String {
         // Priority: url > region > default cloud endpoint
 
@@ -321,6 +364,20 @@ mod test {
         };
         let endpoint = config.build_endpoint();
         assert_eq!(endpoint, "https://api.eu.axiom.co/v1/datasets/qoo/ingest");
+    }
+
+    #[test]
+    fn validate_produces_usable_uri() {
+        use crate::config::ValidatedSink;
+        let config = super::AxiomConfig {
+            dataset: "foo".to_string(),
+            ..Default::default()
+        };
+        let validated = config.validate().expect("validation should succeed");
+        assert_eq!(
+            validated.uri.get_ref(),
+            "https://api.axiom.co/v1/datasets/foo/ingest"
+        );
     }
 
     #[test]

--- a/src/sinks/http/config.rs
+++ b/src/sinks/http/config.rs
@@ -9,8 +9,8 @@ use aws_types::region::Region;
 use http::{HeaderName, HeaderValue, Method, Request, StatusCode, header::AUTHORIZATION};
 use hyper::Body;
 use vector_lib::codecs::{
-    CharacterDelimitedEncoder,
-    encoding::{Framer, Serializer},
+    CharacterDelimitedEncoderConfig, LengthDelimitedEncoderConfig,
+    encoding::{Framer, FramingConfig, SerializerConfig},
 };
 #[cfg(feature = "aws-core")]
 use vector_lib::config::proxy::ProxyConfig;
@@ -25,11 +25,12 @@ use crate::aws::AwsAuthentication;
 use crate::sinks::util::http::SigV4Config;
 use crate::{
     codecs::{EncodingConfigWithFraming, SinkType},
+    config::{DynValidatedSink, ValidatedSink},
     http::{Auth, HttpClient, MaybeAuth},
     sinks::{
         prelude::*,
         util::{
-            RealtimeSizeBasedDefaultBatchSettings, UriSerde,
+            RealtimeSizeBasedDefaultBatchSettings, TowerRequestSettings, UriSerde,
             http::{
                 HttpService, OrderedHeaderName, RequestConfig, RetryStrategy,
                 http_response_retry_logic,
@@ -169,6 +170,7 @@ impl HttpSinkConfig {
         Ok(HttpClient::new(tls, cx.proxy())?)
     }
 
+    #[cfg(test)]
     pub(super) fn build_encoder(&self) -> crate::Result<Encoder<Framer>> {
         let (framer, serializer) = self.encoding.build(SinkType::MessageBased)?;
         Ok(Encoder::<Framer>::new(framer, serializer))
@@ -218,22 +220,58 @@ pub(super) fn validate_headers(
     Ok(headers)
 }
 
+/// Returns the effective framing configuration for the `http` sink (which is
+/// message-based): the explicit framing if set, otherwise the default for the
+/// serializer. This mirrors the framer selection in
+/// `EncodingConfigWithFraming::build` without building the serializer (which
+/// may read files for codecs such as protobuf).
+fn effective_framer_config(encoding: &EncodingConfigWithFraming) -> FramingConfig {
+    match encoding.config().0 {
+        Some(framing) => framing.clone(),
+        None => match encoding.config().1 {
+            SerializerConfig::Json(_) => {
+                FramingConfig::CharacterDelimited(CharacterDelimitedEncoderConfig::new(b','))
+            }
+            SerializerConfig::Avro { .. } | SerializerConfig::Native => {
+                FramingConfig::LengthDelimited(LengthDelimitedEncoderConfig::default())
+            }
+            SerializerConfig::Gelf(_) => {
+                FramingConfig::CharacterDelimited(CharacterDelimitedEncoderConfig::new(0))
+            }
+            SerializerConfig::Protobuf(_) => {
+                FramingConfig::LengthDelimited(LengthDelimitedEncoderConfig::default())
+            }
+            SerializerConfig::Cef(_)
+            | SerializerConfig::Csv(_)
+            | SerializerConfig::Logfmt
+            | SerializerConfig::NativeJson
+            | SerializerConfig::RawMessage
+            | SerializerConfig::Text(_) => FramingConfig::NewlineDelimited,
+            #[cfg(feature = "codecs-syslog")]
+            SerializerConfig::Syslog(_) => FramingConfig::NewlineDelimited,
+            #[cfg(feature = "codecs-opentelemetry")]
+            SerializerConfig::Otlp => FramingConfig::Bytes,
+        },
+    }
+}
+
 pub(super) fn validate_payload_wrapper(
     payload_prefix: &str,
     payload_suffix: &str,
-    encoder: &Encoder<Framer>,
+    serializer: &SerializerConfig,
+    framer: &FramingConfig,
 ) -> crate::Result<(String, String)> {
     let payload = [payload_prefix, "{}", payload_suffix].join("");
     match (
-        encoder.serializer(),
-        encoder.framer(),
+        serializer,
+        framer,
         serde_json::from_str::<serde_json::Value>(&payload),
     ) {
-        (
-            Serializer::Json(_),
-            Framer::CharacterDelimited(CharacterDelimitedEncoder { delimiter: b',' }),
-            Err(_),
-        ) => Err("Payload prefix and suffix wrapper must produce a valid JSON object.".into()),
+        (SerializerConfig::Json(_), FramingConfig::CharacterDelimited(cfg), Err(_))
+            if cfg.character_delimited.delimiter == b',' =>
+        {
+            Err("Payload prefix and suffix wrapper must produce a valid JSON object.".into())
+        }
         _ => Ok((payload_prefix.to_owned(), payload_suffix.to_owned())),
     }
 }
@@ -241,10 +279,6 @@ pub(super) fn validate_payload_wrapper(
 #[async_trait]
 #[typetag::serde(name = "http")]
 impl SinkConfig for HttpSinkConfig {
-    async fn build(&self, cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
-        self.build_with_component_type(cx, Self::NAME).await
-    }
-
     fn confinement_config(&self) -> Option<&crate::template::ConfinementConfig> {
         Some(&self.confinement)
     }
@@ -269,21 +303,34 @@ impl SinkConfig for HttpSinkConfig {
     fn acknowledgements(&self) -> &AcknowledgementsConfig {
         &self.acknowledgements
     }
+
+    fn as_dyn_validated(&self) -> Option<&dyn DynValidatedSink> {
+        Some(self)
+    }
 }
 
-impl HttpSinkConfig {
-    /// Confinement + sink construction. `component_name` is threaded through so
-    /// per-template security warnings carry the outer sink type — `http` when
-    /// this is the top-level sink, `opentelemetry` when
-    /// [`OpenTelemetryConfig::build`] delegates here.
-    pub(crate) async fn build_with_component_type(
-        &self,
-        cx: SinkContext,
-        component_name: &'static str,
-    ) -> crate::Result<(VectorSink, Healthcheck)> {
+#[derive(Clone, Debug)]
+pub struct ValidatedHttp {
+    batch_settings: BatcherSettings,
+    transformer: Transformer,
+    template_headers: BTreeMap<String, Template>,
+    payload_prefix: String,
+    payload_suffix: String,
+    content_type: Option<String>,
+    content_encoding: Option<String>,
+    converted_static_headers: BTreeMap<OrderedHeaderName, HeaderValue>,
+    request_limits: TowerRequestSettings,
+}
+
+#[async_trait::async_trait]
+impl ValidatedSink for HttpSinkConfig {
+    type Validated = ValidatedHttp;
+
+    fn validate(&self) -> crate::Result<ValidatedHttp> {
         let batch_settings = self.batch.validate()?.into_batcher_settings()?;
 
-        let encoder = self.build_encoder()?;
+        let serializer_config = self.encoding.config().1;
+        let framer_config = effective_framer_config(&self.encoding);
         let transformer = self.encoding.transformer();
 
         let request = self.request.clone();
@@ -291,36 +338,59 @@ impl HttpSinkConfig {
         validate_headers(&request.headers, self.auth.is_some())?;
         let (static_headers, template_headers) = request.split_headers();
 
-        let (payload_prefix, payload_suffix) =
-            validate_payload_wrapper(&self.payload_prefix, &self.payload_suffix, &encoder)?;
-
-        let client = self.build_http_client(&cx)?;
-
-        let healthcheck = match cx.healthcheck.uri {
-            Some(healthcheck_uri) => {
-                healthcheck(healthcheck_uri, self.auth.clone(), client.clone()).boxed()
+        // Pure confinement checks for the URI and templated headers. The actual
+        // confinement (with the component name threaded from the
+        // `opentelemetry`/`axiom` delegations) happens in `build_from_validated`;
+        // running the checks here lets `vector validate --no-environment` catch
+        // unconfined routing templates. Skipped under the full opt-out, where
+        // `confine` only emits a warning.
+        if !self
+            .confinement
+            .dangerously_allow_unconfined_template_resolution
+        {
+            self.uri
+                .clone()
+                .confine(&self.confinement, Self::NAME, "uri")?;
+            for tpl in template_headers.values() {
+                tpl.clone()
+                    .confine(&self.confinement, Self::NAME, "request.headers")?;
             }
-            None => future::ok(()).boxed(),
-        };
+        }
+
+        // A static URI can be parsed and checked for embedded credentials up
+        // front; dynamic URIs are only validated at render time.
+        if !self.uri.is_dynamic() {
+            let uri_serde: UriSerde = self.uri.get_ref().parse()?;
+            self.auth.choose_one(&uri_serde.auth)?;
+            if uri_serde.uri.scheme().is_none() || uri_serde.uri.authority().is_none() {
+                return Err(format!(
+                    "uri must include a scheme and host, e.g. `https://example.com/endpoint`; got `{}`",
+                    self.uri.get_ref()
+                )
+                .into());
+            }
+        }
+
+        let (payload_prefix, payload_suffix) = validate_payload_wrapper(
+            &self.payload_prefix,
+            &self.payload_suffix,
+            serializer_config,
+            &framer_config,
+        )?;
 
         let content_type = {
-            use Framer::*;
-            use Serializer::*;
-            match (encoder.serializer(), encoder.framer()) {
-                (RawMessage(_) | Text(_), _) => Some(CONTENT_TYPE_TEXT.to_owned()),
-                (Json(_), NewlineDelimited(_)) => Some(CONTENT_TYPE_NDJSON.to_owned()),
-                (Json(_), CharacterDelimited(CharacterDelimitedEncoder { delimiter: b',' })) => {
+            use FramingConfig::*;
+            use SerializerConfig::*;
+            match (serializer_config, &framer_config) {
+                (RawMessage | Text(_), _) => Some(CONTENT_TYPE_TEXT.to_owned()),
+                (Json(_), NewlineDelimited) => Some(CONTENT_TYPE_NDJSON.to_owned()),
+                (Json(_), CharacterDelimited(cfg)) if cfg.character_delimited.delimiter == b',' => {
                     Some(CONTENT_TYPE_JSON.to_owned())
                 }
                 #[cfg(feature = "codecs-opentelemetry")]
-                (Otlp(_), _) => Some("application/x-protobuf".to_owned()),
+                (Otlp, _) => Some("application/x-protobuf".to_owned()),
                 _ => None,
             }
-        };
-
-        let request_builder = HttpRequestBuilder {
-            encoder: HttpEncoder::new(encoder, transformer, payload_prefix, payload_suffix),
-            compression: self.compression,
         };
 
         let content_encoding = self.compression.is_compressed().then(|| {
@@ -340,12 +410,81 @@ impl HttpSinkConfig {
             })
             .collect::<Result<BTreeMap<_, _>, _>>()?;
 
+        let request_limits = self.request.tower.into_settings();
+
+        Ok(ValidatedHttp {
+            batch_settings,
+            transformer,
+            template_headers,
+            payload_prefix,
+            payload_suffix,
+            content_type,
+            content_encoding,
+            converted_static_headers,
+            request_limits,
+        })
+    }
+
+    async fn build(
+        &self,
+        validated: &ValidatedHttp,
+        cx: SinkContext,
+    ) -> crate::Result<(VectorSink, Healthcheck)> {
+        self.build_from_validated(validated, cx, Self::NAME).await
+    }
+}
+
+impl HttpSinkConfig {
+    /// Builds the sink from the validated state. Confinement of the URI and
+    /// templated headers happens here (not in `validate`) because the
+    /// `component_name` threaded from the `opentelemetry`/`axiom` delegations
+    /// must appear in per-template security warnings.
+    pub(crate) async fn build_from_validated(
+        &self,
+        validated: &ValidatedHttp,
+        cx: SinkContext,
+        component_name: &'static str,
+    ) -> crate::Result<(VectorSink, Healthcheck)> {
+        let ValidatedHttp {
+            batch_settings,
+            transformer,
+            template_headers,
+            payload_prefix,
+            payload_suffix,
+            content_type,
+            content_encoding,
+            converted_static_headers,
+            request_limits,
+        } = validated;
+
+        let client = self.build_http_client(&cx)?;
+
+        let healthcheck = match cx.healthcheck.uri {
+            Some(healthcheck_uri) => {
+                healthcheck(healthcheck_uri, self.auth.clone(), client.clone()).boxed()
+            }
+            None => future::ok(()).boxed(),
+        };
+
+        let (framer, serializer) = self.encoding.build(SinkType::MessageBased)?;
+        let encoder = Encoder::<Framer>::new(framer, serializer);
+
+        let request_builder = HttpRequestBuilder {
+            encoder: HttpEncoder::new(
+                encoder,
+                transformer.clone(),
+                payload_prefix.clone(),
+                payload_suffix.clone(),
+            ),
+            compression: self.compression,
+        };
+
         let http_sink_request_builder = HttpSinkRequestBuilder::new(
             self.method,
             self.auth.clone(),
-            converted_static_headers,
-            content_type,
-            content_encoding,
+            converted_static_headers.clone(),
+            content_type.clone(),
+            content_encoding.clone(),
         );
 
         let service = match &self.auth {
@@ -378,11 +517,9 @@ impl HttpSinkConfig {
             _ => HttpService::new(client, http_sink_request_builder),
         };
 
-        let request_limits = self.request.tower.into_settings();
-
         let service = ServiceBuilder::new()
             .settings(
-                request_limits,
+                request_limits.clone(),
                 http_response_retry_logic(self.retry_strategy.clone()),
             )
             .service(service);
@@ -397,6 +534,7 @@ impl HttpSinkConfig {
         // routing — an event that controls the header field picks the
         // destination tenant unless we confine the header template too.
         let template_headers = template_headers
+            .clone()
             .into_iter()
             .map(|(name, tpl)| {
                 tpl.confine(&self.confinement, component_name, "request.headers")
@@ -408,7 +546,7 @@ impl HttpSinkConfig {
             service,
             uri,
             template_headers,
-            batch_settings,
+            *batch_settings,
             request_builder,
         );
 
@@ -481,6 +619,74 @@ mod tests {
     register_validatable_component!(HttpSinkConfig);
 
     #[test]
+    fn validate_rejects_static_uri_with_auth_conflict() {
+        use crate::config::ValidatedSink;
+        let config: HttpSinkConfig = serde_yaml::from_str(
+            r#"
+            uri: "http://user:pass@localhost:9000/endpoint"
+            auth:
+              strategy: basic
+              user: user
+              password: pass
+            encoding:
+              codec: json
+            "#,
+        )
+        .unwrap();
+        assert!(
+            config.validate().is_err(),
+            "embedded credentials plus auth should fail validation"
+        );
+    }
+
+    #[test]
+    fn validate_accepts_static_uri() {
+        use crate::config::ValidatedSink;
+        let config: HttpSinkConfig = serde_yaml::from_str(
+            r#"
+            uri: "http://localhost:9000/endpoint"
+            encoding:
+              codec: json
+            "#,
+        )
+        .unwrap();
+        config.validate().expect("valid static uri should validate");
+    }
+
+    #[test]
+    fn validate_accepts_dynamic_uri() {
+        use crate::config::ValidatedSink;
+        let config: HttpSinkConfig = serde_yaml::from_str(
+            r#"
+            uri: "http://example.com/{{ path }}"
+            encoding:
+              codec: json
+            "#,
+        )
+        .unwrap();
+        config
+            .validate()
+            .expect("dynamic uri validation is deferred to render time");
+    }
+
+    #[test]
+    fn validate_rejects_relative_static_uri() {
+        use crate::config::ValidatedSink;
+        let config: HttpSinkConfig = serde_yaml::from_str(
+            r#"
+            uri: "/ingest"
+            encoding:
+              codec: json
+            "#,
+        )
+        .unwrap();
+        assert!(
+            config.validate().is_err(),
+            "relative static uri should fail validation"
+        );
+    }
+
+    #[test]
     fn confinement_rejects_unconfined_uri() {
         let template: Template = "{{ endpoint }}".try_into().unwrap();
         let err = template
@@ -520,5 +726,25 @@ mod tests {
             .as_mut_log()
             .insert(event_path!("tenant"), "../../evil.com/steal?data=");
         assert!(template.render_string(&event).is_err());
+    }
+
+    #[test]
+    fn validate_returns_usable_values() {
+        let config: HttpSinkConfig = serde_yaml::from_str(
+            r#"
+            uri: "http://127.0.0.1:9000/endpoint"
+            encoding:
+              codec: json
+            "#,
+        )
+        .unwrap();
+
+        let validated = config.validate().expect("validation should succeed");
+        // JSON + newline-delimited framing maps to the NDJSON content type.
+        assert_eq!(validated.content_type.as_deref(), Some(CONTENT_TYPE_JSON));
+        assert_eq!(validated.payload_prefix, "");
+        assert_eq!(validated.payload_suffix, "");
+        assert!(validated.template_headers.is_empty());
+        assert!(validated.converted_static_headers.is_empty());
     }
 }

--- a/src/sinks/http/config.rs
+++ b/src/sinks/http/config.rs
@@ -357,6 +357,17 @@ impl ValidatedSink for HttpSinkConfig {
             }
         }
 
+        // `Template::default()` — produced by delegating sinks such as
+        // `opentelemetry` before the user supplies a URI — yields an empty
+        // template whose `is_static` is false, so `is_dynamic()` reports true
+        // even though there is nothing to render. Reject the empty URI up
+        // front rather than deferring a guaranteed per-request failure.
+        if self.uri.is_empty() {
+            return Err("uri must not be empty, e.g. `https://example.com/endpoint`"
+                .to_string()
+                .into());
+        }
+
         // A static URI can be parsed and checked for embedded credentials up
         // front; dynamic URIs are only validated at render time.
         if !self.uri.is_dynamic() {
@@ -667,6 +678,29 @@ mod tests {
         config
             .validate()
             .expect("dynamic uri validation is deferred to render time");
+    }
+
+    #[test]
+    fn validate_rejects_empty_default_uri() {
+        use crate::config::ValidatedSink;
+        // `Template::default()` — produced by delegating sinks such as
+        // `opentelemetry` before the user supplies a URI — is empty but reports
+        // `is_dynamic() == true` (the derived default leaves `is_static` false),
+        // so it must be rejected explicitly rather than deferred as a dynamic
+        // template that can never render.
+        let mut config: HttpSinkConfig = serde_yaml::from_str(
+            r#"
+            uri: "http://localhost:9000/endpoint"
+            encoding:
+              codec: json
+            "#,
+        )
+        .unwrap();
+        config.uri = Template::default();
+        assert!(
+            config.validate().is_err(),
+            "empty default uri should fail validation"
+        );
     }
 
     #[test]

--- a/src/sinks/http/tests.rs
+++ b/src/sinks/http/tests.rs
@@ -14,7 +14,7 @@ use vector_common::decompression::CappedDecoder;
 use vector_lib::{
     codecs::{
         JsonSerializerConfig, NewlineDelimitedEncoderConfig, TextSerializerConfig,
-        encoding::{Framer, FramingConfig},
+        encoding::FramingConfig,
     },
     event::{BatchNotifier, BatchStatus, Event, LogEvent},
     finalization::AddBatchNotifier,
@@ -28,7 +28,7 @@ use super::{
 };
 use crate::{
     assert_downcast_matches,
-    codecs::{EncodingConfigWithFraming, SinkType},
+    codecs::EncodingConfigWithFraming,
     log_event,
     sinks::{
         prelude::*,
@@ -168,10 +168,21 @@ fn http_validates_payload_prefix_and_suffix() {
         payload_suffix: "}"
         "#};
     let config: HttpSinkConfig = serde_yaml::from_str(config).unwrap();
-    let (framer, serializer) = config.encoding.build(SinkType::MessageBased).unwrap();
-    let encoder = Encoder::<Framer>::new(framer, serializer);
+    let serializer = config.encoding.config().1;
+    let framer = config.encoding.config().0.clone().unwrap_or_else(|| {
+        // Message-based default for JSON is comma-delimited framing.
+        FramingConfig::CharacterDelimited(vector_lib::codecs::CharacterDelimitedEncoderConfig::new(
+            b',',
+        ))
+    });
     assert!(
-        validate_payload_wrapper(&config.payload_prefix, &config.payload_suffix, &encoder).is_ok()
+        validate_payload_wrapper(
+            &config.payload_prefix,
+            &config.payload_suffix,
+            serializer,
+            &framer,
+        )
+        .is_ok()
     );
 }
 
@@ -185,10 +196,21 @@ fn http_validates_payload_prefix_and_suffix_fails_on_invalid_json() {
         payload_suffix: ""
         "#};
     let config: HttpSinkConfig = serde_yaml::from_str(config).unwrap();
-    let (framer, serializer) = config.encoding.build(SinkType::MessageBased).unwrap();
-    let encoder = Encoder::<Framer>::new(framer, serializer);
+    let serializer = config.encoding.config().1;
+    let framer = config.encoding.config().0.clone().unwrap_or_else(|| {
+        // Message-based default for JSON is comma-delimited framing.
+        FramingConfig::CharacterDelimited(vector_lib::codecs::CharacterDelimitedEncoderConfig::new(
+            b',',
+        ))
+    });
     assert!(
-        validate_payload_wrapper(&config.payload_prefix, &config.payload_suffix, &encoder).is_err()
+        validate_payload_wrapper(
+            &config.payload_prefix,
+            &config.payload_suffix,
+            serializer,
+            &framer,
+        )
+        .is_err()
     );
 }
 
@@ -965,31 +987,16 @@ async fn http_uri_auth_conflict() {
 
     let cx = SinkContext::default();
 
-    let (sink, _) = config.build(cx).await.unwrap();
-    let (rx, trigger, server) = build_test_server(in_addr);
-
-    let (batch, mut receiver) = BatchNotifier::new_with_receiver();
-    let mut event = Event::Log(LogEvent::default());
-    event.add_batch_notifier(batch);
-
-    tokio::spawn(server);
-
-    let expected_emitted_error_events = ["CallError", "SinkRequestBuildError"];
-    run_and_assert_sink_error_with_events(
-        sink,
-        stream::once(ready(event)),
-        &expected_emitted_error_events,
-        &COMPONENT_ERROR_TAGS,
-    )
-    .await;
-
-    drop(trigger);
-
-    assert_eq!(receiver.try_recv(), Ok(BatchStatus::Rejected));
-
-    // No requests should have been made to the server
-    let requests = rx.collect::<Vec<_>>().await;
-    assert!(requests.is_empty());
+    // The URI embeds credentials that conflict with the explicit `auth`;
+    // validation now rejects this configuration up front instead of failing
+    // at request time.
+    match config.build(cx).await {
+        Err(err) => assert!(
+            err.to_string().contains("Two authorization credentials"),
+            "unexpected error: {err}"
+        ),
+        Ok(_) => panic!("build should reject the URI/auth credential conflict"),
+    }
 }
 
 fn parse_compressed_json<T>(compression: &str, buf: Bytes) -> T

--- a/src/sinks/opentelemetry/mod.rs
+++ b/src/sinks/opentelemetry/mod.rs
@@ -10,10 +10,12 @@ use vector_lib::{
 
 use crate::{
     codecs::{EncodingConfigWithFraming, Transformer},
-    config::{AcknowledgementsConfig, Input, SinkConfig, SinkContext},
+    config::{
+        AcknowledgementsConfig, DynValidatedSink, Input, SinkConfig, SinkContext, ValidatedSink,
+    },
     sinks::{
         Healthcheck, VectorSink,
-        http::config::{HttpMethod, HttpSinkConfig},
+        http::config::{HttpMethod, HttpSinkConfig, ValidatedHttp},
     },
 };
 
@@ -78,18 +80,6 @@ impl GenerateConfig for OpenTelemetryConfig {
 #[async_trait::async_trait]
 #[typetag::serde(name = "opentelemetry")]
 impl SinkConfig for OpenTelemetryConfig {
-    async fn build(&self, cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
-        match &self.protocol {
-            Protocol::Http(config) => {
-                warn_on_invalid_otlp_batching(config);
-                // Delegate to the HTTP sink, but thread through `opentelemetry`
-                // as the component type so security warnings carry the outer
-                // sink type rather than `http`.
-                config.build_with_component_type(cx, Self::NAME).await
-            }
-        }
-    }
-
     fn confinement_config(&self) -> Option<&crate::template::ConfinementConfig> {
         match &self.protocol {
             Protocol::Http(config) => Some(&config.confinement),
@@ -103,8 +93,39 @@ impl SinkConfig for OpenTelemetryConfig {
     }
 
     fn acknowledgements(&self) -> &AcknowledgementsConfig {
-        match self.protocol {
-            Protocol::Http(ref config) => config.acknowledgements(),
+        match &self.protocol {
+            Protocol::Http(config) => config.acknowledgements(),
+        }
+    }
+
+    fn as_dyn_validated(&self) -> Option<&dyn DynValidatedSink> {
+        Some(self)
+    }
+}
+
+#[async_trait::async_trait]
+impl ValidatedSink for OpenTelemetryConfig {
+    type Validated = ValidatedHttp;
+
+    fn validate(&self) -> crate::Result<ValidatedHttp> {
+        match &self.protocol {
+            Protocol::Http(config) => config.validate(),
+        }
+    }
+
+    async fn build(
+        &self,
+        validated: &ValidatedHttp,
+        cx: SinkContext,
+    ) -> crate::Result<(VectorSink, Healthcheck)> {
+        match &self.protocol {
+            Protocol::Http(config) => {
+                warn_on_invalid_otlp_batching(config);
+                // Confinement of the URI and templated headers happens here (not in
+                // `validate`) so per-template security warnings carry the outer
+                // `opentelemetry` component type rather than `http`.
+                config.build_from_validated(validated, cx, Self::NAME).await
+            }
         }
     }
 }
@@ -126,8 +147,16 @@ fn warn_on_invalid_otlp_batching(config: &HttpSinkConfig) {
 
 #[cfg(test)]
 mod test {
+    use super::*;
+
     #[test]
     fn generate_config() {
         crate::test_util::test_generate_config::<super::OpenTelemetryConfig>();
+    }
+
+    #[test]
+    fn validate_produces_usable_state() {
+        let config = OpenTelemetryConfig::default();
+        config.validate().expect("validation should succeed");
     }
 }

--- a/src/sinks/opentelemetry/mod.rs
+++ b/src/sinks/opentelemetry/mod.rs
@@ -1,27 +1,20 @@
 use indoc::indoc;
 use vector_config::component::GenerateConfig;
-use vector_lib::{
-    codecs::{
-        JsonSerializerConfig,
-        encoding::{FramingConfig, SerializerConfig},
-    },
-    configurable::configurable_component,
-};
+use vector_lib::{codecs::encoding::SerializerConfig, configurable::configurable_component};
 
 use crate::{
-    codecs::{EncodingConfigWithFraming, Transformer},
     config::{
         AcknowledgementsConfig, DynValidatedSink, Input, SinkConfig, SinkContext, ValidatedSink,
     },
     sinks::{
         Healthcheck, VectorSink,
-        http::config::{HttpMethod, HttpSinkConfig, ValidatedHttp},
+        http::config::{HttpSinkConfig, ValidatedHttp},
     },
 };
 
 /// Configuration for the `OpenTelemetry` sink.
 #[configurable_component(sink("opentelemetry", "Deliver OTLP data over HTTP."))]
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct OpenTelemetryConfig {
     /// Protocol configuration
     #[configurable(derived)]
@@ -38,30 +31,6 @@ pub struct OpenTelemetryConfig {
 pub enum Protocol {
     /// Send data over HTTP.
     Http(HttpSinkConfig),
-}
-
-impl Default for Protocol {
-    fn default() -> Self {
-        Protocol::Http(HttpSinkConfig {
-            encoding: EncodingConfigWithFraming::new(
-                Some(FramingConfig::NewlineDelimited),
-                SerializerConfig::Json(JsonSerializerConfig::default()),
-                Transformer::default(),
-            ),
-            uri: Default::default(),
-            method: HttpMethod::Post,
-            auth: Default::default(),
-            compression: Default::default(),
-            payload_prefix: Default::default(),
-            payload_suffix: Default::default(),
-            batch: Default::default(),
-            request: Default::default(),
-            tls: Default::default(),
-            acknowledgements: Default::default(),
-            retry_strategy: Default::default(),
-            confinement: Default::default(),
-        })
-    }
 }
 
 impl GenerateConfig for OpenTelemetryConfig {
@@ -156,7 +125,8 @@ mod test {
 
     #[test]
     fn validate_produces_usable_state() {
-        let config = OpenTelemetryConfig::default();
+        let config: OpenTelemetryConfig =
+            serde_json::from_value(OpenTelemetryConfig::generate_config()).unwrap();
         config.validate().expect("validation should succeed");
     }
 }

--- a/website/cue/reference/components/sinks/generated/axiom.cue
+++ b/website/cue/reference/components/sinks/generated/axiom.cue
@@ -122,7 +122,7 @@ generated: components: sinks: axiom: configuration: {
 			Cannot be used together with `url`.
 			"""
 		required: false
-		type: string: examples: ["${AXIOM_REGION}", "mumbai.axiom.co", "eu-central-1.aws.edge.axiom.co"]
+		type: string: examples: ["mumbai.axiom.co", "${AXIOM_REGION}", "eu-central-1.aws.edge.axiom.co"]
 	}
 	request: {
 		description: "Outbound HTTP request settings."
@@ -464,6 +464,6 @@ generated: components: sinks: axiom: configuration: {
 			This takes precedence over `region` if both are set (but both should not be set).
 			"""
 		required: false
-		type: string: examples: ["https://api.eu.axiom.co", "http://localhost:3400/ingest", "${AXIOM_URL}"]
+		type: string: {}
 	}
 }

--- a/website/generated/example-configs/sinks/axiom/advanced.yaml
+++ b/website/generated/example-configs/sinks/axiom/advanced.yaml
@@ -7,6 +7,5 @@ sinks:
     dangerously_allow_unconfined_template_resolution: false
     dataset: ${AXIOM_DATASET}
     org_id: ${AXIOM_ORG_ID}
-    region: ${AXIOM_REGION}
+    region: mumbai.axiom.co
     token: ${AXIOM_TOKEN}
-    url: https://api.eu.axiom.co


### PR DESCRIPTION
## Summary
Migrate the `http`, `axiom`, and `opentelemetry` sinks to the validated config lifecycle: structural validation now runs at config-compile time and the validated state is retained for build.

All these sinks are built on top of the http sink

### References
Related: #26048

## Vector configuration
NA

## How did you test this PR?
- `make check-clippy` with `sinks-http,sinks-axiom,sinks-opentelemetry` features
- `make test` with the same features, `SCOPE="-E 'test(http) or test(axiom) or test(opentelemetry)'"` (110 passed)
- `make generate-docs` (no doc changes required)

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## Contributor Guidelines

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them. To catch issues early, add a `pre-push` hook ([template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push)) or run the following locally before pushing:
  - `make fmt`
  - `make check-clippy` (auto-fix with `make clippy-fix`)
  - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details on the [dd-rust-license-tool](https://crates.io/crates/dd-rust-license-tool).
