### PR TITLE
chore: revamp vdev minimal-feature builds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,17 +98,16 @@ cargo run -- --config path/to/config-with-merge-keys.yaml
 
 #### Running tests
 
-Start with the minimum feature set required by the configuration:
-
-```bash
-# Derive the required features and run the relevant tests
-cargo vdev test --config path/to/config.yaml test_some_function
-```
-
-If there is no configuration file, specify the relevant component feature directly:
+For most Rust changes, specify the relevant component feature directly:
 
 ```bash
 make test FEATURES="sources-file" SCOPE="truncate"
+```
+
+If you have a representative configuration file, derive its required features automatically:
+
+```bash
+cargo vdev test --config path/to/config.yaml test_some_function
 ```
 
 Other testing methods, from targeted to broad:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,7 +63,7 @@ After the task is complete run the following `make` commands to check for errors
 targets.
 
 1. Run `make fmt` to format your code.
-2. Run `make test SCOPE="<scope>"` to run tests. `<scope>` is a test filter passed to `cargo nextest`.
+2. Run the narrowest relevant tests using the minimum feature set as described below.
 
 ## Code change workflows and validation
 
@@ -71,26 +71,51 @@ targets.
 
 If you're working on Vector's Rust codebase:
 
-#### Running tests
+When building and running Vector with a configuration file, use `cargo vdev run <config>`. It
+automatically selects the minimum set of features required by the configuration, reducing compile
+times.
+
+Automatic feature selection does not support configuration providers, feature selectors, or VRL
+programs supplied through an environment variable or a `SECRET[...]` reference. It also does not
+apply YAML merge keys (`<<`). Use vanilla Cargo instead:
 
 ```bash
-# Run all tests
-make test
+# Environment variable interpolation
+cargo run -- --config path/to/config.yaml --dangerously-allow-env-var-interpolation
 
-# Target a single test
-make test SCOPE="test_some_function"
+# Secret substitution
+cargo run -- --config path/to/config.yaml
 
-# Filter to a specific package
-make test SCOPE="-p vector"
+# Configuration provider
+cargo run -- --config path/to/provider-config.yaml
 
+# YAML merge keys
+cargo run -- --config path/to/config-with-merge-keys.yaml
+```
+
+#### Running tests
+
+Start with the minimum feature set required by the configuration:
+
+```bash
+# Derive the required features and run the relevant tests
+cargo vdev test --config path/to/config.yaml test_some_function
+```
+
+If there is no configuration file, specify the relevant component feature directly:
+
+```bash
+make test FEATURES="sources-file" SCOPE="truncate"
+```
+
+Other testing methods, from targeted to broad:
+
+```bash
 # Use a nextest filter expression (note the quoting)
 make test SCOPE="-E 'test(foo) and not test(bar)'"
 
-# Run tests for a specific feature only
-make test FEATURES="sources-file"
-
-# Run tests matching a substring for a specific feature only
-make test FEATURES="sources-file" SCOPE="truncate"
+# Run all tests
+make test
 ```
 
 #### Running integration tests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,9 +75,9 @@ When building and running Vector with a configuration file, use `cargo vdev run 
 automatically selects the minimum set of features required by the configuration, reducing compile
 times.
 
-Automatic feature selection does not support configuration providers, feature selectors, or VRL
-programs supplied through an environment variable or a `SECRET[...]` reference. It also does not
-apply YAML merge keys (`<<`). Use vanilla Cargo instead:
+Automatic feature selection does not support configuration providers or feature selectors supplied
+through an environment variable or a `SECRET[...]` reference. It also does not apply YAML merge
+keys (`<<`). Use vanilla Cargo instead:
 
 ```bash
 # Environment variable interpolation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,9 +75,7 @@ When building and running Vector with a configuration file, use `cargo vdev run 
 automatically selects the minimum set of features required by the configuration, reducing compile
 times.
 
-Automatic feature selection does not support configuration providers, component types supplied
-through environment or secret references, or YAML merge keys (`<<`). If it cannot handle a
-configuration or the local build environment, use vanilla Cargo instead.
+If `cargo vdev run <config>` fails, fall back to `cargo run -- --config <config>`.
 
 #### Running tests
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,26 +75,9 @@ When building and running Vector with a configuration file, use `cargo vdev run 
 automatically selects the minimum set of features required by the configuration, reducing compile
 times.
 
-Automatic feature selection does not support configuration providers or feature selectors supplied
-through an environment variable or a `SECRET[...]` reference. It also does not apply YAML merge
-keys (`<<`). Use vanilla Cargo instead:
-
-If automatic feature selection cannot handle the local build environment, use vanilla Cargo as
-the fallback as well.
-
-```bash
-# Environment variable interpolation
-cargo run -- --config path/to/config.yaml --dangerously-allow-env-var-interpolation
-
-# Secret substitution
-cargo run -- --config path/to/config.yaml
-
-# Configuration provider
-cargo run -- --config path/to/provider-config.yaml
-
-# YAML merge keys
-cargo run -- --config path/to/config-with-merge-keys.yaml
-```
+Automatic feature selection does not support configuration providers, component types supplied
+through environment or secret references, or YAML merge keys (`<<`). If it cannot handle a
+configuration or the local build environment, use vanilla Cargo instead.
 
 #### Running tests
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,9 @@ Automatic feature selection does not support configuration providers or feature 
 through an environment variable or a `SECRET[...]` reference. It also does not apply YAML merge
 keys (`<<`). Use vanilla Cargo instead:
 
+If automatic feature selection cannot handle the local build environment, use vanilla Cargo as
+the fallback as well.
+
 ```bash
 # Environment variable interpolation
 cargo run -- --config path/to/config.yaml --dangerously-allow-env-var-interpolation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13145,7 +13145,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vdev"
