### PR TITLE
enhancement(aws_cloudwatch_logs): relax stream name confinement

### DIFF
--- a/changelog.d/25922_cloudwatch_stream_name_confinement.enhancement.md
+++ b/changelog.d/25922_cloudwatch_stream_name_confinement.enhancement.md
@@ -1,0 +1,4 @@
+Dynamic `aws_cloudwatch_logs` sink `stream_name` templates no longer require a literal prefix or
+`dangerously_allow_unconfined_template_resolution`. `group_name` remains confined.
+
+authors: pront

--- a/src/sinks/aws_cloudwatch_logs/config.rs
+++ b/src/sinks/aws_cloudwatch_logs/config.rs
@@ -29,7 +29,7 @@ use crate::{
             http::{OrderedHeaderName, RequestConfig, validate_headers},
         },
     },
-    template::{ConfinedTemplate, ConfinementConfig, Template},
+    template::{ConfinedTemplate, ConfinementConfig, Template, UnconfinedTemplate},
     tls::TlsConfig,
 };
 
@@ -106,7 +106,7 @@ pub struct CloudwatchLogsSinkConfig {
     #[configurable(metadata(docs::examples = "stream-{{ host }}"))]
     #[configurable(metadata(docs::examples = "%Y-%m-%d"))]
     #[configurable(metadata(docs::examples = "stream-name"))]
-    pub stream_name: Template,
+    pub stream_name: UnconfinedTemplate,
 
     /// The [AWS region][aws_region] of the target service.
     ///
@@ -235,7 +235,7 @@ impl SinkConfig for CloudwatchLogsSinkConfig {
 #[derive(Clone, Debug)]
 pub struct ValidatedCloudwatchLogs {
     group_template: ConfinedTemplate,
-    stream_template: ConfinedTemplate,
+    stream_template: UnconfinedTemplate,
     batcher_settings: BatcherSettings,
     headers: BTreeMap<OrderedHeaderName, HeaderValue>,
 }
@@ -249,10 +249,7 @@ impl ValidatedSink for CloudwatchLogsSinkConfig {
             self.group_name
                 .clone()
                 .confine(&self.confinement, Self::NAME, "group_name")?;
-        let stream_template =
-            self.stream_name
-                .clone()
-                .confine(&self.confinement, Self::NAME, "stream_name")?;
+        let stream_template = self.stream_name.clone();
         let batcher_settings = self.batch.into_batcher_settings()?;
         let headers = validate_headers(&self.request.headers)?;
 

--- a/src/sinks/aws_cloudwatch_logs/config.rs
+++ b/src/sinks/aws_cloudwatch_logs/config.rs
@@ -235,7 +235,6 @@ impl SinkConfig for CloudwatchLogsSinkConfig {
 #[derive(Clone, Debug)]
 pub struct ValidatedCloudwatchLogs {
     group_template: ConfinedTemplate,
-    stream_template: UnconfinedTemplate,
     batcher_settings: BatcherSettings,
     headers: BTreeMap<OrderedHeaderName, HeaderValue>,
 }
@@ -249,13 +248,11 @@ impl ValidatedSink for CloudwatchLogsSinkConfig {
             self.group_name
                 .clone()
                 .confine(&self.confinement, Self::NAME, "group_name")?;
-        let stream_template = self.stream_name.clone();
         let batcher_settings = self.batch.into_batcher_settings()?;
         let headers = validate_headers(&self.request.headers)?;
 
         Ok(ValidatedCloudwatchLogs {
             group_template,
-            stream_template,
             batcher_settings,
             headers,
         })
@@ -268,7 +265,6 @@ impl ValidatedSink for CloudwatchLogsSinkConfig {
     ) -> crate::Result<(VectorSink, Healthcheck)> {
         let ValidatedCloudwatchLogs {
             group_template,
-            stream_template,
             batcher_settings,
             headers,
         } = validated.clone();
@@ -289,7 +285,7 @@ impl ValidatedSink for CloudwatchLogsSinkConfig {
             batcher_settings,
             request_builder: CloudwatchRequestBuilder {
                 group_template,
-                stream_template,
+                stream_template: self.stream_name.clone(),
                 transformer,
                 encoder,
             },
@@ -352,7 +348,6 @@ mod tests {
 
         let validated = config.validate().expect("preparation should succeed");
         assert_eq!(validated.group_template.to_string(), "group-{{ file }}");
-        assert_eq!(validated.stream_template.to_string(), "stream");
         assert_eq!(validated.batcher_settings.item_limit, 10_000);
     }
 

--- a/src/sinks/aws_cloudwatch_logs/integration_tests.rs
+++ b/src/sinks/aws_cloudwatch_logs/integration_tests.rs
@@ -15,7 +15,7 @@ use crate::{
     config::{ProxyConfig, SinkConfig, SinkContext, log_schema},
     event::{Event, LogEvent, Value},
     sinks::{aws_cloudwatch_logs::config::CloudwatchLogsClientBuilder, util::BatchConfig},
-    template::Template,
+    template::{Template, UnconfinedTemplate},
     test_util::{
         components::{AWS_SINK_TAGS, run_and_assert_sink_compliance},
         random_lines, random_lines_with_stream, random_string, trace_init,
@@ -50,7 +50,7 @@ async fn cloudwatch_insert_log_event() {
 
     let stream_name = gen_name();
     let config = CloudwatchLogsSinkConfig {
-        stream_name: Template::try_from(stream_name.as_str()).unwrap(),
+        stream_name: UnconfinedTemplate::try_from(stream_name.as_str()).unwrap(),
         group_name: Template::try_from(GROUP_NAME).unwrap(),
         region: RegionOrEndpoint::with_both("us-east-1", cloudwatch_address().as_str()),
         encoding: TextSerializerConfig::default().into(),
@@ -104,7 +104,7 @@ async fn cloudwatch_insert_log_events_sorted() {
 
     let stream_name = gen_name();
     let config = CloudwatchLogsSinkConfig {
-        stream_name: Template::try_from(stream_name.as_str()).unwrap(),
+        stream_name: UnconfinedTemplate::try_from(stream_name.as_str()).unwrap(),
         group_name: Template::try_from(GROUP_NAME).unwrap(),
         region: RegionOrEndpoint::with_both("us-east-1", cloudwatch_address().as_str()),
         encoding: TextSerializerConfig::default().into(),
@@ -183,7 +183,7 @@ async fn cloudwatch_insert_out_of_range_timestamp() {
 
     let stream_name = gen_name();
     let config = CloudwatchLogsSinkConfig {
-        stream_name: Template::try_from(stream_name.as_str()).unwrap(),
+        stream_name: UnconfinedTemplate::try_from(stream_name.as_str()).unwrap(),
         group_name: Template::try_from(GROUP_NAME).unwrap(),
         region: RegionOrEndpoint::with_both("us-east-1", cloudwatch_address().as_str()),
         encoding: TextSerializerConfig::default().into(),
@@ -263,7 +263,7 @@ async fn cloudwatch_dynamic_group_and_stream_creation() {
     let group_name = gen_name();
 
     let config = CloudwatchLogsSinkConfig {
-        stream_name: Template::try_from(stream_name.as_str()).unwrap(),
+        stream_name: UnconfinedTemplate::try_from(stream_name.as_str()).unwrap(),
         group_name: Template::try_from(group_name.as_str()).unwrap(),
         region: RegionOrEndpoint::with_both("us-east-1", cloudwatch_address().as_str()),
         encoding: TextSerializerConfig::default().into(),
@@ -317,7 +317,7 @@ async fn cloudwatch_dynamic_group_and_stream_creation_with_kms_key_and_tags() {
     let group_name = gen_name();
 
     let config = CloudwatchLogsSinkConfig {
-        stream_name: Template::try_from(stream_name.as_str()).unwrap(),
+        stream_name: UnconfinedTemplate::try_from(stream_name.as_str()).unwrap(),
         group_name: Template::try_from(group_name.as_str()).unwrap(),
         region: RegionOrEndpoint::with_both("us-east-1", cloudwatch_address().as_str()),
         encoding: TextSerializerConfig::default().into(),
@@ -407,7 +407,7 @@ async fn cloudwatch_insert_log_event_batched() {
     batch.max_events = Some(2);
 
     let config = CloudwatchLogsSinkConfig {
-        stream_name: Template::try_from(stream_name.as_str()).unwrap(),
+        stream_name: UnconfinedTemplate::try_from(stream_name.as_str()).unwrap(),
         group_name: Template::try_from(group_name.as_str()).unwrap(),
         region: RegionOrEndpoint::with_both("us-east-1", cloudwatch_address().as_str()),
         encoding: TextSerializerConfig::default().into(),
@@ -462,7 +462,7 @@ async fn cloudwatch_insert_log_event_partitioned() {
     let stream_name = gen_name();
     let config = CloudwatchLogsSinkConfig {
         group_name: Template::try_from(GROUP_NAME).unwrap(),
-        stream_name: Template::try_from(format!("{stream_name}-{{{{key}}}}")).unwrap(),
+        stream_name: UnconfinedTemplate::try_from(format!("{stream_name}-{{{{key}}}}")).unwrap(),
         region: RegionOrEndpoint::with_both("us-east-1", cloudwatch_address().as_str()),
         encoding: TextSerializerConfig::default().into(),
         create_missing_group: true,
@@ -557,7 +557,7 @@ async fn cloudwatch_healthcheck() {
     ensure_group().await;
 
     let config = CloudwatchLogsSinkConfig {
-        stream_name: Template::try_from("test-stream").unwrap(),
+        stream_name: UnconfinedTemplate::try_from("test-stream").unwrap(),
         group_name: Template::try_from(GROUP_NAME).unwrap(),
         region: RegionOrEndpoint::with_both("us-east-1", cloudwatch_address().as_str()),
         encoding: TextSerializerConfig::default().into(),

--- a/src/sinks/aws_cloudwatch_logs/request_builder.rs
+++ b/src/sinks/aws_cloudwatch_logs/request_builder.rs
@@ -15,7 +15,7 @@ use crate::{
     event::{Event, Value},
     internal_events::AwsCloudwatchLogsMessageSizeError,
     sinks::{aws_cloudwatch_logs::CloudwatchKey, util::metadata::RequestMetadataBuilder},
-    template::ConfinedTemplate,
+    template::{ConfinedTemplate, UnconfinedTemplate},
 };
 
 // Estimated maximum size of InputLogEvent is 50 bytes with an empty message
@@ -52,7 +52,7 @@ impl MetaDescriptive for CloudwatchRequest {
 
 pub struct CloudwatchRequestBuilder {
     pub group_template: ConfinedTemplate,
-    pub stream_template: ConfinedTemplate,
+    pub stream_template: UnconfinedTemplate,
     pub transformer: Transformer,
     pub encoder: Encoder<()>,
 }
@@ -143,7 +143,7 @@ mod tests {
     use vector_lib::{config::log_schema, event::LogEvent};
 
     use super::{CloudwatchRequestBuilder, MAX_MESSAGE_SIZE};
-    use crate::template::{ConfinedTemplate, ConfinementConfig, Template};
+    use crate::template::{ConfinedTemplate, ConfinementConfig, Template, UnconfinedTemplate};
 
     fn confined(src: &str, field: &'static str) -> ConfinedTemplate {
         Template::try_from(src)
@@ -152,11 +152,15 @@ mod tests {
             .unwrap()
     }
 
+    fn unconfined(src: &str) -> UnconfinedTemplate {
+        UnconfinedTemplate::try_from(src).unwrap()
+    }
+
     #[test]
     fn test() {
         let mut request_builder = CloudwatchRequestBuilder {
             group_template: confined("group", "group_name"),
-            stream_template: confined("stream", "stream_name"),
+            stream_template: unconfined("stream"),
             transformer: Default::default(),
             encoder: Default::default(),
         };
@@ -174,7 +178,7 @@ mod tests {
     fn test_rejects_oversized_log_event() {
         let mut request_builder = CloudwatchRequestBuilder {
             group_template: confined("group", "group_name"),
-            stream_template: confined("stream", "stream_name"),
+            stream_template: unconfined("stream"),
             transformer: Default::default(),
             encoder: Default::default(),
         };


### PR DESCRIPTION
## Summary

### Motivation

The template confinement added in 0.57 was overly constraining for CloudWatch log stream names. A configuration such as `stream_name: "{{ host }}"` now requires the sink-wide `dangerously_allow_unconfined_template_resolution` opt-out, even though the rendered stream remains inside the configured log group.

The log group is the destination boundary here: it owns retention, encryption, subscription filters, and access policy, and Vector can create a missing group by default. This change therefore keeps `group_name` confined while allowing event data to select a stream within that group. AWS IAM enforcement for log groups and streams is unchanged.

### Changes

- Treat `stream_name` as an unconfined template while keeping `group_name` confined.
- Add a changelog fragment for the user-facing behavior change.

Stream-name syntax validation and stream-cardinality controls are outside this change. Prefixed dynamic stream templates already had the same runtime behavior before this relaxation.

### References

Closes: #25922

## Vector configuration

```yaml
sources:
  demo:
    type: demo_logs

sinks:
  cloudwatch:
    type: aws_cloudwatch_logs
    inputs:
      - demo
    group_name: app-logs
    stream_name: "{{ host }}"
    encoding:
      codec: json
```

## How did you test this PR?

- `cargo nextest run -p vector --no-default-features --no-fail-fast --features sinks-aws_cloudwatch_logs aws_cloudwatch_logs` (11 passed)
- `make check-clippy`
- `make fmt`
- `make generate-docs`

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## Contributor Guidelines

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them. To catch issues early, add a `pre-push` hook ([template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push)) or run the following locally before pushing:
  - `make fmt`
  - `make check-clippy` (auto-fix with `make clippy-fix`)
  - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details on the [dd-rust-license-tool](https://crates.io/crates/dd-rust-license-tool).
