### PR TITLE
fix(uri): URI basic auth extraction

### DIFF
--- a/src/sinks/util/uri.rs
+++ b/src/sinks/util/uri.rs
@@ -131,39 +131,26 @@ fn get_basic_auth(authority: &Authority) -> crate::Result<(Authority, Option<Aut
     // `http::Uri` accepts authorities that `url::Url` rejects (e.g. a
     // non-numeric port), so this parse can fail; propagate the error instead
     // of panicking.
-    let mut url = url::Url::parse(&format!("http://{authority}"))?;
+    let url = url::Url::parse(&format!("http://{authority}"))?;
+    let Some((_, host_port)) = authority.as_str().rsplit_once('@') else {
+        return Ok((authority.clone(), None));
+    };
 
-    let user = url.username();
-    if !user.is_empty() {
-        let user = percent_decode_str(user).decode_utf8_lossy().into_owned();
-
-        let password = url.password().unwrap_or("");
-        let password = percent_decode_str(password)
+    let has_auth = !url.username().is_empty() || url.password().is_some();
+    let auth = has_auth.then(|| {
+        let user = percent_decode_str(url.username())
             .decode_utf8_lossy()
             .into_owned();
+        let password = percent_decode_str(url.password().unwrap_or(""))
+            .decode_utf8_lossy()
+            .into_owned();
+        Auth::Basic {
+            user,
+            password: password.into(),
+        }
+    });
 
-        // These methods have the same failure condition as `username`,
-        // because we have a non-empty username, they cannot fail here.
-        url.set_username("")
-            .map_err(|_| "unexpected empty authority")?;
-        url.set_password(None)
-            .map_err(|_| "unexpected empty authority")?;
-
-        let authority = Uri::from_maybe_shared(String::from(url))?
-            .authority()
-            .ok_or_else(|| "unexpected empty authority".to_string())?
-            .clone();
-
-        Ok((
-            authority,
-            Some(Auth::Basic {
-                user,
-                password: password.into(),
-            }),
-        ))
-    } else {
-        Ok((authority.clone(), None))
-    }
+    Ok((host_port.parse()?, auth))
 }
 
 /// Simplify the URI into a protocol and endpoint by removing the
@@ -497,6 +484,18 @@ mod tests {
         );
 
         test_parse("user@example.com", "example.com", Some(("user", "")));
+
+        test_parse(
+            "https://user:pass@example.com:80/api",
+            "https://example.com:80/api",
+            Some(("user", "pass")),
+        );
+
+        test_parse(
+            "https://:secret@example.com/api",
+            "https://example.com/api",
+            Some(("", "secret")),
+        );
     }
 
     #[test]
@@ -561,6 +560,28 @@ mod tests {
 
         assert_eq!(endpoint.to_string(), "http://example.com:8080/path");
         assert!(matches!(auth, Some(Auth::Basic { user, .. }) if user == "user"));
+    }
+
+    #[test]
+    fn http_endpoint_auth_extraction_preserves_explicit_port() {
+        let endpoint = HttpEndpoint::parse("user:pass@example.com:80/path").unwrap();
+        let (endpoint, auth) = endpoint.extract_basic_auth().unwrap();
+
+        assert_eq!(endpoint.to_string(), "https://example.com:80/path");
+        assert!(matches!(auth, Some(Auth::Basic { user, .. }) if user == "user"));
+    }
+
+    #[test]
+    fn http_endpoint_auth_extraction_accepts_empty_username() {
+        let endpoint = HttpEndpoint::parse(":secret@example.com/path").unwrap();
+        let (endpoint, auth) = endpoint.extract_basic_auth().unwrap();
+
+        assert_eq!(endpoint.to_string(), "https://example.com/path");
+        assert!(matches!(
+            auth,
+            Some(Auth::Basic { user, password })
+                if user.is_empty() && password.inner() == "secret"
+        ));
     }
 
     #[test]

