### PR TITLE
feat(postgres sink): validate config at compile time

### DIFF
--- a/src/sinks/postgres/config.rs
+++ b/src/sinks/postgres/config.rs
@@ -121,14 +121,14 @@ fn redact_endpoint(_endpoint: &str) -> String {
     "<redacted endpoint>".to_owned()
 }
 
-/// Validates the PostgreSQL connection string syntax without touching the
-/// network or filesystem.
+/// Validates the PostgreSQL connection string without touching the network or
+/// filesystem.
 ///
-/// `PgConnectOptions::from_str` may read `$PGPASSFILE` or `~/.pgpass` to
-/// resolve a missing password, so it is not invoked here; the options are
-/// constructed in `build` instead.
+/// SQLx applies `.pgpass` when a connection string has no password. An empty
+/// password is appended to the validation-only URL so SQLx validates every
+/// option without reading `$PGPASSFILE` or `~/.pgpass`.
 fn validate_pg_endpoint(endpoint: &str) -> crate::Result<()> {
-    let url = url::Url::parse(endpoint).map_err(|e| {
+    let mut url = url::Url::parse(endpoint).map_err(|e| {
         format!(
             "invalid PostgreSQL connection string `{}`: {e}",
             redact_endpoint(endpoint)
@@ -143,7 +143,8 @@ fn validate_pg_endpoint(endpoint: &str) -> crate::Result<()> {
         )
         .into());
     }
-    Ok(())
+    url.query_pairs_mut().append_pair("password", "");
+    pg_connect_options(url.as_str()).map(|_| ())
 }
 
 /// Parses the PostgreSQL connection string into SQLx connect options.
@@ -168,7 +169,6 @@ impl ValidatedSink for PostgresConfig {
         let batch_settings = self.batch.into_batcher_settings()?;
         let request_settings = self.request.into_settings();
         let endpoint_uri: UriSerde = self.endpoint.parse()?;
-        // Pure syntax check only; see `validate_pg_endpoint`.
         validate_pg_endpoint(&self.endpoint)?;
 
         Ok(ValidatedPostgres {
@@ -263,6 +263,21 @@ mod tests {
         "#})
         .unwrap();
         cfg.validate().expect("valid postgres DSN should validate");
+    }
+
+    #[test]
+    fn validate_rejects_invalid_sqlx_dsn_option() {
+        use crate::config::ValidatedSink;
+
+        let cfg = serde_yaml::from_str::<PostgresConfig>(indoc::indoc! {r#"
+            endpoint: "postgres://user:password@localhost/default?sslmode=bogus"
+            table: "mytable"
+        "#})
+        .unwrap();
+        assert!(
+            cfg.validate().is_err(),
+            "invalid SQLx DSN option should not validate"
+        );
     }
 
     #[test]

--- a/src/sinks/postgres/config.rs
+++ b/src/sinks/postgres/config.rs
@@ -1,10 +1,16 @@
+use std::str::FromStr;
+
 use futures::FutureExt;
-use sqlx::{Pool, Postgres, postgres::PgPoolOptions};
+use sqlx::{
+    Pool, Postgres,
+    postgres::{PgConnectOptions, PgPoolOptions},
+};
 use tower::ServiceBuilder;
 use vector_lib::{
     config::AcknowledgementsConfig,
     configurable::{component::GenerateConfig, configurable_component},
     sink::VectorSink,
+    stream::BatcherSettings,
 };
 
 use super::{
@@ -12,12 +18,12 @@ use super::{
     sink::PostgresSink,
 };
 use crate::{
-    config::{Input, SinkConfig, SinkContext},
+    config::{DynValidatedSink, Input, SinkConfig, SinkContext, ValidatedSink},
     sinks::{
         Healthcheck,
         util::{
             BatchConfig, RealtimeSizeBasedDefaultBatchSettings, ServiceBuilderExt,
-            TowerRequestConfig, UriSerde,
+            TowerRequestConfig, TowerRequestSettings, UriSerde,
         },
     },
 };
@@ -88,17 +94,117 @@ impl GenerateConfig for PostgresConfig {
 #[async_trait::async_trait]
 #[typetag::serde(name = "postgres")]
 impl SinkConfig for PostgresConfig {
-    async fn build(&self, _cx: SinkContext) -> crate::Result<(VectorSink, Healthcheck)> {
+    fn input(&self) -> Input {
+        Input::all()
+    }
+
+    fn acknowledgements(&self) -> &AcknowledgementsConfig {
+        &self.acknowledgements
+    }
+
+    fn as_dyn_validated(&self) -> Option<&dyn DynValidatedSink> {
+        Some(self)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ValidatedPostgres {
+    batch_settings: BatcherSettings,
+    request_settings: TowerRequestSettings,
+    endpoint_uri: UriSerde,
+}
+
+/// Redacts credentials from a PostgreSQL connection string for error messages.
+///
+/// SQLx accepts credentials embedded in the DSN (`postgres://user:secret@host/db`),
+/// and these must not be echoed back into validation output or CI logs.
+fn redact_endpoint(endpoint: &str) -> String {
+    if endpoint.contains('@') {
+        "<redacted endpoint>".to_owned()
+    } else {
+        endpoint.to_owned()
+    }
+}
+
+/// Validates the PostgreSQL connection string syntax without touching the
+/// network or filesystem.
+///
+/// `PgConnectOptions::from_str` may read `$PGPASSFILE` or `~/.pgpass` to
+/// resolve a missing password, so it is not invoked here; the options are
+/// constructed in `build` instead.
+fn validate_pg_endpoint(endpoint: &str) -> crate::Result<()> {
+    let url = url::Url::parse(endpoint).map_err(|e| {
+        format!(
+            "invalid PostgreSQL connection string `{}`: {e}",
+            redact_endpoint(endpoint)
+        )
+    })?;
+    if !matches!(url.scheme(), "postgres" | "postgresql") {
+        return Err(format!(
+            "invalid PostgreSQL connection string `{}`: expected a \
+             `postgres://` or `postgresql://` URL, got scheme `{}`",
+            redact_endpoint(endpoint),
+            url.scheme()
+        )
+        .into());
+    }
+    Ok(())
+}
+
+/// Parses the PostgreSQL connection string into SQLx connect options.
+///
+/// Unlike [`validate_pg_endpoint`], this may read `$PGPASSFILE` or `~/.pgpass`
+/// to resolve a missing password, so it is only invoked at build time.
+fn pg_connect_options(endpoint: &str) -> crate::Result<PgConnectOptions> {
+    PgConnectOptions::from_str(endpoint).map_err(|e| {
+        format!(
+            "invalid PostgreSQL connection string `{}`: {e}",
+            redact_endpoint(endpoint)
+        )
+        .into()
+    })
+}
+
+#[async_trait::async_trait]
+impl ValidatedSink for PostgresConfig {
+    type Validated = ValidatedPostgres;
+
+    fn validate(&self) -> crate::Result<ValidatedPostgres> {
+        let batch_settings = self.batch.into_batcher_settings()?;
+        let request_settings = self.request.into_settings();
+        let endpoint_uri: UriSerde = self.endpoint.parse()?;
+        // Pure syntax check only; see `validate_pg_endpoint`.
+        validate_pg_endpoint(&self.endpoint)?;
+
+        Ok(ValidatedPostgres {
+            batch_settings,
+            request_settings,
+            endpoint_uri,
+        })
+    }
+
+    async fn build(
+        &self,
+        validated: &ValidatedPostgres,
+        _cx: SinkContext,
+    ) -> crate::Result<(VectorSink, Healthcheck)> {
+        let ValidatedPostgres {
+            batch_settings,
+            request_settings,
+            endpoint_uri,
+        } = validated.clone();
+
+        // `PgConnectOptions::from_str` may read `$PGPASSFILE` or `~/.pgpass`
+        // to resolve a missing password, so it runs here rather than in
+        // `validate`.
+        let pg_connect_options = pg_connect_options(&self.endpoint)?;
+
         let connection_pool = PgPoolOptions::new()
             .max_connections(self.pool_size)
-            .connect_lazy(&self.endpoint)?;
+            .connect_lazy_with(pg_connect_options);
 
         let healthcheck = healthcheck(connection_pool.clone()).boxed();
 
-        let batch_settings = self.batch.into_batcher_settings()?;
-        let request_settings = self.request.into_settings();
-
-        let endpoint_uri: UriSerde = self.endpoint.parse()?;
         let service = PostgresService::new(
             connection_pool,
             self.table.clone(),
@@ -111,14 +217,6 @@ impl SinkConfig for PostgresConfig {
         let sink = PostgresSink::new(service, batch_settings);
 
         Ok((VectorSink::from_event_streamsink(sink), healthcheck))
-    }
-
-    fn input(&self) -> Input {
-        Input::all()
-    }
-
-    fn acknowledgements(&self) -> &AcknowledgementsConfig {
-        &self.acknowledgements
     }
 }
 
@@ -145,5 +243,92 @@ mod tests {
         .unwrap();
         assert_eq!(cfg.endpoint, "postgres://user:password@localhost/default");
         assert_eq!(cfg.table, "mytable");
+    }
+
+    #[test]
+    fn validate_produces_usable_values() {
+        use crate::config::ValidatedSink;
+
+        let cfg = serde_yaml::from_str::<PostgresConfig>(indoc::indoc! {r#"
+            endpoint: "postgres://user:password@localhost/default"
+            table: "mytable"
+        "#})
+        .unwrap();
+        let validated = cfg.validate().expect("validation should succeed");
+        // The parsed endpoint URI redacts the password in its Display output.
+        assert_eq!(validated.endpoint_uri.uri.host(), Some("localhost"));
+        assert_eq!(validated.endpoint_uri.uri.path(), "/default");
+    }
+
+    #[test]
+    fn validate_accepts_valid_postgres_dsn() {
+        use crate::config::ValidatedSink;
+
+        let cfg = serde_yaml::from_str::<PostgresConfig>(indoc::indoc! {r#"
+            endpoint: "postgres://user:password@localhost/default"
+            table: "mytable"
+        "#})
+        .unwrap();
+        cfg.validate().expect("valid postgres DSN should validate");
+    }
+
+    #[test]
+    fn validate_rejects_non_postgres_uri() {
+        use crate::config::ValidatedSink;
+
+        let cfg = serde_yaml::from_str::<PostgresConfig>(indoc::indoc! {r#"
+            endpoint: "https://example.com"
+            table: "mytable"
+        "#})
+        .unwrap();
+        let err = cfg
+            .validate()
+            .expect_err("generic URI should not validate as a postgres DSN");
+        assert!(
+            err.to_string()
+                .contains("invalid PostgreSQL connection string"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_rejects_malformed_postgres_dsn() {
+        use crate::config::ValidatedSink;
+
+        let cfg = serde_yaml::from_str::<PostgresConfig>(indoc::indoc! {r#"
+            endpoint: "postgres://user:password@localhost:notaport/default"
+            table: "mytable"
+        "#})
+        .unwrap();
+        assert!(
+            cfg.validate().is_err(),
+            "malformed postgres DSN should not validate"
+        );
+    }
+
+    #[test]
+    fn validate_redacts_credentials_from_errors() {
+        use crate::config::ValidatedSink;
+
+        // A valid URI with credentials but a non-`postgres` scheme parses as a
+        // `UriSerde` and reaches `parse_pg_connect_options`, whose error must
+        // not echo the credentials back into validation output.
+        let cfg = serde_yaml::from_str::<PostgresConfig>(indoc::indoc! {r#"
+            endpoint: "https://user:secret@example.com/db"
+            table: "mytable"
+        "#})
+        .unwrap();
+        let err = cfg
+            .validate()
+            .expect_err("non-postgres URI should not validate as a postgres DSN");
+        let message = err.to_string();
+        assert!(
+            !message.contains("secret"),
+            "credentials must not leak into validation errors: {message}"
+        );
+        assert!(
+            message.contains("<redacted endpoint>"),
+            "unexpected error: {message}"
+        );
     }
 }

--- a/src/sinks/postgres/config.rs
+++ b/src/sinks/postgres/config.rs
@@ -166,6 +166,10 @@ impl ValidatedSink for PostgresConfig {
     type Validated = ValidatedPostgres;
 
     fn validate(&self) -> crate::Result<ValidatedPostgres> {
+        if self.pool_size == 0 {
+            return Err("`pool_size` must be greater than zero".into());
+        }
+
         let batch_settings = self.batch.into_batcher_settings()?;
         let request_settings = self.request.into_settings();
         let endpoint_uri: UriSerde = self.endpoint.parse()?;
@@ -263,6 +267,22 @@ mod tests {
         "#})
         .unwrap();
         cfg.validate().expect("valid postgres DSN should validate");
+    }
+
+    #[test]
+    fn validate_rejects_zero_pool_size() {
+        use crate::config::ValidatedSink;
+
+        let cfg = serde_yaml::from_str::<PostgresConfig>(indoc::indoc! {r#"
+            endpoint: "postgres://user:password@localhost/default"
+            table: "mytable"
+            pool_size: 0
+        "#})
+        .unwrap();
+        assert!(
+            cfg.validate().is_err(),
+            "zero connection pool size should not validate"
+        );
     }
 
     #[test]

--- a/src/sinks/postgres/config.rs
+++ b/src/sinks/postgres/config.rs
@@ -23,7 +23,7 @@ use crate::{
         Healthcheck,
         util::{
             BatchConfig, RealtimeSizeBasedDefaultBatchSettings, ServiceBuilderExt,
-            TowerRequestConfig, TowerRequestSettings, UriSerde,
+            TowerRequestConfig, TowerRequestSettings, UriSerde, uri::redact_unparsed_endpoint,
         },
     },
 };
@@ -114,18 +114,6 @@ pub struct ValidatedPostgres {
     endpoint_uri: UriSerde,
 }
 
-/// Redacts credentials from a PostgreSQL connection string for error messages.
-///
-/// SQLx accepts credentials embedded in the DSN (`postgres://user:secret@host/db`),
-/// and these must not be echoed back into validation output or CI logs.
-fn redact_endpoint(endpoint: &str) -> String {
-    if endpoint.contains('@') {
-        "<redacted endpoint>".to_owned()
-    } else {
-        endpoint.to_owned()
-    }
-}
-
 /// Validates the PostgreSQL connection string syntax without touching the
 /// network or filesystem.
 ///
@@ -136,14 +124,14 @@ fn validate_pg_endpoint(endpoint: &str) -> crate::Result<()> {
     let url = url::Url::parse(endpoint).map_err(|e| {
         format!(
             "invalid PostgreSQL connection string `{}`: {e}",
-            redact_endpoint(endpoint)
+            redact_unparsed_endpoint(endpoint)
         )
     })?;
     if !matches!(url.scheme(), "postgres" | "postgresql") {
         return Err(format!(
             "invalid PostgreSQL connection string `{}`: expected a \
              `postgres://` or `postgresql://` URL, got scheme `{}`",
-            redact_endpoint(endpoint),
+            redact_unparsed_endpoint(endpoint),
             url.scheme()
         )
         .into());
@@ -159,7 +147,7 @@ fn pg_connect_options(endpoint: &str) -> crate::Result<PgConnectOptions> {
     PgConnectOptions::from_str(endpoint).map_err(|e| {
         format!(
             "invalid PostgreSQL connection string `{}`: {e}",
-            redact_endpoint(endpoint)
+            redact_unparsed_endpoint(endpoint)
         )
         .into()
     })
@@ -315,6 +303,31 @@ mod tests {
         // not echo the credentials back into validation output.
         let cfg = serde_yaml::from_str::<PostgresConfig>(indoc::indoc! {r#"
             endpoint: "https://user:secret@example.com/db"
+            table: "mytable"
+        "#})
+        .unwrap();
+        let err = cfg
+            .validate()
+            .expect_err("non-postgres URI should not validate as a postgres DSN");
+        let message = err.to_string();
+        assert!(
+            !message.contains("secret"),
+            "credentials must not leak into validation errors: {message}"
+        );
+        assert!(
+            message.contains("<redacted endpoint>"),
+            "unexpected error: {message}"
+        );
+    }
+
+    #[test]
+    fn validate_redacts_password_query_param_from_errors() {
+        use crate::config::ValidatedSink;
+
+        // SQLx also accepts the password as a `password` query parameter; a
+        // DSN carrying one must not echo it into validation errors.
+        let cfg = serde_yaml::from_str::<PostgresConfig>(indoc::indoc! {r#"
+            endpoint: "https://example.com/db?password=secret"
             table: "mytable"
         "#})
         .unwrap();

--- a/src/sinks/postgres/config.rs
+++ b/src/sinks/postgres/config.rs
@@ -23,7 +23,7 @@ use crate::{
         Healthcheck,
         util::{
             BatchConfig, RealtimeSizeBasedDefaultBatchSettings, ServiceBuilderExt,
-            TowerRequestConfig, TowerRequestSettings, UriSerde, uri::redact_unparsed_endpoint,
+            TowerRequestConfig, TowerRequestSettings, UriSerde, uri::protocol_endpoint,
         },
     },
 };
@@ -114,6 +114,13 @@ pub struct ValidatedPostgres {
     endpoint_uri: UriSerde,
 }
 
+/// PostgreSQL endpoints may carry credentials as userinfo or as a `password`
+/// query parameter (SQLx percent-decodes query keys), so they are always
+/// redacted from error messages.
+fn redact_endpoint(_endpoint: &str) -> String {
+    "<redacted endpoint>".to_owned()
+}
+
 /// Validates the PostgreSQL connection string syntax without touching the
 /// network or filesystem.
 ///
@@ -124,14 +131,14 @@ fn validate_pg_endpoint(endpoint: &str) -> crate::Result<()> {
     let url = url::Url::parse(endpoint).map_err(|e| {
         format!(
             "invalid PostgreSQL connection string `{}`: {e}",
-            redact_unparsed_endpoint(endpoint)
+            redact_endpoint(endpoint)
         )
     })?;
     if !matches!(url.scheme(), "postgres" | "postgresql") {
         return Err(format!(
             "invalid PostgreSQL connection string `{}`: expected a \
              `postgres://` or `postgresql://` URL, got scheme `{}`",
-            redact_unparsed_endpoint(endpoint),
+            redact_endpoint(endpoint),
             url.scheme()
         )
         .into());
@@ -147,7 +154,7 @@ fn pg_connect_options(endpoint: &str) -> crate::Result<PgConnectOptions> {
     PgConnectOptions::from_str(endpoint).map_err(|e| {
         format!(
             "invalid PostgreSQL connection string `{}`: {e}",
-            redact_unparsed_endpoint(endpoint)
+            redact_endpoint(endpoint)
         )
         .into()
     })
@@ -193,11 +200,9 @@ impl ValidatedSink for PostgresConfig {
 
         let healthcheck = healthcheck(connection_pool.clone()).boxed();
 
-        let service = PostgresService::new(
-            connection_pool,
-            self.table.clone(),
-            endpoint_uri.to_string(),
-        );
+        // The endpoint label must not carry credentials or query parameters.
+        let endpoint = protocol_endpoint(endpoint_uri.uri.clone()).1;
+        let service = PostgresService::new(connection_pool, self.table.clone(), endpoint);
         let service = ServiceBuilder::new()
             .settings(request_settings, PostgresRetryLogic)
             .service(service);

--- a/src/sinks/util/uri.rs
+++ b/src/sinks/util/uri.rs
@@ -285,12 +285,13 @@ pub(crate) fn redact_unparsed_endpoint(endpoint: &str) -> String {
 }
 
 /// Returns `true` if the query portion of `endpoint` contains a `password`
-/// parameter (for example `postgres://host/db?password=secret`).
+/// parameter (for example `postgres://host/db?password=secret`). Query keys
+/// are percent-decoded, matching how SQLx parses them.
 fn has_password_query_param(endpoint: &str) -> bool {
     endpoint.split_once('?').is_some_and(|(_, query)| {
         query.split('&').any(|pair| {
             pair.split_once('=')
-                .is_some_and(|(key, _)| key == "password")
+                .is_some_and(|(key, _)| percent_decode_str(key).decode_utf8_lossy() == "password")
         })
     })
 }
@@ -833,9 +834,9 @@ mod tests {
             redact_unparsed_endpoint("postgres://user:secret@host/db"),
             "<redacted endpoint>"
         );
-        // A `password` query parameter, as accepted by PostgreSQL DSNs.
+        // A percent-encoded `password` query key, which SQLx decodes.
         assert_eq!(
-            redact_unparsed_endpoint("postgres://host/db?password=secret"),
+            redact_unparsed_endpoint("postgres://host/db?pass%77ord=secret"),
             "<redacted endpoint>"
         );
         // Both forms together.

--- a/src/sinks/util/uri.rs
+++ b/src/sinks/util/uri.rs
@@ -271,12 +271,28 @@ fn redact_uri(uri: &Uri) -> String {
     }
 }
 
-fn redact_unparsed_endpoint(endpoint: &str) -> String {
-    if endpoint.contains('@') {
+/// Redacts credentials from an endpoint string for error messages.
+///
+/// Redacts the whole endpoint when it may carry credentials: userinfo in the
+/// authority (`@`) or a `password` query parameter, which some backends (for
+/// example PostgreSQL) accept as an alternative to userinfo.
+pub(crate) fn redact_unparsed_endpoint(endpoint: &str) -> String {
+    if endpoint.contains('@') || has_password_query_param(endpoint) {
         "<redacted endpoint>".to_owned()
     } else {
         endpoint.to_owned()
     }
+}
+
+/// Returns `true` if the query portion of `endpoint` contains a `password`
+/// parameter (for example `postgres://host/db?password=secret`).
+fn has_password_query_param(endpoint: &str) -> bool {
+    endpoint.split_once('?').is_some_and(|(_, query)| {
+        query.split('&').any(|pair| {
+            pair.split_once('=')
+                .is_some_and(|(key, _)| key == "password")
+        })
+    })
 }
 
 impl TryFrom<String> for HttpEndpoint {
@@ -808,6 +824,34 @@ mod tests {
             assert!(message.contains("<redacted endpoint>"), "{message}");
             assert!(!message.contains("secret"), "{message}");
         }
+    }
+
+    #[test]
+    fn redact_unparsed_endpoint_redacts_credentials() {
+        // Userinfo in the authority.
+        assert_eq!(
+            redact_unparsed_endpoint("postgres://user:secret@host/db"),
+            "<redacted endpoint>"
+        );
+        // A `password` query parameter, as accepted by PostgreSQL DSNs.
+        assert_eq!(
+            redact_unparsed_endpoint("postgres://host/db?password=secret"),
+            "<redacted endpoint>"
+        );
+        // Both forms together.
+        assert_eq!(
+            redact_unparsed_endpoint("postgres://user:secret@host/db?password=secret"),
+            "<redacted endpoint>"
+        );
+        // Endpoints without credentials are left intact.
+        assert_eq!(
+            redact_unparsed_endpoint("postgres://host/db"),
+            "postgres://host/db"
+        );
+        assert_eq!(
+            redact_unparsed_endpoint("postgres://host/db?user=alice"),
+            "postgres://host/db?user=alice"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Migrates the `postgres` sink to the validated sink lifecycle, so `vector validate --no-environment` catches pure configuration errors (DSN parsing, batch settings) at config-compile time instead of at startup. Credentials are deferred to build and redacted from validation errors.

This is an intermediate PR split from #26048; the changelog for the overall effort is carried by #26048.

### References
- Related: #26211
- Related: #26213
- Related: #26215
- Related: #26218
- Related: #26219
- Related: #26224
- Related: #26048

## Vector configuration
NA

## How did you test this PR?
`make check-clippy FEATURES="sinks-postgres"` and `make test FEATURES="sinks-postgres" SCOPE="sinks::postgres"`.

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.