### PR TITLE
fix(uri): redact credentials from endpoint errors

### DIFF
--- a/src/sinks/util/uri.rs
+++ b/src/sinks/util/uri.rs
@@ -388,12 +388,17 @@ impl HttpEndpoint {
         } else {
             format!("{base_path}/{}", path.strip_prefix('/').unwrap_or(path))
         };
-        parts.path_and_query = Some(joined.parse::<PathAndQuery>().context(InvalidPathSnafu {
-            endpoint: self.0.to_string(),
-            path: joined,
-        })?);
-        let uri = Uri::from_parts(parts).context(InvalidUriPartsSnafu {
-            endpoint: self.0.to_string(),
+        parts.path_and_query =
+            Some(
+                joined
+                    .parse::<PathAndQuery>()
+                    .with_context(|_| InvalidPathSnafu {
+                        endpoint: redact_uri(&self.0),
+                        path: joined,
+                    })?,
+            );
+        let uri = Uri::from_parts(parts).with_context(|_| InvalidUriPartsSnafu {
+            endpoint: redact_uri(&self.0),
         })?;
         Self::new(uri)
     }
@@ -414,12 +419,17 @@ impl HttpEndpoint {
             .map(PathAndQuery::path)
             .unwrap_or_default();
         let joined = format!("{base_path}{suffix}");
-        parts.path_and_query = Some(joined.parse::<PathAndQuery>().context(InvalidPathSnafu {
-            endpoint: self.0.to_string(),
-            path: joined,
-        })?);
-        let uri = Uri::from_parts(parts).context(InvalidUriPartsSnafu {
-            endpoint: self.0.to_string(),
+        parts.path_and_query =
+            Some(
+                joined
+                    .parse::<PathAndQuery>()
+                    .with_context(|_| InvalidPathSnafu {
+                        endpoint: redact_uri(&self.0),
+                        path: joined,
+                    })?,
+            );
+        let uri = Uri::from_parts(parts).with_context(|_| InvalidUriPartsSnafu {
+            endpoint: redact_uri(&self.0),
         })?;
         Self::new(uri)
     }
@@ -676,6 +686,21 @@ mod tests {
             "http://user:secret@exa mple.com",
         ] {
             let message = HttpEndpoint::parse(endpoint).unwrap_err().to_string();
+            assert!(message.contains("<redacted endpoint>"), "{message}");
+            assert!(!message.contains("secret"), "{message}");
+        }
+    }
+
+    #[test]
+    fn http_endpoint_append_errors_redact_userinfo() {
+        let endpoint = HttpEndpoint::parse("https://user:secret@example.com/base").unwrap();
+
+        for error in [
+            endpoint.append_path("invalid path").unwrap_err(),
+            endpoint.append_raw_suffix(" invalid suffix").unwrap_err(),
+        ] {
+            assert!(matches!(&error, HttpEndpointError::InvalidPath { .. }));
+            let message = error.to_string();
             assert!(message.contains("<redacted endpoint>"), "{message}");
             assert!(!message.contains("secret"), "{message}");
         }

--- a/src/sinks/util/uri.rs
+++ b/src/sinks/util/uri.rs
@@ -249,6 +249,25 @@ pub enum HttpEndpointError {
 #[serde(try_from = "String", into = "String")]
 pub struct HttpEndpoint(Uri);
 
+fn redact_uri(uri: &Uri) -> String {
+    if uri
+        .authority()
+        .is_some_and(|authority| authority.as_str().contains('@'))
+    {
+        "<redacted endpoint>".to_owned()
+    } else {
+        uri.to_string()
+    }
+}
+
+fn redact_unparsed_endpoint(endpoint: &str) -> String {
+    if endpoint.contains('@') {
+        "<redacted endpoint>".to_owned()
+    } else {
+        endpoint.to_owned()
+    }
+}
+
 impl TryFrom<String> for HttpEndpoint {
     type Error = HttpEndpointError;
 
@@ -276,12 +295,12 @@ impl HttpEndpoint {
             && uri.host().is_some_and(|host| !host.is_empty());
         if !has_valid_scheme_and_host {
             return Err(HttpEndpointError::NotAbsoluteHttp {
-                endpoint: uri.to_string(),
+                endpoint: redact_uri(&uri),
             });
         }
         if authority_has_invalid_port(&uri) {
             return Err(HttpEndpointError::InvalidPort {
-                endpoint: uri.to_string(),
+                endpoint: redact_uri(&uri),
             });
         }
         Ok(Self(uri))
@@ -298,14 +317,18 @@ impl HttpEndpoint {
         // `host:port/path` without a scheme (it reads `host` as a scheme), so
         // the scheme is added up front rather than relying on the parser to
         // accept authority-form input.
+        let parse = |value: &str| {
+            value
+                .parse::<Uri>()
+                .map_err(|source| HttpEndpointError::InvalidUri {
+                    endpoint: redact_unparsed_endpoint(endpoint),
+                    source,
+                })
+        };
         let uri = if has_scheme(endpoint) {
-            endpoint
-                .parse::<Uri>()
-                .context(InvalidUriSnafu { endpoint })?
+            parse(endpoint)?
         } else {
-            format!("https://{endpoint}")
-                .parse::<Uri>()
-                .context(InvalidUriSnafu { endpoint })?
+            parse(&format!("https://{endpoint}"))?
         };
         Self::new(uri)
     }
@@ -627,8 +650,10 @@ mod tests {
 
     #[test]
     fn http_endpoint_reports_unparseable_endpoints() {
-        let error = HttpEndpoint::parse("http://exa mple.com").unwrap_err();
+        let endpoint = "http://exa mple.com";
+        let error = HttpEndpoint::parse(endpoint).unwrap_err();
         assert!(matches!(error, HttpEndpointError::InvalidUri { .. }));
+        assert!(error.to_string().contains(endpoint));
     }
 
     #[test]
@@ -641,6 +666,18 @@ mod tests {
                 HttpEndpoint::parse(endpoint),
                 Err(HttpEndpointError::InvalidPort { .. })
             ));
+        }
+    }
+
+    #[test]
+    fn http_endpoint_errors_redact_userinfo() {
+        for endpoint in [
+            "http://user:secret@localhost:notaport",
+            "http://user:secret@exa mple.com",
+        ] {
+            let message = HttpEndpoint::parse(endpoint).unwrap_err().to_string();
+            assert!(message.contains("<redacted endpoint>"), "{message}");
+            assert!(!message.contains("secret"), "{message}");
         }
     }
 


### PR DESCRIPTION
## Summary
Redacts credentials from HTTP endpoint validation errors.

### References
Related: #26195

## Vector configuration
NA

## How did you test this PR?
- `make test SCOPE="sinks::util::uri::tests"`
- `make test FEATURES="sinks-loki" SCOPE="sinks::loki"`
- `make check-clippy`
- `make check-fmt`

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## Contributor Guidelines

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them. To catch issues early, add a `pre-push` hook ([template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#pre-push)) or run the following locally before pushing:
  - `make fmt`
  - `make check-clippy` (auto-fix with `make clippy-fix`)
  - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details on the [dd-rust-license-tool](https://crates.io/crates/dd-rust-license-tool).