### PR TITLE
docs(releasing): apply 0.58.0 release note review suggestions

### DIFF
--- a/website/content/en/highlights/2026-08-26-0-58-0-upgrade-guide.md
+++ b/website/content/en/highlights/2026-08-26-0-58-0-upgrade-guide.md
@@ -88,8 +88,8 @@ deprecated since v0.24.0 in favor of `measurement`. Configurations using it now 
 Replace `namespace` with `measurement`. Previously, `namespace` prefixed the measurement name
 with `<namespace>.vector`, so set `measurement` to `<namespace>.vector` for the same effect:
 
-Note: if your configuration sets both `namespace` and `measurement`, `measurement` was used and
-`namespace` ignored; remove the `namespace` option and leave `measurement` unchanged.
+Note: If your configuration sets both `namespace` and `measurement`, `measurement` was used and
+`namespace` was ignored. Remove the `namespace` option and leave `measurement` unchanged.
 
 #### Old
 
@@ -146,9 +146,9 @@ sinks:
 
 ### Summary
 
-Vector now refuses to build configs where a `{{ field }}` reference lands inside
-the hostname (or immediately adjacent to it without a path separator). Previously,
-such templates built successfully but silently dropped every event at render time.
+Vector now rejects configs where a `{{ field }}` reference appears inside
+the hostname or immediately adjacent to it without a path separator. Previously,
+these templates built successfully but silently dropped all events during rendering.
 
 ### Migration
 

