### PR TITLE
feat(websocket sinks): validate config at compile time

### DIFF
--- a/src/common/http/server_auth.rs
+++ b/src/common/http/server_auth.rs
@@ -178,11 +178,11 @@ impl HttpServerAuthConfig {
         }
     }
 
-    /// Validates the auth configuration without a runtime context, compiling any
-    /// custom VRL program with empty registries so `vector validate --no-environment`
-    /// catches syntax/result-type errors.
-    pub fn validate(&self) -> crate::Result<()> {
-        self.build(&TableRegistry::default(), &MetricsStorage::default())
+    /// Validates the auth configuration against the given enrichment tables,
+    /// compiling any custom VRL program so `vector validate --no-environment`
+    /// catches syntax/type errors while resolving enrichment table names.
+    pub fn validate(&self, enrichment_tables: &TableRegistry) -> crate::Result<()> {
+        self.build(enrichment_tables, &MetricsStorage::default())
             .map(|_| ())
     }
 }

--- a/src/common/http/server_auth.rs
+++ b/src/common/http/server_auth.rs
@@ -11,6 +11,7 @@ use serde::{
 use vector_config::configurable_component;
 use vector_lib::{
     TimeZone, compile_vrl,
+    enrichment::TableRegistry,
     event::{Event, LogEvent, MetricTagMode, VrlTarget},
     lookup::OwnedTargetPath,
     sensitive_string::SensitiveString,
@@ -175,6 +176,14 @@ impl HttpServerAuthConfig {
                 Ok(HttpServerAuthMatcher::Vrl { program })
             }
         }
+    }
+
+    /// Validates the auth configuration without a runtime context, compiling any
+    /// custom VRL program with empty registries so `vector validate --no-environment`
+    /// catches syntax/result-type errors.
+    pub fn validate(&self) -> crate::Result<()> {
+        self.build(&TableRegistry::default(), &MetricsStorage::default())
+            .map(|_| ())
     }
 }
 

