### PR TITLE
chore(website): version Amplify build configuration

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -10,9 +10,8 @@ applications:
             - export CI=true
         build:
           commands:
-            - export DEPLOY_PRIME_URL="https://$(echo "${AWS_BRANCH}" | sed 's/[./]/-/g').d1a7j77663uxsc.amplifyapp.com"
-            - if [[ "${AWS_BRANCH}" == "website" ]]; then DEPLOY_COMMAND="ci-production-build"; else DEPLOY_COMMAND="ci-preview-build"; fi
-            - make "${DEPLOY_COMMAND}"
+            - test "${AWS_BRANCH}" = "website"
+            - make ci-production-build
       artifacts:
         baseDirectory: public
         files:

--- a/amplify.yml
+++ b/amplify.yml
@@ -7,7 +7,6 @@ applications:
           commands:
             - source ~/.nvm/nvm.sh
             - nvm use 24.11.0
-            - export CI=true
         build:
           commands:
             - test "${AWS_BRANCH}" = "website"

--- a/amplify.yml
+++ b/amplify.yml
@@ -1,0 +1,22 @@
+version: 1
+applications:
+  - appRoot: website
+    frontend:
+      phases:
+        preBuild:
+          commands:
+            - source ~/.nvm/nvm.sh
+            - nvm use 24.11.0
+            - export CI=true
+        build:
+          commands:
+            - export DEPLOY_PRIME_URL="https://$(echo "${AWS_BRANCH}" | sed 's/[./]/-/g').d1a7j77663uxsc.amplifyapp.com"
+            - if [[ "${AWS_BRANCH}" == "website" ]]; then DEPLOY_COMMAND="ci-production-build"; else DEPLOY_COMMAND="ci-preview-build"; fi
+            - make "${DEPLOY_COMMAND}"
+      artifacts:
+        baseDirectory: public
+        files:
+          - "**/*"
+      cache:
+        paths:
+          - node_modules/**/*


### PR DESCRIPTION
## Summary

### Motivation

Keep the Amplify production-build command alongside the website it deploys without granting preview builds access to the Typesense synchronization path. Removes fragile console-only setup.

### Changes

Adds amplify yaml.

## Vector configuration

N/A

## How did you test this PR?

- `cd website && make serve`
- Confirmed HTTP 200 from `http://127.0.0.1:1313/`.
- Parsed `amplify.yml` with Ruby YAML.

## Change Type

- [x] Non-functional (chore, refactoring, docs)

## Is this a breaking change?

- [x] No

## Does this PR include user facing changes?

- [x] No. A maintainer will apply the `no-changelog` label to this PR.