### PR TITLE
fix(website): Add Amplify builds for VRL web playground and rust-doc

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -45,8 +45,10 @@ applications:
         preBuild:
           commands:
             - mkdir -p ./public
+            - bash ../scripts/environment/install-protoc.sh "$HOME/.local/bin"
         build:
           commands:
+            - export PATH="$HOME/.local/bin:$PATH"
             - make ci-docs-build
             - echo "<meta charset=\"UTF-8\" >" > ../target/doc/index.html
             - mv ../target/doc ./public

--- a/amplify.yml
+++ b/amplify.yml
@@ -23,3 +23,37 @@ applications:
       cache:
         paths:
           - node_modules/**/*
+  - appRoot: lib/vector-vrl/web-playground
+    frontend:
+      phases:
+        preBuild:
+          commands:
+            - mv ../../../scripts/ensure-wasm-target-installed.sh ./
+            - chmod +x ./ensure-wasm-target-installed.sh
+        build:
+          commands:
+            - ./ensure-wasm-target-installed.sh && wasm-pack build --target web --out-dir public/pkg
+      artifacts:
+        baseDirectory: public
+        files:
+          - "**/*"
+      cache:
+        paths: []
+  - appRoot: rust-doc
+    frontend:
+      phases:
+        preBuild:
+          commands:
+            - mkdir -p ./public
+        build:
+          commands:
+            - make ci-docs-build
+            - echo "<meta charset=\"UTF-8\" >" > ../target/doc/index.html
+            - mv ../target/doc ./public
+            - rm -rf ../target
+      artifacts:
+        baseDirectory: public/doc
+        files:
+          - "**/*"
+      cache:
+        paths: []

--- a/amplify.yml
+++ b/amplify.yml
@@ -45,7 +45,7 @@ applications:
         preBuild:
           commands:
             - mkdir -p ./public
-            - bash ../scripts/environment/install-protoc.sh "$HOME/.local/bin"
+            - bash ../scripts/environment/prepare.sh --modules=rustup,protoc
         build:
           commands:
             - export PATH="$HOME/.local/bin:$PATH"


### PR DESCRIPTION
## Summary
Adds Amplify applications to build and host the VRL web playground and rust-doc.

### References
NA

## Vector configuration
NA

## How did you test this PR?
NA

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.
