### PR TITLE
docs(website): add scoped agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,34 +137,6 @@ make check-generated-docs     # Check generated documentation
 make check-changelog-fragments  # Verify changelog
 ```
 
-### Website/Docs Development (Separate Process)
-
-If you're working on vector.dev website or documentation content:
-
-**Prerequisites:**
-
-- Hugo static site generator
-- CUE CLI tool
-- Node.js and Yarn
-- htmltest
-
-**Run the site locally:**
-
-```bash
-make generate-docs
-cd website && make serve
-# Navigate to http://localhost:1313
-```
-
-**Build website:**
-
-```bash
-cd website
-make cue-build
-```
-
-**Note:** Website changes use Hugo, CUE, Tailwind CSS, and TypeScript. See [website/README.md](website/README.md) for details.
-
 ## Configuration Format
 
 Always generate Vector configuration examples in **YAML** unless the user explicitly asks for TOML or JSON. YAML is Vector's recommended and default configuration format.

--- a/website/AGENTS.md
+++ b/website/AGENTS.md
@@ -1,0 +1,24 @@
+# Vector Website Development
+
+These instructions apply to changes under `website/`. See [README.md](README.md)
+for the website architecture and prerequisites.
+
+Target website changes to `master`.
+
+Run the site locally from the repository root:
+
+```bash
+make generate-docs
+cd website
+make serve
+```
+
+The local site is available at <http://localhost:1313>.
+
+Build CUE documentation from the `website/` directory:
+
+```bash
+make cue-build
+```
+
+After editing Markdown, run `make check-markdown` from the repository root.

--- a/website/CLAUDE.md
+++ b/website/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## Summary

### Motivation

Website work uses a distinct Hugo and CUE workflow. Keeping that guidance under
`website/` makes it available where it is relevant and keeps the root agent
guide focused on repository-wide development.

### Changes

- Move the existing website development commands out of the root `AGENTS.md`
  section and into a concise `website/AGENTS.md`.
- Add `website/CLAUDE.md` importing `AGENTS.md` so Codex and Claude Code share
  the same website instructions.

### References

N/A

## Vector configuration

N/A; documentation-only change.

## How did you test this PR?

- `make check-markdown`
- `git diff --cached --check`

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.
