### PR TITLE
fix(databricks_zerobus sink): trim trailing slash from Unity Catalog endpoint

### DIFF
--- a/src/sinks/databricks_zerobus/service.rs
+++ b/src/sinks/databricks_zerobus/service.rs
@@ -318,7 +318,12 @@ impl ZerobusService {
     ) -> Result<Self, ZerobusSinkError> {
         let mut builder = ZerobusSdk::builder()
             .endpoint(config.ingestion_endpoint.to_string())
-            .unity_catalog_url(config.unity_catalog_endpoint.to_string().trim_end_matches('/'))
+            .unity_catalog_url(
+                config
+                    .unity_catalog_endpoint
+                    .to_string()
+                    .trim_end_matches('/'),
+            )
             .application_name(config.user_agent_suffix());
         builder = builder.connector_factory(build_connector_factory(proxy)?);
         let sdk = builder.build().map_err(|e| ZerobusSinkError::ConfigError {
@@ -587,7 +592,12 @@ impl ZerobusService {
 
         let sdk = ZerobusSdk::builder()
             .endpoint(config.ingestion_endpoint.to_string())
-            .unity_catalog_url(config.unity_catalog_endpoint.to_string().trim_end_matches('/'))
+            .unity_catalog_url(
+                config
+                    .unity_catalog_endpoint
+                    .to_string()
+                    .trim_end_matches('/'),
+            )
             .build()
             .map_err(|e| ZerobusSinkError::ConfigError {
                 message: format!("Failed to create Zerobus SDK: {}", e),

--- a/src/sinks/databricks_zerobus/service.rs
+++ b/src/sinks/databricks_zerobus/service.rs
@@ -318,7 +318,7 @@ impl ZerobusService {
     ) -> Result<Self, ZerobusSinkError> {
         let mut builder = ZerobusSdk::builder()
             .endpoint(config.ingestion_endpoint.to_string())
-            .unity_catalog_url(config.unity_catalog_endpoint.to_string())
+            .unity_catalog_url(config.unity_catalog_endpoint.to_string().trim_end_matches('/'))
             .application_name(config.user_agent_suffix());
         builder = builder.connector_factory(build_connector_factory(proxy)?);
         let sdk = builder.build().map_err(|e| ZerobusSinkError::ConfigError {
@@ -587,7 +587,7 @@ impl ZerobusService {
 
         let sdk = ZerobusSdk::builder()
             .endpoint(config.ingestion_endpoint.to_string())
-            .unity_catalog_url(config.unity_catalog_endpoint.to_string())
+            .unity_catalog_url(config.unity_catalog_endpoint.to_string().trim_end_matches('/'))
             .build()
             .map_err(|e| ZerobusSinkError::ConfigError {
                 message: format!("Failed to create Zerobus SDK: {}", e),


### PR DESCRIPTION
## Summary
The `databricks_zerobus` sink passed `unity_catalog_endpoint` to the Zerobus SDK verbatim. The SDK builds the OAuth token URL as `{endpoint}/oidc/v1/token` without trimming, so a trailing slash in the endpoint (as in the documented example) produced `//oidc/v1/token` on every stream build and the healthcheck. The endpoint is now trimmed before being passed to the SDK.

### References
Related: #26170

## Vector configuration
NA

## How did you test this PR?
`cargo check -p vector --features sinks-databricks-zerobus`

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.
