### PR TITLE
fix(website): install protoc in rust-doc Amplify build

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -45,8 +45,10 @@ applications:
         preBuild:
           commands:
             - mkdir -p ./public
+            - bash ../scripts/environment/install-protoc.sh "$HOME/.local/bin"
         build:
           commands:
+            - export PATH="$HOME/.local/bin:$PATH"
             - make ci-docs-build
             - echo "<meta charset=\"UTF-8\" >" > ../target/doc/index.html
             - mv ../target/doc ./public

--- a/amplify.yml
+++ b/amplify.yml
@@ -45,7 +45,7 @@ applications:
         preBuild:
           commands:
             - mkdir -p ./public
-            - bash ../scripts/environment/prepare.sh --modules=rustup
+            - bash ../scripts/environment/prepare.sh --modules=rustup,protoc
         build:
           commands:
             - export PATH="$HOME/.local/bin:$PATH"

--- a/amplify.yml
+++ b/amplify.yml
@@ -45,7 +45,7 @@ applications:
         preBuild:
           commands:
             - mkdir -p ./public
-            - bash ../scripts/environment/install-protoc.sh "$HOME/.local/bin"
+            - bash ../scripts/environment/prepare.sh --modules=rustup
         build:
           commands:
             - export PATH="$HOME/.local/bin:$PATH"


### PR DESCRIPTION
## Summary
Installs protoc in the rust-doc Amplify build so cargo doc can compile vector-core.

### References
NA

## Vector configuration
NA

## How did you test this PR?
NA

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.