--- a/src/common/websocket.rs
+++ b/src/common/websocket.rs
@@ -13,7 +13,7 @@ use tokio_tungstenite::{
     tungstenite::{
         client::{IntoClientRequest, uri_mode},
         error::{Error as TungsteniteError, ProtocolError, UrlError},
-        handshake::client::Request,
+        http::Uri,
         protocol::WebSocketConfig,
         stream::Mode as UriMode,
     },
@@ -46,53 +46,45 @@ pub enum WebSocketError {
 
 #[derive(Clone)]
 pub(crate) struct WebSocketConnector {
-    uri: String,
-    host: String,
-    port: u16,
+    uri: Uri,
     tls: MaybeTlsSettings,
     auth: Option<Auth>,
 }
 
 impl WebSocketConnector {
-    /// Parse the URI and extract the host and port, without any TLS setup.
+    /// Parse the URI, without any TLS setup.
     ///
     /// This is pure parsing that can run during validation; TLS resolution
     /// happens later when the connector is built.
-    pub(crate) fn parse_uri(uri: &str) -> Result<(String, u16), WebSocketError> {
+    pub(crate) fn parse_uri(uri: &str) -> Result<Uri, WebSocketError> {
         let request = uri.into_client_request().context(CreateFailedSnafu)?;
-        let (host, port) = Self::extract_host_and_port(&request).context(CreateFailedSnafu)?;
-        Ok((host, port))
+        let uri = request.uri().clone();
+        // Validate that the host and port can be extracted (including the scheme),
+        // so malformed URIs are rejected during validation rather than at connect time.
+        Self::extract_host_and_port(&uri).context(CreateFailedSnafu)?;
+        Ok(uri)
     }
 
-    /// Construct a connector from an already-parsed host and port.
+    /// Construct a connector from an already-parsed URI.
     ///
     /// Used by callers whose `validate` already parsed the URI, so the parsed
-    /// values are plumbed through the validated state rather than re-parsed
+    /// value is plumbed through the validated state rather than re-parsed
     /// here. TLS resolution still happens in this method.
     pub(crate) const fn from_validated(
-        uri: String,
-        host: String,
-        port: u16,
+        uri: Uri,
         tls: MaybeTlsSettings,
         auth: Option<Auth>,
     ) -> Self {
-        Self {
-            uri,
-            host,
-            port,
-            tls,
-            auth,
-        }
+        Self { uri, tls, auth }
     }
 
-    fn extract_host_and_port(request: &Request) -> Result<(String, u16), TungsteniteError> {
-        let host = request
-            .uri()
+    fn extract_host_and_port(uri: &Uri) -> Result<(String, u16), TungsteniteError> {
+        let host = uri
             .host()
             .ok_or(TungsteniteError::Url(UrlError::NoHostName))?
             .to_string();
-        let mode = uri_mode(request.uri())?;
-        let port = request.uri().port_u16().unwrap_or(match mode {
+        let mode = uri_mode(uri)?;
+        let port = uri.port_u16().unwrap_or(match mode {
             UriMode::Tls => 443,
             UriMode::Plain => 80,
         });
@@ -101,18 +93,16 @@ impl WebSocketConnector {
     }
 
     async fn tls_connect(&self) -> Result<MaybeTlsStream<TcpStream>, WebSocketError> {
+        let (host, port) = Self::extract_host_and_port(&self.uri).context(CreateFailedSnafu)?;
         let ip = dns::Resolver
-            .lookup_ip(self.host.clone())
+            .lookup_ip(host.clone())
             .await
             .context(DnsSnafu)?
             .next()
             .ok_or(WebSocketError::NoAddresses)?;
 
-        let addr = SocketAddr::new(ip, self.port);
-        self.tls
-            .connect(&self.host, &addr)
-            .await
-            .context(ConnectSnafu)
+        let addr = SocketAddr::new(ip, port);
+        self.tls.connect(&host, &addr).await.context(ConnectSnafu)
     }
 
     async fn connect(&self) -> Result<WebSocketStream<MaybeTlsStream<TcpStream>>, WebSocketError> {

--- a/src/common/websocket.rs
+++ b/src/common/websocket.rs
@@ -54,21 +54,35 @@ pub(crate) struct WebSocketConnector {
 }
 
 impl WebSocketConnector {
-    pub(crate) fn new(
+    /// Parse the URI and extract the host and port, without any TLS setup.
+    ///
+    /// This is pure parsing that can run during validation; TLS resolution
+    /// happens later when the connector is built.
+    pub(crate) fn parse_uri(uri: &str) -> Result<(String, u16), WebSocketError> {
+        let request = uri.into_client_request().context(CreateFailedSnafu)?;
+        let (host, port) = Self::extract_host_and_port(&request).context(CreateFailedSnafu)?;
+        Ok((host, port))
+    }
+
+    /// Construct a connector from an already-parsed host and port.
+    ///
+    /// Used by callers whose `validate` already parsed the URI, so the parsed
+    /// values are plumbed through the validated state rather than re-parsed
+    /// here. TLS resolution still happens in this method.
+    pub(crate) const fn from_validated(
         uri: String,
+        host: String,
+        port: u16,
         tls: MaybeTlsSettings,
         auth: Option<Auth>,
-    ) -> Result<Self, WebSocketError> {
-        let request = (&uri).into_client_request().context(CreateFailedSnafu)?;
-        let (host, port) = Self::extract_host_and_port(&request).context(CreateFailedSnafu)?;
-
-        Ok(Self {
+    ) -> Self {
+        Self {
             uri,
             host,
             port,
             tls,
             auth,
-        })
+        }
     }
 
     fn extract_host_and_port(request: &Request) -> Result<(String, u16), TungsteniteError> {

--- a/src/config/sink_validated.rs
+++ b/src/config/sink_validated.rs
@@ -76,6 +76,15 @@ pub trait ValidatedSink {
     /// dependent operations belong in `build`.
     fn validate(&self) -> crate::Result<Self::Validated>;
 
+    /// Performs context-dependent validation that requires the enrichment tables.
+    ///
+    /// Defaults to a no-op; sinks that resolve enrichment tables at compile time
+    /// (e.g. custom-auth VRL programs) override this to run against the configured
+    /// tables, which are only available at the config-validation layer.
+    fn validate_with_context(&self, _cx: &SinkContext) -> crate::Result<()> {
+        Ok(())
+    }
+
     /// Builds the sink from the validated state, without redoing pure validation.
     ///
     /// May perform environment-dependent construction (HTTP clients, schema fetching, etc.).
@@ -96,6 +105,10 @@ pub trait DynValidatedSink {
     /// Erases the validated state into a `Box<dyn Any>`.
     fn validate_dyn(&self) -> crate::Result<Box<dyn Any + Send + Sync>>;
 
+    /// Validates context-dependent configuration (e.g. VRL programs that resolve
+    /// enrichment tables) against the given context.
+    fn validate_with_context_dyn(&self, cx: &SinkContext) -> crate::Result<()>;
+
     /// Restores the validated state from `&dyn Any` and builds the sink.
     async fn build_dyn(
         &self,
@@ -111,6 +124,10 @@ where
 {
     fn validate_dyn(&self) -> crate::Result<Box<dyn Any + Send + Sync>> {
         Ok(Box::new(self.validate()?))
+    }
+
+    fn validate_with_context_dyn(&self, cx: &SinkContext) -> crate::Result<()> {
+        self.validate_with_context(cx)
     }
 
     async fn build_dyn(

--- a/src/sinks/websocket/config.rs
+++ b/src/sinks/websocket/config.rs
@@ -1,4 +1,5 @@
 use snafu::ResultExt;
+use tokio_tungstenite::tungstenite::http::Uri;
 use vector_lib::{codecs::JsonSerializerConfig, configurable::configurable_component};
 
 use crate::{
@@ -65,8 +66,7 @@ impl SinkConfig for WebSocketSinkConfig {
 
 #[derive(Clone, Debug)]
 pub struct ValidatedWebSocketSink {
-    host: String,
-    port: u16,
+    uri: Uri,
     transformer: Transformer,
 }
 
@@ -75,13 +75,9 @@ impl ValidatedSink for WebSocketSinkConfig {
     type Validated = ValidatedWebSocketSink;
 
     fn validate(&self) -> crate::Result<ValidatedWebSocketSink> {
-        let (host, port) = WebSocketConnector::parse_uri(&self.common.uri)?;
+        let uri = WebSocketConnector::parse_uri(&self.common.uri)?;
         let transformer = self.encoding.transformer();
-        Ok(ValidatedWebSocketSink {
-            host,
-            port,
-            transformer,
-        })
+        Ok(ValidatedWebSocketSink { uri, transformer })
     }
 
     async fn build(
@@ -91,12 +87,8 @@ impl ValidatedSink for WebSocketSinkConfig {
     ) -> crate::Result<(VectorSink, Healthcheck)> {
         // TLS settings may read certificate files from disk, so the connector is
         // resolved at build time rather than during validation.
-        let ValidatedWebSocketSink {
-            host,
-            port,
-            transformer,
-        } = validated.clone();
-        let connector = self.build_connector(host, port)?;
+        let ValidatedWebSocketSink { uri, transformer } = validated.clone();
+        let connector = self.build_connector(uri)?;
         let serializer = self.encoding.build()?;
         let ws_sink = WebSocketSink::new(self, connector.clone(), transformer, serializer)?;
 
@@ -108,17 +100,11 @@ impl ValidatedSink for WebSocketSinkConfig {
 }
 
 impl WebSocketSinkConfig {
-    fn build_connector(
-        &self,
-        host: String,
-        port: u16,
-    ) -> Result<WebSocketConnector, WebSocketError> {
+    fn build_connector(&self, uri: Uri) -> Result<WebSocketConnector, WebSocketError> {
         let tls =
             MaybeTlsSettings::from_config(self.common.tls.as_ref(), false).context(ConnectSnafu)?;
         Ok(WebSocketConnector::from_validated(
-            self.common.uri.clone(),
-            host,
-            port,
+            uri,
             tls,
             self.common.auth.clone(),
         ))

--- a/src/sinks/websocket/config.rs
+++ b/src/sinks/websocket/config.rs
@@ -2,9 +2,12 @@ use snafu::ResultExt;
 use vector_lib::{codecs::JsonSerializerConfig, configurable::configurable_component};
 
 use crate::{
-    codecs::EncodingConfig,
+    codecs::{EncodingConfig, Transformer},
     common::websocket::{ConnectSnafu, WebSocketCommonConfig, WebSocketConnector, WebSocketError},
-    config::{AcknowledgementsConfig, GenerateConfig, Input, SinkConfig, SinkContext},
+    config::{
+        AcknowledgementsConfig, DynValidatedSink, GenerateConfig, Input, SinkConfig, SinkContext,
+        ValidatedSink,
+    },
     sinks::{Healthcheck, VectorSink, websocket::sink::WebSocketSink},
     tls::MaybeTlsSettings,
 };
@@ -47,16 +50,6 @@ impl GenerateConfig for WebSocketSinkConfig {
 #[async_trait::async_trait]
 #[typetag::serde(name = "websocket")]
 impl SinkConfig for WebSocketSinkConfig {
-    async fn build(&self, _cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
-        let connector = self.build_connector()?;
-        let ws_sink = WebSocketSink::new(self, connector.clone())?;
-
-        Ok((
-            VectorSink::from_event_streamsink(ws_sink),
-            Box::pin(async move { connector.healthcheck().await }),
-        ))
-    }
-
     fn input(&self) -> Input {
         Input::new(self.encoding.config().input_type())
     }
@@ -64,22 +57,136 @@ impl SinkConfig for WebSocketSinkConfig {
     fn acknowledgements(&self) -> &AcknowledgementsConfig {
         &self.acknowledgements
     }
+
+    fn as_dyn_validated(&self) -> Option<&dyn DynValidatedSink> {
+        Some(self)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ValidatedWebSocketSink {
+    host: String,
+    port: u16,
+    transformer: Transformer,
+}
+
+#[async_trait::async_trait]
+impl ValidatedSink for WebSocketSinkConfig {
+    type Validated = ValidatedWebSocketSink;
+
+    fn validate(&self) -> crate::Result<ValidatedWebSocketSink> {
+        let (host, port) = WebSocketConnector::parse_uri(&self.common.uri)?;
+        let transformer = self.encoding.transformer();
+        Ok(ValidatedWebSocketSink {
+            host,
+            port,
+            transformer,
+        })
+    }
+
+    async fn build(
+        &self,
+        validated: &ValidatedWebSocketSink,
+        _cx: SinkContext,
+    ) -> crate::Result<(VectorSink, Healthcheck)> {
+        // TLS settings may read certificate files from disk, so the connector is
+        // resolved at build time rather than during validation.
+        let ValidatedWebSocketSink {
+            host,
+            port,
+            transformer,
+        } = validated.clone();
+        let connector = self.build_connector(host, port)?;
+        let serializer = self.encoding.build()?;
+        let ws_sink = WebSocketSink::new(self, connector.clone(), transformer, serializer)?;
+
+        Ok((
+            VectorSink::from_event_streamsink(ws_sink),
+            Box::pin(async move { connector.healthcheck().await }),
+        ))
+    }
 }
 
 impl WebSocketSinkConfig {
-    fn build_connector(&self) -> Result<WebSocketConnector, WebSocketError> {
+    fn build_connector(
+        &self,
+        host: String,
+        port: u16,
+    ) -> Result<WebSocketConnector, WebSocketError> {
         let tls =
             MaybeTlsSettings::from_config(self.common.tls.as_ref(), false).context(ConnectSnafu)?;
-        WebSocketConnector::new(self.common.uri.clone(), tls, self.common.auth.clone())
+        Ok(WebSocketConnector::from_validated(
+            self.common.uri.clone(),
+            host,
+            port,
+            tls,
+            self.common.auth.clone(),
+        ))
     }
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
+    use vector_lib::codecs::encoding::SerializerConfig;
+
+    use crate::config::ValidatedSink;
 
     #[test]
     fn generate_config() {
         crate::test_util::test_generate_config::<WebSocketSinkConfig>();
+    }
+
+    #[test]
+    fn validate_produces_usable_state() {
+        let config = WebSocketSinkConfig {
+            common: WebSocketCommonConfig {
+                uri: "ws://127.0.0.1:8080".to_string(),
+                ..Default::default()
+            },
+            encoding: JsonSerializerConfig::default().into(),
+            acknowledgements: Default::default(),
+        };
+        let _validated = config.validate().expect("validation should succeed");
+        // Serializer construction is deferred to `build`; validation retains the
+        // transformer so `build` can construct the serializer.
+        assert!(matches!(
+            config.encoding.config(),
+            SerializerConfig::Json(_)
+        ));
+    }
+
+    #[test]
+    fn validate_rejects_malformed_uri() {
+        let config = WebSocketSinkConfig {
+            common: WebSocketCommonConfig {
+                uri: "not a valid uri".to_string(),
+                ..Default::default()
+            },
+            encoding: JsonSerializerConfig::default().into(),
+            acknowledgements: Default::default(),
+        };
+
+        assert!(
+            config.validate().is_err(),
+            "a malformed URI should fail validation"
+        );
+    }
+
+    #[test]
+    fn validate_rejects_uri_without_host() {
+        let config = WebSocketSinkConfig {
+            common: WebSocketCommonConfig {
+                uri: "ws:///path".to_string(),
+                ..Default::default()
+            },
+            encoding: JsonSerializerConfig::default().into(),
+            acknowledgements: Default::default(),
+        };
+
+        assert!(
+            config.validate().is_err(),
+            "a URI without a host should fail validation"
+        );
     }
 }

--- a/src/sinks/websocket/sink.rs
+++ b/src/sinks/websocket/sink.rs
@@ -19,7 +19,9 @@ use futures::{Sink, Stream, StreamExt, pin_mut, sink::SinkExt, stream::BoxStream
 use tokio_tungstenite::tungstenite::{error::Error as TungsteniteError, protocol::Message};
 use tokio_util::codec::Encoder as _;
 use vector_lib::{
-    EstimatedJsonEncodedSizeOf, emit,
+    EstimatedJsonEncodedSizeOf,
+    codecs::encoding::Serializer,
+    emit,
     internal_event::{
         ByteSize, BytesSent, CountByteSize, EventsSent, InternalEventHandle as _, Output, Protocol,
     },
@@ -37,9 +39,9 @@ impl WebSocketSink {
     pub(crate) fn new(
         config: &WebSocketSinkConfig,
         connector: WebSocketConnector,
+        transformer: Transformer,
+        serializer: Serializer,
     ) -> crate::Result<Self> {
-        let transformer = config.encoding.transformer();
-        let serializer = config.encoding.build()?;
         let encoder = Encoder::<()>::new(serializer);
 
         Ok(Self {

--- a/src/sinks/websocket_server/config.rs
+++ b/src/sinks/websocket_server/config.rs
@@ -170,10 +170,16 @@ impl ValidatedSink for WebSocketListenerSinkConfig {
 
     fn validate(&self) -> crate::Result<ValidatedWebSocketListenerSink> {
         let transformer = self.encoding.transformer();
-        if let Some(auth) = &self.auth {
-            auth.validate()?;
-        }
+        // Custom-auth VRL compilation is deferred to `validate_with_context`, which
+        // has the enrichment tables needed to resolve `get_enrichment_table_record!`.
         Ok(ValidatedWebSocketListenerSink { transformer })
+    }
+
+    fn validate_with_context(&self, cx: &SinkContext) -> crate::Result<()> {
+        if let Some(auth) = &self.auth {
+            auth.validate(&cx.enrichment_tables)?;
+        }
+        Ok(())
     }
 
     async fn build(
@@ -203,6 +209,19 @@ mod test {
 
     use crate::config::ValidatedSink;
 
+    fn sink_context_with_allowed_users() -> SinkContext {
+        let cx = SinkContext::default();
+        let mut stubs: HashMap<String, Box<dyn vector_lib::enrichment::Table + Send + Sync>> =
+            HashMap::new();
+        stubs.insert(
+            "allowed_users".to_string(),
+            Box::new(crate::validate::StubEnrichmentTable)
+                as Box<dyn vector_lib::enrichment::Table + Send + Sync>,
+        );
+        cx.enrichment_tables.load(stubs);
+        cx
+    }
+
     #[test]
     fn generate_config() {
         crate::test_util::test_generate_config::<WebSocketListenerSinkConfig>();
@@ -228,12 +247,14 @@ mod test {
         let config = WebSocketListenerSinkConfig {
             address: "0.0.0.0:8080".parse().unwrap(),
             auth: Some(HttpServerAuthConfig::Custom {
-                source: "invalid VRL source".to_string(),
+                source: "\"unterminated".to_string(),
             }),
             ..Default::default()
         };
         assert!(
-            config.validate().is_err(),
+            config
+                .validate_with_context(&SinkContext::default())
+                .is_err(),
             "an invalid custom auth VRL source must fail validation"
         );
     }
@@ -251,8 +272,33 @@ mod test {
             ..Default::default()
         };
         assert!(
-            config.validate().is_ok(),
+            config
+                .validate_with_context(&SinkContext::default())
+                .is_ok(),
             "a valid custom auth VRL source must pass validation"
+        );
+    }
+
+    #[test]
+    fn validate_succeeds_on_custom_auth_with_enrichment() {
+        // Custom-auth VRL is compiled against the configured enrichment tables
+        // (stubbed during validation); a program referencing a configured table
+        // must pass without loading actual data.
+        let config = WebSocketListenerSinkConfig {
+            address: "0.0.0.0:8080".parse().unwrap(),
+            auth: Some(HttpServerAuthConfig::Custom {
+                source: indoc! {r#"
+                    get_enrichment_table_record!("allowed_users", { "user": .headers.authorization }) != null
+                    "#}
+                .to_string(),
+            }),
+            ..Default::default()
+        };
+        assert!(
+            config
+                .validate_with_context(&sink_context_with_allowed_users())
+                .is_ok(),
+            "custom auth using enrichment tables must pass validation"
         );
     }
 }

--- a/src/sinks/websocket_server/config.rs
+++ b/src/sinks/websocket_server/config.rs
@@ -4,11 +4,13 @@ use vector_lib::{codecs::JsonSerializerConfig, configurable::configurable_compon
 
 use super::{buffering::MessageBufferingConfig, sink::WebSocketListenerSink};
 use crate::{
-    codecs::EncodingConfig,
+    codecs::{EncodingConfig, Transformer},
     common::http::server_auth::HttpServerAuthConfig,
-    config::{AcknowledgementsConfig, Input, SinkConfig, SinkContext},
+    config::{
+        AcknowledgementsConfig, DynValidatedSink, Input, SinkConfig, SinkContext, ValidatedSink,
+    },
     sinks::{Healthcheck, VectorSink},
-    tls::TlsEnableableConfig,
+    tls::{MaybeTlsSettings, TlsEnableableConfig},
 };
 
 /// Configuration for the `websocket_server` sink.
@@ -144,21 +146,50 @@ impl Default for WebSocketListenerSinkConfig {
 #[async_trait::async_trait]
 #[typetag::serde(name = "websocket_server")]
 impl SinkConfig for WebSocketListenerSinkConfig {
-    async fn build(&self, cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
-        let ws_sink = WebSocketListenerSink::new(self.clone(), cx)?;
-
-        Ok((
-            VectorSink::from_event_streamsink(ws_sink),
-            Box::pin(async move { Ok(()) }),
-        ))
-    }
-
     fn input(&self) -> Input {
         Input::new(self.encoding.config().input_type())
     }
 
     fn acknowledgements(&self) -> &AcknowledgementsConfig {
         &self.acknowledgements
+    }
+
+    fn as_dyn_validated(&self) -> Option<&dyn DynValidatedSink> {
+        Some(self)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ValidatedWebSocketListenerSink {
+    pub(super) transformer: Transformer,
+}
+
+#[async_trait::async_trait]
+impl ValidatedSink for WebSocketListenerSinkConfig {
+    type Validated = ValidatedWebSocketListenerSink;
+
+    fn validate(&self) -> crate::Result<ValidatedWebSocketListenerSink> {
+        let transformer = self.encoding.transformer();
+        if let Some(auth) = &self.auth {
+            auth.validate()?;
+        }
+        Ok(ValidatedWebSocketListenerSink { transformer })
+    }
+
+    async fn build(
+        &self,
+        validated: &ValidatedWebSocketListenerSink,
+        cx: SinkContext,
+    ) -> crate::Result<(VectorSink, Healthcheck)> {
+        // TLS settings may read certificate files from disk, so they are
+        // resolved at build time rather than during pure validation.
+        let tls = MaybeTlsSettings::from_config(self.tls.as_ref(), true)?;
+        let ws_sink = WebSocketListenerSink::from_validated(self.clone(), validated, tls, cx)?;
+
+        Ok((
+            VectorSink::from_event_streamsink(ws_sink),
+            Box::pin(async move { Ok(()) }),
+        ))
     }
 }
 
@@ -167,9 +198,61 @@ impl_generate_config_from_default!(WebSocketListenerSinkConfig);
 #[cfg(test)]
 mod test {
     use super::*;
+    use indoc::indoc;
+    use vector_lib::codecs::encoding::SerializerConfig;
+
+    use crate::config::ValidatedSink;
 
     #[test]
     fn generate_config() {
         crate::test_util::test_generate_config::<WebSocketListenerSinkConfig>();
+    }
+
+    #[test]
+    fn validate_produces_usable_state() {
+        let config = WebSocketListenerSinkConfig {
+            address: "0.0.0.0:8080".parse().unwrap(),
+            ..Default::default()
+        };
+        let _validated = config.validate().expect("validation should succeed");
+        // Serializer construction is deferred to `build`; validation retains the
+        // transformer so `build` can construct the serializer.
+        assert!(matches!(
+            config.encoding.config(),
+            SerializerConfig::Json(_)
+        ));
+    }
+
+    #[test]
+    fn validate_fails_on_invalid_custom_auth_source() {
+        let config = WebSocketListenerSinkConfig {
+            address: "0.0.0.0:8080".parse().unwrap(),
+            auth: Some(HttpServerAuthConfig::Custom {
+                source: "invalid VRL source".to_string(),
+            }),
+            ..Default::default()
+        };
+        assert!(
+            config.validate().is_err(),
+            "an invalid custom auth VRL source must fail validation"
+        );
+    }
+
+    #[test]
+    fn validate_succeeds_on_valid_custom_auth_source() {
+        let config = WebSocketListenerSinkConfig {
+            address: "0.0.0.0:8080".parse().unwrap(),
+            auth: Some(HttpServerAuthConfig::Custom {
+                source: indoc! {r#"
+                    .headers.authorization == "Basic test"
+                    "#}
+                .to_string(),
+            }),
+            ..Default::default()
+        };
+        assert!(
+            config.validate().is_ok(),
+            "a valid custom auth VRL source must pass validation"
+        );
     }
 }

--- a/src/sinks/websocket_server/sink.rs
+++ b/src/sinks/websocket_server/sink.rs
@@ -7,7 +7,7 @@ use std::{
 use super::{
     WebSocketListenerSinkConfig,
     buffering::MessageBufferingConfig,
-    config::{ExtraMetricTagsConfig, SubProtocolConfig},
+    config::{ExtraMetricTagsConfig, SubProtocolConfig, ValidatedWebSocketListenerSink},
 };
 use crate::{
     codecs::{Encoder, Transformer},
@@ -22,6 +22,9 @@ use crate::{
         websocket_server::buffering::{BufferReplayRequest, WsMessageBufferConfig},
     },
 };
+
+#[cfg(test)]
+use crate::config::ValidatedSink;
 use async_trait::async_trait;
 use bytes::BytesMut;
 use futures::{
@@ -62,20 +65,33 @@ pub struct WebSocketListenerSink {
 }
 
 impl WebSocketListenerSink {
+    #[cfg(test)]
     pub fn new(config: WebSocketListenerSinkConfig, cx: SinkContext) -> crate::Result<Self> {
+        let validated = config.validate()?;
         let tls = MaybeTlsSettings::from_config(config.tls.as_ref(), true)?;
-        let transformer = config.encoding.transformer();
-        let serializer = config.encoding.build()?;
-        let encoder = Encoder::<()>::new(serializer);
+        Self::from_validated(config, &validated, tls, cx)
+    }
+
+    /// Constructs the sink from the validated state, performing only the
+    /// context-dependent work: building the auth matcher from the enrichment
+    /// tables / metrics storage.
+    pub(crate) fn from_validated(
+        config: WebSocketListenerSinkConfig,
+        validated: &ValidatedWebSocketListenerSink,
+        tls: MaybeTlsSettings,
+        cx: SinkContext,
+    ) -> crate::Result<Self> {
         let auth = config
             .auth
             .map(|config| config.build(&cx.enrichment_tables, &cx.metrics_storage))
             .transpose()?;
+        let serializer = config.encoding.build()?;
+        let encoder = Encoder::<()>::new(serializer);
 
         Ok(Self {
             tls,
             address: config.address,
-            transformer,
+            transformer: validated.transformer.clone(),
             encoder,
             auth,
             extra_tags_config: config.internal_metrics.extra_tags,

--- a/src/sources/websocket/config.rs
+++ b/src/sources/websocket/config.rs
@@ -158,8 +158,14 @@ impl SourceConfig for WebSocketConfig {
     async fn build(&self, cx: SourceContext) -> crate::Result<Source> {
         let tls =
             MaybeTlsSettings::from_config(self.common.tls.as_ref(), false).context(ConnectSnafu)?;
-        let connector =
-            WebSocketConnector::new(self.common.uri.clone(), tls, self.common.auth.clone())?;
+        let (host, port) = WebSocketConnector::parse_uri(&self.common.uri)?;
+        let connector = WebSocketConnector::from_validated(
+            self.common.uri.clone(),
+            host,
+            port,
+            tls,
+            self.common.auth.clone(),
+        );
 
         let log_namespace = cx.log_namespace(self.log_namespace);
         let decoder =

--- a/src/sources/websocket/config.rs
+++ b/src/sources/websocket/config.rs
@@ -158,14 +158,8 @@ impl SourceConfig for WebSocketConfig {
     async fn build(&self, cx: SourceContext) -> crate::Result<Source> {
         let tls =
             MaybeTlsSettings::from_config(self.common.tls.as_ref(), false).context(ConnectSnafu)?;
-        let (host, port) = WebSocketConnector::parse_uri(&self.common.uri)?;
-        let connector = WebSocketConnector::from_validated(
-            self.common.uri.clone(),
-            host,
-            port,
-            tls,
-            self.common.auth.clone(),
-        );
+        let uri = WebSocketConnector::parse_uri(&self.common.uri)?;
+        let connector = WebSocketConnector::from_validated(uri, tls, self.common.auth.clone());
 
         let log_namespace = cx.log_namespace(self.log_namespace);
         let decoder =

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -10,7 +10,9 @@ use vector_vrl_metrics::MetricsStorage;
 use vrl::value::ObjectMap;
 
 use crate::{
-    config::{self, Config, ConfigDiff, TransformContext, loading::ConfigBuilderLoader},
+    config::{
+        self, Config, ConfigDiff, SinkContext, TransformContext, loading::ConfigBuilderLoader,
+    },
     schema::Definition,
     topology::{
         self,
@@ -18,10 +20,10 @@ use crate::{
     },
 };
 
-/// Stub enrichment table used during transform validation so VRL can resolve
+/// Stub enrichment table used during config validation so VRL can resolve
 /// table name references without loading actual table data.
 #[derive(Clone)]
-struct StubEnrichmentTable;
+pub(crate) struct StubEnrichmentTable;
 
 impl vector_lib::enrichment::Table for StubEnrichmentTable {
     fn find_table_row<'a>(
@@ -168,6 +170,7 @@ pub async fn validate(opts: &Opts, color: bool) -> ExitCode {
     };
 
     validated &= validate_transforms(&config, &mut fmt).await;
+    validated &= validate_sinks_with_context(&config, &mut fmt);
 
     if !opts.no_environment {
         if let Some(tmp_directory) = create_tmp_directory(&mut config, &mut fmt) {
@@ -231,11 +234,12 @@ pub fn validate_config(opts: &Opts, fmt: &mut Formatter) -> Option<Config> {
     Some(config)
 }
 
-async fn validate_transforms(config: &Config, fmt: &mut Formatter) -> bool {
+/// Builds a `TableRegistry` with stub tables for the configured enrichment tables,
+/// so VRL can resolve table names without loading actual data. This lets config
+/// validation catch real VRL errors (syntax, type, wrong table name) while
+/// deferring data-loading to the environment phase.
+fn stub_enrichment_tables(config: &Config) -> TableRegistry {
     let enrichment_tables = TableRegistry::default();
-    // Register stub tables so VRL can resolve configured enrichment table names
-    // without loading actual data. This lets us catch real VRL errors (syntax,
-    // type, wrong table name) while deferring data-loading to the environment phase.
     let stubs: HashMap<String, Box<dyn vector_lib::enrichment::Table + Send + Sync>> = config
         .enrichment_tables
         .keys()
@@ -253,6 +257,11 @@ async fn validate_transforms(config: &Config, fmt: &mut Formatter) -> bool {
         // VRL compilation) both operate on the loading stage. finish_load()
         // would move tables to the ArcSwap and make table_ids() return nothing.
     }
+    enrichment_tables
+}
+
+async fn validate_transforms(config: &Config, fmt: &mut Formatter) -> bool {
+    let enrichment_tables = stub_enrichment_tables(config);
     let mut definition_cache = HashMap::new();
     let mut errors = Vec::new();
 
@@ -297,6 +306,31 @@ async fn validate_transforms(config: &Config, fmt: &mut Formatter) -> bool {
         true
     } else {
         fmt.title("Transform errors");
+        fmt.sub_error(errors);
+        false
+    }
+}
+
+fn validate_sinks_with_context(config: &Config, fmt: &mut Formatter) -> bool {
+    let cx = SinkContext {
+        enrichment_tables: stub_enrichment_tables(config),
+        ..Default::default()
+    };
+    let mut errors = Vec::new();
+
+    for (key, sink) in config.sinks() {
+        if let Some(dyn_sink) = sink.inner.as_dyn_validated()
+            && let Err(error) = dyn_sink.validate_with_context_dyn(&cx)
+        {
+            errors.push(format!("Sink \"{key}\": {error}"));
+        }
+    }
+
+    if errors.is_empty() {
+        fmt.success("Sinks configuration");
+        true
+    } else {
+        fmt.title("Sink errors");
         fmt.sub_error(errors);
         false
     }


### PR DESCRIPTION
## Summary
Migrates the `websocket` and `websocket_server` sinks to the validated sink lifecycle, so `vector validate --no-environment` catches pure configuration errors (URI parsing, batch settings) at config-compile time instead of at startup.

Custom-auth VRL for `websocket_server` is validated at the config-validation layer via a new defaulted `ValidatedSink::validate_with_context(&SinkContext)`, compiling the program against the configured enrichment tables (stubbed during validation). This catches VRL syntax/type errors while letting programs reference `get_enrichment_table_record!` without loading actual table data.

This is an intermediate PR split from #26048; the changelog for the overall effort is carried by #26048.

### References
- Related: #26211
- Related: #26213
- Related: #26048

## Vector configuration
NA

## How did you test this PR?
`make check-clippy FEATURES="sinks-websocket sinks-websocket-server sources-websocket"` and `make test FEATURES="sinks-websocket sinks-websocket-server" SCOPE="sinks::websocket"`.

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.