### PR TITLE
fix(website): ensure component examples are generated

### DIFF
--- a/website/Makefile
+++ b/website/Makefile
@@ -30,9 +30,12 @@ cue-build:
 cue-%:
 	${CUE} $*
 
-.PHONY: config-examples
-config-examples: setup-vdev
+.PHONY: component-examples
+component-examples: setup-vdev
 	$(VDEV) build component-examples website/generated/example-configs
+
+.PHONY: config-examples
+config-examples: component-examples
 
 generate-vrl-docs:
 	$(VDEV) build vrl-docs --output-dir cue/reference/remap/functions \
@@ -41,7 +44,7 @@ generate-vrl-docs:
 generate-deprecations-json:
 	$(VDEV) deprecation generate
 
-structured-data: generate-vrl-docs generate-deprecations-json config-examples
+structured-data: generate-vrl-docs generate-deprecations-json component-examples
 
 serve: clean setup cargo-data structured-data
 	hugo server \


### PR DESCRIPTION
## Summary

### Motivation

Component configuration examples can be silently omitted when the website's structured-data pipeline depends on the compatibility `config-examples` target and that target is disabled downstream.

### Changes

- Add a canonical `component-examples` generation target.
- Keep `config-examples` as a compatibility alias.
- Make the production structured-data pipeline depend directly on the canonical target.

## Vector configuration

N/A

## How did you test this PR?

- `make -C website config-examples`
- `make -C website structured-data`
- `make -C website cargo-data production-build`
- Verified that all components have minimal and advanced example data and that the rendered Mezmo page contains its examples.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Dependencies
- [ ] Non-functional (chore, refactoring, docs)
- [ ] Performance

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## References

N/A
