### PR TITLE
Link breaking changes on release pages to upgrade guide

### DIFF
--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -147,9 +147,9 @@ markdown headings inside the body.
 ### Breaking
 
 Breaking fragments start with an H1 title (optionally with a Hugo-style `{#anchor}` for a stable
-backlink) followed by `## Summary` and `## Migration` sections. Only the `## Summary` content
-lands in the changelog list; the title, anchor, and `## Migration` body feed the
-auto-generated upgrade guide.
+backlink) followed by `## Summary` and `## Migration` sections. The `## Summary` content lands in
+the changelog list; the title and anchor are also rendered on the release page as links into the
+auto-generated upgrade guide, which uses the title, anchor, and `## Migration` body.
 
     $ cat changelog.d/env_var_interpolation.breaking.md
     # Environment variable interpolation disabled by default {#env-var-interpolation}

--- a/vdev/src/commands/release/generate_cue.rs
+++ b/vdev/src/commands/release/generate_cue.rs
@@ -474,6 +474,10 @@ fn render_changelog(entries: &[ChangelogEntry]) -> String {
             writeln!(s, "\t\t\ttype: {}", json!(e.cue_type)).unwrap();
             if e.breaking {
                 s.push_str("\t\t\tbreaking: true\n");
+                if let Some(details) = &e.breaking_details {
+                    writeln!(s, "\t\t\ttitle: {}", json!(details.title)).unwrap();
+                    writeln!(s, "\t\t\tanchor: {}", json!(details.anchor)).unwrap();
+                }
             }
             s.push_str("\t\t\tdescription: #\"\"\"\n");
             for line in e.description.lines() {
@@ -716,6 +720,18 @@ mod tests {
                 contributors: vec![],
                 breaking_details: None,
             },
+            ChangelogEntry {
+                cue_type: "chore".into(),
+                breaking: true,
+                description: "Removed legacy thing.".into(),
+                contributors: vec![],
+                breaking_details: Some(BreakingDetails {
+                    title: "Legacy thing removed".into(),
+                    anchor: "legacy-thing-removed".into(),
+                    summary: "Removed legacy thing.".into(),
+                    migration: "N/A".into(),
+                }),
+            },
         ];
         let out = render_release_cue(&Version::new(0, 99, 0), &entries);
 
@@ -727,6 +743,10 @@ mod tests {
         assert!(out.contains("\t\t\t\tMulti-line.\n"));
         assert!(out.contains("contributors: [\"alice\"]"));
         assert!(out.contains("\t\t\ttype: \"fix\"\n"));
+        assert!(out.contains("\t\t\ttype: \"chore\"\n"));
+        assert!(out.contains("\t\t\tbreaking: true\n"));
+        assert!(out.contains("\t\t\ttitle: \"Legacy thing removed\"\n"));
+        assert!(out.contains("\t\t\tanchor: \"legacy-thing-removed\"\n"));
         assert!(!out.contains("commits:"));
     }
 

--- a/website/cue/reference/releases.cue
+++ b/website/cue/reference/releases.cue
@@ -23,6 +23,8 @@ releases: {
 		type: #SemanticType
 		scopes: [string, ...string] | *[]
 		breaking:    bool | *false
+		title?:      string
+		anchor?:     string
 		description: string
 		pr_numbers: [uint, ...uint] | *[]
 		contributors: [string, ...string] | *[]

--- a/website/cue/reference/releases/0.58.0.cue
+++ b/website/cue/reference/releases/0.58.0.cue
@@ -269,6 +269,8 @@ releases: "0.58.0": {
 		{
 			type:     "chore"
 			breaking: true
+			title:    "`azure_monitor_logs` sink removed"
+			anchor:   "azure-monitor-logs-sink-removed"
 			description: #"""
 				The deprecated `azure_monitor_logs` sink has been removed. Configurations using it now fail
 				validation. Microsoft ends support for the sink's underlying Data Collector API in September
@@ -279,6 +281,8 @@ releases: "0.58.0": {
 		{
 			type:     "chore"
 			breaking: true
+			title:    "Legacy buffer metrics removed"
+			anchor:   "legacy-buffer-metrics-removed"
 			description: #"""
 				The deprecated `buffer_byte_size` and `buffer_events` gauge metrics have been removed.
 				"""#
@@ -362,6 +366,8 @@ releases: "0.58.0": {
 		{
 			type:     "chore"
 			breaking: true
+			title:    "HTTP server `encoding` option removed"
+			anchor:   "http-server-encoding-removed"
 			description: #"""
 				The deprecated `encoding` option has been removed from the `http_server` source
 				and its deprecated `http` alias. Configurations using it now fail validation.
@@ -371,6 +377,8 @@ releases: "0.58.0": {
 		{
 			type:     "chore"
 			breaking: true
+			title:    "`influxdb_logs` sink `namespace` option removed"
+			anchor:   "influxdb-logs-namespace-removed"
 			description: #"""
 				The deprecated `namespace` option has been removed from the `influxdb_logs` sink. It has been
 				deprecated since v0.24.0 in favor of `measurement`. Configurations using it now fail validation.
@@ -417,6 +425,8 @@ releases: "0.58.0": {
 		{
 			type:     "chore"
 			breaking: true
+			title:    "`logdna` sink alias removed"
+			anchor:   "logdna-sink-alias-removed"
 			description: #"""
 				The deprecated `logdna` sink alias has been removed. It was renamed to `mezmo` in v0.29.0.
 				Configurations using `type: logdna` now fail validation.
@@ -501,6 +511,8 @@ releases: "0.58.0": {
 		{
 			type:     "chore"
 			breaking: true
+			title:    "URI template field references inside the authority are rejected"
+			anchor:   "uri-template-partial-authority"
 			description: #"""
 				Vector now refuses to build configs where a `{{ field }}` reference lands inside
 				the hostname (or immediately adjacent to it without a path separator). Previously,
@@ -530,6 +542,8 @@ releases: "0.58.0": {
 		{
 			type:     "chore"
 			breaking: true
+			title:    "`webhdfs` sink defaults endpoints to `https://`"
+			anchor:   "webhdfs-sink-defaults-endpoints-to-https"
 			description: #"""
 				The `webhdfs` sink's `endpoint` option now defaults a missing scheme to `https://` instead of
 				`http://`. A scheme-less endpoint (for example `endpoint: "127.0.0.1:9870"`) still loads and

--- a/website/layouts/releases/single.html
+++ b/website/layouts/releases/single.html
@@ -102,7 +102,10 @@
         {{ if and (gt (len $breakingTitled) 0) (gt (len $upgradeGuides) 0) }}
         <div class="mt-6">
           <div class="prose dark:prose-invert max-w-none">
-            {{ partial "heading.html" (dict "text" "Breaking changes" "level" 3 "icon" false) }}
+            {{ $numBreaking := len $breakingTitled }}
+            {{ $breakingWord := cond (eq $numBreaking 1) "breaking change" "breaking changes" }}
+            {{ $breakingHeading := printf "%d %s" $numBreaking $breakingWord }}
+            {{ partial "heading.html" (dict "text" $breakingHeading "level" 3 "icon" false) }}
           </div>
 
           <ul class="prose dark:prose-invert list-disc ml-6">

--- a/website/layouts/releases/single.html
+++ b/website/layouts/releases/single.html
@@ -6,6 +6,9 @@
 {{ $version := .File.BaseFileName }}
 {{ $release := index site.Data.docs.releases $version }}
 {{ $highlights := where (where site.RegularPages "Section" "highlights") ".Params.release" "eq" $version }}
+{{ $breaking := where ($release.changelog | default slice) "breaking" true }}
+{{ $breakingTitled := where $breaking "title" "ne" nil }}
+{{ $upgradeGuides := where $highlights ".Title" "like" "Upgrade Guide$" }}
 {{ $groups := dict "enhancement" "enhancements" "feat" "new features" "fix" "bug fixes" "security" "security changes" "deprecation" "deprecations" "chore" "chore"}}
 {{ $orderedGroups := slice "security" "feat" "enhancement" "fix" "deprecation" "chore" }}
 
@@ -47,6 +50,24 @@
         </div>
       </div>
     </div>
+
+    {{ if and (gt (len $breakingTitled) 0) (gt (len $upgradeGuides) 0) }}
+    <div class="mt-8">
+      <div class="prose dark:prose-invert max-w-none">
+        {{ partial "heading.html" (dict "text" "Breaking changes" "level" 2) }}
+      </div>
+
+      <ul class="mt-4 space-y-2 list-disc ml-6">
+        {{ range $breakingTitled }}
+        <li class="marker:text-dark dark:marker:text-gray-300">
+          <a href="{{ (index $upgradeGuides 0).RelPermalink }}#{{ .anchor }}" class="text-secondary dark:text-primary hover:underline">
+            {{ .title | markdownify }}
+          </a>
+        </li>
+        {{ end }}
+      </ul>
+    </div>
+    {{ end }}
 
     {{ with $release.known_issues }}
     {{ if gt (len $release.known_issues) 0 }}

--- a/website/layouts/releases/single.html
+++ b/website/layouts/releases/single.html
@@ -51,24 +51,6 @@
       </div>
     </div>
 
-    {{ if and (gt (len $breakingTitled) 0) (gt (len $upgradeGuides) 0) }}
-    <div class="mt-8">
-      <div class="prose dark:prose-invert max-w-none">
-        {{ partial "heading.html" (dict "text" "Breaking changes" "level" 2) }}
-      </div>
-
-      <ul class="mt-4 space-y-2 list-disc ml-6">
-        {{ range $breakingTitled }}
-        <li class="marker:text-dark dark:marker:text-gray-300">
-          <a href="{{ (index $upgradeGuides 0).RelPermalink }}#{{ .anchor }}" class="text-primary-dark dark:text-primary hover:underline">
-            {{ .title | markdownify }}
-          </a>
-        </li>
-        {{ end }}
-      </ul>
-    </div>
-    {{ end }}
-
     {{ with $release.known_issues }}
     {{ if gt (len $release.known_issues) 0 }}
     <div class="mt-4 admonition dark:prose-invert prose rounded-xl border-3 px-3 py-3.5 lg:px-5 lg:py-4 border-yellow-400">
@@ -116,6 +98,24 @@
         <div class="prose dark:prose-invert max-w-none">
           {{ partial "heading.html" (dict "text" "Vector Changelog" "level" 2) }}
         </div>
+
+        {{ if and (gt (len $breakingTitled) 0) (gt (len $upgradeGuides) 0) }}
+        <div class="mt-6">
+          <div class="prose dark:prose-invert max-w-none">
+            {{ partial "heading.html" (dict "text" "Breaking changes" "level" 3 "icon" false) }}
+          </div>
+
+          <ul class="prose dark:prose-invert list-disc ml-6">
+            {{ range $breakingTitled }}
+            <li>
+              <a href="{{ (index $upgradeGuides 0).RelPermalink }}#{{ .anchor }}" class="text-primary-dark dark:text-primary hover:underline">
+                {{ .title | markdownify }}
+              </a>
+            </li>
+            {{ end }}
+          </ul>
+        </div>
+        {{ end }}
 
         <div class="mt-6 flex flex-col space-y-8">
           {{ range $orderedGroups }}

--- a/website/layouts/releases/single.html
+++ b/website/layouts/releases/single.html
@@ -60,7 +60,7 @@
       <ul class="mt-4 space-y-2 list-disc ml-6">
         {{ range $breakingTitled }}
         <li class="marker:text-dark dark:marker:text-gray-300">
-          <a href="{{ (index $upgradeGuides 0).RelPermalink }}#{{ .anchor }}" class="text-secondary dark:text-primary hover:underline">
+          <a href="{{ (index $upgradeGuides 0).RelPermalink }}#{{ .anchor }}" class="text-primary-dark dark:text-primary hover:underline">
             {{ .title | markdownify }}
           </a>
         </li>

--- a/website/layouts/releases/single.html
+++ b/website/layouts/releases/single.html
@@ -91,8 +91,6 @@
       </div>
       {{ end }}
 
-      {{ partial "releases/deprecations.html" (dict "version" $version) }}
-
       {{ if gt (len $release.changelog) 0 }}
       <div class="mt-8">
         <div class="prose dark:prose-invert max-w-none">
@@ -241,6 +239,7 @@
         </div>
       </div>
     </div>
+    {{ partial "releases/deprecations.html" (dict "version" $version) }}
   </main>
 
   <div class="hidden lg:block xl:col-span-1">


### PR DESCRIPTION
## Summary
Release pages now render a "Breaking changes" list for breaking changelog entries, linking each title to its section in the auto-generated upgrade guide. The release CUE generator now emits `title` and `anchor` fields for breaking entries.

### References
NA

## Vector configuration
NA

## How did you test this PR?
NA

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## Contributor Guidelines

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them. To catch issues early, add a `pre-push` hook ([template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push)) or run the following locally before pushing:
  - `make fmt`
  - `make check-clippy` (auto-fix with `make clippy-fix`)
  - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details on the [dd-rust-license-tool](https://crates.io/crates/dd-rust-license-tool).
