### PR TITLE
feat(databricks_zerobus): Allow ingestion of variant data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -773,6 +773,10 @@ name = "arrow-schema"
 version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6fed2ca0d1eade57e811cbe73b98ad50cc08a1183e13b2d2aa43a7df593f40e"
+dependencies = [
+ "serde_core",
+ "serde_json",
+]
 
 [[package]]
 name = "arrow-select"
@@ -2815,6 +2819,7 @@ dependencies = [
  "dyn-clone",
  "flate2",
  "futures",
+ "hex",
  "indoc",
  "influxdb-line-protocol",
  "memchr",
@@ -2822,6 +2827,8 @@ dependencies = [
  "opentelemetry-proto",
  "ordered-float 5.3.0",
  "parquet",
+ "parquet-variant",
+ "parquet-variant-json",
  "pin-project",
  "prost 0.12.6",
  "prost-reflect 0.14.7",
@@ -8246,6 +8253,36 @@ dependencies = [
  "snap",
  "twox-hash",
  "zstd 0.13.2",
+]
+
+[[package]]
+name = "parquet-variant"
+version = "59.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f7e5fff3ed0c07514a7fb8bee3f2ea5a53f36939410ecac4a466620213539a8"
+dependencies = [
+ "arrow 59.2.0",
+ "arrow-schema 59.2.0",
+ "chrono",
+ "half",
+ "indexmap 2.12.0",
+ "num-traits",
+ "simdutf8",
+ "uuid",
+]
+
+[[package]]
+name = "parquet-variant-json"
+version = "59.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb19dfe1bd24c17addd761ba4f7000f615e2fa12525871c7baa835dbb3d7f147"
+dependencies = [
+ "arrow-schema 59.2.0",
+ "base64 0.23.0",
+ "chrono",
+ "parquet-variant",
+ "serde_json",
+ "uuid",
 ]
 
 [[package]]

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -550,6 +550,8 @@ parking,https://github.com/smol-rs/parking,Apache-2.0 OR MIT,"Stjepan Glavina <s
 parking_lot,https://github.com/Amanieu/parking_lot,MIT OR Apache-2.0,Amanieu d'Antras <amanieu@gmail.com>
 parking_lot_core,https://github.com/Amanieu/parking_lot,MIT OR Apache-2.0,Amanieu d'Antras <amanieu@gmail.com>
 parquet,https://github.com/apache/arrow-rs,Apache-2.0,Apache Arrow <dev@arrow.apache.org>
+parquet-variant,https://github.com/apache/arrow-rs,Apache-2.0,Apache Arrow <dev@arrow.apache.org>
+parquet-variant-json,https://github.com/apache/arrow-rs,Apache-2.0,Apache Arrow <dev@arrow.apache.org>
 parse-size,https://github.com/kennytm/parse-size,MIT,kennytm <kennytm@gmail.com>
 pastey,https://github.com/as1100k/pastey,MIT OR Apache-2.0,"Aditya Kumar <git@adityais.dev>, David Tolnay <dtolnay@gmail.com>"
 pbkdf2,https://github.com/RustCrypto/password-hashes/tree/master/pbkdf2,MIT OR Apache-2.0,RustCrypto Developers

--- a/changelog.d/databricks_zerobus_variant.enhancement.md
+++ b/changelog.d/databricks_zerobus_variant.enhancement.md
@@ -1,0 +1,3 @@
+The `databricks_zerobus` sink now supports Unity Catalog `VARIANT` columns. VARIANT columns are detected via the `arrow.parquet.variant` extension marker on the resolved Arrow schema, and their JSON values are encoded into the Parquet Variant binary representation before ingestion. VARIANT fields nested inside structs, lists, and maps are supported.
+
+authors: flaviofcruz

--- a/lib/codecs/Cargo.toml
+++ b/lib/codecs/Cargo.toml
@@ -22,6 +22,9 @@ parquet = { version = "59.2.0", default-features = false, features = [
     "lz4",
     "flate2-rust_backened",
 ], optional = true }
+parquet-variant = { version = "59.2.0", optional = true }
+parquet-variant-json = { version = "59.2.0", optional = true }
+hex = { version = "0.4.3", default-features = false, features = ["std"], optional = true }
 async-trait.workspace = true
 bytes.workspace = true
 chrono.workspace = true
@@ -81,7 +84,7 @@ vrl.workspace = true
 zstd = { workspace = true, features = ["zdict_builder"] }
 
 [features]
-arrow = ["dep:arrow", "arrow/chrono-tz"]
+arrow = ["dep:arrow", "arrow/chrono-tz", "dep:parquet-variant", "dep:parquet-variant-json", "dep:hex"]
 parquet = ["dep:parquet", "arrow"]
 opentelemetry = ["dep:opentelemetry-proto"]
 syslog = ["dep:syslog_loose", "dep:strum", "dep:derive_more", "dep:serde-aux", "dep:toml"]

--- a/lib/codecs/src/encoding/format/arrow.rs
+++ b/lib/codecs/src/encoding/format/arrow.rs
@@ -14,6 +14,7 @@ use arrow::{
 use async_trait::async_trait;
 use bytes::{BufMut, Bytes, BytesMut};
 use snafu::{ResultExt, Snafu, ensure};
+use std::sync::Arc;
 use vector_config::configurable_component;
 use vector_core::event::Event;
 
@@ -90,6 +91,10 @@ impl ArrowStreamSerializerConfig {
 #[derive(Clone, Debug)]
 pub struct ArrowStreamSerializer {
     schema: SchemaRef,
+    /// Variant-encoding plan for `schema`, built once at construction and reused
+    /// for every batch (the schema is fixed for this serializer's lifetime).
+    /// `Arc` keeps the derived `Clone` cheap.
+    variant_plan: Arc<super::variant::VariantPlan>,
 }
 
 impl ArrowStreamSerializer {
@@ -103,7 +108,7 @@ impl ArrowStreamSerializer {
                 source: arrow::error::ArrowError::JsonError(e.to_string()),
             }
         })?;
-        build_record_batch(self.schema.clone(), &values)
+        build_record_batch(self.schema.clone(), &self.variant_plan, values)
     }
 
     /// Create a new ArrowStreamSerializer with the given configuration
@@ -124,8 +129,11 @@ impl ArrowStreamSerializer {
             schema
         };
 
+        let schema = SchemaRef::new(schema);
+        let variant_plan = Arc::new(super::variant::VariantPlan::build(&schema));
         Ok(Self {
-            schema: SchemaRef::new(schema),
+            schema,
+            variant_plan,
         })
     }
 }
