### PR TITLE
fix(topology): await removed disk sinks on shutdown

### DIFF
--- a/changelog.d/await_removed_disk_sink_shutdown.fix.md
+++ b/changelog.d/await_removed_disk_sink_shutdown.fix.md
@@ -1,0 +1,4 @@
+Graceful shutdown now waits for removed durable disk-buffered sinks that are still draining after a
+configuration reload.
+
+authors: Jansen-w

--- a/src/test_util/mock/sinks/basic.rs
+++ b/src/test_util/mock/sinks/basic.rs
@@ -1,7 +1,11 @@
 use async_trait::async_trait;
 use futures_util::{FutureExt, StreamExt, stream::BoxStream};
 use snafu::Snafu;
+#[cfg(test)]
+use std::sync::Arc;
 use tokio::sync::oneshot;
+#[cfg(test)]
+use tokio::sync::{Barrier, Semaphore};
 use vector_lib::{
     config::{AcknowledgementsConfig, Input},
     configurable::configurable_component,
@@ -31,6 +35,10 @@ pub struct BasicSinkConfig {
     #[serde(skip)]
     confinement: Option<crate::template::ConfinementConfig>,
 
+    #[cfg(test)]
+    #[serde(skip)]
+    event_gate: Option<(Arc<Barrier>, Arc<Semaphore>)>,
+
     /// Dummy field used for generating unique configurations to trigger reloads.
     data: Option<String>,
 }
@@ -51,6 +59,8 @@ impl BasicSinkConfig {
             sink: Mode::Normal(sink),
             healthy,
             confinement: None,
+            #[cfg(test)]
+            event_gate: None,
             data: None,
         }
     }
@@ -60,6 +70,8 @@ impl BasicSinkConfig {
             sink: Mode::Normal(sink),
             healthy,
             confinement: None,
+            #[cfg(test)]
+            event_gate: None,
             data: Some(data.into()),
         }
     }
@@ -72,6 +84,12 @@ impl BasicSinkConfig {
         self.confinement = Some(crate::template::ConfinementConfig {
             dangerously_allow_unconfined_template_resolution: allowed,
         });
+        self
+    }
+
+    #[cfg(test)]
+    pub fn with_event_gate(mut self, entered: Arc<Barrier>, release: Arc<Semaphore>) -> Self {
+        self.event_gate = Some((entered, release));
         self
     }
 }
