### PR TITLE
fix(websites): add playground and rust-doc to Amplify monorepo spec

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -23,3 +23,37 @@ applications:
       cache:
         paths:
           - node_modules/**/*
+  - appRoot: lib/vector-vrl/web-playground
+    frontend:
+      phases:
+        preBuild:
+          commands:
+            - mv ../../../scripts/ensure-wasm-target-installed.sh ./
+            - chmod +x ./ensure-wasm-target-installed.sh
+        build:
+          commands:
+            - ./ensure-wasm-target-installed.sh && wasm-pack build --target web --out-dir public/pkg
+      artifacts:
+        baseDirectory: public
+        files:
+          - '**/*'
+      cache:
+        paths: []
+  - appRoot: rust-doc
+    frontend:
+      phases:
+        preBuild:
+          commands:
+            - mkdir -p ./public
+        build:
+          commands:
+            - make ci-docs-build
+            - echo "<meta charset=\"UTF-8\" >" > ../target/doc/index.html
+            - mv ../target/doc ./public
+            - rm -rf ../target
+      artifacts:
+        baseDirectory: public/doc
+        files:
+          - '**/*'
+      cache:
+        paths: []

--- a/amplify.yml
+++ b/amplify.yml
@@ -36,7 +36,7 @@ applications:
       artifacts:
         baseDirectory: public
         files:
-          - '**/*'
+          - "**/*"
       cache:
         paths: []
   - appRoot: rust-doc
@@ -54,6 +54,6 @@ applications:
       artifacts:
         baseDirectory: public/doc
         files:
-          - '**/*'
+          - "**/*"
       cache:
         paths: []


### PR DESCRIPTION
## Summary
Adds the `websites-vector-playground` and `rust-doc` apps to the committed Amplify monorepo build spec so both deploy again on the `website` branch.

## Vector configuration
NA

## How did you test this PR?
NA

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?
- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## Contributor Guidelines

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them. To catch issues early, add a `pre-push` hook ([template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push)) or run the following locally before pushing:
  - `make fmt`
  - `make check-clippy` (auto-fix with `make clippy-fix`)
  - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details on the [dd-rust-license-tool](https://crates.io/crates/dd-rust-license-tool).
