### PR TITLE
fix(website): restore Amplify preview builds

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -9,12 +9,13 @@ applications:
             - nvm use 24.11.0
             - node --version
         build:
-          - |
-            if [[ "${AWS_BRANCH}" == "website" ]]; then
-              make ci-production-build
-            else
-              make ci-preview-build
-            fi
+          commands:
+            - |
+              if [[ "${AWS_BRANCH}" == "website" ]]; then
+                make ci-production-build
+              else
+                make ci-preview-build
+              fi
       artifacts:
         baseDirectory: public
         files:

--- a/amplify.yml
+++ b/amplify.yml
@@ -9,12 +9,12 @@ applications:
             - nvm use 24.11.0
             - node --version
         build:
-            - |
-              if [[ "${AWS_BRANCH}" == "website" ]]; then
-                make ci-production-build
-              else
-                make ci-preview-build
-              fi
+          - |
+            if [[ "${AWS_BRANCH}" == "website" ]]; then
+              make ci-production-build
+            else
+              make ci-preview-build
+            fi
       artifacts:
         baseDirectory: public
         files:

--- a/amplify.yml
+++ b/amplify.yml
@@ -9,9 +9,12 @@ applications:
             - nvm use 24.11.0
             - node --version
         build:
-          commands:
-            - test "${AWS_BRANCH}" = "website"
-            - make ci-production-build
+            - |
+              if [[ "${AWS_BRANCH}" == "website" ]]; then
+                make ci-production-build
+              else
+                make ci-preview-build
+              fi
       artifacts:
         baseDirectory: public
         files:


### PR DESCRIPTION
## Summary

Replaces the hard `test "${AWS_BRANCH}" = "website"` gate in `amplify.yml` with a branch-conditional build. The `website` branch runs `ci-production-build`; all other branches run `ci-preview-build`, restoring preview deployments.

### References

NA

## Vector configuration

NA

## How did you test this PR?

Verified `amplify.yml` YAML parses and `make -n ci-preview-build` resolves correctly. The Makefile `ci-preview-build` target is unchanged from `master`.

## Is this a breaking change?

- [ ] Yes
- [X] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [X] No. A maintainer will apply the `no-changelog` label to this PR.