@@ -101,6 +119,8 @@ impl SinkConfig for BasicSinkConfig {
         let sink = MockSink {
             sink: self.sink.clone(),
             health_tx,
+            #[cfg(test)]
+            event_gate: self.event_gate.clone(),
         };
 
         let healthcheck = async move { rx.await.unwrap() };
@@ -124,6 +144,8 @@ impl SinkConfig for BasicSinkConfig {
 struct MockSink {
     sink: Mode,
     health_tx: Option<oneshot::Sender<crate::Result<()>>>,
+    #[cfg(test)]
+    event_gate: Option<(Arc<Barrier>, Arc<Semaphore>)>,
 }
 
 #[async_trait]
@@ -137,6 +159,15 @@ impl StreamSink<Event> for MockSink {
 
                 // We have an inner sink, so forward the input normally
                 while let Some(mut event) = input.next().await {
+                    #[cfg(test)]
+                    if let Some((entered, release)) = self.event_gate.take() {
+                        entered.wait().await;
+                        release
+                            .acquire()
+                            .await
+                            .expect("event gate semaphore closed")
+                            .forget();
+                    }
                     let finalizers = event.take_finalizers();
                     if let Err(error) = sink.send_event(event).await {
                         error!(message = "Ingesting an event failed at mock sink.", %error);

--- a/src/topology/controller.rs
+++ b/src/topology/controller.rs
@@ -150,8 +150,9 @@ impl TopologyController {
         }
     }
 
-    /// Stops the topology. Returns `true` if every component finished on its own before the
-    /// graceful shutdown deadline, or `false` if any component had to be forcefully killed.
+    /// Stops the topology. Returns `true` if every component task completed successfully before
+    /// the graceful shutdown deadline, or `false` if any task failed or had to be forcefully
+    /// killed.
     #[cfg_attr(not(feature = "api"), allow(unused_mut))]
     pub async fn stop(mut self) -> bool {
         // Phase 1: Mark the gRPC API as unavailable so that external probes

--- a/src/topology/running.rs
+++ b/src/topology/running.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::{HashMap, HashSet},
+    fmt,
     pin::Pin,
     sync::{Arc, Mutex},
     task::{Context, Poll},
@@ -67,6 +68,21 @@ impl<T> Future for AbortOnDropTask<T> {
 impl<T> Drop for AbortOnDropTask<T> {
     fn drop(&mut self) {
         self.0.abort();
+    }
+}
+
+#[derive(Clone, Eq, Hash, PartialEq)]
+enum ShutdownTaskKey {
+    Component(ComponentKey),
+    Auxiliary(&'static str),
+}
+
+impl fmt::Display for ShutdownTaskKey {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Component(key) => key.fmt(formatter),
+            Self::Auxiliary(label) => label.fmt(formatter),
+        }
     }
 }
 
@@ -177,10 +193,18 @@ impl RunningTopology {
         let mut wait_handles = Vec::new();
         // We need a Vec here since source components have two tasks. One for
         // pump in self.tasks, and the other for source in self.source_tasks.
-        let mut check_handles = HashMap::<ComponentKey, Vec<_>>::new();
+        let mut check_handles = HashMap::<ShutdownTaskKey, Vec<_>>::new();
 
         let map_closure =
             |result: Result<TaskResult, tokio::task::JoinError>| matches!(result, Ok(Ok(_)));
+
+        // Each task is represented by one abort-on-drop future shared between completion and
+        // progress tracking.
+        let mut register_task = |key, task| {
+            let task = AbortOnDropTask(task).map(map_closure).shared();
+            wait_handles.push(task.clone());
+            check_handles.entry(key).or_default().push(task);
+        };
 
         // We need to give some time to the sources to gracefully shutdown, so
         // we will merge them with other tasks.
@@ -190,18 +214,21 @@ impl RunningTopology {
             .chain(self.source_tasks)
             .chain(self.retired_disk_sink_tasks)
         {
-            let task = AbortOnDropTask(task).map(map_closure).shared();
-
-            wait_handles.push(task.clone());
-            check_handles.entry(key).or_default().push(task);
+            register_task(ShutdownTaskKey::Component(key), task);
         }
 
         if let Some(utilization_task) = self.utilization_task {
-            wait_handles.push(AbortOnDropTask(utilization_task).map(map_closure).shared());
+            register_task(
+                ShutdownTaskKey::Auxiliary("utilization_heartbeat"),
+                utilization_task,
+            );
         }
 
         if let Some(metrics_task) = self.metrics_task {
-            wait_handles.push(AbortOnDropTask(metrics_task).map(map_closure).shared());
+            register_task(
+                ShutdownTaskKey::Auxiliary("metrics_heartbeat"),
+                metrics_task,
+            );
         }
 
         // If we reach this, we will forcefully abort all tracked component and auxiliary tasks. If
@@ -222,15 +249,15 @@ impl RunningTopology {
                     retain(handles, |handle| handle.peek().is_none());
                     !handles.is_empty()
                 });
-                let remaining_components = check_handles2
+                let remaining_tasks = check_handles2
                     .keys()
                     .map(|item| item.to_string())
                     .collect::<Vec<_>>()
                     .join(", ");
 
                 error!(
-                    components = ?remaining_components,
-                    message = "Failed to gracefully shut down in time. Killing components.",
+                    tasks = ?remaining_tasks,
+                    message = "Failed to gracefully shut down in time. Killing tasks.",
                     internal_log_rate_limit = false
                 );
                 false
@@ -250,7 +277,7 @@ impl RunningTopology {
                     retain(handles, |handle| handle.peek().is_none());
                     !handles.is_empty()
                 });
-                let remaining_components = check_handles
+                let remaining_tasks = check_handles
                     .keys()
                     .map(|item| item.to_string())
                     .collect::<Vec<_>>()
@@ -265,18 +292,19 @@ impl RunningTopology {
                 };
 
                 info!(
-                    remaining_components = ?remaining_components,
+                    remaining_tasks = ?remaining_tasks,
                     time_remaining = ?time_remaining,
-                    "Shutting down... Waiting on running components."
+                    "Shutting down... Waiting on running tasks."
                 );
 
                 let all_done = check_handles.is_empty();
 
                 if all_done {
-                    info!("All components shut down; waiting for auxiliary tasks.");
+                    // `success` is the authoritative result because a completed task can fail.
+                    info!("All tracked tasks shut down; waiting for shutdown result.");
                     return future::pending::<bool>().await;
                 } else if deadline_passed {
-                    error!(remaining_components = ?remaining_components, "Shutdown reporter: deadline exceeded.");
+                    error!(remaining_tasks = ?remaining_tasks, "Shutdown reporter: deadline exceeded.");
                 }
             }
         };
@@ -1589,9 +1617,13 @@ fn enrichment_table_sink_buffer(
 #[cfg(test)]
 mod abort_on_drop_task_tests {
     use futures::future;
-    use tokio::{sync::oneshot, time::Duration};
+    use tokio::{
+        sync::{mpsc, oneshot},
+        time::Duration,
+    };
 
-    use super::AbortOnDropTask;
+    use super::{AbortOnDropTask, RunningTopology, TaskOutput};
+    use crate::config::Config;
 
     struct NotifyOnDrop(Option<oneshot::Sender<()>>);
 
@@ -1599,6 +1631,15 @@ mod abort_on_drop_task_tests {
         fn drop(&mut self) {
             self.0.take().unwrap().send(()).unwrap_or(());
         }
+    }
+
+    fn empty_topology(graceful_shutdown_duration: Option<Duration>) -> RunningTopology {
+        let mut config = Config::builder();
+        config.allow_empty = true;
+        config.graceful_shutdown_duration = graceful_shutdown_duration;
+        let (abort_tx, _) = mpsc::unbounded_channel();
+
+        RunningTopology::new(config.build().unwrap(), abort_tx)
     }
 
     #[tokio::test]
@@ -1625,5 +1666,49 @@ mod abort_on_drop_task_tests {
             .await
             .expect("aborted task was not dropped")
             .unwrap();
+    }
+
+    #[tokio::test]
+    async fn shutdown_waits_for_auxiliary_tasks() {
+        let (complete_tx, complete_rx) = oneshot::channel();
+        let mut topology = empty_topology(None);
+        topology.metrics_task = Some(tokio::spawn(async move {
+            complete_rx.await.unwrap();
+            Ok(TaskOutput::Healthcheck)
+        }));
+
+        let mut shutdown = Box::pin(topology.stop());
+        assert!(futures::poll!(shutdown.as_mut()).is_pending());
+
+        complete_tx.send(()).unwrap();
+
+        assert!(
+            tokio::time::timeout(Duration::from_secs(5), shutdown)
+                .await
+                .expect("topology did not wait for auxiliary task")
+        );
+    }
+
+    #[tokio::test]
+    async fn failed_auxiliary_task_causes_unsuccessful_shutdown() {
+        let mut topology = empty_topology(None);
+        topology.utilization_task = Some(tokio::spawn(async {
+            panic!("auxiliary task failed");
+        }));
+
+        assert!(!topology.stop().await);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn shutdown_deadline_applies_to_auxiliary_tasks() {
+        let graceful_shutdown_duration = Duration::from_secs(30);
+        let mut topology = empty_topology(Some(graceful_shutdown_duration));
+        topology.metrics_task = Some(tokio::spawn(future::pending()));
+
+        let mut shutdown = Box::pin(topology.stop());
+        assert!(futures::poll!(shutdown.as_mut()).is_pending());
+        tokio::time::advance(graceful_shutdown_duration).await;
+
+        assert!(!shutdown.await);
     }
 }

--- a/src/topology/running.rs
+++ b/src/topology/running.rs
@@ -61,6 +61,8 @@ pub struct RunningTopology {
     component_type_names: HashMap<ComponentKey, String>,
     source_tasks: HashMap<ComponentKey, TaskHandle>,
     tasks: HashMap<ComponentKey, TaskHandle>,
+    retired_disk_sink_tasks: Vec<(ComponentKey, TaskHandle)>,
+    retired_disk_sink_task_failed: bool,
     shutdown_coordinator: SourceShutdownCoordinator,
     detach_triggers: HashMap<ComponentKey, DisabledTrigger>,
     pub(crate) config: Config,
@@ -88,6 +90,8 @@ impl RunningTopology {
             detach_triggers: HashMap::new(),
             source_tasks: HashMap::new(),
             tasks: HashMap::new(),
+            retired_disk_sink_tasks: Vec::new(),
+            retired_disk_sink_task_failed: false,
             abort_tx,
             watch: watch::channel(TapResource::default()),
             graceful_shutdown_duration: config.graceful_shutdown_duration,
@@ -141,15 +145,14 @@ impl RunningTopology {
     /// transforms, and sinks) have finished shutting down. Transforms and sinks
     /// will shut down automatically once their input tasks finish.
     ///
-    /// This function takes ownership of `self`, so once it returns everything
-    /// in the [`RunningTopology`] instance has been dropped except for the
-    /// `tasks` map. This map gets moved into the returned future and is used to
-    /// poll for when the tasks have completed. Once the returned future is
-    /// dropped then everything from this RunningTopology instance is fully
-    /// dropped.
+    /// This function takes ownership of `self`. Component task handles, including handles for
+    /// retired disk-buffered sinks that are still draining after a reload, are moved into the
+    /// returned future and polled until completion. Dropping the returned future drops those
+    /// handles and everything else owned by this [`RunningTopology`].
     ///
-    /// The returned future resolves to `true` if every component finished on its own before
-    /// the graceful shutdown deadline, or `false` if any component had to be forcefully killed.
+    /// The returned future resolves to `true` if every component task completed successfully
+    /// before the graceful shutdown deadline, or `false` if any task failed or had to be
+    /// forcefully killed.
     pub fn stop(self) -> impl Future<Output = bool> {
         // Create handy handles collections of all tasks for the subsequent
         // operations.
@@ -163,7 +166,12 @@ impl RunningTopology {
 
         // We need to give some time to the sources to gracefully shutdown, so
         // we will merge them with other tasks.
-        for (key, task) in self.tasks.into_iter().chain(self.source_tasks) {
+        for (key, task) in self
+            .tasks
+            .into_iter()
+            .chain(self.source_tasks)
+            .chain(self.retired_disk_sink_tasks)
+        {
             let task = task.map(map_closure).shared();
 
             wait_handles.push(task.clone());
@@ -261,12 +269,13 @@ impl RunningTopology {
 
         // Aggregate future that ends once anything detects that all tasks have shutdown.
         // Resolves to `true` only if the winning branch got there without forcing anything.
+        let retired_disk_sink_task_failed = self.retired_disk_sink_task_failed;
         let shutdown_complete_future = future::select_all(vec![
             Box::pin(timeout) as future::BoxFuture<'static, bool>,
             Box::pin(reporter) as future::BoxFuture<'static, bool>,
             Box::pin(success) as future::BoxFuture<'static, bool>,
         ])
-        .map(|(graceful, _index, _remaining)| graceful);
+        .map(move |(graceful, _index, _remaining)| graceful && !retired_disk_sink_task_failed);
 
         // Now kick off the shutdown process by shutting down the sources.
         let source_shutdown_complete = self.shutdown_coordinator.shutdown_all(deadline);
@@ -316,6 +325,7 @@ impl RunningTopology {
         } else {
             ConfigDiff::new(&self.config, &new_config, HashSet::new())
         };
+        self.reap_completed_retired_disk_sink_tasks();
         let buffers = self.shutdown_diff(&diff, &new_config).await;
 
         // Gives windows some time to make available any port
@@ -387,6 +397,26 @@ impl RunningTopology {
         );
 
         Err(ReloadError::FailedToRestore)
+    }
+
+    /// Reaps completed tasks while preserving active handles and observed failure status.
+    fn reap_completed_retired_disk_sink_tasks(&mut self) {
+        let mut still_running = Vec::with_capacity(self.retired_disk_sink_tasks.len());
+        for (key, mut task) in std::mem::take(&mut self.retired_disk_sink_tasks) {
+            if task.is_finished()
+                && let Some(result) = (&mut task).now_or_never()
+            {
+                self.retired_disk_sink_task_failed |= !matches!(result, Ok(Ok(_)));
+            } else {
+                still_running.push((key, task));
+            }
+        }
+        self.retired_disk_sink_tasks = still_running;
+    }
+
+    #[cfg(test)]
+    pub(crate) const fn retired_disk_sink_task_count(&self) -> usize {
+        self.retired_disk_sink_tasks.len()
     }
 
     /// Attempts to reload enrichment tables.
@@ -701,6 +731,13 @@ impl RunningTopology {
             if wait_for_sinks.contains(key) {
                 debug!(message = "Waiting for sink to shutdown.", component_id = %key);
                 previous.await.unwrap().unwrap();
+            } else if self
+                .config
+                .sink(key)
+                .is_some_and(|sink| sink.buffer.has_disk_stage())
+            {
+                self.retired_disk_sink_tasks
+                    .push(((*key).clone(), previous));
             } else {
                 drop(previous); // detach and forget
             }

--- a/src/topology/running.rs
+++ b/src/topology/running.rs
@@ -80,8 +80,8 @@ enum ShutdownTaskKey {
 impl fmt::Display for ShutdownTaskKey {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Component(key) => key.fmt(formatter),
-            Self::Auxiliary(label) => label.fmt(formatter),
+            Self::Component(key) => write!(formatter, "component:{key}"),
+            Self::Auxiliary(label) => write!(formatter, "auxiliary:{label}"),
         }
     }
 }

--- a/src/topology/running.rs
+++ b/src/topology/running.rs
@@ -1,6 +1,8 @@
 use std::{
     collections::{HashMap, HashSet},
+    pin::Pin,
     sync::{Arc, Mutex},
+    task::{Context, Poll},
 };
 
 use futures::{Future, FutureExt, future};
@@ -52,13 +54,19 @@ pub enum ReloadError {
     FailedToRestore,
 }
 
-struct AbortTasksOnDrop(Vec<tokio::task::AbortHandle>);
+struct AbortOnDropTask<T>(tokio::task::JoinHandle<T>);
 
-impl Drop for AbortTasksOnDrop {
+impl<T> Future for AbortOnDropTask<T> {
+    type Output = Result<T, tokio::task::JoinError>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        Pin::new(&mut self.0).poll(cx)
+    }
+}
+
+impl<T> Drop for AbortOnDropTask<T> {
     fn drop(&mut self) {
-        for handle in &self.0 {
-            handle.abort();
-        }
+        self.0.abort();
     }
 }
 
@@ -167,7 +175,6 @@ impl RunningTopology {
         // Create handy handles collections of all tasks for the subsequent
         // operations.
         let mut wait_handles = Vec::new();
-        let mut abort_handles = Vec::new();
         // We need a Vec here since source components have two tasks. One for
         // pump in self.tasks, and the other for source in self.source_tasks.
         let mut check_handles = HashMap::<ComponentKey, Vec<_>>::new();
@@ -183,21 +190,18 @@ impl RunningTopology {
             .chain(self.source_tasks)
             .chain(self.retired_disk_sink_tasks)
         {
-            abort_handles.push(task.abort_handle());
-            let task = task.map(map_closure).shared();
+            let task = AbortOnDropTask(task).map(map_closure).shared();
 
             wait_handles.push(task.clone());
             check_handles.entry(key).or_default().push(task);
         }
 
         if let Some(utilization_task) = self.utilization_task {
-            abort_handles.push(utilization_task.abort_handle());
-            wait_handles.push(utilization_task.map(map_closure).shared());
+            wait_handles.push(AbortOnDropTask(utilization_task).map(map_closure).shared());
         }
 
         if let Some(metrics_task) = self.metrics_task {
-            abort_handles.push(metrics_task.abort_handle());
-            wait_handles.push(metrics_task.map(map_closure).shared());
+            wait_handles.push(AbortOnDropTask(metrics_task).map(map_closure).shared());
         }
 
         // If we reach this, we will forcefully abort all tracked component and auxiliary tasks. If
@@ -278,18 +282,18 @@ impl RunningTopology {
         };
 
         // Finishes once all tasks have shutdown.
-        let success =
-            futures::future::join_all(wait_handles).map(|results| results.into_iter().all(|ok| ok));
+        let retired_disk_sink_task_failed = self.retired_disk_sink_task_failed;
+        let success = futures::future::join_all(wait_handles)
+            .map(move |results| !retired_disk_sink_task_failed && results.into_iter().all(|ok| ok));
 
         // Aggregate future that ends once anything detects that all tasks have shutdown.
         // Resolves to `true` only if the winning branch got there without forcing anything.
-        let retired_disk_sink_task_failed = self.retired_disk_sink_task_failed;
         let shutdown_complete_future = future::select_all(vec![
             Box::pin(timeout) as future::BoxFuture<'static, bool>,
             Box::pin(reporter) as future::BoxFuture<'static, bool>,
             Box::pin(success) as future::BoxFuture<'static, bool>,
         ])
-        .map(move |(graceful, _index, _remaining)| graceful && !retired_disk_sink_task_failed);
+        .map(|(graceful, _index, _remaining)| graceful);
 
         // Now kick off the shutdown process by shutting down the sources.
         let source_shutdown_complete = self.shutdown_coordinator.shutdown_all(deadline);
@@ -300,13 +304,8 @@ impl RunningTopology {
             trigger.cancel();
         }
 
-        let abort_tasks = AbortTasksOnDrop(abort_handles);
-        async move {
-            let _abort_tasks = abort_tasks;
-            let (_, graceful) =
-                futures::future::join(source_shutdown_complete, shutdown_complete_future).await;
-            graceful
-        }
+        futures::future::join(source_shutdown_complete, shutdown_complete_future)
+            .map(|(_, graceful)| graceful)
     }
 
     /// Attempts to load a new configuration and update this running topology.
@@ -1585,4 +1584,46 @@ fn enrichment_table_sink_buffer(
         .filter_map(|(table_key, table)| table.as_sink(table_key))
         .find(|(key, _)| key == sink_key)
         .map(|(_, sink)| sink.buffer)
+}
+
+#[cfg(test)]
+mod abort_on_drop_task_tests {
+    use futures::future;
+    use tokio::{sync::oneshot, time::Duration};
+
+    use super::AbortOnDropTask;
+
+    struct NotifyOnDrop(Option<oneshot::Sender<()>>);
+
+    impl Drop for NotifyOnDrop {
+        fn drop(&mut self) {
+            self.0.take().unwrap().send(()).unwrap_or(());
+        }
+    }
+
+    #[tokio::test]
+    async fn returns_completed_task_output() {
+        let task = AbortOnDropTask(tokio::spawn(async { 42 }));
+
+        assert_eq!(task.await.unwrap(), 42);
+    }
+
+    #[tokio::test]
+    async fn aborts_unfinished_task_on_drop() {
+        let (started_tx, started_rx) = oneshot::channel();
+        let (dropped_tx, dropped_rx) = oneshot::channel();
+        let task = AbortOnDropTask(tokio::spawn(async move {
+            let _notify = NotifyOnDrop(Some(dropped_tx));
+            started_tx.send(()).unwrap();
+            future::pending::<()>().await;
+        }));
+        started_rx.await.unwrap();
+
+        drop(task);
+
+        tokio::time::timeout(Duration::from_secs(5), dropped_rx)
+            .await
+            .expect("aborted task was not dropped")
+            .unwrap();
+    }
 }

--- a/src/topology/running.rs
+++ b/src/topology/running.rs
@@ -52,6 +52,16 @@ pub enum ReloadError {
     FailedToRestore,
 }
 
+struct AbortTasksOnDrop(Vec<tokio::task::AbortHandle>);
+
+impl Drop for AbortTasksOnDrop {
+    fn drop(&mut self) {
+        for handle in &self.0 {
+            handle.abort();
+        }
+    }
+}
+
 #[allow(dead_code)]
 pub struct RunningTopology {
     inputs: HashMap<ComponentKey, BufferSender<EventArray>>,
@@ -145,10 +155,10 @@ impl RunningTopology {
     /// transforms, and sinks) have finished shutting down. Transforms and sinks
     /// will shut down automatically once their input tasks finish.
     ///
-    /// This function takes ownership of `self`. Component task handles, including handles for
-    /// retired disk-buffered sinks that are still draining after a reload, are moved into the
-    /// returned future and polled until completion. Dropping the returned future drops those
-    /// handles and everything else owned by this [`RunningTopology`].
+    /// This function takes ownership of `self`. Tracked component task handles, including handles
+    /// for retired disk-buffered sinks that are still draining after a reload, and internal
+    /// telemetry task handles are moved into the returned future and polled until completion.
+    /// Dropping the returned future aborts any tracked tasks that have not completed.
     ///
     /// The returned future resolves to `true` if every component task completed successfully
     /// before the graceful shutdown deadline, or `false` if any task failed or had to be
@@ -157,6 +167,7 @@ impl RunningTopology {
         // Create handy handles collections of all tasks for the subsequent
         // operations.
         let mut wait_handles = Vec::new();
+        let mut abort_handles = Vec::new();
         // We need a Vec here since source components have two tasks. One for
         // pump in self.tasks, and the other for source in self.source_tasks.
         let mut check_handles = HashMap::<ComponentKey, Vec<_>>::new();
@@ -172,6 +183,7 @@ impl RunningTopology {
             .chain(self.source_tasks)
             .chain(self.retired_disk_sink_tasks)
         {
+            abort_handles.push(task.abort_handle());
             let task = task.map(map_closure).shared();
 
             wait_handles.push(task.clone());
@@ -179,22 +191,25 @@ impl RunningTopology {
         }
 
         if let Some(utilization_task) = self.utilization_task {
+            abort_handles.push(utilization_task.abort_handle());
             wait_handles.push(utilization_task.map(map_closure).shared());
         }
 
         if let Some(metrics_task) = self.metrics_task {
+            abort_handles.push(metrics_task.abort_handle());
             wait_handles.push(metrics_task.map(map_closure).shared());
         }
 
-        // If we reach this, we will forcefully shutdown the sources. If None, we will never force shutdown.
+        // If we reach this, we will forcefully abort all tracked component and auxiliary tasks. If
+        // None, we will never force shutdown.
         let deadline = self
             .graceful_shutdown_duration
             .map(|grace_period| Instant::now() + grace_period);
 
         let timeout = if let Some(deadline) = deadline {
             // If we reach the deadline, this future will print out which components
-            // won't gracefully shutdown since we will start to forcefully shutdown
-            // the sources.
+            // won't gracefully shut down before all tracked component and auxiliary
+            // tasks are forcefully aborted.
             let mut check_handles2 = check_handles.clone();
             Box::pin(async move {
                 sleep_until(deadline).await;
@@ -254,11 +269,10 @@ impl RunningTopology {
                 let all_done = check_handles.is_empty();
 
                 if all_done {
-                    info!("Shutdown reporter exiting: all components shut down.");
-                    break true;
+                    info!("All components shut down; waiting for auxiliary tasks.");
+                    return future::pending::<bool>().await;
                 } else if deadline_passed {
                     error!(remaining_components = ?remaining_components, "Shutdown reporter: deadline exceeded.");
-                    break false;
                 }
             }
         };
@@ -286,8 +300,13 @@ impl RunningTopology {
             trigger.cancel();
         }
 
-        futures::future::join(source_shutdown_complete, shutdown_complete_future)
-            .map(|(_, graceful)| graceful)
+        let abort_tasks = AbortTasksOnDrop(abort_handles);
+        async move {
+            let _abort_tasks = abort_tasks;
+            let (_, graceful) =
+                futures::future::join(source_shutdown_complete, shutdown_complete_future).await;
+            graceful
+        }
     }
 
     /// Attempts to load a new configuration and update this running topology.

--- a/src/topology/test/mod.rs
+++ b/src/topology/test/mod.rs
@@ -170,14 +170,31 @@ async fn topology_shutdown_while_active() {
 async fn dropping_shutdown_future_aborts_component_tasks() {
     trace_init();
 
-    let (input, source) = basic_source();
+    let (mut input, source) = basic_source();
     let (mut output, sink) = basic_sink(1);
+    let entered = Arc::new(Barrier::new(2));
+    let release = Arc::new(Semaphore::new(0));
 
     let mut config = Config::builder();
     config.add_source("in", source);
-    config.add_sink("out", &["in"], sink);
+    config.add_sink(
+        "out",
+        &["in"],
+        sink.with_event_gate(Arc::clone(&entered), Arc::clone(&release)),
+    );
 
     let (topology, _) = start_topology(config.build().unwrap(), false).await;
+    tokio::time::timeout(
+        ASYNC_TEST_TIMEOUT,
+        input.send_event(Event::Log(LogEvent::from("event"))),
+    )
+    .await
+    .expect("sending event to gated sink timed out")
+    .unwrap();
+    tokio::time::timeout(ASYNC_TEST_TIMEOUT, entered.wait())
+        .await
+        .expect("sink did not reach event gate");
+
     let shutdown = topology.stop();
     drop(shutdown);
     drop(input);

--- a/src/topology/test/mod.rs
+++ b/src/topology/test/mod.rs
@@ -16,7 +16,7 @@ use tokio::{
 use vector_lib::{
     buffers::{BufferConfig, BufferType, WhenFull},
     config::{ComponentKey, OutputId},
-    source_sender::SourceSenderItem,
+    source_sender::{SourceSender, SourceSenderItem},
 };
 
 use crate::{
@@ -31,7 +31,7 @@ use crate::{
         },
         start_topology, trace_init,
     },
-    topology::{ReloadError::*, RunningTopology, builder::TopologyPiecesBuilder},
+    topology::{ReloadError, ReloadError::*, RunningTopology, builder::TopologyPiecesBuilder},
 };
 
 mod backpressure;
@@ -83,6 +83,28 @@ fn disk_buffer() -> BufferConfig {
 }
 
 const ASYNC_TEST_TIMEOUT: Duration = Duration::from_secs(5);
+
+async fn send_test_event(input: &mut SourceSender) {
+    tokio::time::timeout(
+        ASYNC_TEST_TIMEOUT,
+        input.send_event(Event::Log(LogEvent::from("event"))),
+    )
+    .await
+    .expect("sending event to sink timed out")
+    .unwrap();
+}
+
+async fn reload_with_timeout(
+    topology: &mut RunningTopology,
+    config: Config,
+) -> Result<(), ReloadError> {
+    tokio::time::timeout(
+        ASYNC_TEST_TIMEOUT,
+        topology.reload_config_and_respawn(config, Default::default()),
+    )
+    .await
+    .expect("reload timed out")
+}
 
 fn into_message(event: Event) -> String {
     let message_key = crate::config::log_schema()
@@ -437,13 +459,7 @@ async fn shutdown_waits_for_removed_disk_buffered_sink() {
     config.sinks[&ComponentKey::from("out")].buffer = disk_buffer();
 
     let (mut topology, _) = start_topology(config.build().unwrap(), false).await;
-    tokio::time::timeout(
-        ASYNC_TEST_TIMEOUT,
-        input.send_event(Event::Log(LogEvent::from("event"))),
-    )
-    .await
-    .expect("sending event to gated sink timed out")
-    .unwrap();
+    send_test_event(&mut input).await;
     tokio::time::timeout(ASYNC_TEST_TIMEOUT, entered.wait())
         .await
         .expect("sink did not reach event gate");
@@ -452,20 +468,12 @@ async fn shutdown_waits_for_removed_disk_buffered_sink() {
     let mut config = Config::builder();
     config.set_data_dir(tmpdir.path());
     config.allow_empty = true;
-    tokio::time::timeout(
-        ASYNC_TEST_TIMEOUT,
-        topology.reload_config_and_respawn(config.clone().build().unwrap(), Default::default()),
-    )
-    .await
-    .expect("removing gated disk sink stalled reload")
-    .unwrap();
-    tokio::time::timeout(
-        ASYNC_TEST_TIMEOUT,
-        topology.reload_config_and_respawn(config.build().unwrap(), Default::default()),
-    )
-    .await
-    .expect("active retired disk sink stalled subsequent reload")
-    .unwrap();
+    reload_with_timeout(&mut topology, config.clone().build().unwrap())
+        .await
+        .expect("removing gated disk sink stalled reload");
+    reload_with_timeout(&mut topology, config.build().unwrap())
+        .await
+        .expect("active retired disk sink stalled subsequent reload");
 
     let mut shutdown = Box::pin(topology.stop());
     assert!(futures::poll!(shutdown.as_mut()).is_pending());
@@ -507,13 +515,7 @@ async fn shutdown_deadline_aborts_retired_disk_buffered_sink() {
     config.sinks[&ComponentKey::from("out")].buffer = disk_buffer();
 
     let (mut topology, _) = start_topology(config.build().unwrap(), false).await;
-    tokio::time::timeout(
-        ASYNC_TEST_TIMEOUT,
-        input.send_event(Event::Log(LogEvent::from("event"))),
-    )
-    .await
-    .expect("sending event to gated sink timed out")
-    .unwrap();
+    send_test_event(&mut input).await;
     tokio::time::timeout(ASYNC_TEST_TIMEOUT, entered.wait())
         .await
         .expect("sink did not reach event gate");
@@ -523,13 +525,9 @@ async fn shutdown_deadline_aborts_retired_disk_buffered_sink() {
     config.set_data_dir(tmpdir.path());
     config.graceful_shutdown_duration = Some(graceful_shutdown_duration);
     config.allow_empty = true;
-    tokio::time::timeout(
-        ASYNC_TEST_TIMEOUT,
-        topology.reload_config_and_respawn(config.build().unwrap(), Default::default()),
-    )
-    .await
-    .expect("removing gated disk sink stalled reload")
-    .unwrap();
+    reload_with_timeout(&mut topology, config.build().unwrap())
+        .await
+        .expect("removing gated disk sink stalled reload");
 
     tokio::time::pause();
     let mut shutdown = Box::pin(topology.stop());
@@ -564,13 +562,7 @@ async fn completed_retired_disk_sink_tasks_are_reaped_without_losing_failures() 
     config.sinks[&ComponentKey::from("out")].buffer = disk_buffer();
 
     let (mut topology, mut errors) = start_topology(config.build().unwrap(), false).await;
-    tokio::time::timeout(
-        ASYNC_TEST_TIMEOUT,
-        input.send_event(Event::Log(LogEvent::from("event"))),
-    )
-    .await
-    .expect("sending event to failing sink timed out")
-    .unwrap();
+    send_test_event(&mut input).await;
     tokio::time::timeout(ASYNC_TEST_TIMEOUT, errors.recv())
         .await
         .expect("sink task failure timed out")
@@ -580,22 +572,14 @@ async fn completed_retired_disk_sink_tasks_are_reaped_without_losing_failures() 
     let mut config = Config::builder();
     config.set_data_dir(tmpdir.path());
     config.allow_empty = true;
-    tokio::time::timeout(
-        ASYNC_TEST_TIMEOUT,
-        topology.reload_config_and_respawn(config.clone().build().unwrap(), Default::default()),
-    )
-    .await
-    .expect("removing failed disk sink stalled reload")
-    .unwrap();
+    reload_with_timeout(&mut topology, config.clone().build().unwrap())
+        .await
+        .expect("removing failed disk sink stalled reload");
     assert_eq!(topology.retired_disk_sink_task_count(), 1);
 
-    tokio::time::timeout(
-        ASYNC_TEST_TIMEOUT,
-        topology.reload_config_and_respawn(config.build().unwrap(), Default::default()),
-    )
-    .await
-    .expect("reaping failed disk sink stalled reload")
-    .unwrap();
+    reload_with_timeout(&mut topology, config.build().unwrap())
+        .await
+        .expect("reaping failed disk sink stalled reload");
     assert_eq!(topology.retired_disk_sink_task_count(), 0);
     assert!(
         !tokio::time::timeout(ASYNC_TEST_TIMEOUT, topology.stop())

--- a/src/topology/test/mod.rs
+++ b/src/topology/test/mod.rs
@@ -167,6 +167,30 @@ async fn topology_shutdown_while_active() {
 }
 
 #[tokio::test]
+async fn dropping_shutdown_future_aborts_component_tasks() {
+    trace_init();
+
+    let (input, source) = basic_source();
+    let (mut output, sink) = basic_sink(1);
+
+    let mut config = Config::builder();
+    config.add_source("in", source);
+    config.add_sink("out", &["in"], sink);
+
+    let (topology, _) = start_topology(config.build().unwrap(), false).await;
+    let shutdown = topology.stop();
+    drop(shutdown);
+    drop(input);
+
+    assert!(
+        tokio::time::timeout(ASYNC_TEST_TIMEOUT, output.next())
+            .await
+            .expect("aborted sink did not close its output")
+            .is_none()
+    );
+}
+
+#[tokio::test]
 async fn topology_source_and_sink() {
     trace_init();
 
@@ -444,7 +468,7 @@ async fn shutdown_waits_for_removed_disk_buffered_sink() {
 }
 
 #[tokio::test]
-async fn shutdown_deadline_expires_with_retired_disk_buffered_sink() {
+async fn shutdown_deadline_aborts_retired_disk_buffered_sink() {
     trace_init();
 
     let tmpdir = tempfile::tempdir().expect("no tmpdir");
@@ -501,12 +525,11 @@ async fn shutdown_deadline_expires_with_retired_disk_buffered_sink() {
             .await
             .expect("topology did not stop after graceful shutdown deadline")
     );
-    release.add_permits(1);
     assert!(
         tokio::time::timeout(ASYNC_TEST_TIMEOUT, output.next())
             .await
-            .expect("sink did not emit gated event")
-            .is_some()
+            .expect("aborted sink did not close its output")
+            .is_none()
     );
 }
 

--- a/src/topology/test/mod.rs
+++ b/src/topology/test/mod.rs
@@ -1,5 +1,6 @@
 use std::{
     iter,
+    num::NonZeroU64,
     sync::{
         Arc,
         atomic::{AtomicBool, AtomicUsize, Ordering},
@@ -8,6 +9,7 @@ use std::{
 
 use futures::{StreamExt, future, stream};
 use tokio::{
+    sync::{Barrier, Semaphore},
     task::yield_now,
     time::{Duration, sleep},
 };
@@ -25,7 +27,7 @@ use crate::{
         mock::{
             basic_sink, basic_sink_failing_healthcheck, basic_sink_with_data, basic_source,
             basic_source_with_data, basic_source_with_event_counter, basic_transform,
-            error_definition_transform,
+            error_definition_transform, error_sink,
         },
         start_topology, trace_init,
     },
@@ -72,6 +74,15 @@ fn basic_config_with_sink_failing_healthcheck() -> Config {
     config.add_sink("out1", &["in1"], basic_sink_failing_healthcheck(10).1);
     config.build().unwrap()
 }
+
+fn disk_buffer() -> BufferConfig {
+    BufferConfig::Single(BufferType::DiskV2 {
+        max_size: NonZeroU64::new(268435488).unwrap(),
+        when_full: WhenFull::Block,
+    })
+}
+
+const ASYNC_TEST_TIMEOUT: Duration = Duration::from_secs(5);
 
 fn into_message(event: Event) -> String {
     let message_key = crate::config::log_schema()
@@ -362,6 +373,195 @@ async fn topology_remove_one_sink() {
 
     assert_eq!(vec![event], res1);
     assert_eq!(Vec::<Event>::new(), res2);
+}
+
+#[tokio::test]
+async fn shutdown_waits_for_removed_disk_buffered_sink() {
+    trace_init();
+
+    let tmpdir = tempfile::tempdir().expect("no tmpdir");
+    let (mut input, source) = basic_source();
+    let (mut output, sink) = basic_sink(1);
+    let entered = Arc::new(Barrier::new(2));
+    let release = Arc::new(Semaphore::new(0));
+
+    let mut config = Config::builder();
+    config.set_data_dir(tmpdir.path());
+    config.add_source("in", source);
+    config.add_sink(
+        "out",
+        &["in"],
+        sink.with_event_gate(Arc::clone(&entered), Arc::clone(&release)),
+    );
+    config.sinks[&ComponentKey::from("out")].buffer = disk_buffer();
+
+    let (mut topology, _) = start_topology(config.build().unwrap(), false).await;
+    tokio::time::timeout(
+        ASYNC_TEST_TIMEOUT,
+        input.send_event(Event::Log(LogEvent::from("event"))),
+    )
+    .await
+    .expect("sending event to gated sink timed out")
+    .unwrap();
+    tokio::time::timeout(ASYNC_TEST_TIMEOUT, entered.wait())
+        .await
+        .expect("sink did not reach event gate");
+    drop(input);
+
+    let mut config = Config::builder();
+    config.set_data_dir(tmpdir.path());
+    config.allow_empty = true;
+    tokio::time::timeout(
+        ASYNC_TEST_TIMEOUT,
+        topology.reload_config_and_respawn(config.clone().build().unwrap(), Default::default()),
+    )
+    .await
+    .expect("removing gated disk sink stalled reload")
+    .unwrap();
+    tokio::time::timeout(
+        ASYNC_TEST_TIMEOUT,
+        topology.reload_config_and_respawn(config.build().unwrap(), Default::default()),
+    )
+    .await
+    .expect("active retired disk sink stalled subsequent reload")
+    .unwrap();
+
+    let mut shutdown = Box::pin(topology.stop());
+    assert!(futures::poll!(shutdown.as_mut()).is_pending());
+
+    release.add_permits(1);
+    assert!(
+        tokio::time::timeout(ASYNC_TEST_TIMEOUT, shutdown)
+            .await
+            .expect("topology did not stop after releasing sink")
+    );
+    assert!(
+        tokio::time::timeout(ASYNC_TEST_TIMEOUT, output.next())
+            .await
+            .expect("sink did not emit gated event")
+            .is_some()
+    );
+}
+
+#[tokio::test]
+async fn shutdown_deadline_expires_with_retired_disk_buffered_sink() {
+    trace_init();
+
+    let tmpdir = tempfile::tempdir().expect("no tmpdir");
+    let (mut input, source) = basic_source();
+    let (mut output, sink) = basic_sink(1);
+    let entered = Arc::new(Barrier::new(2));
+    let release = Arc::new(Semaphore::new(0));
+    let graceful_shutdown_duration = Duration::from_secs(30);
+
+    let mut config = Config::builder();
+    config.set_data_dir(tmpdir.path());
+    config.graceful_shutdown_duration = Some(graceful_shutdown_duration);
+    config.add_source("in", source);
+    config.add_sink(
+        "out",
+        &["in"],
+        sink.with_event_gate(Arc::clone(&entered), Arc::clone(&release)),
+    );
+    config.sinks[&ComponentKey::from("out")].buffer = disk_buffer();
+
+    let (mut topology, _) = start_topology(config.build().unwrap(), false).await;
+    tokio::time::timeout(
+        ASYNC_TEST_TIMEOUT,
+        input.send_event(Event::Log(LogEvent::from("event"))),
+    )
+    .await
+    .expect("sending event to gated sink timed out")
+    .unwrap();
+    tokio::time::timeout(ASYNC_TEST_TIMEOUT, entered.wait())
+        .await
+        .expect("sink did not reach event gate");
+    drop(input);
+
+    let mut config = Config::builder();
+    config.set_data_dir(tmpdir.path());
+    config.graceful_shutdown_duration = Some(graceful_shutdown_duration);
+    config.allow_empty = true;
+    tokio::time::timeout(
+        ASYNC_TEST_TIMEOUT,
+        topology.reload_config_and_respawn(config.build().unwrap(), Default::default()),
+    )
+    .await
+    .expect("removing gated disk sink stalled reload")
+    .unwrap();
+
+    tokio::time::pause();
+    let mut shutdown = Box::pin(topology.stop());
+    assert!(futures::poll!(shutdown.as_mut()).is_pending());
+    tokio::time::advance(graceful_shutdown_duration).await;
+    tokio::time::resume();
+
+    assert!(
+        !tokio::time::timeout(ASYNC_TEST_TIMEOUT, shutdown)
+            .await
+            .expect("topology did not stop after graceful shutdown deadline")
+    );
+    release.add_permits(1);
+    assert!(
+        tokio::time::timeout(ASYNC_TEST_TIMEOUT, output.next())
+            .await
+            .expect("sink did not emit gated event")
+            .is_some()
+    );
+}
+
+#[tokio::test]
+async fn completed_retired_disk_sink_tasks_are_reaped_without_losing_failures() {
+    trace_init();
+
+    let tmpdir = tempfile::tempdir().expect("no tmpdir");
+    let (mut input, source) = basic_source();
+
+    let mut config = Config::builder();
+    config.set_data_dir(tmpdir.path());
+    config.add_source("in", source);
+    config.add_sink("out", &["in"], error_sink());
+    config.sinks[&ComponentKey::from("out")].buffer = disk_buffer();
+
+    let (mut topology, mut errors) = start_topology(config.build().unwrap(), false).await;
+    tokio::time::timeout(
+        ASYNC_TEST_TIMEOUT,
+        input.send_event(Event::Log(LogEvent::from("event"))),
+    )
+    .await
+    .expect("sending event to failing sink timed out")
+    .unwrap();
+    tokio::time::timeout(ASYNC_TEST_TIMEOUT, errors.recv())
+        .await
+        .expect("sink task failure timed out")
+        .expect("sink task did not fail");
+    drop(input);
+
+    let mut config = Config::builder();
+    config.set_data_dir(tmpdir.path());
+    config.allow_empty = true;
+    tokio::time::timeout(
+        ASYNC_TEST_TIMEOUT,
+        topology.reload_config_and_respawn(config.clone().build().unwrap(), Default::default()),
+    )
+    .await
+    .expect("removing failed disk sink stalled reload")
+    .unwrap();
+    assert_eq!(topology.retired_disk_sink_task_count(), 1);
+
+    tokio::time::timeout(
+        ASYNC_TEST_TIMEOUT,
+        topology.reload_config_and_respawn(config.build().unwrap(), Default::default()),
+    )
+    .await
+    .expect("reaping failed disk sink stalled reload")
+    .unwrap();
+    assert_eq!(topology.retired_disk_sink_task_count(), 0);
+    assert!(
+        !tokio::time::timeout(ASYNC_TEST_TIMEOUT, topology.stop())
+            .await
+            .expect("topology did not stop after retired sink failure")
+    );
 }
 
 #[tokio::test]

--- a/src/topology/test/mod.rs
+++ b/src/topology/test/mod.rs
@@ -84,26 +84,27 @@ fn disk_buffer() -> BufferConfig {
 
 const ASYNC_TEST_TIMEOUT: Duration = Duration::from_secs(5);
 
-async fn send_test_event(input: &mut SourceSender) {
+async fn send_test_event(input: &mut SourceSender, timeout_message: &'static str) {
     tokio::time::timeout(
         ASYNC_TEST_TIMEOUT,
         input.send_event(Event::Log(LogEvent::from("event"))),
     )
     .await
-    .expect("sending event to sink timed out")
+    .expect(timeout_message)
     .unwrap();
 }
 
 async fn reload_with_timeout(
     topology: &mut RunningTopology,
     config: Config,
+    timeout_message: &'static str,
 ) -> Result<(), ReloadError> {
     tokio::time::timeout(
         ASYNC_TEST_TIMEOUT,
         topology.reload_config_and_respawn(config, Default::default()),
     )
     .await
-    .expect("reload timed out")
+    .expect(timeout_message)
 }
 
 fn into_message(event: Event) -> String {
@@ -459,7 +460,7 @@ async fn shutdown_waits_for_removed_disk_buffered_sink() {
     config.sinks[&ComponentKey::from("out")].buffer = disk_buffer();
 
     let (mut topology, _) = start_topology(config.build().unwrap(), false).await;
-    send_test_event(&mut input).await;
+    send_test_event(&mut input, "sending event to gated sink timed out").await;
     tokio::time::timeout(ASYNC_TEST_TIMEOUT, entered.wait())
         .await
         .expect("sink did not reach event gate");
@@ -468,12 +469,20 @@ async fn shutdown_waits_for_removed_disk_buffered_sink() {
     let mut config = Config::builder();
     config.set_data_dir(tmpdir.path());
     config.allow_empty = true;
-    reload_with_timeout(&mut topology, config.clone().build().unwrap())
-        .await
-        .expect("removing gated disk sink stalled reload");
-    reload_with_timeout(&mut topology, config.build().unwrap())
-        .await
-        .expect("active retired disk sink stalled subsequent reload");
+    reload_with_timeout(
+        &mut topology,
+        config.clone().build().unwrap(),
+        "removing gated disk sink stalled reload",
+    )
+    .await
+    .unwrap();
+    reload_with_timeout(
+        &mut topology,
+        config.build().unwrap(),
+        "active retired disk sink stalled subsequent reload",
+    )
+    .await
+    .unwrap();
 
     let mut shutdown = Box::pin(topology.stop());
     assert!(futures::poll!(shutdown.as_mut()).is_pending());
@@ -515,7 +524,7 @@ async fn shutdown_deadline_aborts_retired_disk_buffered_sink() {
     config.sinks[&ComponentKey::from("out")].buffer = disk_buffer();
 
     let (mut topology, _) = start_topology(config.build().unwrap(), false).await;
-    send_test_event(&mut input).await;
+    send_test_event(&mut input, "sending event to gated sink timed out").await;
     tokio::time::timeout(ASYNC_TEST_TIMEOUT, entered.wait())
         .await
         .expect("sink did not reach event gate");
@@ -525,9 +534,13 @@ async fn shutdown_deadline_aborts_retired_disk_buffered_sink() {
     config.set_data_dir(tmpdir.path());
     config.graceful_shutdown_duration = Some(graceful_shutdown_duration);
     config.allow_empty = true;
-    reload_with_timeout(&mut topology, config.build().unwrap())
-        .await
-        .expect("removing gated disk sink stalled reload");
+    reload_with_timeout(
+        &mut topology,
+        config.build().unwrap(),
+        "removing gated disk sink stalled reload",
+    )
+    .await
+    .unwrap();
 
     tokio::time::pause();
     let mut shutdown = Box::pin(topology.stop());
@@ -562,7 +575,7 @@ async fn completed_retired_disk_sink_tasks_are_reaped_without_losing_failures() 
     config.sinks[&ComponentKey::from("out")].buffer = disk_buffer();
 
     let (mut topology, mut errors) = start_topology(config.build().unwrap(), false).await;
-    send_test_event(&mut input).await;
+    send_test_event(&mut input, "sending event to failing sink timed out").await;
     tokio::time::timeout(ASYNC_TEST_TIMEOUT, errors.recv())
         .await
         .expect("sink task failure timed out")
@@ -572,14 +585,22 @@ async fn completed_retired_disk_sink_tasks_are_reaped_without_losing_failures() 
     let mut config = Config::builder();
     config.set_data_dir(tmpdir.path());
     config.allow_empty = true;
-    reload_with_timeout(&mut topology, config.clone().build().unwrap())
-        .await
-        .expect("removing failed disk sink stalled reload");
+    reload_with_timeout(
+        &mut topology,
+        config.clone().build().unwrap(),
+        "removing failed disk sink stalled reload",
+    )
+    .await
+    .unwrap();
     assert_eq!(topology.retired_disk_sink_task_count(), 1);
 
-    reload_with_timeout(&mut topology, config.build().unwrap())
-        .await
-        .expect("reaping failed disk sink stalled reload");
+    reload_with_timeout(
+        &mut topology,
+        config.build().unwrap(),
+        "reaping failed disk sink stalled reload",
+    )
+    .await
+    .unwrap();
     assert_eq!(topology.retired_disk_sink_task_count(), 0);
     assert!(
         !tokio::time::timeout(ASYNC_TEST_TIMEOUT, topology.stop())


### PR DESCRIPTION
## Summary

Retain task handles for removed durable disk-buffered sinks that continue draining after configuration reload, and include those tasks in the existing graceful-shutdown wait and deadline handling.

- Reload remains non-blocking and never waits for active retired sinks.
- Completed handles are synchronously reaped on later reloads without cancellation points; failures remain sticky so final shutdown reports `false`.
- Active retired disk sinks remain tracked until final shutdown or its configured deadline.
- Removed memory-buffered sinks keep their existing best-effort reload behavior; this change is intentionally limited to durable buffers.

### References

Related: #26050

## Vector configuration

Covered with topology regressions using an active sink and a removed sink with a blocking disk buffer.

## How did you test this PR?

- Deterministic reload/shutdown drain regression, repeated 10 times
- Graceful-shutdown deadline expiry regression
- Reload-does-not-wait regression
- Completed-handle cleanup and failure-preservation regression, repeated 10 times
- Serial topology reload suite: 13 passed
- Transient-state and existing ordinary sink-removal tests
- `cargo clippy --lib --tests -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo vdev check changelog-fragments`

The parallel reload suite retains an unrelated existing enrichment-state timing flake; the test passes serially and in isolation.

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [x] Yes. A changelog fragment is included.
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## Contributor Guidelines

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- After review begins, avoid force pushes so commit history remains reviewable.
