### PR TITLE
feat(influxdb sinks): validate config at compile time

### DIFF
--- a/changelog.d/influxdb_sinks_validate_no_environment.fix.md
+++ b/changelog.d/influxdb_sinks_validate_no_environment.fix.md
@@ -1,4 +1,0 @@
-`vector validate --no-environment` now catches configuration errors for the `influxdb_logs` and
-`influxdb_metrics` sinks that previously only surfaced when Vector booted.
-
-authors: thomasqueirozb

--- a/changelog.d/influxdb_sinks_validate_no_environment.fix.md
+++ b/changelog.d/influxdb_sinks_validate_no_environment.fix.md
@@ -1,0 +1,4 @@
+`vector validate --no-environment` now catches configuration errors for the `influxdb_logs` and
+`influxdb_metrics` sinks that previously only surfaced when Vector booted.
+
+authors: thomasqueirozb

--- a/src/sinks/influxdb/logs.rs
+++ b/src/sinks/influxdb/logs.rs
@@ -1,6 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
 use bytes::{Bytes, BytesMut};
+use derivative::Derivative;
 use futures::SinkExt;
 use http::{Request, Uri};
 use indoc::indoc;
@@ -240,11 +241,14 @@ impl SinkConfig for InfluxDbLogsConfig {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Derivative)]
+#[derivative(Debug)]
 pub struct ValidatedInfluxDbLogs {
     measurement: String,
     tags: HashSet<KeyString>,
     batch: BatchSettings<Buffer>,
+    // Omitted: the retained `uri` embeds the v1 password in its `p` query parameter.
+    #[derivative(Debug = "ignore")]
     uri: Uri,
     token: SensitiveString,
     protocol_version: ProtocolVersion,

--- a/src/sinks/influxdb/logs.rs
+++ b/src/sinks/influxdb/logs.rs
@@ -19,14 +19,18 @@ use super::{
 };
 use crate::{
     codecs::Transformer,
-    config::{AcknowledgementsConfig, GenerateConfig, Input, SinkConfig, SinkContext},
+    config::{
+        AcknowledgementsConfig, DynValidatedSink, GenerateConfig, Input, SinkConfig, SinkContext,
+        ValidatedSink,
+    },
     event::{Event, KeyString, MetricTags, Value},
     http::HttpClient,
     internal_events::InfluxdbEncodingError,
     sinks::{
         Healthcheck, VectorSink,
         util::{
-            BatchConfig, Buffer, Compression, HttpEndpoint, SinkBatchSettings, TowerRequestConfig,
+            BatchConfig, BatchSettings, Buffer, Compression, HttpEndpoint, SinkBatchSettings,
+            TowerRequestConfig,
             http::{BatchedHttpSink, HttpEventEncoder, HttpSink},
         },
     },
@@ -218,52 +222,119 @@ impl GenerateConfig for InfluxDbLogsConfig {
 #[async_trait::async_trait]
 #[typetag::serde(name = "influxdb_logs")]
 impl SinkConfig for InfluxDbLogsConfig {
-    async fn build(&self, cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
+    fn input(&self) -> Input {
+        let requirements = schema::Requirement::empty()
+            .optional_meaning("message", Kind::bytes())
+            .optional_meaning("host", Kind::bytes())
+            .optional_meaning("timestamp", Kind::timestamp());
+
+        Input::log().with_schema_requirement(requirements)
+    }
+
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &self.acknowledgements
+    }
+
+    fn as_dyn_validated(&self) -> Option<&dyn DynValidatedSink> {
+        Some(self)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ValidatedInfluxDbLogs {
+    measurement: String,
+    tags: HashSet<KeyString>,
+    batch: BatchSettings<Buffer>,
+    uri: Uri,
+    token: SensitiveString,
+    protocol_version: ProtocolVersion,
+    host_key: Option<OwnedValuePath>,
+    message_key: Option<OwnedValuePath>,
+    source_type_key: Option<OwnedValuePath>,
+}
+
+#[async_trait::async_trait]
+impl ValidatedSink for InfluxDbLogsConfig {
+    type Validated = ValidatedInfluxDbLogs;
+
+    fn validate(&self) -> crate::Result<ValidatedInfluxDbLogs> {
         let measurement = self.get_measurement()?;
         let tags: HashSet<KeyString> = self.tags.iter().cloned().collect();
+
+        let batch = self.batch.into_batch_settings()?;
+
+        let settings = influxdb_settings(self.settings()?);
+
+        let uri = settings.write_uri(self.endpoint.clone())?;
+
+        let token = settings.token();
+        let protocol_version = settings.protocol_version();
+
+        // Only the config-provided keys are retained here; the `log_schema()`
+        // fallbacks are resolved in `build`, after the global log schema has
+        // been initialized. Resolving them here would capture the built-in
+        // defaults, since validation runs before `init_log_schema` at startup.
+        let host_key = self.host_key.as_ref().and_then(|k| k.path.clone());
+        let message_key = self.message_key.as_ref().and_then(|k| k.path.clone());
+        let source_type_key = self.source_type_key.as_ref().and_then(|k| k.path.clone());
+
+        Ok(ValidatedInfluxDbLogs {
+            measurement,
+            tags,
+            batch,
+            uri,
+            token,
+            protocol_version,
+            host_key,
+            message_key,
+            source_type_key,
+        })
+    }
+
+    async fn build(
+        &self,
+        validated: &ValidatedInfluxDbLogs,
+        cx: SinkContext,
+    ) -> crate::Result<(VectorSink, Healthcheck)> {
+        let ValidatedInfluxDbLogs {
+            measurement,
+            tags,
+            batch,
+            uri,
+            token,
+            protocol_version,
+            host_key,
+            message_key,
+            source_type_key,
+        } = validated;
 
         let tls_settings = TlsSettings::from_options(self.tls.as_ref())?;
         let client = HttpClient::new(tls_settings, cx.proxy())?;
         let healthcheck = self.healthcheck(client.clone())?;
 
-        let batch = self.batch.into_batch_settings()?;
         let request = self.request.into_settings();
 
-        let settings = influxdb_settings(self.settings()?);
-
-        let endpoint = self.endpoint.clone();
-        let uri = settings.write_uri(endpoint).unwrap();
-
-        let token = settings.token();
-        let protocol_version = settings.protocol_version();
-
-        let host_key = self
-            .host_key
-            .as_ref()
-            .and_then(|k| k.path.clone())
+        // Resolve the `log_schema()` fallbacks here, after the global log schema
+        // has been initialized, so custom global log schema keys are honored.
+        let host_key = host_key
+            .clone()
             .or_else(|| log_schema().host_key().cloned())
             .expect("global log_schema.host_key to be valid path");
-
-        let message_key = self
-            .message_key
-            .as_ref()
-            .and_then(|k| k.path.clone())
+        let message_key = message_key
+            .clone()
             .or_else(|| log_schema().message_key().cloned())
             .expect("global log_schema.message_key to be valid path");
-
-        let source_type_key = self
-            .source_type_key
-            .as_ref()
-            .and_then(|k| k.path.clone())
+        let source_type_key = source_type_key
+            .clone()
             .or_else(|| log_schema().source_type_key().cloned())
             .expect("global log_schema.source_type_key to be valid path");
 
         let sink = InfluxDbLogsSink {
-            uri,
+            uri: uri.clone(),
             token: token.inner().to_owned(),
-            protocol_version,
-            measurement,
-            tags,
+            protocol_version: *protocol_version,
+            measurement: measurement.clone(),
+            tags: tags.clone(),
             transformer: self.encoding.clone(),
             host_key,
             message_key,
@@ -281,19 +352,6 @@ impl SinkConfig for InfluxDbLogsConfig {
 
         #[allow(deprecated)]
         Ok((VectorSink::from_event_sink(sink), healthcheck))
-    }
-
-    fn input(&self) -> Input {
-        let requirements = schema::Requirement::empty()
-            .optional_meaning("message", Kind::bytes())
-            .optional_meaning("host", Kind::bytes())
-            .optional_meaning("timestamp", Kind::timestamp());
-
-        Input::log().with_schema_requirement(requirements)
-    }
-
-    fn acknowledgements(&self) -> &AcknowledgementsConfig {
-        &self.acknowledgements
     }
 }
 
@@ -521,6 +579,7 @@ mod tests {
 
     use super::*;
     use crate::{
+        config::ValidatedSink,
         sinks::{
             influxdb::test_util::{assert_fields, split_line_protocol, ts},
             util::test::{build_test_server_status, load_sink},
@@ -573,100 +632,72 @@ mod tests {
     }
 
     #[test]
-    fn test_infer_version_v2() {
-        let config = indoc! {r#"
-            endpoint: "http://localhost:9999"
-            bucket: "my-bucket"
-            org: "my-org"
-            token: "my-token"
-        "#};
-        let config: InfluxDbLogsConfig = serde_yaml::from_str(config).unwrap();
-        assert_eq!(config.infer_version().unwrap(), InfluxDbVersion::V2);
+    fn prepares_valid_config() {
+        let config = InfluxDbLogsConfig {
+            measurement: Some("vector".to_string()),
+            endpoint: HttpEndpoint::parse("http://localhost:9999").unwrap(),
+            org: Some("my-org".to_string()),
+            bucket: Some("my-bucket".to_string()),
+            token: Some("my-token".to_string().into()),
+            tags: vec![],
+            version: Some(InfluxDbVersion::V2),
+            database: None,
+            consistency: None,
+            retention_policy_name: None,
+            username: None,
+            password: None,
+            encoding: Default::default(),
+            batch: Default::default(),
+            request: Default::default(),
+            tls: None,
+            acknowledgements: Default::default(),
+            host_key: None,
+            message_key: None,
+            source_type_key: None,
+        };
+
+        let validated = config.validate().expect("preparation should succeed");
+        assert_eq!(validated.measurement, "vector");
+        assert!(matches!(validated.protocol_version, ProtocolVersion::V2));
+        assert_eq!(
+            validated.uri.to_string(),
+            "http://localhost:9999/api/v2/write?org=my-org&bucket=my-bucket&precision=ns"
+        );
     }
 
     #[test]
-    fn test_infer_version_v1() {
-        let config = indoc! {r#"
-            endpoint: "http://localhost:9999"
-            database: "my-database"
-        "#};
-        let config: InfluxDbLogsConfig = serde_yaml::from_str(config).unwrap();
-        assert_eq!(config.infer_version().unwrap(), InfluxDbVersion::V1);
-    }
+    fn validate_retains_config_keys_without_log_schema_fallback() {
+        let config = InfluxDbLogsConfig {
+            measurement: Some("vector".to_string()),
+            endpoint: HttpEndpoint::parse("http://localhost:9999").unwrap(),
+            org: Some("my-org".to_string()),
+            bucket: Some("my-bucket".to_string()),
+            token: Some("my-token".to_string().into()),
+            host_key: Some(OptionalValuePath::new("custom_host")),
+            tags: vec![],
+            version: Some(InfluxDbVersion::V2),
+            database: None,
+            consistency: None,
+            retention_policy_name: None,
+            username: None,
+            password: None,
+            encoding: Default::default(),
+            batch: Default::default(),
+            request: Default::default(),
+            tls: None,
+            acknowledgements: Default::default(),
+            message_key: None,
+            source_type_key: None,
+        };
 
-    #[test]
-    fn test_infer_version_missing() {
-        let config = indoc! {r#"
-            endpoint: "http://localhost:9999"
-        "#};
-        let config: InfluxDbLogsConfig = serde_yaml::from_str(config).unwrap();
-        assert!(config.infer_version().is_err());
-    }
-
-    #[test]
-    fn test_infer_version_both() {
-        let config = indoc! {r#"
-            endpoint: "http://localhost:9999"
-            database: "my-database"
-            bucket: "my-bucket"
-            org: "my-org"
-            token: "my-token"
-        "#};
-        let config: InfluxDbLogsConfig = serde_yaml::from_str(config).unwrap();
-        assert!(config.infer_version().is_err());
-    }
-
-    #[test]
-    fn test_settings_explicit_v2_rejects_v1_settings() {
-        let config = indoc! {r#"
-            endpoint: "http://localhost:9999"
-            version: "2"
-            bucket: "my-bucket"
-            org: "my-org"
-            token: "my-token"
-            database: "stale-v1-database"
-            username: "stale-v1-user"
-        "#};
-        let config: InfluxDbLogsConfig = serde_yaml::from_str(config).unwrap();
-        assert!(config.settings().is_err());
-    }
-
-    #[test]
-    fn test_settings_explicit_v1_rejects_v2_settings() {
-        let config = indoc! {r#"
-            endpoint: "http://localhost:9999"
-            version: "1"
-            database: "my-database"
-            org: "stale-v2-org"
-            bucket: "stale-v2-bucket"
-            token: "stale-v2-token"
-        "#};
-        let config: InfluxDbLogsConfig = serde_yaml::from_str(config).unwrap();
-        assert!(config.settings().is_err());
-    }
-
-    #[test]
-    fn test_settings_explicit_v2_accepts_only_v2_settings() {
-        let config = indoc! {r#"
-            endpoint: "http://localhost:9999"
-            version: "2"
-            bucket: "my-bucket"
-            org: "my-org"
-            token: "my-token"
-        "#};
-        let config: InfluxDbLogsConfig = serde_yaml::from_str(config).unwrap();
-        assert!(config.settings().is_ok());
-    }
-
-    #[test]
-    fn test_settings_explicit_v1_accepts_only_v1_settings() {
-        let config = indoc! {r#"
-            endpoint: "http://localhost:9999"
-            version: "1"
-            database: "my-database"
-        "#};
-        let config: InfluxDbLogsConfig = serde_yaml::from_str(config).unwrap();
-        assert!(config.settings().is_ok());
+        let validated = config.validate().expect("validation should succeed");
+        // Config-provided keys are retained...
+        assert_eq!(validated.host_key, Some(owned_value_path!("custom_host")));
+        // ...but unset keys stay unset: `validate` must not resolve the global
+        // `log_schema()` defaults, which aren't initialized yet at validation
+        // time in the startup path. The fallbacks are resolved in `build`.
+        assert_eq!(validated.message_key, None);
+        assert_eq!(validated.source_type_key, None);
     }
 
     #[test]
@@ -1007,7 +1038,7 @@ mod tests {
         let (mut config, cx) = load_sink::<InfluxDbLogsConfig>(&config).unwrap();
 
         // Make sure we can build the config
-        _ = config.build(cx.clone()).await.unwrap();
+        _ = SinkConfig::build(&config, cx.clone()).await.unwrap();
 
         let (_guard, addr) = next_addr();
         // Swap out the host so we can force send it
@@ -1015,7 +1046,7 @@ mod tests {
         let host = format!("http://{addr}");
         config.endpoint = HttpEndpoint::parse(&host).unwrap();
 
-        let (sink, _) = config.build(cx).await.unwrap();
+        let (sink, _) = SinkConfig::build(&config, cx).await.unwrap();
 
         let (rx, _trigger, server) = build_test_server_status(addr, status_code);
         tokio::spawn(server);
@@ -1174,7 +1205,7 @@ mod integration_tests {
             source_type_key: None,
         };
 
-        let (sink, _) = config.build(cx).await.unwrap();
+        let (sink, _) = SinkConfig::build(&config, cx).await.unwrap();
 
         let (batch, mut receiver) = BatchNotifier::new_with_receiver();
 

--- a/src/sinks/influxdb/logs.rs
+++ b/src/sinks/influxdb/logs.rs
@@ -1,3 +1,8 @@
+#![expect(
+    clippy::let_underscore_must_use,
+    reason = "derivative's Debug derive with ignored fields expands to a must_use let binding"
+)]
+
 use std::collections::{HashMap, HashSet};
 
 use bytes::{Bytes, BytesMut};

--- a/src/sinks/influxdb/metrics.rs
+++ b/src/sinks/influxdb/metrics.rs
@@ -1,3 +1,8 @@
+#![expect(
+    clippy::let_underscore_must_use,
+    reason = "derivative's Debug derive with ignored fields expands to a must_use let binding"
+)]
+
 use std::{collections::HashMap, future::ready, task::Poll};
 
 use bytes::{Bytes, BytesMut};

--- a/src/sinks/influxdb/metrics.rs
+++ b/src/sinks/influxdb/metrics.rs
@@ -12,7 +12,10 @@ use vector_lib::{
 };
 
 use crate::{
-    config::{AcknowledgementsConfig, GenerateConfig, Input, SinkConfig, SinkContext},
+    config::{
+        AcknowledgementsConfig, DynValidatedSink, GenerateConfig, Input, SinkConfig, SinkContext,
+        ValidatedSink,
+    },
     event::{
         Event, KeyString,
         metric::{Metric, MetricValue, Sample, StatisticKind},
@@ -27,7 +30,8 @@ use crate::{
             influxdb_settings,
         },
         util::{
-            BatchConfig, EncodedEvent, HttpEndpoint, SinkBatchSettings, TowerRequestConfig,
+            BatchConfig, BatchSettings, EncodedEvent, HttpEndpoint, SinkBatchSettings,
+            TowerRequestConfig,
             buffer::metrics::{MetricNormalize, MetricNormalizer, MetricSet, MetricsBuffer},
             encode_namespace,
             http::{HttpBatchService, HttpRetryLogic},
@@ -283,15 +287,6 @@ impl InfluxDbConfig {
 #[async_trait::async_trait]
 #[typetag::serde(name = "influxdb_metrics")]
 impl SinkConfig for InfluxDbConfig {
-    async fn build(&self, cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
-        let tls_settings = TlsSettings::from_options(self.tls.as_ref())?;
-        let client = HttpClient::new(tls_settings, cx.proxy())?;
-        let healthcheck = healthcheck(self.clone().endpoint, self.settings()?, client.clone())?;
-        validate_quantiles(&self.quantiles)?;
-        let sink = InfluxDbSvc::new(self.clone(), client)?;
-        Ok((sink, healthcheck))
-    }
-
     fn input(&self) -> Input {
         Input::metric()
     }
@@ -299,26 +294,94 @@ impl SinkConfig for InfluxDbConfig {
     fn acknowledgements(&self) -> &AcknowledgementsConfig {
         &self.acknowledgements
     }
+
+    fn as_dyn_validated(&self) -> Option<&dyn DynValidatedSink> {
+        Some(self)
+    }
 }
 
-impl InfluxDbSvc {
-    pub fn new(config: InfluxDbConfig, client: HttpClient) -> crate::Result<VectorSink> {
-        let settings = influxdb_settings(config.settings()?);
+#[derive(Clone)]
+pub struct ValidatedInfluxDbMetrics {
+    uri: http::Uri,
+    token: SensitiveString,
+    protocol_version: ProtocolVersion,
+    batch: BatchSettings<MetricsBuffer>,
+}
 
-        let endpoint = config.endpoint.clone();
+impl std::fmt::Debug for ValidatedInfluxDbMetrics {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ValidatedInfluxDbMetrics")
+            .field("uri", &self.uri)
+            .field("token", &self.token)
+            .field("protocol_version", &self.protocol_version)
+            .finish_non_exhaustive()
+    }
+}
+
+#[async_trait::async_trait]
+impl ValidatedSink for InfluxDbConfig {
+    type Validated = ValidatedInfluxDbMetrics;
+
+    fn validate(&self) -> crate::Result<ValidatedInfluxDbMetrics> {
+        validate_quantiles(&self.quantiles)?;
+
+        let settings = influxdb_settings(self.settings()?);
+
+        let uri = settings.write_uri(self.endpoint.clone())?;
+
         let token = settings.token();
         let protocol_version = settings.protocol_version();
 
-        let batch = config.batch.into_batch_settings()?;
+        let batch = self.batch.into_batch_settings()?;
+
+        Ok(ValidatedInfluxDbMetrics {
+            uri,
+            token,
+            protocol_version,
+            batch,
+        })
+    }
+
+    async fn build(
+        &self,
+        validated: &ValidatedInfluxDbMetrics,
+        cx: SinkContext,
+    ) -> crate::Result<(VectorSink, Healthcheck)> {
+        let tls_settings = TlsSettings::from_options(self.tls.as_ref())?;
+        let client = HttpClient::new(tls_settings, cx.proxy())?;
+        let healthcheck = healthcheck(self.clone().endpoint, self.settings()?, client.clone())?;
+        let sink = InfluxDbSvc::from_validated(self.clone(), validated, client)?;
+        Ok((sink, healthcheck))
+    }
+}
+
+impl InfluxDbSvc {
+    #[cfg(all(test, feature = "influxdb-integration-tests"))]
+    pub fn new(config: InfluxDbConfig, client: HttpClient) -> crate::Result<VectorSink> {
+        let validated = config.validate()?;
+        Self::from_validated(config, &validated, client)
+    }
+
+    fn from_validated(
+        config: InfluxDbConfig,
+        validated: &ValidatedInfluxDbMetrics,
+        client: HttpClient,
+    ) -> crate::Result<VectorSink> {
+        let ValidatedInfluxDbMetrics {
+            uri,
+            token,
+            protocol_version,
+            batch,
+        } = validated;
+
         let request = config.request.into_settings();
 
-        let uri = settings.write_uri(endpoint)?;
-
-        let http_service = HttpBatchService::new(client, create_build_request(uri, token.inner()));
+        let http_service =
+            HttpBatchService::new(client, create_build_request(uri.clone(), token.inner()));
 
         let influxdb_http_service = InfluxDbSvc {
             config,
-            protocol_version,
+            protocol_version: *protocol_version,
             inner: http_service,
         };
         let mut normalizer = MetricNormalizer::<InfluxMetricNormalize>::default();
@@ -595,6 +658,7 @@ mod tests {
 
     use super::*;
     use crate::{
+        config::ValidatedSink,
         event::metric::{Metric, MetricKind, MetricValue, StatisticKind},
         sinks::influxdb::test_util::{assert_fields, split_line_protocol, tags, ts},
     };
@@ -621,56 +685,33 @@ mod tests {
     }
 
     #[test]
-    fn test_settings_explicit_v2_rejects_v1_settings() {
-        let config = indoc! {r#"
-            endpoint: "http://localhost:9999"
-            version: "2"
-            bucket: "my-bucket"
-            org: "my-org"
-            token: "my-token"
-            database: "stale-v1-database"
-            username: "stale-v1-user"
-        "#};
-        let config: InfluxDbConfig = serde_yaml::from_str(config).unwrap();
-        assert!(config.settings().is_err());
-    }
+    fn prepares_valid_config() {
+        let config = InfluxDbConfig {
+            endpoint: HttpEndpoint::parse("http://localhost:9999").unwrap(),
+            org: Some("my-org".to_string()),
+            bucket: Some("my-bucket".to_string()),
+            token: Some("my-token".to_string().into()),
+            default_namespace: None,
+            version: Some(InfluxDbVersion::V2),
+            database: None,
+            consistency: None,
+            retention_policy_name: None,
+            username: None,
+            password: None,
+            batch: Default::default(),
+            request: Default::default(),
+            tags: None,
+            tls: None,
+            quantiles: default_summary_quantiles(),
+            acknowledgements: Default::default(),
+        };
 
-    #[test]
-    fn test_settings_explicit_v1_rejects_v2_settings() {
-        let config = indoc! {r#"
-            endpoint: "http://localhost:9999"
-            version: "1"
-            database: "my-database"
-            org: "stale-v2-org"
-            bucket: "stale-v2-bucket"
-            token: "stale-v2-token"
-        "#};
-        let config: InfluxDbConfig = serde_yaml::from_str(config).unwrap();
-        assert!(config.settings().is_err());
-    }
-
-    #[test]
-    fn test_settings_explicit_v2_accepts_only_v2_settings() {
-        let config = indoc! {r#"
-            endpoint: "http://localhost:9999"
-            version: "2"
-            bucket: "my-bucket"
-            org: "my-org"
-            token: "my-token"
-        "#};
-        let config: InfluxDbConfig = serde_yaml::from_str(config).unwrap();
-        assert!(config.settings().is_ok());
-    }
-
-    #[test]
-    fn test_settings_explicit_v1_accepts_only_v1_settings() {
-        let config = indoc! {r#"
-            endpoint: "http://localhost:9999"
-            version: "1"
-            database: "my-database"
-        "#};
-        let config: InfluxDbConfig = serde_yaml::from_str(config).unwrap();
-        assert!(config.settings().is_ok());
+        let validated = config.validate().expect("preparation should succeed");
+        assert!(matches!(validated.protocol_version, ProtocolVersion::V2));
+        assert_eq!(
+            validated.uri.to_string(),
+            "http://localhost:9999/api/v2/write?org=my-org&bucket=my-bucket&precision=ns"
+        );
     }
 
     #[test]

--- a/src/sinks/influxdb/metrics.rs
+++ b/src/sinks/influxdb/metrics.rs
@@ -1,6 +1,7 @@
 use std::{collections::HashMap, future::ready, task::Poll};
 
 use bytes::{Bytes, BytesMut};
+use derivative::Derivative;
 use futures::{SinkExt, future::BoxFuture, stream};
 use indoc::indoc;
 use tower::Service;
@@ -300,22 +301,16 @@ impl SinkConfig for InfluxDbConfig {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Derivative)]
+#[derivative(Debug)]
 pub struct ValidatedInfluxDbMetrics {
+    // Omitted: the retained `uri` embeds the v1 password in its `p` query parameter.
+    #[derivative(Debug = "ignore")]
     uri: http::Uri,
     token: SensitiveString,
     protocol_version: ProtocolVersion,
+    #[derivative(Debug = "ignore")]
     batch: BatchSettings<MetricsBuffer>,
-}
-
-impl std::fmt::Debug for ValidatedInfluxDbMetrics {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("ValidatedInfluxDbMetrics")
-            .field("uri", &self.uri)
-            .field("token", &self.token)
-            .field("protocol_version", &self.protocol_version)
-            .finish_non_exhaustive()
-    }
 }
 
 #[async_trait::async_trait]


### PR DESCRIPTION
## Summary
Migrates the `influxdb_logs` and `influxdb_metrics` sinks to the validated sink lifecycle, so `vector validate --no-environment` catches pure configuration errors (endpoint URI, batch settings, quantiles) at config-compile time instead of at startup.

### References
- Related: #26048

## Vector configuration
NA

## How did you test this PR?
`make test FEATURES="sinks-influxdb" SCOPE="sinks::influxdb"` and `cargo check -p vector --all-features`.

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.