@@ -138,7 +146,8 @@ impl tokio_util::codec::Encoder<Vec<Event>> for ArrowStreamSerializer {
             return Err(ArrowEncodingError::NoEvents);
         }
 
-        let bytes = encode_events_to_arrow_ipc_stream(&events, self.schema.clone())?;
+        let bytes =
+            encode_events_to_arrow_ipc_stream(&events, self.schema.clone(), &self.variant_plan)?;
 
         buffer.extend_from_slice(&bytes);
         Ok(())
@@ -212,6 +221,7 @@ pub enum ArrowEncodingError {
 pub fn encode_events_to_arrow_ipc_stream(
     events: &[Event],
     schema: SchemaRef,
+    variant_plan: &super::variant::VariantPlan,
 ) -> Result<Bytes, ArrowEncodingError> {
     if events.is_empty() {
         return Err(ArrowEncodingError::NoEvents);
@@ -223,7 +233,7 @@ pub fn encode_events_to_arrow_ipc_stream(
         }
     })?;
 
-    let record_batch = build_record_batch(schema, &json_values)?;
+    let record_batch = build_record_batch(schema, variant_plan, json_values)?;
 
     let mut buffer = BytesMut::new().writer();
     let mut writer =
@@ -322,13 +332,25 @@ pub(crate) fn vector_log_events_to_json_values(
 /// Build an Arrow RecordBatch from a slice of events using the provided schema.
 pub(crate) fn build_record_batch(
     schema: SchemaRef,
-    values: &[serde_json::Value],
+    variant_plan: &super::variant::VariantPlan,
+    mut values: Vec<serde_json::Value>,
 ) -> Result<RecordBatch, ArrowEncodingError> {
     if values.is_empty() {
         return Err(ArrowEncodingError::NoEvents);
     }
 
-    let missing = find_null_non_nullable_fields(&schema, values);
+    // VARIANT columns (marked `arrow.parquet.variant`) can't be built from a
+    // JSON object by the arrow-json decoder, so pre-encode them into the
+    // `{"metadata": hex, "value": hex}` shape it can decode as `LargeBinary`.
+    // `variant_plan` is built once from the schema (by the caller) and applied
+    // in place; it is empty (no work) when the schema carries no variant field.
+    if !variant_plan.is_empty() {
+        variant_plan
+            .apply(&mut values)
+            .context(RecordBatchCreationSnafu)?;
+    }
+
+    let missing = find_null_non_nullable_fields(&schema, &values);
     if !missing.is_empty() {
         let error: vector_common::Error = Box::new(ArrowEncodingError::NullConstraint {
             field_name: missing.join(", "),
@@ -352,7 +374,7 @@ pub(crate) fn build_record_batch(
         .context(RecordBatchCreationSnafu)?;
 
     decoder
-        .serialize(values)
+        .serialize(&values)
         .inspect_err(|e| {
             vector_common::internal_event::emit(crate::internal_events::EncoderRecordBatchError {
                 error: e,
@@ -391,7 +413,8 @@ mod tests {
         events: Vec<Event>,
         schema: SchemaRef,
     ) -> Result<RecordBatch, Box<dyn std::error::Error>> {
-        let bytes = encode_events_to_arrow_ipc_stream(&events, schema.clone())?;
+        let variant_plan = crate::encoding::format::variant::VariantPlan::build(&schema);
+        let bytes = encode_events_to_arrow_ipc_stream(&events, schema.clone(), &variant_plan)?;
         let cursor = Cursor::new(bytes);
         let mut reader = StreamReader::try_new(cursor, None)?;
         Ok(reader.next().unwrap()?)
@@ -407,6 +430,129 @@ mod tests {
             log.insert(&vrl::path::parse_target_path(key).unwrap(), value.into());
         }
         Event::Log(log)
+    }
+
+    mod variant {
+        use super::*;
+        use arrow::array::{ArrayRef, LargeBinaryArray};
+        use arrow::datatypes::Fields;
+        use std::sync::Arc;
+        use vrl::value::ObjectMap;
+
+        /// A Parquet Variant field: `Struct<metadata, value>` (both non-nullable
+        /// LargeBinary) carrying the `arrow.parquet.variant` extension marker.
+        fn variant_field(name: &str, nullable: bool) -> Field {
+            let children = Fields::from(vec![
+                Field::new("metadata", DataType::LargeBinary, false),
+                Field::new("value", DataType::LargeBinary, false),
+            ]);
+            Field::new(name, DataType::Struct(children), nullable).with_metadata(
+                std::collections::HashMap::from([(
+                    "ARROW:extension:name".to_string(),
+                    "arrow.parquet.variant".to_string(),
+                )]),
+            )
+        }
+
+        fn obj(pairs: Vec<(&str, Value)>) -> Value {
+            let mut m = ObjectMap::new();
+            for (k, v) in pairs {
+                m.insert(k.into(), v);
+            }
+            Value::Object(m)
+        }
+
+        /// Decode a variant cell back to a `serde_json::Value`.
+        fn decode(col: &ArrayRef, row: usize) -> serde_json::Value {
+            use parquet_variant::Variant;
+            use parquet_variant_json::VariantToJson;
+
+            let s = col.as_struct();
+            let metadata = s
+                .column(0)
+                .as_any()
+                .downcast_ref::<LargeBinaryArray>()
+                .unwrap();
+            let value = s
+                .column(1)
+                .as_any()
+                .downcast_ref::<LargeBinaryArray>()
+                .unwrap();
+            let variant = Variant::new(metadata.value(row), value.value(row));
+            serde_json::from_str(&variant.to_json_string().unwrap()).unwrap()
+        }
+
+        #[test]
+        fn top_level_object_scalar_and_null() {
+            let schema = SchemaRef::new(Schema::new(vec![variant_field("v", true)]));
+            let events = vec![
+                create_event(vec![("v", obj(vec![("a", Value::Integer(1))]))]),
+                create_event(vec![("v", Value::from("hi"))]),
+                create_event(vec![("v", Value::Null)]),
+            ];
+            let batch = encode_and_decode(events, schema).unwrap();
+            let col = batch.column(0);
+            assert_eq!(decode(col, 0), serde_json::json!({"a": 1}));
+            assert_eq!(decode(col, 1), serde_json::json!("hi"));
+            assert!(col.is_null(2), "null value -> null variant row");
+        }
+
+        #[test]
+        fn nested_in_struct() {
+            let schema = SchemaRef::new(Schema::new(vec![Field::new(
+                "payload",
+                DataType::Struct(Fields::from(vec![variant_field("attrs", true)])),
+                true,
+            )]));
+            let events = vec![create_event(vec![(
+                "payload",
+                obj(vec![("attrs", obj(vec![("k", Value::Integer(7))]))]),
+            )])];
+            let batch = encode_and_decode(events, schema).unwrap();
+            let payload = batch.column(0).as_struct();
+            assert_eq!(decode(payload.column(0), 0), serde_json::json!({"k": 7}));
+        }
+
+        #[test]
+        fn nested_in_list() {
+            let schema = SchemaRef::new(Schema::new(vec![Field::new(
+                "tags",
+                DataType::List(Arc::new(variant_field("item", true))),
+                true,
+            )]));
+            let events = vec![create_event(vec![(
+                "tags",
+                Value::Array(vec![obj(vec![("a", Value::Integer(1))]), Value::from("hi")]),
+            )])];
+            let batch = encode_and_decode(events, schema).unwrap();
+            let items = batch.column(0).as_list::<i32>().values();
+            assert_eq!(decode(items, 0), serde_json::json!({"a": 1}));
+            assert_eq!(decode(items, 1), serde_json::json!("hi"));
+        }
+
+        #[test]
+        fn nested_in_map() {
+            let entries = Field::new(
+                "entries",
+                DataType::Struct(Fields::from(vec![
+                    Field::new("keys", DataType::LargeUtf8, false),
+                    variant_field("values", true),
+                ])),
+                false,
+            );
+            let schema = SchemaRef::new(Schema::new(vec![Field::new(
+                "props",
+                DataType::Map(Arc::new(entries), false),
+                true,
+            )]));
+            let events = vec![create_event(vec![(
+                "props",
+                obj(vec![("k1", obj(vec![("x", Value::Integer(1))]))]),
+            )])];
+            let batch = encode_and_decode(events, schema).unwrap();
+            let values = batch.column(0).as_map().values();
+            assert_eq!(decode(values, 0), serde_json::json!({"x": 1}));
+        }
     }
 
     mod comprehensive {
@@ -610,9 +756,11 @@ mod tests {
 
         #[test]
         fn test_encode_empty_events() {
-            let schema = Schema::new(vec![Field::new("message", DataType::Utf8, true)]).into();
+            let schema: SchemaRef =
+                Schema::new(vec![Field::new("message", DataType::Utf8, true)]).into();
             let events: Vec<Event> = vec![];
-            let result = encode_events_to_arrow_ipc_stream(&events, schema);
+            let variant_plan = crate::encoding::format::variant::VariantPlan::build(&schema);
+            let result = encode_events_to_arrow_ipc_stream(&events, schema, &variant_plan);
             assert!(matches!(result.unwrap_err(), ArrowEncodingError::NoEvents));
         }
 
@@ -620,14 +768,15 @@ mod tests {
         fn test_missing_non_nullable_field_errors() {
             let events = vec![create_event(vec![("other_field", "value")])];
 
-            let schema = Schema::new(vec![Field::new(
+            let schema: SchemaRef = Schema::new(vec![Field::new(
                 "required_field",
                 DataType::Utf8,
                 false, // non-nullable
             )])
             .into();
 
-            let result = encode_events_to_arrow_ipc_stream(&events, schema);
+            let variant_plan = crate::encoding::format::variant::VariantPlan::build(&schema);
+            let result = encode_events_to_arrow_ipc_stream(&events, schema, &variant_plan);
             assert!(result.is_err());
         }
     }
@@ -889,7 +1038,8 @@ mod tests {
             // Event is missing "required_field" entirely
             let event = create_event(vec![("optional_field", "hello")]);
 
-            let result = encode_events_to_arrow_ipc_stream(&[event], schema);
+            let variant_plan = crate::encoding::format::variant::VariantPlan::build(&schema);
+            let result = encode_events_to_arrow_ipc_stream(&[event], schema, &variant_plan);
             let err = result.unwrap_err().to_string();
             assert!(
                 err.contains("required_field"),
@@ -912,7 +1062,8 @@ mod tests {
             // Event has "id" but "name" is null
             let event = create_event(vec![("id", Value::Integer(1))]);
 
-            let result = encode_events_to_arrow_ipc_stream(&[event], schema);
+            let variant_plan = crate::encoding::format::variant::VariantPlan::build(&schema);
+            let result = encode_events_to_arrow_ipc_stream(&[event], schema, &variant_plan);
             let err = result.unwrap_err().to_string();
             assert!(
                 err.contains("name"),

--- a/lib/codecs/src/encoding/format/mod.rs
+++ b/lib/codecs/src/encoding/format/mod.rs
@@ -23,6 +23,8 @@ mod raw_message;
 #[cfg(feature = "syslog")]
 mod syslog;
 mod text;
+#[cfg(feature = "arrow")]
+mod variant;
 
 use std::fmt::Debug;
 

--- a/lib/codecs/src/encoding/format/parquet.rs
+++ b/lib/codecs/src/encoding/format/parquet.rs
@@ -234,6 +234,9 @@ fn reject_unsupported_arrow_types(
 #[derivative(Debug, Clone)]
 pub struct ParquetSerializer {
     schema: SchemaRef,
+    /// Variant-encoding plan for `schema`. Built once at construction; rebuilt
+    /// only in `AutoInfer` mode, which re-infers the schema per batch.
+    variant_plan: Arc<super::variant::VariantPlan>,
     writer_props: Arc<WriterProperties>,
     schema_mode: ParquetSchemaMode,
     /// Pre-built set of schema field names for O(1) strict-mode lookups.
@@ -264,8 +267,11 @@ impl ParquetSerializer {
                 .build(),
         );
 
+        let variant_plan = Arc::new(super::variant::VariantPlan::build(&schema_ref));
+
         Ok(Self {
             schema: schema_ref,
+            variant_plan,
             writer_props,
             schema_mode: config.schema_mode,
             schema_field_names,
@@ -366,12 +372,15 @@ impl tokio_util::codec::Encoder<Vec<Event>> for ParquetSerializer {
                 self.schema = Arc::new(ParquetSchemaGenerator::try_normalize_schema(
                     &events, schema,
                 ));
+                // The schema was just re-inferred, so the cached plan is stale.
+                self.variant_plan = Arc::new(super::variant::VariantPlan::build(&self.schema));
             }
             ParquetSchemaMode::Relaxed => {}
         }
 
         let record_batch =
-            build_record_batch(Arc::clone(&self.schema), &json_values).map_err(Box::new)?;
+            build_record_batch(Arc::clone(&self.schema), &self.variant_plan, json_values)
+                .map_err(Box::new)?;
 
         Self::write_record_batch(&record_batch, buffer, &self.writer_props).map_err(Box::new)?;
 

--- a/lib/codecs/src/encoding/format/variant.rs
+++ b/lib/codecs/src/encoding/format/variant.rs
@@ -1,0 +1,227 @@
+//! Helpers for encoding Parquet Variant columns into the Arrow JSON decoder's
+//! input.
+//!
+//! A Parquet Variant column is an Arrow `Struct<metadata: LargeBinary, value:
+//! LargeBinary>` carrying the canonical `arrow.parquet.variant` extension marker
+//! (Arrow's `VariantType::NAME`). The Arrow JSON decoder cannot build that binary
+//! form from a plain JSON object, so before decoding we rewrite each
+//! variant-marked field's value into `{"metadata": "<hex>", "value": "<hex>"}` —
+//! the Parquet Variant binary encoded as hex, which the decoder ingests natively
+//! as `LargeBinary`. The rewrite recurses through struct/list/map, so nested
+//! variants work too.
+//!
+//! A value is encoded by the shape it already has: a JSON object/array/scalar
+//! becomes the matching Variant, and a string stays a Variant string — a string
+//! that happens to hold JSON text is not re-parsed into structure. Parse such a
+//! field upstream so it arrives structured if a structured Variant is wanted.
+//!
+//! The variant-bearing paths are resolved once per batch into a [`VariantPlan`]
+//! (built from the schema), then applied to every row — so per-row work is
+//! proportional to the variant columns, not the whole schema, and no marker
+//! lookup happens per row.
+
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::error::ArrowError;
+use parquet_variant::VariantBuilder;
+use serde_json::Value;
+
+/// Arrow extension name marking a Parquet Variant field (Arrow's
+/// `VariantType::NAME`).
+const VARIANT_EXTENSION_NAME: &str = "arrow.parquet.variant";
+
+/// Arrow's `EXTENSION_TYPE_NAME_KEY`. Spelled out to avoid depending on the
+/// exact re-export path across arrow versions.
+const EXTENSION_TYPE_NAME_KEY: &str = "ARROW:extension:name";
+
+/// True iff `field` carries the `arrow.parquet.variant` extension marker.
+fn is_variant_field(field: &Field) -> bool {
+    field
+        .metadata()
+        .get(EXTENSION_TYPE_NAME_KEY)
+        .map(String::as_str)
+        == Some(VARIANT_EXTENSION_NAME)
+}
+
+/// Encode a JSON value into the Parquet Variant `(metadata, value)` binary pair.
+///
+/// Source values arrive as `serde_json::Value`, so temporal/binary values take
+/// their JSON forms rather than native Variant temporal/binary types.
+fn value_to_variant(json: &Value) -> Result<(Vec<u8>, Vec<u8>), ArrowError> {
+    let mut builder = VariantBuilder::new();
+    parquet_variant_json::append_json(json, &mut builder)?;
+    Ok(builder.finish())
+}
+
+/// Precomputed description of every variant-bearing path in a schema. Built once
+/// per batch (see [`VariantPlan::build`]) and applied to each row, so a field
+/// that carries no variant at any depth is never revisited per row and no
+/// [`is_variant_field`] lookup happens on the hot path. Built once when the
+/// schema is known and reused across batches; only a schema change requires
+/// rebuilding it.
+#[derive(Debug)]
+pub(crate) struct VariantPlan(Vec<(String, FieldPlan)>);
+
+/// How to rewrite one field's value to expose its variant(s). Only built for
+/// fields that actually carry a variant somewhere.
+#[derive(Debug)]
+enum FieldPlan {
+    /// The field is variant-marked: encode its value into `{metadata, value}`.
+    Encode,
+    /// Recurse into the named struct children that bear a variant.
+    Struct(Vec<(String, FieldPlan)>),
+    /// Recurse into every list element.
+    List(Box<FieldPlan>),
+    /// Recurse into every map value.
+    Map(Box<FieldPlan>),
+}
+
+impl VariantPlan {
+    /// Walk `schema` once, keeping only the fields that carry a variant at some
+    /// depth. Empty when the schema has no variant column, which lets the caller
+    /// skip the row rewrite entirely.
+    pub(crate) fn build(schema: &Schema) -> Self {
+        let fields = schema
+            .fields()
+            .iter()
+            .filter_map(|f| field_plan(f).map(|p| (f.name().clone(), p)))
+            .collect();
+        Self(fields)
+    }
+
+    /// True when no field carries a variant — nothing to rewrite.
+    pub(crate) fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Rewrite the variant-bearing fields of every row in place.
+    pub(crate) fn apply(&self, values: &mut [Value]) -> Result<(), ArrowError> {
+        for row in values {
+            if let Value::Object(map) = row {
+                for (name, plan) in &self.0 {
+                    if let Some(v) = map.get_mut(name) {
+                        plan.apply(v)?;
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+impl FieldPlan {
+    /// Rewrite `value` in place per this plan. Struct/list/map recurse into
+    /// their children; `Encode` turns a (non-null) value into the
+    /// `{"metadata": hex, "value": hex}` shape the Arrow JSON decoder ingests.
+    fn apply(&self, value: &mut Value) -> Result<(), ArrowError> {
+        match self {
+            FieldPlan::Encode => {
+                // Null / absent stays null (the decoder yields a null struct
+                // row); only a present value is encoded into the binary pair.
+                if !value.is_null() {
+                    let (metadata, val) = value_to_variant(value)?;
+                    *value = serde_json::json!({
+                        "metadata": hex::encode(&metadata),
+                        "value": hex::encode(&val),
+                    });
+                }
+            }
+            FieldPlan::Struct(children) => {
+                if let Value::Object(map) = value {
+                    for (name, child) in children {
+                        if let Some(v) = map.get_mut(name) {
+                            child.apply(v)?;
+                        }
+                    }
+                }
+            }
+            FieldPlan::List(item) => {
+                if let Value::Array(items) = value {
+                    for v in items {
+                        item.apply(v)?;
+                    }
+                }
+            }
+            FieldPlan::Map(value_plan) => {
+                // Arrow JSON encodes a map as an object; rewrite each map value.
+                if let Value::Object(map) = value {
+                    for (_k, v) in map.iter_mut() {
+                        value_plan.apply(v)?;
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Build the [`FieldPlan`] for one field, or `None` if it carries no variant at
+/// any depth. Recurses through struct/list/map; the exhaustive `DataType` match
+/// makes a future Arrow container type a compile error here rather than a silent
+/// skip.
+fn field_plan(field: &Field) -> Option<FieldPlan> {
+    if is_variant_field(field) {
+        return Some(FieldPlan::Encode);
+    }
+    match field.data_type() {
+        DataType::Struct(fields) => {
+            let children: Vec<(String, FieldPlan)> = fields
+                .iter()
+                .filter_map(|f| field_plan(f).map(|p| (f.name().clone(), p)))
+                .collect();
+            (!children.is_empty()).then_some(FieldPlan::Struct(children))
+        }
+        DataType::List(item) | DataType::LargeList(item) | DataType::FixedSizeList(item, _) => {
+            field_plan(item).map(|p| FieldPlan::List(Box::new(p)))
+        }
+        DataType::Map(entry, _) => match entry.data_type() {
+            // A Map entry is always Struct(key, value) by Arrow's contract; only
+            // the value field (index 1) can carry a variant (keys never do). Any
+            // other shape is malformed — no variant.
+            DataType::Struct(fields) => fields
+                .get(1)
+                .and_then(|f| field_plan(f))
+                .map(|p| FieldPlan::Map(Box::new(p))),
+            _ => None,
+        },
+        // Leaf/scalar types hold no nested field. The remaining container kinds
+        // (ListView/LargeListView/Union/Dictionary/RunEndEncoded) are not
+        // traversed for variant markers. Enumerated with no `_` arm so a future
+        // Arrow DataType fails to compile here and forces a decision.
+        DataType::Null
+        | DataType::Boolean
+        | DataType::Int8
+        | DataType::Int16
+        | DataType::Int32
+        | DataType::Int64
+        | DataType::UInt8
+        | DataType::UInt16
+        | DataType::UInt32
+        | DataType::UInt64
+        | DataType::Float16
+        | DataType::Float32
+        | DataType::Float64
+        | DataType::Timestamp(_, _)
+        | DataType::Date32
+        | DataType::Date64
+        | DataType::Time32(_)
+        | DataType::Time64(_)
+        | DataType::Duration(_)
+        | DataType::Interval(_)
+        | DataType::Binary
+        | DataType::FixedSizeBinary(_)
+        | DataType::LargeBinary
+        | DataType::BinaryView
+        | DataType::Utf8
+        | DataType::LargeUtf8
+        | DataType::Utf8View
+        | DataType::ListView(_)
+        | DataType::LargeListView(_)
+        | DataType::Union(_, _)
+        | DataType::Dictionary(_, _)
+        | DataType::Decimal32(_, _)
+        | DataType::Decimal64(_, _)
+        | DataType::Decimal128(_, _)
+        | DataType::Decimal256(_, _)
+        | DataType::RunEndEncoded(_, _) => None,
+    }
+}

--- a/src/sinks/databricks_zerobus/unity_catalog_schema.rs
+++ b/src/sinks/databricks_zerobus/unity_catalog_schema.rs
@@ -5,7 +5,7 @@
 //! the HTTP fetching that the sink needs.
 
 use bytes::Buf;
-use databricks_zerobus_ingest_sdk::schema::arrow_schema_from_uc_schema;
+use databricks_zerobus_ingest_sdk::schema::arrow_schema_from_uc_schema_with_options;
 use http::{Request, StatusCode, Uri};
 use http_body::Body as HttpBody;
 use hyper::Body;
@@ -218,10 +218,16 @@ async fn get_oauth_token(
 pub fn generate_arrow_schema_from_schema(
     schema: &UnityCatalogTableSchema,
 ) -> Result<arrow::datatypes::Schema, ZerobusSinkError> {
-    let arrow_schema =
-        arrow_schema_from_uc_schema(schema).map_err(|e| ZerobusSinkError::ConfigError {
+    // Mark VARIANT columns with `arrow.parquet.variant` so the Arrow batch
+    // encoder can detect them; without the marker they'd be indistinguishable
+    // from a plain `Struct<metadata, value>` and encode as all-null.
+    let mut options = databricks_zerobus_ingest_sdk::schema::ArrowSchemaOptions::default();
+    options.annotate_variant_extension = true;
+    let arrow_schema = arrow_schema_from_uc_schema_with_options(schema, &options).map_err(|e| {
+        ZerobusSinkError::ConfigError {
             message: format!("Failed to convert Unity Catalog schema to Arrow: {}", e),
-        })?;
+        }
+    })?;
 
     if tracing::enabled!(tracing::Level::INFO) {
         info!(


### PR DESCRIPTION
## Summary
Add support to the `databricks_zerobus` sink to push variant data. We rely on the zerobus SDK to give us variant annotations on the arrow batch schema, which we use to optionally iterate over the batch and rewrite it in a variant compatible way. Since we are using the `serde_json` crate to do the event -> batch conversion, we need to update the existing arrow batch when variants are detected. We have a variant plan which is used to cache and speed up arrow batch updates.

### References
This is similar to https://github.com/vectordotdev/vector/pull/25890 but takes advantage of the new functionality in the Zerobus SDK.
<!-- Closes: <#issue/#PR or full link> -->
<!-- Related: <#issue/#PR or full link> -->

## Vector configuration
```
  sinks:
    zb:
      type: databricks_zerobus
      inputs: [demo]
      ingestion_endpoint: "https://ingest.dev.databricks.com"
      unity_catalog_endpoint: "https://workspace.cloud.databricks.com"
      table_name: "main.default.my_table"
      user_agent: "My Application"
      auth:
        strategy: oauth
        client_id: "${DATABRICKS_CLIENT_ID}"
        client_secret: "${DATABRICKS_CLIENT_SECRET}"
```
<!-- Include Vector configuration(s) you used to test and debug your changes. -->

## How did you test this PR?

This was tested with a Databricks table that uses variants. Ingestion worked fine and I was able to query the data.

Manually with a Databricks table containing a variant field.
<!-- Please describe how you tested your changes. Also include any information about your setup. -->

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## Contributor Guidelines

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them. To catch issues early, add a `pre-push` hook ([template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push)) or run the following locally before pushing:
  - `make fmt`
  - `make check-clippy` (auto-fix with `make clippy-fix`)
  - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details on the [dd-rust-license-tool](https://crates.io/crates/dd-rust-license-tool).