-version = "0.3.15"
+version = "0.3.16"
 dependencies = [
  "anyhow",
  "cfg-if",

--- a/vdev/Cargo.toml
+++ b/vdev/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vdev"
-version = "0.3.15"
+version = "0.3.16"
 edition = "2024"
 authors = ["Vector Contributors <vector@datadoghq.com>"]
 license = "MPL-2.0"

--- a/vdev/src/commands/run.rs
+++ b/vdev/src/commands/run.rs
@@ -10,11 +10,11 @@ use crate::{app::CommandExt as _, utils::features};
 #[command()]
 pub struct Cli {
     /// Build and run `vector` in debug mode (default)
-    #[arg(long, default_value_t = true)]
+    #[arg(long, conflicts_with = "release")]
     debug: bool,
 
     /// Build and run `vector` in release mode
-    #[arg(long)]
+    #[arg(long, conflicts_with = "debug")]
     release: bool,
 
     /// Name an additional feature to add to the build
@@ -38,7 +38,14 @@ impl Cli {
         features.extend(self.feature);
         let features = features.join(",");
         let mut command = Command::new("cargo");
-        command.args(["run", "--no-default-features", "--features", &features]);
+        command.args([
+            "run",
+            "--package",
+            "vector",
+            "--no-default-features",
+            "--features",
+            &features,
+        ]);
         if self.release {
             command.arg("--release");
         }

--- a/vdev/src/commands/run.rs
+++ b/vdev/src/commands/run.rs
@@ -1,6 +1,6 @@
 use std::{path::PathBuf, process::Command};
 
-use anyhow::{Result, bail};
+use anyhow::Result;
 use clap::Args;
 
 use crate::{app::CommandExt as _, utils::features};
@@ -10,7 +10,7 @@ use crate::{app::CommandExt as _, utils::features};
 #[command()]
 pub struct Cli {
     /// Build and run `vector` in debug mode (default)
-    #[arg(long, conflicts_with = "release")]
+    #[arg(long)]
     debug: bool,
 
     /// Build and run `vector` in release mode
@@ -30,10 +30,6 @@ pub struct Cli {
 
 impl Cli {
     pub(super) fn exec(self) -> Result<()> {
-        if self.debug && self.release {
-            bail!("Can only set one of `--debug` and `--release`");
-        }
-
         let mut features = features::load_and_extract(&self.config)?;
         features.extend(self.feature);
         let features = features.join(",");

--- a/vdev/src/commands/test.rs
+++ b/vdev/src/commands/test.rs
@@ -43,15 +43,16 @@ fn parse_env(env: Vec<String>) -> BTreeMap<String, Option<String>> {
 }
 
 fn select_features(
-    explicit: Vec<String>,
+    explicit: &[String],
     environment: Option<&str>,
     derived: Vec<String>,
     config_selected: bool,
 ) -> (Vec<String>, bool) {
     let mut ignored_environment_default = false;
     let mut selected: Vec<_> = explicit
-        .into_iter()
+        .iter()
         .filter(|feature| !feature.is_empty())
+        .cloned()
         .collect();
     if let Some(environment) = environment {
         for feature in environment
@@ -73,7 +74,7 @@ fn select_features(
 }
 
 impl Cli {
-    pub fn exec(self) -> Result<()> {
+    fn resolve_features(&self) -> Result<Vec<String>> {
         let config_selected = self.config.is_some();
         let derived_features = self
             .config
@@ -83,7 +84,7 @@ impl Cli {
             .unwrap_or_default();
         let environment_features = std::env::var("FEATURES").ok();
         let (selected_features, ignored_environment_default) = select_features(
-            self.features,
+            &self.features,
             environment_features.as_deref(),
             derived_features,
             config_selected,
@@ -91,6 +92,13 @@ impl Cli {
         if ignored_environment_default {
             warn!("Ignoring `default` from FEATURES because --config uses --no-default-features");
         }
+
+        Ok(selected_features)
+    }
+
+    pub fn exec(self) -> Result<()> {
+        let config_selected = self.config.is_some();
+        let selected_features = self.resolve_features()?;
 
         let mut args = vec!["--workspace".to_string()];
 
@@ -143,7 +151,7 @@ mod tests {
     }
 
     #[test]
-    fn propagates_config_loading_errors_before_starting_tests() {
+    fn resolve_features_propagates_config_loading_errors() {
         let error = Cli {
             args: None,
             env: None,
@@ -151,7 +159,7 @@ mod tests {
             config: Some(PathBuf::from("missing-vector-config.yaml")),
             no_default_features: false,
         }
-        .exec()
+        .resolve_features()
         .expect_err("missing configuration must fail");
 
         assert!(error.to_string().contains("failed to read"));
@@ -160,7 +168,7 @@ mod tests {
     #[test]
     fn config_ignores_only_environment_default() {
         let (features, ignored_default) = select_features(
-            vec!["default".to_string(), "sinks-console".to_string()],
+            &["default".to_string(), "sinks-console".to_string()],
             Some("default,rdkafka/dynamic-linking"),
             vec!["sources-file".to_string()],
             true,

--- a/vdev/src/commands/test.rs
+++ b/vdev/src/commands/test.rs
@@ -18,8 +18,8 @@ pub struct Cli {
     #[arg(short, long)]
     env: Option<Vec<String>>,
 
-    /// Features to activate (comma-separated, or set FEATURES env var)
-    #[arg(short = 'F', long, value_delimiter = ',', env = "FEATURES")]
+    /// Features to activate explicitly (comma-separated, additive with FEATURES)
+    #[arg(short = 'F', long, value_delimiter = ',')]
     features: Vec<String>,
 
     /// Derive the minimum feature set from a configuration file
@@ -42,23 +42,59 @@ fn parse_env(env: Vec<String>) -> BTreeMap<String, Option<String>> {
         .collect()
 }
 
+fn select_features(
+    explicit: Vec<String>,
+    environment: Option<&str>,
+    derived: Vec<String>,
+    config_selected: bool,
+) -> (Vec<String>, bool) {
+    let mut ignored_environment_default = false;
+    let mut selected: Vec<_> = explicit
+        .into_iter()
+        .filter(|feature| !feature.is_empty())
+        .collect();
+    if let Some(environment) = environment {
+        for feature in environment
+            .split(|character: char| character == ',' || character.is_ascii_whitespace())
+            .filter(|feature| !feature.is_empty())
+        {
+            if config_selected && feature == "default" {
+                ignored_environment_default = true;
+            } else {
+                selected.push(feature.to_owned());
+            }
+        }
+    }
+    selected.extend(derived);
+    selected.sort();
+    selected.dedup();
+
+    (selected, ignored_environment_default)
+}
+
 impl Cli {
     pub fn exec(self) -> Result<()> {
-        let mut selected_features: Vec<String> = self
-            .features
-            .into_iter()
-            .filter(|f| !f.is_empty())
-            .collect();
-
-        if let Some(config) = &self.config {
-            selected_features.extend(features::load_and_extract(config)?);
-            selected_features.sort();
-            selected_features.dedup();
+        let config_selected = self.config.is_some();
+        let derived_features = self
+            .config
+            .as_deref()
+            .map(features::load_and_extract)
+            .transpose()?
+            .unwrap_or_default();
+        let environment_features = std::env::var("FEATURES").ok();
+        let (selected_features, ignored_environment_default) = select_features(
+            self.features,
+            environment_features.as_deref(),
+            derived_features,
+            config_selected,
+        );
+        if ignored_environment_default {
+            warn!("Ignoring `default` from FEATURES because --config uses --no-default-features");
         }
 
         let mut args = vec!["--workspace".to_string()];
 
-        if self.no_default_features || self.config.is_some() {
+        if self.no_default_features || config_selected {
             args.push("--no-default-features".to_string());
         }
         if !selected_features.is_empty() {
@@ -87,7 +123,7 @@ mod tests {
 
     use clap::Parser;
 
-    use super::Cli;
+    use super::{Cli, select_features};
 
     #[derive(Parser)]
     struct TestCli {
@@ -119,5 +155,26 @@ mod tests {
         .expect_err("missing configuration must fail");
 
         assert!(error.to_string().contains("failed to read"));
+    }
+
+    #[test]
+    fn config_ignores_only_environment_default() {
+        let (features, ignored_default) = select_features(
+            vec!["default".to_string(), "sinks-console".to_string()],
+            Some("default,rdkafka/dynamic-linking"),
+            vec!["sources-file".to_string()],
+            true,
+        );
+
+        assert!(ignored_default);
+        assert_eq!(
+            features,
+            [
+                "default",
+                "rdkafka/dynamic-linking",
+                "sinks-console",
+                "sources-file",
+            ]
+        );
     }
 }

--- a/vdev/src/commands/test.rs
+++ b/vdev/src/commands/test.rs
@@ -1,8 +1,11 @@
 use anyhow::Result;
 use clap::Args;
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, path::PathBuf};
 
-use crate::testing::runner::{LocalTestRunner, TestRunner as _};
+use crate::{
+    testing::runner::{LocalTestRunner, TestRunner as _},
+    utils::features,
+};
 
 /// Execute tests
 #[derive(Args, Debug)]
@@ -18,6 +21,10 @@ pub struct Cli {
     /// Features to activate (comma-separated, or set FEATURES env var)
     #[arg(short = 'F', long, value_delimiter = ',', env = "FEATURES")]
     features: Vec<String>,
+
+    /// Derive the minimum feature set from a configuration file
+    #[arg(long)]
+    config: Option<PathBuf>,
 
     #[arg(long)]
     no_default_features: bool,
@@ -37,19 +44,25 @@ fn parse_env(env: Vec<String>) -> BTreeMap<String, Option<String>> {
 
 impl Cli {
     pub fn exec(self) -> Result<()> {
-        let features: Vec<String> = self
+        let mut selected_features: Vec<String> = self
             .features
             .into_iter()
             .filter(|f| !f.is_empty())
             .collect();
 
+        if let Some(config) = &self.config {
+            selected_features.extend(features::load_and_extract(config)?);
+            selected_features.sort();
+            selected_features.dedup();
+        }
+
         let mut args = vec!["--workspace".to_string()];
 
-        if self.no_default_features {
+        if self.no_default_features || self.config.is_some() {
             args.push("--no-default-features".to_string());
         }
-        if !features.is_empty() {
-            args.extend(["--features".to_string(), features.join(",")]);
+        if !selected_features.is_empty() {
+            args.extend(["--features".to_string(), selected_features.join(",")]);
         }
 
         if let Some(mut extra_args) = self.args {
@@ -65,5 +78,46 @@ impl Cli {
             false,
             None,
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use clap::Parser;
+
+    use super::Cli;
+
+    #[derive(Parser)]
+    struct TestCli {
+        #[command(flatten)]
+        test: Cli,
+    }
+
+    #[test]
+    fn accepts_a_config_before_the_test_filter() {
+        let cli =
+            TestCli::try_parse_from(["vdev-test", "--config", "vector.yaml", "test_some_function"])
+                .expect("test arguments must parse")
+                .test;
+
+        assert_eq!(cli.config, Some(PathBuf::from("vector.yaml")));
+        assert_eq!(cli.args, Some(vec!["test_some_function".to_string()]));
+    }
+
+    #[test]
+    fn propagates_config_loading_errors_before_starting_tests() {
+        let error = Cli {
+            args: None,
+            env: None,
+            features: Vec::new(),
+            config: Some(PathBuf::from("missing-vector-config.yaml")),
+            no_default_features: false,
+        }
+        .exec()
+        .expect_err("missing configuration must fail");
+
+        assert!(error.to_string().contains("failed to read"));
     }
 }

--- a/vdev/src/utils/cargo.rs
+++ b/vdev/src/utils/cargo.rs
@@ -1,6 +1,6 @@
 //! Cargo.toml parsing and version utilities
 
-use std::{collections::BTreeMap, fs};
+use std::{collections::BTreeMap, fs, path::Path};
 
 use anyhow::{Context, Result};
 use serde::Deserialize;
@@ -20,7 +20,12 @@ pub struct CargoToml {
 
 impl CargoToml {
     pub fn load() -> Result<CargoToml> {
-        let text = fs::read_to_string("Cargo.toml").context("Could not read `Cargo.toml`")?;
+        Self::load_from(Path::new("Cargo.toml"))
+    }
+
+    pub fn load_from(path: &Path) -> Result<CargoToml> {
+        let text = fs::read_to_string(path)
+            .with_context(|| format!("Could not read `{}`", path.display()))?;
         toml::from_str::<CargoToml>(&text).context("Invalid contents in `Cargo.toml`")
     }
 }

--- a/vdev/src/utils/features.rs
+++ b/vdev/src/utils/features.rs
@@ -71,7 +71,7 @@ const CUSTOM_STRATEGY: &str = "custom";
 const CONDITION_KEY: &str = "condition";
 const SOURCE_KEY: &str = "source";
 
-const UNSUPPORTED_DYNAMIC_COMPONENT_TYPE: &str = "cargo vdev feature selection does not support environment or secret interpolation in component types; use `cargo run` instead";
+const UNSUPPORTED_DYNAMIC_FEATURE_SELECTOR: &str = "cargo vdev feature selection does not support environment or secret interpolation in feature selectors; use `cargo run` instead";
 const UNSUPPORTED_YAML_MERGE_KEY: &str =
     "cargo vdev feature selection does not support YAML merge keys; use `cargo run` instead";
 const UNSUPPORTED_PROVIDER: &str = "cargo vdev feature selection does not support configuration providers; use `cargo run` instead";
@@ -163,9 +163,9 @@ fn from_config(config: &FeatureConfig, declared_features: &FeatureSet) -> Result
     ]
     .into_iter()
     .flat_map(|section| section.values())
-    .any(|component| component.r#type.contains('$') || component.r#type.contains("SECRET["))
+    .any(|component| has_dynamic_reference(&component.r#type))
     {
-        bail!(UNSUPPORTED_DYNAMIC_COMPONENT_TYPE);
+        bail!(UNSUPPORTED_DYNAMIC_FEATURE_SELECTOR);
     }
     let mut features = FeatureSet::default();
     add_option(&mut features, "api", config.api.as_ref());
@@ -197,12 +197,12 @@ fn from_config(config: &FeatureConfig, declared_features: &FeatureSet) -> Result
     ] {
         for component in section.values() {
             for (key, value) in &component.options {
-                get_nested_features(&mut features, &mut uses_vrl, Some(key.as_str()), value);
+                get_nested_features(&mut features, &mut uses_vrl, Some(key.as_str()), value)?;
             }
         }
     }
     for (key, value) in &config.other {
-        get_nested_features(&mut features, &mut uses_vrl, Some(key.as_str()), value);
+        get_nested_features(&mut features, &mut uses_vrl, Some(key.as_str()), value)?;
     }
 
     if uses_vrl {
@@ -255,11 +255,11 @@ fn get_nested_features(
     uses_vrl: &mut bool,
     parent_key: Option<&str>,
     value: &Value,
-) {
+) -> Result<()> {
     match value {
         Value::Array(values) => {
             for value in values {
-                get_nested_features(features, uses_vrl, parent_key, value);
+                get_nested_features(features, uses_vrl, parent_key, value)?;
             }
         }
         Value::Object(object) => {
@@ -292,11 +292,34 @@ fn get_nested_features(
                 *uses_vrl = true;
             }
             for (key, value) in object {
-                get_nested_features(features, uses_vrl, Some(key.as_str()), value);
+                if is_feature_selector(parent_key, key)
+                    && value.as_str().is_some_and(has_dynamic_reference)
+                {
+                    bail!(UNSUPPORTED_DYNAMIC_FEATURE_SELECTOR);
+                }
+                get_nested_features(features, uses_vrl, Some(key.as_str()), value)?;
             }
         }
         Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {}
     }
+
+    Ok(())
+}
+
+fn is_feature_selector(parent_key: Option<&str>, key: &str) -> bool {
+    NESTED_FEATURE_RULES.iter().any(|rule| {
+        rule.key == key
+            && rule
+                .parent_key
+                .is_none_or(|required| parent_key == Some(required))
+    }) || VRL_DISCRIMINATORS
+        .iter()
+        .any(|(selector, _)| *selector == key)
+        || (parent_key == Some(KAFKA_OPTIONS_KEY) && KAFKA_GSSAPI_KEYS.contains(&key))
+}
+
+fn has_dynamic_reference(value: &str) -> bool {
+    value.contains('$') || value.contains("SECRET[")
 }
 
 fn kafka_gssapi_feature() -> &'static str {
@@ -616,21 +639,38 @@ mod tests {
     }
 
     #[test]
-    fn rejects_dynamic_component_types() {
-        for component_type in ["${SOURCE_TYPE}", "SECRET[features.source_type]"] {
-            let config = format!(
-                indoc! {"
+    fn rejects_dynamic_feature_selectors() {
+        for config in [
+            indoc! {"
                     sources:
                       input:
-                        type: '{component_type}'
+                        type: '${SOURCE_TYPE}'
                 "},
-                component_type = component_type,
-            );
-            let config = serde_yaml::from_str::<FeatureConfig>(&config).expect("config must parse");
+            indoc! {"
+                    sources:
+                      input:
+                        type: 'SECRET[features.source_type]'
+                "},
+            indoc! {"
+                    sources:
+                      input:
+                        type: socket
+                        decoding:
+                          codec: '${CODEC}'
+                "},
+            indoc! {"
+                    sources:
+                      input:
+                        type: socket
+                        decoding:
+                          codec: 'SECRET[features.codec]'
+                "},
+        ] {
+            let config = serde_yaml::from_str::<FeatureConfig>(config).expect("config must parse");
             let error = from_config(&config, &DECLARED_FEATURES)
-                .expect_err("dynamic component type must fail");
+                .expect_err("dynamic feature selector must fail");
 
-            assert!(error.to_string().contains("component types"));
+            assert!(error.to_string().contains("feature selectors"));
             assert!(error.to_string().contains("use `cargo run` instead"));
         }
     }

--- a/vdev/src/utils/features.rs
+++ b/vdev/src/utils/features.rs
@@ -5,11 +5,9 @@ use std::{
     fs,
     path::Path,
     process::Command,
-    sync::LazyLock,
 };
 
 use anyhow::{Context, Result, bail};
-use regex::Regex;
 use serde::Deserialize;
 use serde_json::Value;
 
@@ -62,16 +60,14 @@ const ALWAYS_COMPILED_FEATURES: &[&str] = &[
     "secrets-file",
     "secrets-test",
 ];
-const VRL_FUNCTION_FEATURES: &[&str] = &[
+const VRL_FEATURES: &[&str] = &[
+    "sources-dnstap",
     "vrl-functions-crypto",
     "vrl-functions-env",
     "vrl-functions-network",
     "vrl-functions-system",
 ];
-const DYNAMIC_SELECTOR_KEYS: &[&str] = &["type", "codec", "sasl.mechanism", "sasl.mechanisms"];
 const VRL_DISCRIMINATORS: &[(&str, &str)] = &[("type", "vrl"), ("codec", "vrl")];
-const VRL_PROGRAM_KEYS: &[&str] = &["source", "value"];
-const TRANSFORM_PROGRAM_KEYS: &[&str] = &["source", "condition"];
 const KAFKA_OPTIONS_KEY: &str = "librdkafka_options";
 const KAFKA_GSSAPI_KEYS: &[&str] = &["sasl.mechanism", "sasl.mechanisms"];
 const KAFKA_GSSAPI_VALUE: &str = "GSSAPI";
@@ -82,20 +78,9 @@ const STRATEGY_KEY: &str = "strategy";
 const CUSTOM_STRATEGY: &str = "custom";
 const CONDITION_KEY: &str = "condition";
 const SOURCE_KEY: &str = "source";
-const DNSTAP_FUNCTION: &str = "parse_dnstap";
-const DNSTAP_FEATURE: &str = "sources-dnstap";
 const CARGO_CONFIG_FILENAMES: &[&str] = &["config.toml", "config"];
 
-const UNSUPPORTED_INTERPOLATION: &str = "cargo vdev feature selection does not support environment or secret interpolation in feature selectors or VRL programs; use `cargo run` instead";
 const UNSUPPORTED_PROVIDER: &str = "cargo vdev feature selection does not support configuration providers; use `cargo run` instead";
-static ENV_INTERPOLATION: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"\$\$|\$([[:word:].]+)|\$\{([[:word:].]+)(?:(:?-|:?\?)([^}]*))?\}")
-        .expect("environment interpolation regex must compile")
-});
-static SECRET_INTERPOLATION: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"SECRET\[([[:word:]\-]+)\.([[:word:].\-/]+)\]")
-        .expect("secret interpolation regex must compile")
-});
 
 /// Partial configuration used to discover the features needed to compile Vector.
 ///
@@ -158,8 +143,6 @@ fn from_config(config: &FeatureConfig, declared_features: &FeatureSet) -> Result
     if config.provider.is_some() {
         bail!(UNSUPPORTED_PROVIDER);
     }
-    validate_feature_selectors(config)?;
-
     let mut features = FeatureSet::default();
     add_option(&mut features, "api", config.api.as_ref());
 
@@ -199,11 +182,7 @@ fn from_config(config: &FeatureConfig, declared_features: &FeatureSet) -> Result
     }
 
     if uses_vrl {
-        features.extend(
-            VRL_FUNCTION_FEATURES
-                .iter()
-                .map(|feature| (*feature).into()),
-        );
+        features.extend(VRL_FEATURES.iter().map(|feature| (*feature).into()));
     }
 
     for feature in ALWAYS_COMPILED_FEATURES {
@@ -211,89 +190,6 @@ fn from_config(config: &FeatureConfig, declared_features: &FeatureSet) -> Result
     }
 
     Ok(features.into_iter().collect())
-}
-
-fn validate_feature_selectors(config: &FeatureConfig) -> Result<()> {
-    for (section, contains_transforms) in [
-        (&config.enrichment_tables, false),
-        (&config.secret, false),
-        (&config.sources, false),
-        (&config.transforms, true),
-        (&config.sinks, false),
-    ] {
-        for component in section.values() {
-            if is_dynamic(&component.r#type)
-                || component.options.iter().any(|(key, value)| {
-                    (contains_transforms
-                        && TRANSFORM_PROGRAM_KEYS.contains(&key.as_str())
-                        && contains_dynamic_value(value))
-                        || has_dynamic_feature_input(Some(key.as_str()), value)
-                })
-            {
-                bail!(UNSUPPORTED_INTERPOLATION);
-            }
-        }
-    }
-    if config
-        .other
-        .iter()
-        .any(|(key, value)| has_dynamic_feature_input(Some(key.as_str()), value))
-    {
-        bail!(UNSUPPORTED_INTERPOLATION);
-    }
-    Ok(())
-}
-
-fn has_dynamic_feature_input(parent_key: Option<&str>, value: &Value) -> bool {
-    match value {
-        Value::Array(values) => values
-            .iter()
-            .any(|value| has_dynamic_feature_input(parent_key, value)),
-        Value::Object(object) => {
-            DYNAMIC_SELECTOR_KEYS
-                .iter()
-                .filter_map(|key| object.get(*key).and_then(Value::as_str))
-                .any(is_dynamic)
-                || (parent_key == Some(AUTH_KEY)
-                    && object
-                        .get(STRATEGY_KEY)
-                        .and_then(Value::as_str)
-                        .is_some_and(is_dynamic))
-                || object
-                    .get(CONDITION_KEY)
-                    .is_some_and(contains_dynamic_value)
-                || (VRL_DISCRIMINATORS
-                    .iter()
-                    .any(|(key, value)| object.get(*key).and_then(Value::as_str) == Some(*value))
-                    && VRL_PROGRAM_KEYS
-                        .iter()
-                        .filter_map(|key| object.get(*key))
-                        .any(contains_dynamic_value))
-                || (parent_key == Some(AUTH_KEY)
-                    && object.get(STRATEGY_KEY).and_then(Value::as_str) == Some(CUSTOM_STRATEGY)
-                    && object.get(SOURCE_KEY).is_some_and(contains_dynamic_value))
-                || object
-                    .iter()
-                    .any(|(key, value)| has_dynamic_feature_input(Some(key.as_str()), value))
-        }
-        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => false,
-    }
-}
-
-fn contains_dynamic_value(value: &Value) -> bool {
-    match value {
-        Value::Array(values) => values.iter().any(contains_dynamic_value),
-        Value::Object(object) => object.values().any(contains_dynamic_value),
-        Value::String(value) => is_dynamic(value),
-        Value::Null | Value::Bool(_) | Value::Number(_) => false,
-    }
-}
-
-fn is_dynamic(value: &str) -> bool {
-    ENV_INTERPOLATION
-        .captures_iter(value)
-        .any(|captures| captures.get(1).is_some() || captures.get(2).is_some())
-        || SECRET_INTERPOLATION.is_match(value)
 }
 
 fn add_option<T>(features: &mut FeatureSet, name: &str, field: Option<&T>) {
@@ -378,35 +274,8 @@ fn get_nested_features(
                 get_nested_features(features, uses_vrl, Some(key.as_str()), value);
             }
         }
-        Value::String(value) => {
-            if uses_dnstap(value) {
-                features.insert(DNSTAP_FEATURE.into());
-            }
-        }
-        Value::Null | Value::Bool(_) | Value::Number(_) => {}
+        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {}
     }
-}
-
-fn uses_dnstap(mut value: &str) -> bool {
-    while let Some(index) = value.find(DNSTAP_FUNCTION) {
-        let (prefix, matched) = value.split_at(index);
-        let suffix = matched
-            .strip_prefix(DNSTAP_FUNCTION)
-            .expect("find returned the start of the function name");
-        let has_identifier_prefix = prefix
-            .chars()
-            .next_back()
-            .is_some_and(|character| character.is_alphanumeric() || character == '_');
-        let call = suffix.trim_start();
-
-        if !has_identifier_prefix && (call.starts_with('(') || call.starts_with("!(")) {
-            return true;
-        }
-
-        value = suffix;
-    }
-
-    false
 }
 
 fn kafka_gssapi_feature() -> &'static str {
@@ -563,6 +432,7 @@ sinks:
                 "sinks-sematext",
                 "sinks-splunk_hec",
                 "sinks-websocket_server",
+                "sources-dnstap",
                 "sources-gcp_pubsub",
                 "sources-prometheus_scrape",
                 "transforms-exclusive_route",
@@ -606,6 +476,7 @@ secret:
         assert_eq!(
             features("transforms:\n  metrics:\n    type: log_to_metric\n"),
             [
+                "sources-dnstap",
                 "transforms-log_to_metric",
                 "vrl-functions-crypto",
                 "vrl-functions-env",
@@ -635,6 +506,7 @@ sinks:
             [
                 "codecs-parquet",
                 "sinks-aws_s3",
+                "sources-dnstap",
                 "transforms-remap",
                 "vrl-functions-crypto",
                 "vrl-functions-env",
@@ -642,23 +514,6 @@ sinks:
                 "vrl-functions-system",
             ]
         );
-    }
-
-    #[test]
-    fn enables_dnstap_for_both_vrl_call_variants() {
-        for call in ["parse_dnstap(.message)", "parse_dnstap!(.message)"] {
-            let config = format!(
-                r"
-transforms:
-  remap:
-    type: remap
-    source: |
-      .dns = {call}
-"
-            );
-
-            assert!(features(&config).contains(&"sources-dnstap".into()));
-        }
     }
 
     #[test]
@@ -722,6 +577,7 @@ sources:
         let features = features(config);
 
         for feature in [
+            "sources-dnstap",
             "vrl-functions-crypto",
             "vrl-functions-env",
             "vrl-functions-network",
@@ -745,6 +601,7 @@ sources:
             let features = features(config);
 
             for feature in [
+                "sources-dnstap",
                 "vrl-functions-crypto",
                 "vrl-functions-env",
                 "vrl-functions-network",
@@ -768,56 +625,6 @@ sources:
             from_config(&config, &DECLARED_FEATURES).expect_err("configuration provider must fail");
 
         assert!(error.to_string().contains("use `cargo run` instead"));
-    }
-
-    #[test]
-    fn rejects_interpolated_feature_selectors() {
-        for config in [
-            "sources:\n  input:\n    type: ${SOURCE_TYPE}\n",
-            "sources:\n  input:\n    type: SECRET[features.source_type]\n",
-            "sinks:\n  output:\n    type: aws_s3\n    encoding:\n      codec: ${CODEC}\n",
-            "sinks:\n  output:\n    type: http\n    auth:\n      strategy: ${AUTH_STRATEGY}\n",
-            "sources:\n  input:\n    type: kafka\n    librdkafka_options:\n      sasl.mechanism: ${SASL_MECHANISM}\n",
-            "sources:\n  input:\n    type: kafka\n    librdkafka_options:\n      sasl.mechanisms: ${SASL_MECHANISMS}\n",
-            "sources:\n  input:\n    type: http_client\n    query:\n      host:\n        type: ${QUERY_TYPE}\n        value: get_hostname!()\n",
-        ] {
-            let config = serde_yaml::from_str::<FeatureConfig>(config).expect("config must parse");
-            let error = from_config(&config, &DECLARED_FEATURES)
-                .expect_err("interpolated selector must fail");
-            assert!(error.to_string().contains("use `cargo run` instead"));
-        }
-
-        assert_eq!(
-            features(
-                "sources:\n  input:\n    type: file\n    include: [app.log]\n    fingerprint:\n      strategy: ${FINGERPRINT_STRATEGY}\n",
-            ),
-            ["sources-file"]
-        );
-    }
-
-    #[test]
-    fn rejects_dynamic_vrl_programs() {
-        for config in [
-            "transforms:\n  remap:\n    type: remap\n    source: ${VRL_SOURCE}\n",
-            "sources:\n  input:\n    type: http_client\n    query:\n      host:\n        type: vrl\n        value: SECRET[programs.query]\n",
-            "transforms:\n  route:\n    type: route\n    route:\n      dynamic:\n        type: vrl\n        source: ${ROUTE_CONDITION}\n",
-            "tests:\n  - condition: ${TEST_CONDITION}\n",
-        ] {
-            let config = serde_yaml::from_str::<FeatureConfig>(config).expect("config must parse");
-            let error = from_config(&config, &DECLARED_FEATURES)
-                .expect_err("dynamic VRL program must fail");
-            assert!(error.to_string().contains("use `cargo run` instead"));
-        }
-    }
-
-    #[test]
-    fn allows_non_interpolation_syntax_in_vrl_programs() {
-        for source in [r#".currency = "$""#, r#".message = "SECRET[missing_dot]""#] {
-            let config =
-                format!("transforms:\n  remap:\n    type: remap\n    source: '{source}'\n");
-
-            assert!(features(&config).contains(&"transforms-remap".into()));
-        }
     }
 
     #[test]

--- a/vdev/src/utils/features.rs
+++ b/vdev/src/utils/features.rs
@@ -78,6 +78,9 @@ const CUSTOM_STRATEGY: &str = "custom";
 const CONDITION_KEY: &str = "condition";
 const SOURCE_KEY: &str = "source";
 
+const UNSUPPORTED_DYNAMIC_COMPONENT_TYPE: &str = "cargo vdev feature selection does not support environment or secret interpolation in component types; use `cargo run` instead";
+const UNSUPPORTED_YAML_MERGE_KEY: &str =
+    "cargo vdev feature selection does not support YAML merge keys; use `cargo run` instead";
 const UNSUPPORTED_PROVIDER: &str = "cargo vdev feature selection does not support configuration providers; use `cargo run` instead";
 
 /// Partial configuration used to discover the features needed to compile Vector.
@@ -125,7 +128,13 @@ pub fn load_and_extract(filename: &Path) -> Result<Vec<String>> {
         None => bail!("Invalid filename {}, no extension", filename.display()),
         Some("json") => serde_json::from_str(&config)?,
         Some("toml") => toml::from_str(&config)?,
-        Some("yaml" | "yml") => serde_yaml::from_str(&config)?,
+        Some("yaml" | "yml") => {
+            let value: serde_yaml::Value = serde_yaml::from_str(&config)?;
+            if contains_yaml_merge_key(&value) {
+                bail!(UNSUPPORTED_YAML_MERGE_KEY);
+            }
+            serde_yaml::from_value(value)?
+        }
         Some(_) => bail!("Invalid filename {}, unknown extension", filename.display()),
     };
 
@@ -137,9 +146,33 @@ pub fn load_and_extract(filename: &Path) -> Result<Vec<String>> {
     from_config(&config, &declared_features)
 }
 
+fn contains_yaml_merge_key(value: &serde_yaml::Value) -> bool {
+    match value {
+        serde_yaml::Value::Sequence(values) => values.iter().any(contains_yaml_merge_key),
+        serde_yaml::Value::Mapping(mapping) => mapping
+            .iter()
+            .any(|(key, value)| key.as_str() == Some("<<") || contains_yaml_merge_key(value)),
+        serde_yaml::Value::Tagged(tagged) => contains_yaml_merge_key(&tagged.value),
+        _ => false,
+    }
+}
+
 fn from_config(config: &FeatureConfig, declared_features: &FeatureSet) -> Result<Vec<String>> {
     if config.provider.is_some() {
         bail!(UNSUPPORTED_PROVIDER);
+    }
+    if [
+        &config.enrichment_tables,
+        &config.secret,
+        &config.sources,
+        &config.transforms,
+        &config.sinks,
+    ]
+    .into_iter()
+    .flat_map(|section| section.values())
+    .any(|component| component.r#type.contains('$') || component.r#type.contains("SECRET["))
+    {
+        bail!(UNSUPPORTED_DYNAMIC_COMPONENT_TYPE);
     }
     let mut features = FeatureSet::default();
     add_option(&mut features, "api", config.api.as_ref());
@@ -296,7 +329,9 @@ mod tests {
     use indoc::indoc;
     use std::{fs, path::Path, sync::LazyLock};
 
-    use super::{CargoToml, FeatureConfig, FeatureSet, from_config, kafka_gssapi_feature};
+    use super::{
+        CargoToml, FeatureConfig, FeatureSet, from_config, kafka_gssapi_feature, load_and_extract,
+    };
 
     static DECLARED_FEATURES: LazyLock<FeatureSet> = LazyLock::new(|| {
         let manifest = Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -587,6 +622,50 @@ mod tests {
         let error =
             from_config(&config, &DECLARED_FEATURES).expect_err("configuration provider must fail");
 
+        assert!(error.to_string().contains("use `cargo run` instead"));
+    }
+
+    #[test]
+    fn rejects_dynamic_component_types() {
+        for component_type in ["${SOURCE_TYPE}", "SECRET[features.source_type]"] {
+            let config = format!(
+                indoc! {"
+                    sources:
+                      input:
+                        type: '{component_type}'
+                "},
+                component_type = component_type,
+            );
+            let config = serde_yaml::from_str::<FeatureConfig>(&config).expect("config must parse");
+            let error = from_config(&config, &DECLARED_FEATURES)
+                .expect_err("dynamic component type must fail");
+
+            assert!(error.to_string().contains("component types"));
+            assert!(error.to_string().contains("use `cargo run` instead"));
+        }
+    }
+
+    #[test]
+    fn rejects_yaml_merge_keys() {
+        let config = tempfile::Builder::new()
+            .suffix(".yaml")
+            .tempfile()
+            .expect("temporary config must be created");
+        fs::write(
+            config.path(),
+            indoc! {"
+                defaults: &defaults
+                  type: console
+                sinks:
+                  output:
+                    <<: *defaults
+            "},
+        )
+        .expect("temporary config must be written");
+
+        let error = load_and_extract(config.path()).expect_err("YAML merge key must fail");
+
+        assert!(error.to_string().contains("YAML merge keys"));
         assert!(error.to_string().contains("use `cargo run` instead"));
     }
 

--- a/vdev/src/utils/features.rs
+++ b/vdev/src/utils/features.rs
@@ -60,7 +60,7 @@ const ALWAYS_COMPILED_FEATURES: &[&str] = &[
     "secrets-test",
 ];
 const VRL_FEATURES: &[&str] = &[
-    "sources-dnstap",
+    "vector-vrl-functions/dnstap",
     "vrl-functions-crypto",
     "vrl-functions-env",
     "vrl-functions-network",
@@ -397,10 +397,10 @@ mod tests {
                 "sinks-sematext",
                 "sinks-splunk_hec",
                 "sinks-websocket_server",
-                "sources-dnstap",
                 "sources-gcp_pubsub",
                 "sources-prometheus_scrape",
                 "transforms-exclusive_route",
+                "vector-vrl-functions/dnstap",
                 "vrl-functions-crypto",
                 "vrl-functions-env",
                 "vrl-functions-network",
@@ -445,8 +445,8 @@ mod tests {
                     type: log_to_metric
             "}),
             [
-                "sources-dnstap",
                 "transforms-log_to_metric",
+                "vector-vrl-functions/dnstap",
                 "vrl-functions-crypto",
                 "vrl-functions-env",
                 "vrl-functions-network",
@@ -475,8 +475,8 @@ mod tests {
             [
                 "codecs-parquet",
                 "sinks-aws_s3",
-                "sources-dnstap",
                 "transforms-remap",
+                "vector-vrl-functions/dnstap",
                 "vrl-functions-crypto",
                 "vrl-functions-env",
                 "vrl-functions-network",
@@ -547,7 +547,7 @@ mod tests {
         let features = features(config);
 
         for feature in [
-            "sources-dnstap",
+            "vector-vrl-functions/dnstap",
             "vrl-functions-crypto",
             "vrl-functions-env",
             "vrl-functions-network",
@@ -597,7 +597,7 @@ mod tests {
             let features = features(config);
 
             for feature in [
-                "sources-dnstap",
+                "vector-vrl-functions/dnstap",
                 "vrl-functions-crypto",
                 "vrl-functions-env",
                 "vrl-functions-network",
@@ -693,7 +693,8 @@ mod tests {
                 let path = path.expect("example path must be readable");
                 let config = fs::read_to_string(&path).expect("example config must be readable");
                 for feature in features(&config) {
-                    if !DECLARED_FEATURES.contains(&feature) {
+                    // Cargo also accepts dependency features as `dependency/feature`.
+                    if !feature.contains('/') && !DECLARED_FEATURES.contains(&feature) {
                         missing.push(format!("{} -> {feature}", path.display()));
                     }
                 }

--- a/vdev/src/utils/features.rs
+++ b/vdev/src/utils/features.rs
@@ -1,77 +1,139 @@
 use std::{
     collections::{BTreeSet, HashMap},
+    env,
     ffi::OsStr,
     fs,
     path::Path,
+    process::Command,
     sync::LazyLock,
 };
 
 use anyhow::{Context, Result, bail};
+use regex::Regex;
 use serde::Deserialize;
 use serde_json::Value;
+
+use crate::utils::{cargo::CargoToml, paths::find_repo_root};
 
 type ComponentMap = HashMap<String, Component>;
 
 // Use a BTree to keep the results in sorted order
 type FeatureSet = BTreeSet<String>;
 
-macro_rules! mapping {
-    ( $( $key:ident => $value:ident, )* ) => {
-        HashMap::from([
-            $( (stringify!($key), stringify!($value)), )*
-        ])
-    };
+// Feature extraction rules and special cases. Keep additions here so the supported surface is
+// visible without reading the traversal code below.
+struct NestedFeatureRule {
+    parent_key: Option<&'static str>,
+    key: &'static str,
+    value: &'static str,
+    feature: &'static str,
 }
 
-// Mapping of component names to feature name exceptions.
+const NESTED_FEATURE_RULES: &[NestedFeatureRule] = &[
+    NestedFeatureRule {
+        parent_key: None,
+        key: "codec",
+        value: "otlp",
+        feature: "codecs-opentelemetry",
+    },
+    NestedFeatureRule {
+        parent_key: None,
+        key: "codec",
+        value: "parquet",
+        feature: "codecs-parquet",
+    },
+    NestedFeatureRule {
+        parent_key: None,
+        key: "codec",
+        value: "syslog",
+        feature: "codecs-syslog",
+    },
+    NestedFeatureRule {
+        parent_key: Some("auth"),
+        key: "strategy",
+        value: "aws",
+        feature: "aws-core",
+    },
+];
+const ALWAYS_COMPILED_FEATURES: &[&str] = &[
+    "enrichment-tables-file",
+    "secrets-directory",
+    "secrets-exec",
+    "secrets-file",
+    "secrets-test",
+];
+const VRL_FUNCTION_FEATURES: &[&str] = &[
+    "vrl-functions-crypto",
+    "vrl-functions-env",
+    "vrl-functions-network",
+    "vrl-functions-system",
+];
+const DYNAMIC_SELECTOR_KEYS: &[&str] = &["type", "codec", "sasl.mechanism", "sasl.mechanisms"];
+const VRL_DISCRIMINATORS: &[(&str, &str)] = &[("type", "vrl"), ("codec", "vrl")];
+const VRL_PROGRAM_KEYS: &[&str] = &["source", "value"];
+const TRANSFORM_PROGRAM_KEYS: &[&str] = &["source", "condition"];
+const KAFKA_OPTIONS_KEY: &str = "librdkafka_options";
+const KAFKA_GSSAPI_KEYS: &[&str] = &["sasl.mechanism", "sasl.mechanisms"];
+const KAFKA_GSSAPI_VALUE: &str = "GSSAPI";
+const GSSAPI_FEATURE: &str = "gssapi";
+const GSSAPI_VENDORED_FEATURE: &str = "gssapi-vendored";
+const AUTH_KEY: &str = "auth";
+const STRATEGY_KEY: &str = "strategy";
+const CUSTOM_STRATEGY: &str = "custom";
+const CONDITION_KEY: &str = "condition";
+const SOURCE_KEY: &str = "source";
+const DNSTAP_FUNCTION: &str = "parse_dnstap";
+const DNSTAP_FEATURE: &str = "sources-dnstap";
+const CARGO_CONFIG_FILENAMES: &[&str] = &["config.toml", "config"];
 
-static SOURCE_FEATURE_MAP: LazyLock<HashMap<&'static str, &'static str>> = LazyLock::new(|| {
-    mapping!(
-        prometheus_pushgateway => prometheus,
-        prometheus_scrape => prometheus,
-        prometheus_remote_write => prometheus,
-    )
+const UNSUPPORTED_INTERPOLATION: &str = "cargo vdev feature selection does not support environment or secret interpolation in feature selectors or VRL programs; use `cargo run` instead";
+const UNSUPPORTED_PROVIDER: &str = "cargo vdev feature selection does not support configuration providers; use `cargo run` instead";
+static ENV_INTERPOLATION: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"\$\$|\$([[:word:].]+)|\$\{([[:word:].]+)(?:(:?-|:?\?)([^}]*))?\}")
+        .expect("environment interpolation regex must compile")
+});
+static SECRET_INTERPOLATION: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"SECRET\[([[:word:]\-]+)\.([[:word:].\-/]+)\]")
+        .expect("secret interpolation regex must compile")
 });
 
-static TRANSFORM_FEATURE_MAP: LazyLock<HashMap<&'static str, &'static str>> =
-    LazyLock::new(|| mapping!());
-
-static SINK_FEATURE_MAP: LazyLock<HashMap<&'static str, &'static str>> = LazyLock::new(|| {
-    mapping!(
-        gcp_pubsub => gcp,
-        gcp_cloud_storage => gcp,
-        gcp_stackdriver_logs => gcp,
-        gcp_stackdriver_metrics => gcp,
-        prometheus_exporter => prometheus,
-        prometheus_remote_write => prometheus,
-        splunk_hec_logs => splunk_hec,
-    )
-});
-
-/// This is a ersatz copy of the Vector config, containing just the elements we are interested in
-/// examining. Everything else is thrown away.
+/// Partial configuration used to discover the features needed to compile Vector.
+///
+/// This cannot use `vector::config::ConfigBuilder`: deserializing that type requires the component
+/// features that this pass is responsible for discovering.
 #[derive(Deserialize)]
-pub struct VectorConfig {
+struct FeatureConfig {
     api: Option<Value>,
+    provider: Option<Value>,
 
+    #[serde(default)]
+    enrichment_tables: ComponentMap,
+    #[serde(default)]
+    secret: ComponentMap,
     #[serde(default)]
     sources: ComponentMap,
     #[serde(default)]
     transforms: ComponentMap,
     #[serde(default)]
     sinks: ComponentMap,
+
+    #[serde(flatten)]
+    other: HashMap<String, Value>,
 }
 
 #[derive(Deserialize)]
 struct Component {
     r#type: String,
+
+    #[serde(flatten)]
+    options: HashMap<String, Value>,
 }
 
 pub fn load_and_extract(filename: &Path) -> Result<Vec<String>> {
     let config = fs::read_to_string(filename)
         .with_context(|| format!("failed to read {}", filename.display()))?;
 
-    let config: VectorConfig = match filename
+    let config: FeatureConfig = match filename
         .extension()
         .and_then(OsStr::to_str)
         .map(str::to_lowercase)
@@ -84,32 +146,154 @@ pub fn load_and_extract(filename: &Path) -> Result<Vec<String>> {
         Some(_) => bail!("Invalid filename {}, unknown extension", filename.display()),
     };
 
-    Ok(from_config(config))
+    let declared_features = CargoToml::load_from(&find_repo_root()?.join("Cargo.toml"))?
+        .features
+        .into_keys()
+        .collect();
+
+    from_config(&config, &declared_features)
 }
 
-pub fn from_config(config: VectorConfig) -> Vec<String> {
+fn from_config(config: &FeatureConfig, declared_features: &FeatureSet) -> Result<Vec<String>> {
+    if config.provider.is_some() {
+        bail!(UNSUPPORTED_PROVIDER);
+    }
+    validate_feature_selectors(config)?;
+
     let mut features = FeatureSet::default();
     add_option(&mut features, "api", config.api.as_ref());
 
     get_features(
         &mut features,
-        "sources",
-        config.sources,
-        &SOURCE_FEATURE_MAP,
+        "enrichment-tables",
+        &config.enrichment_tables,
+        declared_features,
     );
+    get_features(&mut features, "secrets", &config.secret, declared_features);
+    get_features(&mut features, "sources", &config.sources, declared_features);
     get_features(
         &mut features,
         "transforms",
-        config.transforms,
-        &TRANSFORM_FEATURE_MAP,
+        &config.transforms,
+        declared_features,
     );
-    get_features(&mut features, "sinks", config.sinks, &SINK_FEATURE_MAP);
+    get_features(&mut features, "sinks", &config.sinks, declared_features);
 
-    // Set of always-compiled components, in terms of their computed feature flag, that should
-    // not be emitted as they don't actually have a feature flag because we always compile them.
-    features.remove("transforms-log_to_metric");
+    let mut uses_vrl = !config.transforms.is_empty();
 
-    features.into_iter().collect()
+    for section in [
+        &config.enrichment_tables,
+        &config.secret,
+        &config.sources,
+        &config.transforms,
+        &config.sinks,
+    ] {
+        for component in section.values() {
+            for (key, value) in &component.options {
+                get_nested_features(&mut features, &mut uses_vrl, Some(key.as_str()), value);
+            }
+        }
+    }
+    for (key, value) in &config.other {
+        get_nested_features(&mut features, &mut uses_vrl, Some(key.as_str()), value);
+    }
+
+    if uses_vrl {
+        features.extend(
+            VRL_FUNCTION_FEATURES
+                .iter()
+                .map(|feature| (*feature).into()),
+        );
+    }
+
+    for feature in ALWAYS_COMPILED_FEATURES {
+        features.remove(*feature);
+    }
+
+    Ok(features.into_iter().collect())
+}
+
+fn validate_feature_selectors(config: &FeatureConfig) -> Result<()> {
+    for (section, contains_transforms) in [
+        (&config.enrichment_tables, false),
+        (&config.secret, false),
+        (&config.sources, false),
+        (&config.transforms, true),
+        (&config.sinks, false),
+    ] {
+        for component in section.values() {
+            if is_dynamic(&component.r#type)
+                || component.options.iter().any(|(key, value)| {
+                    (contains_transforms
+                        && TRANSFORM_PROGRAM_KEYS.contains(&key.as_str())
+                        && contains_dynamic_value(value))
+                        || has_dynamic_feature_input(Some(key.as_str()), value)
+                })
+            {
+                bail!(UNSUPPORTED_INTERPOLATION);
+            }
+        }
+    }
+    if config
+        .other
+        .iter()
+        .any(|(key, value)| has_dynamic_feature_input(Some(key.as_str()), value))
+    {
+        bail!(UNSUPPORTED_INTERPOLATION);
+    }
+    Ok(())
+}
+
+fn has_dynamic_feature_input(parent_key: Option<&str>, value: &Value) -> bool {
+    match value {
+        Value::Array(values) => values
+            .iter()
+            .any(|value| has_dynamic_feature_input(parent_key, value)),
+        Value::Object(object) => {
+            DYNAMIC_SELECTOR_KEYS
+                .iter()
+                .filter_map(|key| object.get(*key).and_then(Value::as_str))
+                .any(is_dynamic)
+                || (parent_key == Some(AUTH_KEY)
+                    && object
+                        .get(STRATEGY_KEY)
+                        .and_then(Value::as_str)
+                        .is_some_and(is_dynamic))
+                || object
+                    .get(CONDITION_KEY)
+                    .is_some_and(contains_dynamic_value)
+                || (VRL_DISCRIMINATORS
+                    .iter()
+                    .any(|(key, value)| object.get(*key).and_then(Value::as_str) == Some(*value))
+                    && VRL_PROGRAM_KEYS
+                        .iter()
+                        .filter_map(|key| object.get(*key))
+                        .any(contains_dynamic_value))
+                || (parent_key == Some(AUTH_KEY)
+                    && object.get(STRATEGY_KEY).and_then(Value::as_str) == Some(CUSTOM_STRATEGY)
+                    && object.get(SOURCE_KEY).is_some_and(contains_dynamic_value))
+                || object
+                    .iter()
+                    .any(|(key, value)| has_dynamic_feature_input(Some(key.as_str()), value))
+        }
+        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => false,
+    }
+}
+
+fn contains_dynamic_value(value: &Value) -> bool {
+    match value {
+        Value::Array(values) => values.iter().any(contains_dynamic_value),
+        Value::Object(object) => object.values().any(contains_dynamic_value),
+        Value::String(value) => is_dynamic(value),
+        Value::Null | Value::Bool(_) | Value::Number(_) => false,
+    }
+}
+
+fn is_dynamic(value: &str) -> bool {
+    ENV_INTERPOLATION
+        .captures_iter(value)
+        .any(|captures| captures.get(1).is_some() || captures.get(2).is_some())
+        || SECRET_INTERPOLATION.is_match(value)
 }
 
 fn add_option<T>(features: &mut FeatureSet, name: &str, field: Option<&T>) {
@@ -118,23 +302,559 @@ fn add_option<T>(features: &mut FeatureSet, name: &str, field: Option<&T>) {
     }
 }
 
-// Extract the set of features for a particular key from the config, using the exception mapping to
-// rewrite component names to their feature names where needed.
+// Prefer the `<section>-<component type>` feature. Components that share an implementation use the
+// longest declared underscore-delimited prefix, such as `sinks-humio` for `humio_metrics`.
 fn get_features(
     features: &mut FeatureSet,
     key: &str,
-    section: ComponentMap,
-    exceptions: &HashMap<&str, &str>,
+    section: &ComponentMap,
+    declared_features: &FeatureSet,
 ) {
     features.extend(
         section
-            .into_values()
-            .map(|component| component.r#type)
-            .map(|name| {
-                exceptions
-                    .get(name.as_str())
-                    .map_or(name, ToString::to_string)
-            })
-            .map(|name| format!("{key}-{name}")),
+            .values()
+            .map(|component| component_feature(key, &component.r#type, declared_features)),
     );
+}
+
+fn component_feature(key: &str, component_type: &str, declared_features: &FeatureSet) -> String {
+    let exact = format!("{key}-{component_type}");
+    let mut prefix = component_type;
+
+    loop {
+        let candidate = format!("{key}-{prefix}");
+        if declared_features.contains(&candidate) {
+            return candidate;
+        }
+        let Some((shorter, _)) = prefix.rsplit_once('_') else {
+            return exact;
+        };
+        prefix = shorter;
+    }
+}
+
+fn get_nested_features(
+    features: &mut FeatureSet,
+    uses_vrl: &mut bool,
+    parent_key: Option<&str>,
+    value: &Value,
+) {
+    match value {
+        Value::Array(values) => {
+            for value in values {
+                get_nested_features(features, uses_vrl, parent_key, value);
+            }
+        }
+        Value::Object(object) => {
+            for rule in NESTED_FEATURE_RULES {
+                if rule
+                    .parent_key
+                    .is_none_or(|required| parent_key == Some(required))
+                    && object.get(rule.key).and_then(Value::as_str) == Some(rule.value)
+                {
+                    features.insert(rule.feature.into());
+                }
+            }
+
+            if parent_key == Some(KAFKA_OPTIONS_KEY)
+                && KAFKA_GSSAPI_KEYS
+                    .iter()
+                    .filter_map(|key| object.get(*key).and_then(Value::as_str))
+                    .any(|mechanism| mechanism.eq_ignore_ascii_case(KAFKA_GSSAPI_VALUE))
+            {
+                features.insert(kafka_gssapi_feature().into());
+            }
+            if object.contains_key(CONDITION_KEY)
+                || VRL_DISCRIMINATORS
+                    .iter()
+                    .any(|(key, value)| object.get(*key).and_then(Value::as_str) == Some(*value))
+                || (parent_key == Some(AUTH_KEY)
+                    && object.get(STRATEGY_KEY).and_then(Value::as_str) == Some(CUSTOM_STRATEGY)
+                    && object.contains_key(SOURCE_KEY))
+            {
+                *uses_vrl = true;
+            }
+            for (key, value) in object {
+                get_nested_features(features, uses_vrl, Some(key.as_str()), value);
+            }
+        }
+        Value::String(value) => {
+            if uses_dnstap(value) {
+                features.insert(DNSTAP_FEATURE.into());
+            }
+        }
+        Value::Null | Value::Bool(_) | Value::Number(_) => {}
+    }
+}
+
+fn uses_dnstap(mut value: &str) -> bool {
+    while let Some(index) = value.find(DNSTAP_FUNCTION) {
+        let (prefix, matched) = value.split_at(index);
+        let suffix = matched
+            .strip_prefix(DNSTAP_FUNCTION)
+            .expect("find returned the start of the function name");
+        let has_identifier_prefix = prefix
+            .chars()
+            .next_back()
+            .is_some_and(|character| character.is_alphanumeric() || character == '_');
+        let call = suffix.trim_start();
+
+        if !has_identifier_prefix && (call.starts_with('(') || call.starts_with("!(")) {
+            return true;
+        }
+
+        value = suffix;
+    }
+
+    false
+}
+
+fn kafka_gssapi_feature() -> &'static str {
+    let configured_target = cargo_build_target();
+    let host_target = rustc_host_target();
+    let native_build = configured_target
+        .as_ref()
+        .is_none_or(|target| host_target.as_ref() == Some(target));
+    let target_is_linux = configured_target
+        .as_deref()
+        .or(host_target.as_deref())
+        .map_or(cfg!(target_os = "linux"), |target| {
+            target.split('-').any(|part| part == "linux")
+        });
+
+    select_kafka_gssapi_feature(target_is_linux, native_build && system_sasl_available())
+}
+
+fn select_kafka_gssapi_feature(
+    target_is_linux: bool,
+    target_system_sasl_available: bool,
+) -> &'static str {
+    if target_is_linux && !target_system_sasl_available {
+        GSSAPI_VENDORED_FEATURE
+    } else {
+        GSSAPI_FEATURE
+    }
+}
+
+fn cargo_build_target() -> Option<String> {
+    env::var("CARGO_BUILD_TARGET")
+        .ok()
+        .filter(|target| !target.is_empty())
+        .or_else(configured_cargo_build_target)
+}
+
+fn configured_cargo_build_target() -> Option<String> {
+    let mut directory = env::current_dir().ok()?;
+
+    loop {
+        for filename in CARGO_CONFIG_FILENAMES {
+            let path = directory.join(".cargo").join(filename);
+            let target = fs::read_to_string(path)
+                .ok()
+                .and_then(|config| toml::from_str::<toml::Value>(&config).ok())
+                .and_then(|config| {
+                    config
+                        .get("build")?
+                        .get("target")?
+                        .as_str()
+                        .map(str::to_owned)
+                });
+            if target.is_some() {
+                return target;
+            }
+        }
+
+        if !directory.pop() {
+            return None;
+        }
+    }
+}
+
+fn rustc_host_target() -> Option<String> {
+    let rustc = env::var_os("RUSTC").unwrap_or_else(|| "rustc".into());
+    let output = Command::new(rustc).arg("-vV").output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    String::from_utf8(output.stdout)
+        .ok()?
+        .lines()
+        .find_map(|line| line.strip_prefix("host: ").map(str::to_owned))
+}
+
+fn system_sasl_available() -> bool {
+    Command::new("pkg-config")
+        .args(["--exists", "libsasl2"])
+        .status()
+        .is_ok_and(|status| status.success())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{fs, path::Path, sync::LazyLock};
+
+    use super::{
+        CargoToml, FeatureConfig, FeatureSet, from_config, kafka_gssapi_feature,
+        select_kafka_gssapi_feature,
+    };
+
+    static DECLARED_FEATURES: LazyLock<FeatureSet> = LazyLock::new(|| {
+        let manifest = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .expect("vdev must have a parent directory")
+            .join("Cargo.toml");
+        CargoToml::load_from(&manifest)
+            .expect("workspace Cargo.toml must load")
+            .features
+            .into_keys()
+            .collect()
+    });
+
+    fn features(config: &str) -> Vec<String> {
+        from_config(
+            &serde_yaml::from_str::<FeatureConfig>(config).expect("config must parse"),
+            &DECLARED_FEATURES,
+        )
+        .expect("feature extraction must succeed")
+    }
+
+    #[test]
+    fn derives_exact_or_shared_component_features() {
+        let config = r"
+sources:
+  gcp:
+    type: gcp_pubsub
+  prometheus:
+    type: prometheus_scrape
+transforms:
+  route:
+    type: exclusive_route
+sinks:
+  databricks:
+    type: databricks_zerobus
+  chronicle:
+    type: gcp_chronicle_unstructured
+  humio_logs:
+    type: humio_logs
+  humio_metrics:
+    type: humio_metrics
+  influxdb_logs:
+    type: influxdb_logs
+  influxdb_metrics:
+    type: influxdb_metrics
+  sematext_logs:
+    type: sematext_logs
+  sematext_metrics:
+    type: sematext_metrics
+  splunk:
+    type: splunk_hec_metrics
+  websocket:
+    type: websocket_server
+";
+
+        assert_eq!(
+            features(config),
+            [
+                "sinks-databricks_zerobus",
+                "sinks-gcp",
+                "sinks-humio",
+                "sinks-influxdb",
+                "sinks-sematext",
+                "sinks-splunk_hec",
+                "sinks-websocket_server",
+                "sources-gcp_pubsub",
+                "sources-prometheus_scrape",
+                "transforms-exclusive_route",
+                "vrl-functions-crypto",
+                "vrl-functions-env",
+                "vrl-functions-network",
+                "vrl-functions-system",
+            ]
+        );
+    }
+
+    #[test]
+    fn extracts_top_level_feature_gates() {
+        let config = r"
+enrichment_tables:
+  memory:
+    type: memory
+  geoip:
+    type: geoip
+  file:
+    type: file
+secret:
+  aws:
+    type: aws_secrets_manager
+  file:
+    type: file
+";
+
+        assert_eq!(
+            features(config),
+            [
+                "enrichment-tables-geoip",
+                "enrichment-tables-memory",
+                "secrets-aws_secrets_manager",
+            ]
+        );
+    }
+
+    #[test]
+    fn extracts_log_to_metric_feature() {
+        assert_eq!(
+            features("transforms:\n  metrics:\n    type: log_to_metric\n"),
+            [
+                "transforms-log_to_metric",
+                "vrl-functions-crypto",
+                "vrl-functions-env",
+                "vrl-functions-network",
+                "vrl-functions-system",
+            ]
+        );
+    }
+
+    #[test]
+    fn extracts_nested_codec_and_enables_all_vrl_function_features() {
+        let config = r#"
+transforms:
+  remap:
+    type: remap
+    source: |
+      .message = "hello"
+sinks:
+  s3:
+    type: aws_s3
+    batch_encoding:
+      codec: parquet
+"#;
+
+        assert_eq!(
+            features(config),
+            [
+                "codecs-parquet",
+                "sinks-aws_s3",
+                "transforms-remap",
+                "vrl-functions-crypto",
+                "vrl-functions-env",
+                "vrl-functions-network",
+                "vrl-functions-system",
+            ]
+        );
+    }
+
+    #[test]
+    fn enables_dnstap_for_both_vrl_call_variants() {
+        for call in ["parse_dnstap(.message)", "parse_dnstap!(.message)"] {
+            let config = format!(
+                r"
+transforms:
+  remap:
+    type: remap
+    source: |
+      .dns = {call}
+"
+            );
+
+            assert!(features(&config).contains(&"sources-dnstap".into()));
+        }
+    }
+
+    #[test]
+    fn extracts_all_gated_codecs_and_aws_auth() {
+        let config = r"
+sources:
+  socket:
+    type: socket
+    decoding:
+      codec: syslog
+sinks:
+  http:
+    type: http
+    encoding:
+      codec: otlp
+    auth:
+      strategy: aws
+";
+
+        assert_eq!(
+            features(config),
+            [
+                "aws-core",
+                "codecs-opentelemetry",
+                "codecs-syslog",
+                "sinks-http",
+                "sources-socket",
+            ]
+        );
+    }
+
+    #[test]
+    fn enables_available_gssapi_implementation_for_kafka() {
+        for key in ["sasl.mechanism", "sasl.mechanisms"] {
+            let config = format!(
+                r"
+sources:
+  kafka:
+    type: kafka
+    librdkafka_options:
+      {key}: GSSAPI
+"
+            );
+            assert_eq!(
+                features(&config),
+                [
+                    kafka_gssapi_feature().to_owned(),
+                    "sources-kafka".to_owned(),
+                ]
+            );
+        }
+
+        assert_eq!(select_kafka_gssapi_feature(true, true), "gssapi");
+        assert_eq!(select_kafka_gssapi_feature(true, false), "gssapi-vendored");
+        assert_eq!(select_kafka_gssapi_feature(false, false), "gssapi");
+    }
+
+    #[test]
+    fn enables_all_vrl_function_features_for_any_transform() {
+        let config = "transforms:\n  transform:\n    type: dedupe\n";
+        let features = features(config);
+
+        for feature in [
+            "vrl-functions-crypto",
+            "vrl-functions-env",
+            "vrl-functions-network",
+            "vrl-functions-system",
+        ] {
+            assert!(
+                features.iter().any(|candidate| candidate == feature),
+                "any transform must enable {feature}"
+            );
+        }
+    }
+
+    #[test]
+    fn enables_all_vrl_function_features_for_nested_vrl_configuration() {
+        for config in [
+            "sources:\n  input:\n    type: http_client\n    query:\n      host:\n        type: vrl\n        value: get_hostname!()\n",
+            "sources:\n  input:\n    type: stdin\n    decoding:\n      codec: vrl\n      vrl:\n        source: get_hostname!()\n",
+            "sources:\n  input:\n    type: http_server\n    auth:\n      strategy: custom\n      source: get_hostname!() == \"host\"\n",
+            "tests:\n  - condition: .message == \"hello\"\n",
+        ] {
+            let features = features(config);
+
+            for feature in [
+                "vrl-functions-crypto",
+                "vrl-functions-env",
+                "vrl-functions-network",
+                "vrl-functions-system",
+            ] {
+                assert!(
+                    features.iter().any(|candidate| candidate == feature),
+                    "nested VRL configuration must enable {feature}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn rejects_configuration_providers() {
+        let config = serde_yaml::from_str::<FeatureConfig>(
+            "provider:\n  type: http\n  url: https://example.com/vector.yaml\n",
+        )
+        .expect("config must parse");
+        let error =
+            from_config(&config, &DECLARED_FEATURES).expect_err("configuration provider must fail");
+
+        assert!(error.to_string().contains("use `cargo run` instead"));
+    }
+
+    #[test]
+    fn rejects_interpolated_feature_selectors() {
+        for config in [
+            "sources:\n  input:\n    type: ${SOURCE_TYPE}\n",
+            "sources:\n  input:\n    type: SECRET[features.source_type]\n",
+            "sinks:\n  output:\n    type: aws_s3\n    encoding:\n      codec: ${CODEC}\n",
+            "sinks:\n  output:\n    type: http\n    auth:\n      strategy: ${AUTH_STRATEGY}\n",
+            "sources:\n  input:\n    type: kafka\n    librdkafka_options:\n      sasl.mechanism: ${SASL_MECHANISM}\n",
+            "sources:\n  input:\n    type: kafka\n    librdkafka_options:\n      sasl.mechanisms: ${SASL_MECHANISMS}\n",
+            "sources:\n  input:\n    type: http_client\n    query:\n      host:\n        type: ${QUERY_TYPE}\n        value: get_hostname!()\n",
+        ] {
+            let config = serde_yaml::from_str::<FeatureConfig>(config).expect("config must parse");
+            let error = from_config(&config, &DECLARED_FEATURES)
+                .expect_err("interpolated selector must fail");
+            assert!(error.to_string().contains("use `cargo run` instead"));
+        }
+
+        assert_eq!(
+            features(
+                "sources:\n  input:\n    type: file\n    include: [app.log]\n    fingerprint:\n      strategy: ${FINGERPRINT_STRATEGY}\n",
+            ),
+            ["sources-file"]
+        );
+    }
+
+    #[test]
+    fn rejects_dynamic_vrl_programs() {
+        for config in [
+            "transforms:\n  remap:\n    type: remap\n    source: ${VRL_SOURCE}\n",
+            "sources:\n  input:\n    type: http_client\n    query:\n      host:\n        type: vrl\n        value: SECRET[programs.query]\n",
+            "transforms:\n  route:\n    type: route\n    route:\n      dynamic:\n        type: vrl\n        source: ${ROUTE_CONDITION}\n",
+            "tests:\n  - condition: ${TEST_CONDITION}\n",
+        ] {
+            let config = serde_yaml::from_str::<FeatureConfig>(config).expect("config must parse");
+            let error = from_config(&config, &DECLARED_FEATURES)
+                .expect_err("dynamic VRL program must fail");
+            assert!(error.to_string().contains("use `cargo run` instead"));
+        }
+    }
+
+    #[test]
+    fn allows_non_interpolation_syntax_in_vrl_programs() {
+        for source in [r#".currency = "$""#, r#".message = "SECRET[missing_dot]""#] {
+            let config =
+                format!("transforms:\n  remap:\n    type: remap\n    source: '{source}'\n");
+
+            assert!(features(&config).contains(&"transforms-remap".into()));
+        }
+    }
+
+    #[test]
+    fn generated_component_examples_only_use_declared_features() {
+        let repo_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .expect("vdev must have a parent directory");
+        let examples_root = repo_root.join("website/generated/example-configs");
+
+        // Published vdev packages do not include Vector's generated examples.
+        if !examples_root.exists() {
+            return;
+        }
+
+        let mut missing = Vec::new();
+
+        for kind in ["sources", "transforms", "sinks"] {
+            let pattern = examples_root
+                .join(kind)
+                .join("*/*.yaml")
+                .display()
+                .to_string();
+            for path in glob::glob(&pattern).expect("example glob must be valid") {
+                let path = path.expect("example path must be readable");
+                let config = fs::read_to_string(&path).expect("example config must be readable");
+                for feature in features(&config) {
+                    if !DECLARED_FEATURES.contains(&feature) {
+                        missing.push(format!("{} -> {feature}", path.display()));
+                    }
+                }
+            }
+        }
+
+        assert!(
+            missing.is_empty(),
+            "generated examples produced undeclared features:\n{}",
+            missing.join("\n")
+        );
+    }
 }

--- a/vdev/src/utils/features.rs
+++ b/vdev/src/utils/features.rs
@@ -52,13 +52,6 @@ const NESTED_FEATURE_RULES: &[NestedFeatureRule] = &[
         feature: "aws-core",
     },
 ];
-const ALWAYS_COMPILED_FEATURES: &[&str] = &[
-    "enrichment-tables-file",
-    "secrets-directory",
-    "secrets-exec",
-    "secrets-file",
-    "secrets-test",
-];
 const VRL_FEATURES: &[&str] = &[
     "vector-vrl-functions/dnstap",
     "vrl-functions-crypto",
@@ -216,10 +209,6 @@ fn from_config(config: &FeatureConfig, declared_features: &FeatureSet) -> Result
         features.extend(VRL_FEATURES.iter().map(|feature| (*feature).into()));
     }
 
-    for feature in ALWAYS_COMPILED_FEATURES {
-        features.remove(*feature);
-    }
-
     Ok(features.into_iter().collect())
 }
 
@@ -240,22 +229,23 @@ fn get_features(
     features.extend(
         section
             .values()
-            .map(|component| component_feature(key, &component.r#type, declared_features)),
+            .filter_map(|component| component_feature(key, &component.r#type, declared_features)),
     );
 }
 
-fn component_feature(key: &str, component_type: &str, declared_features: &FeatureSet) -> String {
-    let exact = format!("{key}-{component_type}");
+fn component_feature(
+    key: &str,
+    component_type: &str,
+    declared_features: &FeatureSet,
+) -> Option<String> {
     let mut prefix = component_type;
 
     loop {
         let candidate = format!("{key}-{prefix}");
         if declared_features.contains(&candidate) {
-            return candidate;
+            return Some(candidate);
         }
-        let Some((shorter, _)) = prefix.rsplit_once('_') else {
-            return exact;
-        };
+        let (shorter, _) = prefix.rsplit_once('_')?;
         prefix = shorter;
     }
 }

--- a/vdev/src/utils/features.rs
+++ b/vdev/src/utils/features.rs
@@ -1,6 +1,5 @@
 use std::{
     collections::{BTreeSet, HashMap},
-    env,
     ffi::OsStr,
     fs,
     path::Path,
@@ -78,7 +77,6 @@ const STRATEGY_KEY: &str = "strategy";
 const CUSTOM_STRATEGY: &str = "custom";
 const CONDITION_KEY: &str = "condition";
 const SOURCE_KEY: &str = "source";
-const CARGO_CONFIG_FILENAMES: &[&str] = &["config.toml", "config"];
 
 const UNSUPPORTED_PROVIDER: &str = "cargo vdev feature selection does not support configuration providers; use `cargo run` instead";
 
@@ -279,77 +277,11 @@ fn get_nested_features(
 }
 
 fn kafka_gssapi_feature() -> &'static str {
-    let configured_target = cargo_build_target();
-    let host_target = rustc_host_target();
-    let native_build = configured_target
-        .as_ref()
-        .is_none_or(|target| host_target.as_ref() == Some(target));
-    let target_is_linux = configured_target
-        .as_deref()
-        .or(host_target.as_deref())
-        .map_or(cfg!(target_os = "linux"), |target| {
-            target.split('-').any(|part| part == "linux")
-        });
-
-    select_kafka_gssapi_feature(target_is_linux, native_build && system_sasl_available())
-}
-
-fn select_kafka_gssapi_feature(
-    target_is_linux: bool,
-    target_system_sasl_available: bool,
-) -> &'static str {
-    if target_is_linux && !target_system_sasl_available {
+    if cfg!(target_os = "linux") && !system_sasl_available() {
         GSSAPI_VENDORED_FEATURE
     } else {
         GSSAPI_FEATURE
     }
-}
-
-fn cargo_build_target() -> Option<String> {
-    env::var("CARGO_BUILD_TARGET")
-        .ok()
-        .filter(|target| !target.is_empty())
-        .or_else(configured_cargo_build_target)
-}
-
-fn configured_cargo_build_target() -> Option<String> {
-    let mut directory = env::current_dir().ok()?;
-
-    loop {
-        for filename in CARGO_CONFIG_FILENAMES {
-            let path = directory.join(".cargo").join(filename);
-            let target = fs::read_to_string(path)
-                .ok()
-                .and_then(|config| toml::from_str::<toml::Value>(&config).ok())
-                .and_then(|config| {
-                    config
-                        .get("build")?
-                        .get("target")?
-                        .as_str()
-                        .map(str::to_owned)
-                });
-            if target.is_some() {
-                return target;
-            }
-        }
-
-        if !directory.pop() {
-            return None;
-        }
-    }
-}
-
-fn rustc_host_target() -> Option<String> {
-    let rustc = env::var_os("RUSTC").unwrap_or_else(|| "rustc".into());
-    let output = Command::new(rustc).arg("-vV").output().ok()?;
-    if !output.status.success() {
-        return None;
-    }
-
-    String::from_utf8(output.stdout)
-        .ok()?
-        .lines()
-        .find_map(|line| line.strip_prefix("host: ").map(str::to_owned))
 }
 
 fn system_sasl_available() -> bool {
@@ -364,10 +296,7 @@ mod tests {
     use indoc::indoc;
     use std::{fs, path::Path, sync::LazyLock};
 
-    use super::{
-        CargoToml, FeatureConfig, FeatureSet, from_config, kafka_gssapi_feature,
-        select_kafka_gssapi_feature,
-    };
+    use super::{CargoToml, FeatureConfig, FeatureSet, from_config, kafka_gssapi_feature};
 
     static DECLARED_FEATURES: LazyLock<FeatureSet> = LazyLock::new(|| {
         let manifest = Path::new(env!("CARGO_MANIFEST_DIR"))
@@ -571,10 +500,6 @@ mod tests {
                 ]
             );
         }
-
-        assert_eq!(select_kafka_gssapi_feature(true, true), "gssapi");
-        assert_eq!(select_kafka_gssapi_feature(true, false), "gssapi-vendored");
-        assert_eq!(select_kafka_gssapi_feature(false, false), "gssapi");
     }
 
     #[test]

--- a/vdev/src/utils/features.rs
+++ b/vdev/src/utils/features.rs
@@ -361,6 +361,7 @@ fn system_sasl_available() -> bool {
 
 #[cfg(test)]
 mod tests {
+    use indoc::indoc;
     use std::{fs, path::Path, sync::LazyLock};
 
     use super::{
@@ -390,37 +391,37 @@ mod tests {
 
     #[test]
     fn derives_exact_or_shared_component_features() {
-        let config = r"
-sources:
-  gcp:
-    type: gcp_pubsub
-  prometheus:
-    type: prometheus_scrape
-transforms:
-  route:
-    type: exclusive_route
-sinks:
-  databricks:
-    type: databricks_zerobus
-  chronicle:
-    type: gcp_chronicle_unstructured
-  humio_logs:
-    type: humio_logs
-  humio_metrics:
-    type: humio_metrics
-  influxdb_logs:
-    type: influxdb_logs
-  influxdb_metrics:
-    type: influxdb_metrics
-  sematext_logs:
-    type: sematext_logs
-  sematext_metrics:
-    type: sematext_metrics
-  splunk:
-    type: splunk_hec_metrics
-  websocket:
-    type: websocket_server
-";
+        let config = indoc! {"
+            sources:
+              gcp:
+                type: gcp_pubsub
+              prometheus:
+                type: prometheus_scrape
+            transforms:
+              route:
+                type: exclusive_route
+            sinks:
+              databricks:
+                type: databricks_zerobus
+              chronicle:
+                type: gcp_chronicle_unstructured
+              humio_logs:
+                type: humio_logs
+              humio_metrics:
+                type: humio_metrics
+              influxdb_logs:
+                type: influxdb_logs
+              influxdb_metrics:
+                type: influxdb_metrics
+              sematext_logs:
+                type: sematext_logs
+              sematext_metrics:
+                type: sematext_metrics
+              splunk:
+                type: splunk_hec_metrics
+              websocket:
+                type: websocket_server
+        "};
 
         assert_eq!(
             features(config),
@@ -446,20 +447,20 @@ sinks:
 
     #[test]
     fn extracts_top_level_feature_gates() {
-        let config = r"
-enrichment_tables:
-  memory:
-    type: memory
-  geoip:
-    type: geoip
-  file:
-    type: file
-secret:
-  aws:
-    type: aws_secrets_manager
-  file:
-    type: file
-";
+        let config = indoc! {"
+            enrichment_tables:
+              memory:
+                type: memory
+              geoip:
+                type: geoip
+              file:
+                type: file
+            secret:
+              aws:
+                type: aws_secrets_manager
+              file:
+                type: file
+        "};
 
         assert_eq!(
             features(config),
@@ -474,7 +475,11 @@ secret:
     #[test]
     fn extracts_log_to_metric_feature() {
         assert_eq!(
-            features("transforms:\n  metrics:\n    type: log_to_metric\n"),
+            features(indoc! {"
+                transforms:
+                  metrics:
+                    type: log_to_metric
+            "}),
             [
                 "sources-dnstap",
                 "transforms-log_to_metric",
@@ -488,18 +493,18 @@ secret:
 
     #[test]
     fn extracts_nested_codec_and_enables_all_vrl_function_features() {
-        let config = r#"
-transforms:
-  remap:
-    type: remap
-    source: |
-      .message = "hello"
-sinks:
-  s3:
-    type: aws_s3
-    batch_encoding:
-      codec: parquet
-"#;
+        let config = indoc! {r#"
+            transforms:
+              remap:
+                type: remap
+                source: |
+                  .message = "hello"
+            sinks:
+              s3:
+                type: aws_s3
+                batch_encoding:
+                  codec: parquet
+        "#};
 
         assert_eq!(
             features(config),
@@ -518,20 +523,20 @@ sinks:
 
     #[test]
     fn extracts_all_gated_codecs_and_aws_auth() {
-        let config = r"
-sources:
-  socket:
-    type: socket
-    decoding:
-      codec: syslog
-sinks:
-  http:
-    type: http
-    encoding:
-      codec: otlp
-    auth:
-      strategy: aws
-";
+        let config = indoc! {"
+            sources:
+              socket:
+                type: socket
+                decoding:
+                  codec: syslog
+            sinks:
+              http:
+                type: http
+                encoding:
+                  codec: otlp
+                auth:
+                  strategy: aws
+        "};
 
         assert_eq!(
             features(config),
@@ -549,13 +554,14 @@ sinks:
     fn enables_available_gssapi_implementation_for_kafka() {
         for key in ["sasl.mechanism", "sasl.mechanisms"] {
             let config = format!(
-                r"
-sources:
-  kafka:
-    type: kafka
-    librdkafka_options:
-      {key}: GSSAPI
-"
+                indoc! {"
+                    sources:
+                      kafka:
+                        type: kafka
+                        librdkafka_options:
+                          {key}: GSSAPI
+                "},
+                key = key,
             );
             assert_eq!(
                 features(&config),
@@ -573,7 +579,11 @@ sources:
 
     #[test]
     fn enables_all_vrl_function_features_for_any_transform() {
-        let config = "transforms:\n  transform:\n    type: dedupe\n";
+        let config = indoc! {"
+            transforms:
+              transform:
+                type: dedupe
+        "};
         let features = features(config);
 
         for feature in [
@@ -593,10 +603,36 @@ sources:
     #[test]
     fn enables_all_vrl_function_features_for_nested_vrl_configuration() {
         for config in [
-            "sources:\n  input:\n    type: http_client\n    query:\n      host:\n        type: vrl\n        value: get_hostname!()\n",
-            "sources:\n  input:\n    type: stdin\n    decoding:\n      codec: vrl\n      vrl:\n        source: get_hostname!()\n",
-            "sources:\n  input:\n    type: http_server\n    auth:\n      strategy: custom\n      source: get_hostname!() == \"host\"\n",
-            "tests:\n  - condition: .message == \"hello\"\n",
+            indoc! {"
+                sources:
+                  input:
+                    type: http_client
+                    query:
+                      host:
+                        type: vrl
+                        value: get_hostname!()
+            "},
+            indoc! {"
+                sources:
+                  input:
+                    type: stdin
+                    decoding:
+                      codec: vrl
+                      vrl:
+                        source: get_hostname!()
+            "},
+            indoc! {r#"
+                sources:
+                  input:
+                    type: http_server
+                    auth:
+                      strategy: custom
+                      source: get_hostname!() == "host"
+            "#},
+            indoc! {r#"
+                tests:
+                  - condition: .message == "hello"
+            "#},
         ] {
             let features = features(config);
 
@@ -617,9 +653,11 @@ sources:
 
     #[test]
     fn rejects_configuration_providers() {
-        let config = serde_yaml::from_str::<FeatureConfig>(
-            "provider:\n  type: http\n  url: https://example.com/vector.yaml\n",
-        )
+        let config = serde_yaml::from_str::<FeatureConfig>(indoc! {"
+            provider:
+              type: http
+              url: https://example.com/vector.yaml
+        "})
         .expect("config must parse");
         let error =
             from_config(&config, &DECLARED_FEATURES).expect_err("configuration provider must fail");


### PR DESCRIPTION
## Summary

### Motivation

Building and testing Vector with its default feature set takes longer than necessary when working from a specific configuration.

### Changes

- Recommend `cargo vdev run <config>` for configuration-based Rust development.
- Prioritize tests that use `cargo vdev features` to derive the minimum feature set from a configuration.
- Reduce and reorder the remaining test examples from targeted to broad.

### References

N/A

## Vector configuration

N/A; documentation-only change.

## How did you test this PR?

- `make check-markdown`
- `git diff --check`
- Verified `cargo vdev run` builds and runs an stdin-to-console configuration with only `sources-stdin` and `sinks-console`.
- Verified the documented extraction pipeline produces `sinks-console,sources-stdin` for that configuration.

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.
