### PR TITLE
fix(nats source): defer JetStream acks until delivery

### DIFF
--- a/changelog.d/nats_jetstream_end_to_end_acknowledgements.fix.md
+++ b/changelog.d/nats_jetstream_end_to_end_acknowledgements.fix.md
@@ -1,0 +1,7 @@
+Fix the `nats` source's JetStream mode to acknowledge messages only after all connected sinks
+confirm delivery when end-to-end acknowledgements are enabled. Failed deliveries are negatively
+acknowledged for redelivery. Core NATS behavior is unchanged.
+JetStream consumers must use the `explicit` acknowledgement policy when end-to-end
+acknowledgements are enabled.
+
+authors: horjulf

--- a/src/sources/nats/config.rs
+++ b/src/sources/nats/config.rs
@@ -1,11 +1,11 @@
 use async_nats::jetstream::{
-    consumer::{PullConsumer, StreamError as ConsumerStreamError},
+    consumer::{AckPolicy, PullConsumer, StreamError as ConsumerStreamError},
     context::GetStreamError,
 };
 use snafu::{ResultExt, Snafu};
 use vector_lib::{
     codecs::decoding::{DeserializerConfig, FramingConfig},
-    config::{LegacyKey, LogNamespace},
+    config::{LegacyKey, LogNamespace, SourceAcknowledgementsConfig},
     configurable::configurable_component,
     lookup::{lookup_v2::OptionalValuePath, owned_value_path},
 };
@@ -38,6 +38,10 @@ pub enum BuildError {
     Consumer { source: async_nats::Error },
     #[snafu(display("Failed to retrieve messages from NATS consumer: {}", source))]
     Messages { source: ConsumerStreamError },
+    #[snafu(display(
+        "NATS consumer uses {policy:?} acknowledgement policy; end-to-end acknowledgements require Explicit"
+    ))]
+    ConsumerAckPolicy { policy: AckPolicy },
 }
 
 /// Batch settings for a JetStream pull consumer.
@@ -84,6 +88,10 @@ pub struct JetStreamConfig {
     /// The name of the stream to bind to.
     pub stream: String,
     /// The name of the durable consumer to pull from.
+    ///
+    /// When end-to-end acknowledgements are enabled, this consumer must use the `explicit`
+    /// acknowledgement policy. Messages remain unacknowledged until all connected sinks confirm
+    /// delivery and can be redelivered after the consumer's acknowledgement wait expires.
     pub consumer: String,
 
     #[serde(default)]
@@ -204,6 +212,8 @@ impl SourceConfig for NatsSourceConfig {
 
         match self.mode() {
             NatsMode::JetStream(js_config) => {
+                let acknowledgements =
+                    cx.do_acknowledgements(SourceAcknowledgementsConfig::DEFAULT);
                 let connection = self.connect().await?;
                 let js = async_nats::jetstream::new(connection.clone());
                 let stream = js
@@ -214,6 +224,11 @@ impl SourceConfig for NatsSourceConfig {
                     .get_consumer(&js_config.consumer)
                     .await
                     .context(ConsumerSnafu)?;
+
+                let ack_policy = consumer.cached_info().config.ack_policy;
+                if acknowledgements && ack_policy != AckPolicy::Explicit {
+                    return Err(BuildError::ConsumerAckPolicy { policy: ack_policy }.into());
+                }
 
                 let batch_config = js_config.batch_config.clone();
 
@@ -233,6 +248,7 @@ impl SourceConfig for NatsSourceConfig {
                     log_namespace,
                     cx.shutdown,
                     cx.out,
+                    acknowledgements,
                 )))
             }
             NatsMode::Core => {
@@ -276,9 +292,8 @@ impl SourceConfig for NatsSourceConfig {
         )]
     }
 
-    // Acknowledgment is only possible with Jetstream.
     fn can_acknowledge(&self) -> bool {
-        true
+        self.jetstream.is_some()
     }
 }
 
