### PR TITLE
docs: replace obsolete GraphQL API references

### DIFF
--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -56,7 +56,7 @@ a major version increment.
 * [Data model]
   * As output in all sinks except the [`vector` sink]
   * As exposed in the source of the [`lua` transform]
-* [GraphQL API]
+* [Observability API]
 * Telemetry
   * Vector's internal metrics as provided by the [`internal_metrics` source]
 * [VRL]
@@ -124,7 +124,7 @@ here. Each minor release bump will include an upgrade guide in the
 [data directory]: https://vector.dev/docs/reference/configuration/global-options/#data_dir
 [data model]: https://vector.dev/docs/architecture/data-model/
 [GitHub repository]: https://github.com/vectordotdev/vector
-[GraphQL API]: https://vector.dev/docs/reference/api/
+[Observability API]: https://vector.dev/docs/reference/api/
 [Installation workflows]: https://vector.dev/docs/setup/installation/
 [`internal_logs_` source]: https://vector.dev/docs/reference/configuration/sources/internal_logs/
 [`internal_metrics` source]: https://vector.dev/docs/reference/configuration/sources/internal_metrics/

--- a/src/api/grpc_server.rs
+++ b/src/api/grpc_server.rs
@@ -152,8 +152,8 @@ impl GrpcServer {
 ///
 /// Returns `200 {"ok":true}` while the server is serving and
 /// `503 {"ok":false}` once [`GrpcServer::set_not_serving`] has been called.
-/// Matches the response shape of the pre-gRPC GraphQL-era endpoint so
-/// existing HTTP health probes (Kubernetes, load balancers) keep working.
+/// Preserves the response shape expected by existing HTTP health probes such as
+/// Kubernetes and load balancers.
 fn http_router(state: ServingState) -> Router {
     Router::new()
         .route("/health", get(health_handler).head(health_handler))

--- a/website/cue/reference/urls.cue
+++ b/website/cue/reference/urls.cue
@@ -242,7 +242,6 @@ urls: {
 	globbing:                                   "\(wikipedia)/wiki/Glob_(programming)"
 	glog:                                       "\(github)/google/glog"
 	graphql:                                    "https://graphql.org"
-	graphql_playground:                         "\(github)/graphql/graphql-playground"
 	graphviz:                                   "https://graphviz.org/"
 	greptimecloud:                              "https://greptime.cloud"
 	greptimedb:                                 "https://github.com/greptimeteam/greptimedb"


### PR DESCRIPTION
## Summary

Small cleanup of old refs.
