### PR TITLE
chore(website): version Amplify build configuration

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -1,0 +1,20 @@
+version: 1
+applications:
+  - appRoot: website
+    frontend:
+      phases:
+        preBuild:
+          commands:
+            - source ~/.nvm/nvm.sh
+            - nvm use 24.11.0
+        build:
+          commands:
+            - test "${AWS_BRANCH}" = "website"
+            - make ci-production-build
+      artifacts:
+        baseDirectory: public
+        files:
+          - "**/*"
+      cache:
+        paths:
+          - node_modules/**/*

--- a/amplify.yml
+++ b/amplify.yml
@@ -5,8 +5,9 @@ applications:
       phases:
         preBuild:
           commands:
-            - source ~/.nvm/nvm.sh
+            - source "${NVM_DIR}/nvm.sh"
             - nvm use 24.11.0
+            - node --version
         build:
           commands:
             - test "${AWS_BRANCH}" = "website"


### PR DESCRIPTION
## Summary

### Motivation

Version the Amplify Hosting build specification in the repository so deployments use the reviewed website build environment.

### Changes

- add the production-only Amplify build specification
- source NVM through the image-provided `NVM_DIR`
- log the selected Node.js version before building

## How did you test this PR?

- Parsed `amplify.yml` as YAML.
- Verified this exact configuration in Amplify Deployment 148 using `public.ecr.aws/x2b9z2t7/vector-website-build:sha-7bfaae8edea58b1873c31b6385ce5fb09f20787f`. Build, deploy, and verification all succeeded.

## Change Type

- [x] Non-functional (chore, refactoring, docs)

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.