--- a/src/sinks/util/uri.rs
+++ b/src/sinks/util/uri.rs
@@ -444,6 +444,7 @@ fn has_scheme(endpoint: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rstest::rstest;
 
     fn test_parse(input: &str, expected_uri: &'static str, expected_auth: Option<(&str, &str)>) {
         let UriSerde { uri, auth } = input.parse().unwrap();
@@ -562,25 +563,28 @@ mod tests {
         assert!(matches!(auth, Some(Auth::Basic { user, .. }) if user == "user"));
     }
 
-    #[test]
-    fn http_endpoint_auth_extraction_preserves_explicit_port() {
-        let endpoint = HttpEndpoint::parse("user:pass@example.com:80/path").unwrap();
+    #[rstest]
+    #[case::explicit_port(
+        "user:pass@example.com:80/path",
+        "https://example.com:80/path",
+        "user",
+        "pass"
+    )]
+    #[case::empty_username(":secret@example.com/path", "https://example.com/path", "", "secret")]
+    fn http_endpoint_auth_extraction_handles_userinfo(
+        #[case] endpoint: &str,
+        #[case] expected_endpoint: &str,
+        #[case] expected_user: &str,
+        #[case] expected_password: &str,
+    ) {
+        let endpoint = HttpEndpoint::parse(endpoint).unwrap();
         let (endpoint, auth) = endpoint.extract_basic_auth().unwrap();
 
-        assert_eq!(endpoint.to_string(), "https://example.com:80/path");
-        assert!(matches!(auth, Some(Auth::Basic { user, .. }) if user == "user"));
-    }
-
-    #[test]
-    fn http_endpoint_auth_extraction_accepts_empty_username() {
-        let endpoint = HttpEndpoint::parse(":secret@example.com/path").unwrap();
-        let (endpoint, auth) = endpoint.extract_basic_auth().unwrap();
-
-        assert_eq!(endpoint.to_string(), "https://example.com/path");
+        assert_eq!(endpoint.to_string(), expected_endpoint);
         assert!(matches!(
             auth,
             Some(Auth::Basic { user, password })
-                if user.is_empty() && password.inner() == "secret"
+                if user == expected_user && password.inner() == expected_password
         ));
     }
 

--- a/src/sinks/util/uri.rs
+++ b/src/sinks/util/uri.rs
@@ -1,11 +1,19 @@
 use std::{fmt, str::FromStr};
 
 use http::uri::{Authority, PathAndQuery, Scheme, Uri};
-use percent_encoding::percent_decode_str;
+use percent_encoding::{AsciiSet, NON_ALPHANUMERIC, percent_decode_str, utf8_percent_encode};
 use snafu::{ResultExt, Snafu};
 use vector_lib::configurable::configurable_component;
 
 use crate::http::Auth;
+
+/// Characters that must be percent-encoded in a URI userinfo.
+/// RFC 3986 unreserved characters are left as-is.
+const USERINFO: &AsciiSet = &NON_ALPHANUMERIC
+    .remove(b'-')
+    .remove(b'.')
+    .remove(b'_')
+    .remove(b'~');
 
 /// A wrapper for `http::Uri` that implements `Deserialize` and `Serialize`.
 ///
@@ -81,6 +89,8 @@ impl fmt::Display for UriSerde {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match (self.uri.authority(), &self.auth) {
             (Some(authority), Some(Auth::Basic { user, password })) => {
+                let user = utf8_percent_encode(user, USERINFO);
+                let password = utf8_percent_encode(password.inner(), USERINFO);
                 let authority = format!("{user}:{password}@{authority}");
                 let authority =
                     Authority::from_maybe_shared(authority).map_err(|_| std::fmt::Error)?;
@@ -150,7 +160,21 @@ fn get_basic_auth(authority: &Authority) -> crate::Result<(Authority, Option<Aut
         }
     });
 
-    Ok((host_port.parse()?, auth))
+    // Rebuild the authority from the parsed URL so the host is normalized
+    // (e.g. host case), while retaining an explicit port from the raw
+    // authority (`url::Url` drops the port when it matches the scheme default).
+    let host = url
+        .host_str()
+        .ok_or_else(|| "unexpected empty authority".to_string())?;
+    let port = host_port
+        .rsplit_once(':')
+        .and_then(|(_, port)| port.parse::<u16>().ok());
+    let authority = match port {
+        Some(port) => format!("{host}:{port}"),
+        None => host.to_string(),
+    };
+
+    Ok((authority.parse()?, auth))
 }
 
 /// Simplify the URI into a protocol and endpoint by removing the
@@ -586,6 +610,27 @@ mod tests {
             Some(Auth::Basic { user, password })
                 if user == expected_user && password.inner() == expected_password
         ));
+    }
+
+    #[test]
+    fn http_endpoint_auth_extraction_normalizes_host() {
+        let endpoint = HttpEndpoint::parse("user:pass@EXAMPLE.com/path").unwrap();
+        let (endpoint, auth) = endpoint.extract_basic_auth().unwrap();
+
+        assert_eq!(endpoint.to_string(), "https://example.com/path");
+        assert!(matches!(auth, Some(Auth::Basic { user, .. }) if user == "user"));
+    }
+
+    #[test]
+    fn http_endpoint_auth_extraction_round_trips_encoded_password() {
+        let endpoint = HttpEndpoint::parse(":%2F@example.com/path").unwrap();
+        let (endpoint, auth) = endpoint.extract_basic_auth().unwrap();
+
+        let uri_serde = UriSerde {
+            uri: endpoint.into_uri(),
+            auth,
+        };
+        assert_eq!(uri_serde.to_string(), "https://:%2F@example.com/path");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Fix basic auth extraction from sink endpoint URIs so explicit ports are preserved and empty usernames are handled.

### References
Related: #26195

## Vector configuration
NA

## How did you test this PR?
Unit tests added in `src/sinks/util/uri.rs`.

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## Contributor Guidelines

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them. To catch issues early, add a `pre-push` hook ([template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push)) or run the following locally before pushing:
  - `make fmt`
  - `make check-clippy` (auto-fix with `make clippy-fix`)
  - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details on the [dd-rust-license-tool](https://crates.io/crates/dd-rust-license-tool).
