### PR TITLE
fix(website): stop component card hover border from shifting content

### DIFF
--- a/website/layouts/_default/component-card.html
+++ b/website/layouts/_default/component-card.html
@@ -3,7 +3,7 @@
 {{ $kind := .Params.component_kind }}
 <div>
   <a href="{{ .RelPermalink }}">
-    <div class="no-prose border hover:border-4 rounded dark:border-gray-700 p-4 shadow-sm hover:border-secondary dark:hover:border-primary">
+    <div class="no-prose border rounded dark:border-gray-700 p-4 shadow-sm hover:border-secondary dark:hover:border-primary">
       <span class="flex justify-between items-center text-sm">
         <span class="text-gray-600 dark:text-gray-300">
           {{ $title }}


### PR DESCRIPTION
## Summary

Component cards on /components no longer grow their border on hover, which was shifting the inner content. The `hover:border-4` utility was inert under Tailwind v3 but takes effect under v4, growing the border 1px to 4px and shifting content 3px per side. Removed it so hover only changes border color, matching the rest of the site.

### References
Related: #25362

## Vector configuration
NA

## How did you test this PR?
Built the site with `make serve` and verified hover no longer shifts card content.

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## Contributor Guidelines

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them. To catch issues early, add a `pre-push` hook ([template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push)) or run the following locally before pushing:
  - `make fmt`
  - `make check-clippy` (auto-fix with `make clippy-fix`)
  - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details on the [dd-rust-license-tool](https://crates.io/crates/dd-rust-license-tool).