--- a/website/cue/reference/releases/0.58.0.cue
+++ b/website/cue/reference/releases/0.58.0.cue
@@ -40,7 +40,7 @@ releases: "0.58.0": {
 		{
 			type: "fix"
 			description: #"""
-				The `redis` source configured with `data_type = "channel"` now automatically reconnects and re-subscribes after the Redis connection drops (for example on a Redis restart or a transient network blip), instead of silently stopping until Vector is restarted. Reconnect attempts use exponential backoff (capped at 30s) and emit `component_errors_total` on failures and `connection_established_total` on recovery.
+				The `redis` source configured with `data_type = "channel"` now automatically reconnects and re-subscribes after the Redis connection drops (for example, on a Redis restart or a transient network blip), instead of silently stopping until Vector is restarted. Reconnect attempts use exponential backoff (capped at 30s) and emit `component_errors_total` on failures and `connection_established_total` on recovery.
 				"""#
 			contributors: ["gibranbadrul"]
 		},
@@ -48,7 +48,7 @@ releases: "0.58.0": {
 			type: "enhancement"
 			description: #"""
 				The `prometheus_exporter` sink's `flush_period_secs` option now accepts `0` to disable metric
-				expiration entirely. Previously, metrics with sparse or bursty updates (for example, high
+				expiration. Previously, metrics with sparse or bursty updates (for example, high
 				cardinality counters produced by `log_to_metric`) could be expired and re-added as a "new"
 				series, causing gaps and apparent counter resets in downstream Prometheus queries even with a
 				large `flush_period_secs` configured. Setting `flush_period_secs: 0` keeps all previously seen
@@ -96,14 +96,14 @@ releases: "0.58.0": {
 		{
 			type: "feat"
 			description: #"""
-				Added cuckoo filter support for `memory` enrichment table, to provide an efficient way to store and check presence of keys with a low memory footprint at the cost of false positives.
+				Added cuckoo filter support for the `memory` enrichment table to provide an efficient way to store and check for the presence of keys with a low memory footprint, at the cost of false positives.
 				"""#
 			contributors: ["esensar", "Quad9DNS"]
 		},
 		{
 			type: "feat"
 			description: #"""
-				Added bloom filter support for `memory` enrichment table, similar to cuckoo filter, providing as imple and efficient way to store and check presence of keys with a low memory footprint at the cost of false positives, but with less features that cuckoo filter.
+				Added bloom filter support for `memory` enrichment table, similar to cuckoo filter, providing a simple and efficient way to store and check the presence of keys with a low memory footprint at the cost of false positives, but with fewer features than cuckoo filter.
 				"""#
 			contributors: ["esensar", "Quad9DNS"]
 		},
@@ -172,7 +172,7 @@ releases: "0.58.0": {
 				      codec: json
 				```
 				
-				previously passed `vector validate --no-environment` and only failed with a full `vector validate` or when running the config. It now fails validation with a confinement error due to `topic` having no confinement base.
+				This configuration previously passed `vector validate --no-environment` and only failed with a full `vector validate` or when running the config. It now fails validation with a confinement error due to `topic` having no confinement base.
 				
 				```yaml
 				sinks:
@@ -190,7 +190,7 @@ releases: "0.58.0": {
 		{
 			type: "fix"
 			description: #"""
-				Allows hyphens in the `<backend name>` portion of the `SECRET[<backend name>.<secret name>]` collector regex. Before, a backend name containing a hyphen (e.g. `my-backend`) would fail to match, leaving the literal `SECRET[...]` string in the resolved config instead of the secret value.
+				Allows hyphens in the `<backend name>` portion of the `SECRET[<backend name>.<secret name>]` collector regex. Before, a backend name containing a hyphen (e.g., `my-backend`) would fail to match, leaving the literal `SECRET[...]` string in the resolved config instead of the secret value.
 				"""#
 			contributors: ["maklean"]
 		},
@@ -228,7 +228,7 @@ releases: "0.58.0": {
 		{
 			type: "fix"
 			description: #"""
-				The `sematext_logs` sink no longer panics when the `token` cannot be parsed as a template (for example `{{ }}`); it now fails configuration validation with a clear error instead of crashing at startup.
+				The `sematext_logs` sink no longer panics when the `token` cannot be parsed as a template (e.g., `{{ }}`). It now fails configuration validation with a clear error instead of crashing at startup.
 				"""#
 			contributors: ["thomasqueirozb"]
 		},
@@ -287,22 +287,21 @@ releases: "0.58.0": {
 		{
 			type: "fix"
 			description: #"""
-				Fixed two problems with the `chunked_gelf` framing decoder's limits. `pending_messages_limit` was applied to every chunk rather than only to new messages, so once the limit was reached even chunks of messages already pending were rejected and those messages could never complete. Separately, dropping a message for exceeding `max_length` left its timeout task running, so the number of live tasks was not bounded by `pending_messages_limit` the way the pending message count was.
+				Fixed two problems with the `chunked_gelf` framing decoder's limits. `pending_messages_limit` was applied to every chunk rather than only to new messages, so once the limit was reached even chunks of messages already pending were rejected and those messages could never complete. Separately, dropping a message for exceeding `max_length` left its timeout task running, so `pending_messages_limit` bounded the pending message count but not the number of live tasks.
 				"""#
 			contributors: ["pront"]
 		},
 		{
 			type: "fix"
 			description: #"""
-				Fixed a panic in the `chunked_gelf` framing decoder when a one-byte message arrived and trace-level logging was enabled for it, which took down the source. Such a message is now passed on for the decoder to reject, as any other malformed payload would be.
+				Fixed a panic in the `chunked_gelf` framing decoder when a one-byte message arrived with trace-level logging enabled, which caused the source to fail. Such a message is now passed on for the decoder to reject, as it would any other malformed payload.
 				"""#
 			contributors: ["pront"]
 		},
 		{
 			type: "fix"
 			description: #"""
-				Improve configuration error messages by including the affected field path. For example, this
-				invalid configuration:
+				Improve configuration error messages by including the affected field path. For example, consider the following invalid configuration:
 				
 				```yaml
 				sources:
@@ -311,7 +310,7 @@ releases: "0.58.0": {
 				    interval: not-a-number
 				```
 				
-				now reports `sources.broken: invalid type: string "not-a-number", expected f64`.
+				This configuration now reports `sources.broken: invalid type: string "not-a-number", expected f64`.
 				"""#
 			contributors: ["pront"]
 		},


### PR DESCRIPTION
## Summary
Apply the review suggestions from PR #26233 to the 0.58.0 release notes (upgrade guide and release notes cue file). All 13 unresolved review threads addressed.

### References
Related: #26233

## Vector configuration
NA

## How did you test this PR?
NA

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## Contributor Guidelines

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them. To catch issues early, add a `pre-push` hook ([template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push)) or run the following locally before pushing:
  - `make fmt`
  - `make check-clippy` (auto-fix with `make clippy-fix`)
  - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details on the [dd-rust-license-tool](https://crates.io/crates/dd-rust-license-tool).
