### PR TITLE
fix(website): source Node from Amplify build image

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -5,8 +5,9 @@ applications:
       phases:
         preBuild:
           commands:
-            - source ~/.nvm/nvm.sh
+            - source "${NVM_DIR}/nvm.sh"
             - nvm use 24.11.0
+            - node --version
         build:
           commands:
             - test "${AWS_BRANCH}" = "website"


### PR DESCRIPTION
## Summary

### Motivation

The Amplify deployment needs to source NVM from the configured custom build image rather than the build runner's home directory.

### Changes

- source NVM through the image-provided `NVM_DIR`
- log the selected Node.js version before building

## How did you test this PR?

- Parsed `amplify.yml` as YAML.
- Verified the published ECR image exposes `NVM_DIR=/root/.nvm`, prepends Node 24.11.0 to `PATH`, and records `nvm install 24.11.0` in its image history.

## Change Type

- [x] Non-functional (chore, refactoring, docs)

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.