@@ -340,6 +355,15 @@ mod tests {
     #[test]
     fn generate_config() {
         crate::test_util::test_generate_config::<NatsSourceConfig>();
+    }
+
+    #[test]
+    fn only_jetstream_can_acknowledge() {
+        let mut config = NatsSourceConfig::default();
+        assert!(!config.can_acknowledge());
+
+        config.jetstream = Some(JetStreamConfig::default());
+        assert!(config.can_acknowledge());
     }
 
     #[test]

--- a/src/sources/nats/integration_tests.rs
+++ b/src/sources/nats/integration_tests.rs
@@ -1,12 +1,14 @@
 #![allow(clippy::print_stdout)]
 use async_nats::jetstream::stream::StorageType;
 use bytes::Bytes;
+use futures::StreamExt;
 use vector_lib::config::log_schema;
 
 use crate::{
     SourceSender,
     codecs::DecodingConfig,
     config::{LogNamespace, SourceConfig, SourceContext},
+    event::EventStatus,
     nats::{
         NatsAuthConfig, NatsAuthCredentialsFile, NatsAuthNKey, NatsAuthToken, NatsAuthUserPassword,
     },
@@ -19,7 +21,7 @@ use crate::{
     test_util::{
         collect_n,
         components::{SOURCE_TAGS, assert_source_compliance},
-        random_string,
+        random_string, wait_for,
     },
     tls::{TlsConfig, TlsEnableableConfig},
 };
@@ -450,6 +452,125 @@ async fn nats_jetstream_valid() {
 
     let result = run_jetstream_test(conf).await;
     assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn nats_jetstream_waits_for_downstream_acknowledgement() {
+    let subject = format!("test-js-ack-{}", random_string(10));
+    let url = std::env::var("NATS_JETSTREAM_ADDRESS")
+        .unwrap_or_else(|_| "nats://localhost:4222".to_string());
+    let stream_name = format!("S_{}", subject.replace('.', "_"));
+    let consumer_name = format!("C_{}", subject.replace('.', "_"));
+
+    let client = async_nats::connect(&url).await.unwrap();
+    let js = async_nats::jetstream::new(client);
+    let stream = js
+        .get_or_create_stream(async_nats::jetstream::stream::Config {
+            name: stream_name.clone(),
+            subjects: vec![subject.clone()],
+            storage: StorageType::Memory,
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    let consumer = stream
+        .create_consumer(async_nats::jetstream::consumer::pull::Config {
+            durable_name: Some(consumer_name.clone()),
+            ack_policy: async_nats::jetstream::consumer::AckPolicy::Explicit,
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+
+    js.publish(subject.clone(), Bytes::from_static(b"ack me"))
+        .await
+        .unwrap()
+        .await
+        .unwrap();
+
+    let mut conf = generate_source_config(&url, &subject);
+    conf.jetstream = Some(JetStreamConfig {
+        stream: stream_name,
+        consumer: consumer_name,
+        ..Default::default()
+    });
+
+    let (tx, mut rx) = SourceSender::new_test();
+    let mut cx = SourceContext::new_test(tx, None);
+    cx.acknowledgements = true;
+    let source = conf.build(cx).await.unwrap();
+    let source_handle = tokio::spawn(source);
+
+    let rejected = rx.next().await.unwrap();
+    assert_eq!(consumer.get_info().await.unwrap().num_ack_pending, 1);
+
+    rejected.metadata().update_status(EventStatus::Rejected);
+    drop(rejected);
+
+    let delivered = rx.next().await.unwrap();
+    delivered.metadata().update_status(EventStatus::Delivered);
+    drop(delivered);
+
+    wait_for({
+        let consumer = consumer.clone();
+        move || {
+            let consumer = consumer.clone();
+            async move { consumer.get_info().await.unwrap().num_ack_pending == 0 }
+        }
+    })
+    .await;
+
+    source_handle.abort();
+}
+
+#[tokio::test]
+async fn nats_jetstream_end_to_end_acknowledgements_require_explicit_policy() {
+    let subject = format!("test-js-ack-policy-{}", random_string(10));
+    let url = std::env::var("NATS_JETSTREAM_ADDRESS")
+        .unwrap_or_else(|_| "nats://localhost:4222".to_string());
+    let stream_name = format!("S_{}", subject.replace('.', "_"));
+    let consumer_name = format!("C_{}", subject.replace('.', "_"));
+
+    let client = async_nats::connect(&url).await.unwrap();
+    let js = async_nats::jetstream::new(client);
+    let stream = js
+        .get_or_create_stream(async_nats::jetstream::stream::Config {
+            name: stream_name.clone(),
+            subjects: vec![subject.clone()],
+            storage: StorageType::Memory,
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+    stream
+        .create_consumer(async_nats::jetstream::consumer::pull::Config {
+            durable_name: Some(consumer_name.clone()),
+            ack_policy: async_nats::jetstream::consumer::AckPolicy::All,
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+
+    let mut conf = generate_source_config(&url, &subject);
+    conf.jetstream = Some(JetStreamConfig {
+        stream: stream_name,
+        consumer: consumer_name,
+        ..Default::default()
+    });
+
+    let (tx, _rx) = SourceSender::new_test();
+    let mut cx = SourceContext::new_test(tx, None);
+    cx.acknowledgements = true;
+    let error = match conf.build(cx).await {
+        Ok(_) => panic!("expected an invalid consumer acknowledgement policy"),
+        Err(error) => error,
+    };
+    assert!(matches!(
+        error.downcast_ref::<BuildError>(),
+        Some(BuildError::ConsumerAckPolicy {
+            policy: async_nats::jetstream::consumer::AckPolicy::All
+        })
+    ));
 }
 
 #[tokio::test]

--- a/src/sources/nats/source.rs
+++ b/src/sources/nats/source.rs
@@ -1,4 +1,9 @@
-use async_nats::jetstream::consumer::pull::Stream as PullConsumerStream;
+use std::fmt;
+
+use async_nats::jetstream::{
+    consumer::pull::Stream as PullConsumerStream,
+    message::{AckKind, Acker},
+};
 use chrono::Utc;
 use futures::StreamExt;
 use snafu::ResultExt;
@@ -6,6 +11,8 @@ use vector_lib::{
     EstimatedJsonEncodedSizeOf,
     codecs::{DecoderFramedRead, decoding::StreamDecodingError},
     config::{LegacyKey, LogNamespace},
+    finalization::BatchStatus,
+    finalizer::UnorderedFinalizer,
     internal_event::{
         ByteSize, BytesReceived, CountByteSize, EventsReceived, EventsReceivedHandle,
         InternalEventHandle as _, Protocol,
@@ -16,11 +23,19 @@ use vector_lib::{
 use crate::{
     SourceSender,
     codecs::Decoder,
-    event::Event,
+    event::{BatchNotifier, Event},
     internal_events::StreamClosedError,
     shutdown::ShutdownSignal,
     sources::nats::config::{BuildError, NatsSourceConfig, SubscribeSnafu},
 };
+
+struct FinalizerEntry(Acker);
+
+impl fmt::Debug for FinalizerEntry {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.debug_struct("FinalizerEntry").finish()
+    }
+}
 
 /// The outcome of processing a single NATS message.
 pub enum ProcessingStatus {
@@ -42,6 +57,7 @@ pub async fn process_message(
     log_namespace: LogNamespace,
     out: &mut SourceSender,
     events_received: &EventsReceivedHandle,
+    batch: &Option<BatchNotifier>,
 ) -> ProcessingStatus {
     let mut framed = DecoderFramedRead::new(msg.payload.as_ref(), decoder.clone());
     let mut success = true;
@@ -77,7 +93,7 @@ pub async fn process_message(
                             msg.subject.as_str(),
                         );
                     }
-                    event
+                    event.with_batch_notifier_option(batch)
                 });
 
                 if out.send_batch(events).await.is_err() {
@@ -103,6 +119,7 @@ pub async fn process_message(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn run_nats_jetstream(
     config: NatsSourceConfig,
     _connection: async_nats::Client,
@@ -111,41 +128,81 @@ pub async fn run_nats_jetstream(
     log_namespace: LogNamespace,
     shutdown: ShutdownSignal,
     mut out: SourceSender,
+    acknowledgements: bool,
 ) -> Result<(), ()> {
+    let (finalizer, mut ack_stream) =
+        UnorderedFinalizer::<FinalizerEntry>::maybe_new(acknowledgements, Some(shutdown.clone()));
     let events_received = register!(EventsReceived);
     let bytes_received = register!(BytesReceived::from(Protocol::TCP));
     let mut message_stream = stream.take_until(shutdown);
 
-    while let Some(Ok(msg)) = message_stream.next().await {
-        bytes_received.emit(ByteSize(msg.payload.len()));
-
-        let status = process_message(
-            &msg,
-            &config,
-            &decoder,
-            log_namespace,
-            &mut out,
-            &events_received,
-        )
-        .await;
-
-        match status {
-            ProcessingStatus::Success => {
-                // Message processed successfully, acknowledge it.
-                if let Err(err) = msg.ack().await {
-                    error!(message = "Failed to acknowledge JetStream message.", %err);
+    loop {
+        tokio::select! {
+            entry = ack_stream.next() => {
+                if let Some((status, entry)) = entry {
+                    handle_ack(status, entry).await;
                 }
-            }
-            ProcessingStatus::Failed => {
-                // Do not acknowledge on failure; the message will be redelivered.
-            }
-            ProcessingStatus::ChannelClosed => {
-                // Downstream channel is closed, shut down the source.
-                return Err(());
-            }
+            },
+            message = message_stream.next() => match message {
+                Some(Ok(msg)) => {
+                    bytes_received.emit(ByteSize(msg.payload.len()));
+                    let (batch, receiver) =
+                        BatchNotifier::maybe_new_with_receiver(acknowledgements);
+
+                    let status = process_message(
+                        &msg,
+                        &config,
+                        &decoder,
+                        log_namespace,
+                        &mut out,
+                        &events_received,
+                        &batch,
+                    )
+                    .await;
+
+                    match status {
+                        ProcessingStatus::Success => match receiver {
+                            Some(receiver) => {
+                                let (_, acker) = msg.split();
+                                finalizer
+                                    .as_ref()
+                                    .expect("Finalizer must exist when acknowledgements are enabled")
+                                    .add(FinalizerEntry(acker), receiver);
+                            }
+                            None => {
+                                if let Err(error) = msg.ack().await {
+                                    error!(message = "Failed to acknowledge JetStream message.", %error);
+                                }
+                            }
+                        },
+                        ProcessingStatus::Failed => {
+                            // Do not acknowledge on failure; the message will be redelivered.
+                        }
+                        ProcessingStatus::ChannelClosed => {
+                            // Downstream channel is closed, shut down the source.
+                            return Err(());
+                        }
+                    }
+                }
+                Some(Err(error)) => {
+                    error!(message = "Failed to read JetStream message.", %error);
+                }
+                None => break,
+            },
         }
     }
     Ok(())
+}
+
+async fn handle_ack(status: BatchStatus, entry: FinalizerEntry) {
+    let result = match status {
+        BatchStatus::Delivered => entry.0.ack().await,
+        BatchStatus::Errored | BatchStatus::Rejected => entry.0.ack_with(AckKind::Nak(None)).await,
+    };
+
+    if let Err(error) = result {
+        error!(message = "Failed to acknowledge JetStream message.", %error);
+    }
 }
 
 pub async fn run_nats_core(
@@ -182,6 +239,7 @@ pub async fn run_nats_core(
                             log_namespace,
                             &mut out,
                             &events_received,
+                            &None,
                         )
                         .await;
 

--- a/website/cue/reference/components/sources/generated/nats.cue
+++ b/website/cue/reference/components/sources/generated/nats.cue
@@ -678,8 +678,14 @@ generated: components: sources: nats: configuration: {
 				}
 			}
 			consumer: {
-				description: "The name of the durable consumer to pull from."
-				required:    true
+				description: """
+					The name of the durable consumer to pull from.
+
+					When end-to-end acknowledgements are enabled, this consumer must use the `explicit`
+					acknowledgement policy. Messages remain unacknowledged until all connected sinks confirm
+					delivery and can be redelivered after the consumer's acknowledgement wait expires.
+					"""
+				required: true
 				type: string: {}
 			}
 			stream: {


### PR DESCRIPTION
## Summary

The JetStream NATS source currently acknowledges a broker message immediately after `send_batch` hands decoded events to the internal topology. That remains ahead of actual sink delivery even when end-to-end acknowledgements are enabled, so a Vector crash can lose an already-ACKed message that was still buffered downstream.

This draft makes JetStream participate in the existing batch-finalizer framework:

- attach one `BatchNotifier` to all events decoded from a NATS message;
- ACK the message only after all connected acknowledgement-enabled sinks report `Delivered`;
- NAK `Errored` or `Rejected` batches so JetStream redelivers them;
- preserve the existing immediate-ACK behavior when end-to-end acknowledgements are disabled;
- advertise acknowledgement support only in JetStream mode; Core NATS remains unchanged.

The source requires an `explicit` JetStream consumer acknowledgement policy when end-to-end acknowledgements are active. An unordered downstream completion paired with cumulative `all` acknowledgements could otherwise acknowledge an earlier failed message.

### References

No existing NATS acknowledgement issue found. Opening this as a draft for design feedback, particularly around NAK pacing and whether periodic progress ACKs should be added for delivery times longer than the consumer `ack_wait`.

## Vector configuration

```yaml
acknowledgements:
  enabled: true

sources:
  queued_logs:
    type: nats
    url: nats://localhost:4222
    subject: logs.vl
    jetstream:
      stream: fleet-logs
      consumer: victorialogs # configured with ack_policy: explicit
    decoding:
      codec: native

sinks:
  output:
    type: console
    inputs: [queued_logs]
    acknowledgements:
      enabled: true
```

## How did you test this PR?

- `make check-clippy` — all workspace targets and features.
- `make test FEATURES=nats-integration-tests SCOPE=nats_jetstream_` against a local NATS JetStream 2.14.5 server — 7/7 tests passed.
- Added a broker-backed test proving a message remains pending until downstream finalization, rejection triggers redelivery, and successful delivery advances the ACK state.
- Added a broker-backed test rejecting cumulative consumer acknowledgement policy when end-to-end acknowledgements are enabled.
- `make check-fmt`.
- `make check-markdown`.
- `make check-changelog-fragments`.
- `make check-generated-docs` — 248 component examples validated.

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [x] Yes. A changelog fragment and generated NATS source documentation are included.
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

AI assistance: OpenAI GPT-5.6 Codex was used to help implement and validate this change. The resulting behavior was verified against the source acknowledgement framework and a real JetStream server.