### PR TITLE
feat(website): make release changelogs easier to scan

### DIFF
--- a/website/assets/css/style.css
+++ b/website/assets/css/style.css
@@ -155,18 +155,18 @@
   margin: 0;
 }
 
-/* Current VRL release entries end with linked PR and author attribution. */
-.vrl-changelog > ul:has(+ p > a[href*="github.com/vectordotdev/vrl/pull/"] ~ a[href^="https://github.com/"]) {
+/* VRL release entries end with linked PR and author attribution. */
+.vrl-changelog > ul:has(+ p a[href*="github.com/vectordotdev/vrl/pull/"] ~ a[href^="https://github.com/"]) {
   @apply mb-0 mt-4 min-w-0 list-none rounded-t-lg border border-b-0 border-gray-200 bg-gray-50/50 px-4 py-4 shadow-sm md:px-5;
 }
-.vrl-changelog > ul:has(+ p > a[href*="github.com/vectordotdev/vrl/pull/"] ~ a[href^="https://github.com/"]) > li {
+.vrl-changelog > ul:has(+ p a[href*="github.com/vectordotdev/vrl/pull/"] ~ a[href^="https://github.com/"]) > li {
   @apply m-0;
 }
-.vrl-changelog > ul + p:has(> a[href*="github.com/vectordotdev/vrl/pull/"] ~ a[href^="https://github.com/"]) {
+.vrl-changelog > ul + p:has(a[href*="github.com/vectordotdev/vrl/pull/"] ~ a[href^="https://github.com/"]) {
   @apply mt-0 rounded-b-lg border border-gray-200 bg-gray-50/50 px-4 py-3 text-sm italic shadow-sm md:px-5;
 }
-.dark .vrl-changelog > ul:has(+ p > a[href*="github.com/vectordotdev/vrl/pull/"] ~ a[href^="https://github.com/"]),
-.dark .vrl-changelog > ul + p:has(> a[href*="github.com/vectordotdev/vrl/pull/"] ~ a[href^="https://github.com/"]) {
+.dark .vrl-changelog > ul:has(+ p a[href*="github.com/vectordotdev/vrl/pull/"] ~ a[href^="https://github.com/"]),
+.dark .vrl-changelog > ul + p:has(a[href*="github.com/vectordotdev/vrl/pull/"] ~ a[href^="https://github.com/"]) {
   @apply border-gray-700 bg-gray-800/40;
 }
 

--- a/website/assets/css/style.css
+++ b/website/assets/css/style.css
@@ -155,18 +155,18 @@
   margin: 0;
 }
 
-/* VRL release entries are emitted as a list followed by a PR attribution paragraph. */
-.vrl-changelog > ul:has(+ p > a[href*="github.com/vectordotdev/vrl/pull/"]) {
+/* Current VRL release entries end with linked PR and author attribution. */
+.vrl-changelog > ul:has(+ p > a[href*="github.com/vectordotdev/vrl/pull/"] ~ a[href^="https://github.com/"]) {
   @apply mb-0 mt-4 min-w-0 list-none rounded-t-lg border border-b-0 border-gray-200 bg-gray-50/50 px-4 py-4 shadow-sm md:px-5;
 }
-.vrl-changelog > ul:has(+ p > a[href*="github.com/vectordotdev/vrl/pull/"]) > li {
+.vrl-changelog > ul:has(+ p > a[href*="github.com/vectordotdev/vrl/pull/"] ~ a[href^="https://github.com/"]) > li {
   @apply m-0;
 }
-.vrl-changelog > ul + p:has(> a[href*="github.com/vectordotdev/vrl/pull/"]) {
+.vrl-changelog > ul + p:has(> a[href*="github.com/vectordotdev/vrl/pull/"] ~ a[href^="https://github.com/"]) {
   @apply mt-0 rounded-b-lg border border-gray-200 bg-gray-50/50 px-4 py-3 text-sm italic shadow-sm md:px-5;
 }
-.dark .vrl-changelog > ul:has(+ p > a[href*="github.com/vectordotdev/vrl/pull/"]),
-.dark .vrl-changelog > ul + p:has(> a[href*="github.com/vectordotdev/vrl/pull/"]) {
+.dark .vrl-changelog > ul:has(+ p > a[href*="github.com/vectordotdev/vrl/pull/"] ~ a[href^="https://github.com/"]),
+.dark .vrl-changelog > ul + p:has(> a[href*="github.com/vectordotdev/vrl/pull/"] ~ a[href^="https://github.com/"]) {
   @apply border-gray-700 bg-gray-800/40;
 }
 

--- a/website/assets/css/style.css
+++ b/website/assets/css/style.css
@@ -155,6 +155,21 @@
   margin: 0;
 }
 
+/* VRL release entries are emitted as a list followed by a PR attribution paragraph. */
+.vrl-changelog > ul:has(+ p > a[href*="github.com/vectordotdev/vrl/pull/"]) {
+  @apply mb-0 mt-4 min-w-0 list-none rounded-t-lg border border-b-0 border-gray-200 bg-gray-50/50 px-4 py-4 shadow-sm md:px-5;
+}
+.vrl-changelog > ul:has(+ p > a[href*="github.com/vectordotdev/vrl/pull/"]) > li {
+  @apply m-0;
+}
+.vrl-changelog > ul + p:has(> a[href*="github.com/vectordotdev/vrl/pull/"]) {
+  @apply mt-0 rounded-b-lg border border-gray-200 bg-gray-50/50 px-4 py-3 text-sm italic shadow-sm md:px-5;
+}
+.dark .vrl-changelog > ul:has(+ p > a[href*="github.com/vectordotdev/vrl/pull/"]),
+.dark .vrl-changelog > ul + p:has(> a[href*="github.com/vectordotdev/vrl/pull/"]) {
+  @apply border-gray-700 bg-gray-800/40;
+}
+
 /* Dark mode prose overrides */
 .dark .prose table th,
 .dark .prose table td {

--- a/website/cue/reference/releases/0.56.0.cue
+++ b/website/cue/reference/releases/0.56.0.cue
@@ -405,7 +405,7 @@ releases: "0.56.0": {
 
 		- Reverted `parse_regex` changes from 0.33.0 which introduced a performance regression in multi-threaded scenarios.
 
-		[PR #1789](https://github.com/vectordotdev/vrl/pull/1789)
+		[PR #1789](https://github.com/vectordotdev/vrl/pull/1789) by [@thomasqueirozb](https://github.com/thomasqueirozb)
 
 
 		### [0.33.0 (2026-05-28)](https://github.com/vectordotdev/vrl/releases/tag/v0.33.0)
@@ -414,73 +414,73 @@ releases: "0.56.0": {
 
 		- VRL string literals now support `\u{HEX}` Unicode escape sequences. Any valid Unicode scalar value can be expressed, e.g. `"hello\u{1F30E}world"`. Invalid sequences (empty braces, non-hex digits, surrogate codepoints, or values above U+10FFFF) are reported as a compile-time error.
 
-		[PR #1771](https://github.com/vectordotdev/vrl/pull/1771)
+		[PR #1771](https://github.com/vectordotdev/vrl/pull/1771) by [@thomasqueirozb](https://github.com/thomasqueirozb)
 		- ~~`parse_regex` now accepts dynamic regex patterns (variables and runtime expressions), consistent with `parse_regex_all`. When the pattern is a literal, return type information remains precise based on named capture groups.~~
 
-		~~[PR #1774](https://github.com/vectordotdev/vrl/pull/1774)~~
+		~~[PR #1774](https://github.com/vectordotdev/vrl/pull/1774) by [@thomasqueirozb](https://github.com/thomasqueirozb)~~
 
 		#### Enhancements
 
 		- Updated user agent data for `parse_user_agent` function
 
-		[PR #1776](https://github.com/vectordotdev/vrl/pull/1776)
+		[PR #1776](https://github.com/vectordotdev/vrl/pull/1776) by [@JakubOnderka](https://github.com/JakubOnderka)
 		- Protobuf encoding now coerces compatible scalar types into the target field type: integers and strings are accepted for `bool` fields (using the same parsing as `to_bool`), and integers are accepted for `float`/`double` fields. Previously these inputs failed encoding and required explicit conversion in VRL.
 
-		[PR #1763](https://github.com/vectordotdev/vrl/pull/1763)
+		[PR #1763](https://github.com/vectordotdev/vrl/pull/1763) by [@flaviofcruz](https://github.com/flaviofcruz)
 		- Added an optional `allow_lossy_string_coercion` argument to `encode_proto`. VRL's protobuf encoding stringifies `Boolean`, `Integer`, `Float`, and `Timestamp` values when assigned to a protobuf `string` field as a convenience for callers handling loosely typed input. The [protobuf JSON mapping](https://protobuf.dev/programming-guides/json/) only accepts a JSON string for a `string` field, so callers who want strict spec-compliant encoding can now pass `allow_lossy_string_coercion: false`. The default stays `true`, so today's behavior is unchanged.
 
-		[PR #1764](https://github.com/vectordotdev/vrl/pull/1764)
+		[PR #1764](https://github.com/vectordotdev/vrl/pull/1764) by [@pront](https://github.com/pront)
 		- ~~Improved performance of `parse_regex`/`parse_regex_all` by pre-computing capture group names and indices at compile time. Users may see anywhere from 4% to 13% speedups in some cases.~~
 
-		~~[PR #1773](https://github.com/vectordotdev/vrl/pull/1773)~~
+		~~[PR #1773](https://github.com/vectordotdev/vrl/pull/1773) by [@thomasqueirozb](https://github.com/thomasqueirozb)~~
 		- Improved performance of `parse_regex_all` by reusing the compiled regex across invocations.
 
-		[PR #1775](https://github.com/vectordotdev/vrl/pull/1775)
+		[PR #1775](https://github.com/vectordotdev/vrl/pull/1775) by [@thomasqueirozb](https://github.com/thomasqueirozb)
 
 		#### Fixes
 
 		- The compiler now reports every unhandled-error in a single compilation pass instead of stopping at the first one. For example:
 
-		```coffee
-		{
-		push(.x, 1)
-		.b = push(.y, 2)
-		}
-		```
+		    ```coffee
+		    {
+		    push(.x, 1)
+		    .b = push(.y, 2)
+		    }
+		    ```
 
-		now reports both `push(.x, 1)` (unhandled error) and `.b = push(.y, 2)` (unhandled fallible assignment) in one go. Previously you'd only see the second one, fix it, recompile, and only then discover the first.
+		    now reports both `push(.x, 1)` (unhandled error) and `.b = push(.y, 2)` (unhandled fallible assignment) in one go. Previously you'd only see the second one, fix it, recompile, and only then discover the first.
 
-		[PR #1759](https://github.com/vectordotdev/vrl/pull/1759)
+		[PR #1759](https://github.com/vectordotdev/vrl/pull/1759) by [@yjagdale](https://github.com/yjagdale)
 		- Fixed a confusing compile error where a fallible call earlier in a block could cause a later, unrelated assignment to be reported as the problem. For example:
 
-		```coffee
-		{
-		.a = 1
-		push(.x, 1)        # the unhandled error is actually here
-		.b = 2             # but the compiler used to flag this line
-		}
-		```
+		    ```coffee
+		    {
+		    .a = 1
+		    push(.x, 1)        # the unhandled error is actually here
+		    .b = 2             # but the compiler used to flag this line
+		    }
+		    ```
 
-		The error is now reported on the actual fallible expression, so adding `!` or the `, err =` form fixes it where you'd expect. This also fixes the same shape inside closure bodies, e.g. inside `for_each`/`map_values`.
+		    The error is now reported on the actual fallible expression, so adding `!` or the `, err =` form fixes it where you'd expect. This also fixes the same shape inside closure bodies, e.g. inside `for_each`/`map_values`.
 
-		[PR #453](https://github.com/vectordotdev/vrl/pull/453)
+		[PR #1758](https://github.com/vectordotdev/vrl/pull/1758) by [@pront](https://github.com/pront)
 		- Fixed a false positive in the unused-variable diagnostic (`E900`) where a variable used before being reassigned (shadowed) was incorrectly flagged as unused at its original assignment.
 
-		[PR #1743](https://github.com/vectordotdev/vrl/pull/1743)
+		[PR #1743](https://github.com/vectordotdev/vrl/pull/1743) by [@pront](https://github.com/pront)
 		- `encode_proto` and `parse_proto` now support proto maps whose keys are integers or booleans, not just strings. Because VRL object keys are always strings, integer and boolean keys are written in their string form:
 
-		```coffee
-		encode_proto({ "by_id": { "42": "alice" } }, "schema.desc", "MyMessage")
-		```
+		    ```coffee
+		    encode_proto({ "by_id": { "42": "alice" } }, "schema.desc", "MyMessage")
+		    ```
 
-		Previously `parse_proto` errored on these maps and `encode_proto` silently dropped the field. Note that `encode_proto` will now return an error if a key string can't be parsed into the schema's key type (for example, `"abc"` against a `map<int32, ...>`).
+		    Previously `parse_proto` errored on these maps and `encode_proto` silently dropped the field. Note that `encode_proto` will now return an error if a key string can't be parsed into the schema's key type (for example, `"abc"` against a `map<int32, ...>`).
 
-		[PR #1762](https://github.com/vectordotdev/vrl/pull/1762)
+		[PR #1762](https://github.com/vectordotdev/vrl/pull/1762) by [@flaviofcruz](https://github.com/flaviofcruz)
 		- Fixed a typo in enum variant that made it impossible to use `SCREAMING_SNAKE` in casing functions such as `pascalcase`, `camelcase` and others.
 
-		`pascalcase("hello", original_case: "SCREAMING_SNAKE")` now compiles properly.
+		    `pascalcase("hello", original_case: "SCREAMING_SNAKE")` now compiles properly.
 
-		[PR #1770](https://github.com/vectordotdev/vrl/pull/1770)
+		[PR #1770](https://github.com/vectordotdev/vrl/pull/1770) by [@simplepad](https://github.com/simplepad)
 		- Allowed the `else` keyword (and `else if`) to appear on a new line after the closing `}` of an `if`-block. Previously the trailing newline terminated the if-expression at the parser level, forcing `else` to share a line with `}`.
 
 		[PR #1756](https://github.com/vectordotdev/vrl/pull/1756) by [@pront](https://github.com/pront)

--- a/website/cue/reference/releases/0.56.0.cue
+++ b/website/cue/reference/releases/0.56.0.cue
@@ -450,7 +450,7 @@ releases: "0.56.0": {
 
 		    now reports both `push(.x, 1)` (unhandled error) and `.b = push(.y, 2)` (unhandled fallible assignment) in one go. Previously you'd only see the second one, fix it, recompile, and only then discover the first.
 
-		[PR #1759](https://github.com/vectordotdev/vrl/pull/1759) by [@yjagdale](https://github.com/yjagdale)
+		[PR #1760](https://github.com/vectordotdev/vrl/pull/1760) by [@pront](https://github.com/pront)
 		- Fixed a confusing compile error where a fallible call earlier in a block could cause a later, unrelated assignment to be reported as the problem. For example:
 
 		    ```coffee

--- a/website/cue/reference/releases/0.56.0.cue
+++ b/website/cue/reference/releases/0.56.0.cue
@@ -399,43 +399,43 @@ releases: "0.56.0": {
 	]
 
 	vrl_changelog: #"""
-		### [0.33.1 (2026-06-02)]
+		### [0.33.1 (2026-06-02)](https://github.com/vectordotdev/vrl/releases/tag/v0.33.1)
 
 		#### Fixes
 
 		- Reverted `parse_regex` changes from 0.33.0 which introduced a performance regression in multi-threaded scenarios.
 
-		(https://github.com/vectordotdev/vrl/pull/1789)
+		[PR #1789](https://github.com/vectordotdev/vrl/pull/1789)
 
 
-		### [0.33.0 (2026-05-28)]
+		### [0.33.0 (2026-05-28)](https://github.com/vectordotdev/vrl/releases/tag/v0.33.0)
 
 		#### New Features
 
 		- VRL string literals now support `\u{HEX}` Unicode escape sequences. Any valid Unicode scalar value can be expressed, e.g. `"hello\u{1F30E}world"`. Invalid sequences (empty braces, non-hex digits, surrogate codepoints, or values above U+10FFFF) are reported as a compile-time error.
 
-		(https://github.com/vectordotdev/vrl/pull/1771)
-		- ~`parse_regex` now accepts dynamic regex patterns (variables and runtime expressions), consistent with `parse_regex_all`. When the pattern is a literal, return type information remains precise based on named capture groups.~
+		[PR #1771](https://github.com/vectordotdev/vrl/pull/1771)
+		- ~~`parse_regex` now accepts dynamic regex patterns (variables and runtime expressions), consistent with `parse_regex_all`. When the pattern is a literal, return type information remains precise based on named capture groups.~~
 
-		~(https://github.com/vectordotdev/vrl/pull/1774)~
+		~~[PR #1774](https://github.com/vectordotdev/vrl/pull/1774)~~
 
 		#### Enhancements
 
 		- Updated user agent data for `parse_user_agent` function
 
-		(https://github.com/vectordotdev/vrl/pull/1776)
+		[PR #1776](https://github.com/vectordotdev/vrl/pull/1776)
 		- Protobuf encoding now coerces compatible scalar types into the target field type: integers and strings are accepted for `bool` fields (using the same parsing as `to_bool`), and integers are accepted for `float`/`double` fields. Previously these inputs failed encoding and required explicit conversion in VRL.
 
-		(https://github.com/vectordotdev/vrl/pull/1763)
+		[PR #1763](https://github.com/vectordotdev/vrl/pull/1763)
 		- Added an optional `allow_lossy_string_coercion` argument to `encode_proto`. VRL's protobuf encoding stringifies `Boolean`, `Integer`, `Float`, and `Timestamp` values when assigned to a protobuf `string` field as a convenience for callers handling loosely typed input. The [protobuf JSON mapping](https://protobuf.dev/programming-guides/json/) only accepts a JSON string for a `string` field, so callers who want strict spec-compliant encoding can now pass `allow_lossy_string_coercion: false`. The default stays `true`, so today's behavior is unchanged.
 
-		(https://github.com/vectordotdev/vrl/pull/1764)
-		- ~Improved performance of `parse_regex`/`parse_regex_all` by pre-computing capture group names and indices at compile time. Users may see anywhere from 4% to 13% speedups in some cases.~
+		[PR #1764](https://github.com/vectordotdev/vrl/pull/1764)
+		- ~~Improved performance of `parse_regex`/`parse_regex_all` by pre-computing capture group names and indices at compile time. Users may see anywhere from 4% to 13% speedups in some cases.~~
 
-		~(https://github.com/vectordotdev/vrl/pull/1773)~
+		~~[PR #1773](https://github.com/vectordotdev/vrl/pull/1773)~~
 		- Improved performance of `parse_regex_all` by reusing the compiled regex across invocations.
 
-		(https://github.com/vectordotdev/vrl/pull/1775)
+		[PR #1775](https://github.com/vectordotdev/vrl/pull/1775)
 
 		#### Fixes
 
@@ -450,7 +450,7 @@ releases: "0.56.0": {
 
 		now reports both `push(.x, 1)` (unhandled error) and `.b = push(.y, 2)` (unhandled fallible assignment) in one go. Previously you'd only see the second one, fix it, recompile, and only then discover the first.
 
-		(https://github.com/vectordotdev/vrl/pull/1759)
+		[PR #1759](https://github.com/vectordotdev/vrl/pull/1759)
 		- Fixed a confusing compile error where a fallible call earlier in a block could cause a later, unrelated assignment to be reported as the problem. For example:
 
 		```coffee
@@ -463,10 +463,10 @@ releases: "0.56.0": {
 
 		The error is now reported on the actual fallible expression, so adding `!` or the `, err =` form fixes it where you'd expect. This also fixes the same shape inside closure bodies, e.g. inside `for_each`/`map_values`.
 
-		(https://github.com/vectordotdev/vrl/pull/453)
+		[PR #453](https://github.com/vectordotdev/vrl/pull/453)
 		- Fixed a false positive in the unused-variable diagnostic (`E900`) where a variable used before being reassigned (shadowed) was incorrectly flagged as unused at its original assignment.
 
-		(https://github.com/vectordotdev/vrl/pull/1743)
+		[PR #1743](https://github.com/vectordotdev/vrl/pull/1743)
 		- `encode_proto` and `parse_proto` now support proto maps whose keys are integers or booleans, not just strings. Because VRL object keys are always strings, integer and boolean keys are written in their string form:
 
 		```coffee
@@ -475,17 +475,15 @@ releases: "0.56.0": {
 
 		Previously `parse_proto` errored on these maps and `encode_proto` silently dropped the field. Note that `encode_proto` will now return an error if a key string can't be parsed into the schema's key type (for example, `"abc"` against a `map<int32, ...>`).
 
-		(https://github.com/vectordotdev/vrl/pull/1762)
+		[PR #1762](https://github.com/vectordotdev/vrl/pull/1762)
 		- Fixed a typo in enum variant that made it impossible to use `SCREAMING_SNAKE` in casing functions such as `pascalcase`, `camelcase` and others.
 
 		`pascalcase("hello", original_case: "SCREAMING_SNAKE")` now compiles properly.
 
-		(https://github.com/vectordotdev/vrl/pull/1770)
+		[PR #1770](https://github.com/vectordotdev/vrl/pull/1770)
 		- Allowed the `else` keyword (and `else if`) to appear on a new line after the closing `}` of an `if`-block. Previously the trailing newline terminated the if-expression at the parser level, forcing `else` to share a line with `}`.
 
-		authors: pront
-
-		(https://github.com/vectordotdev/vrl/pull/1756)
+		[PR #1756](https://github.com/vectordotdev/vrl/pull/1756) by [@pront](https://github.com/pront)
 
 		"""#
 

--- a/website/layouts/releases/single.html
+++ b/website/layouts/releases/single.html
@@ -202,7 +202,7 @@
           {{ partial "heading.html" (dict "text" "VRL Changelog" "level" 2) }}
         </div>
 
-        <div class="mt-6 prose dark:prose-invert max-w-none [&>ul]:mb-0 [&>ul]:mt-4 [&>ul]:min-w-0 [&>ul]:list-none [&>ul]:rounded-t-lg [&>ul]:border [&>ul]:border-gray-200 [&>ul]:border-b-0 [&>ul]:bg-gray-50/50 [&>ul]:px-4 [&>ul]:py-4 [&>ul]:shadow-sm dark:[&>ul]:border-gray-700 dark:[&>ul]:bg-gray-800/40 md:[&>ul]:px-5 [&>ul>li]:m-0 [&>ul+p]:mt-0 [&>ul+p]:rounded-b-lg [&>ul+p]:border [&>ul+p]:border-gray-200 [&>ul+p]:bg-gray-50/50 [&>ul+p]:px-4 [&>ul+p]:py-3 [&>ul+p]:text-sm [&>ul+p]:italic [&>ul+p]:shadow-sm dark:[&>ul+p]:border-gray-700 dark:[&>ul+p]:bg-gray-800/40 md:[&>ul+p]:px-5 [&_code]:max-w-full [&_code]:break-all [&_code]:whitespace-normal">
+        <div class="vrl-changelog mt-6 prose dark:prose-invert max-w-none [&_code]:max-w-full [&_code]:break-all [&_code]:whitespace-normal">
           {{ . | markdownify }}
         </div>
       </div>

--- a/website/layouts/releases/single.html
+++ b/website/layouts/releases/single.html
@@ -131,22 +131,23 @@
               {{ partial "heading.html" (dict "text" $heading "level" 3 "icon" false) }}
             </div>
 
-            <ul class="prose dark:prose-invert list-disc ml-6">
+            <ul class="mt-4 grid min-w-0 list-none gap-3 p-0">
               {{ range $changes }}
-              <li>
-                  <span class="prose dark:prose-invert">
-                    {{ .description | markdownify }}
-                  </span>
+              <li class="m-0 min-w-0 max-w-full overflow-hidden rounded-lg border border-gray-200 bg-gray-50/50 px-4 py-4 shadow-sm dark:border-gray-700 dark:bg-gray-800/40 md:px-5">
+                <div class="prose dark:prose-invert max-w-none leading-relaxed [&_code]:max-w-full [&_code]:break-all [&_code]:whitespace-normal">
+                  {{ .description | markdownify }}
+                </div>
                 {{ if gt (len .contributors) 0 }}
-                <br>
-                <span class="prose dark:prose-invert italic">
+                <div class="mt-3 overflow-x-auto border-t border-gray-200 pt-3 text-sm italic text-gray-600 dark:border-gray-700 dark:text-gray-300">
                   Thanks to
                   {{ $len := len .contributors }}
                   {{ range $i, $contributor := .contributors }}
-                    <a href="https://github.com/{{ replace $contributor "@" "" }}" rel="noopener" target="_blank">{{ $contributor }}</a>{{ if lt (add $i 1) $len }}, {{ end }}
+                    {{ $username := replace $contributor "@" "" }}
+                    {{ $profile := printf "https://github.com/%s" $username }}
+                    <a href="{{ $profile }}" class="text-primary-dark hover:text-secondary dark:text-primary dark:hover:text-secondary" rel="noopener" target="_blank">{{ $contributor }}</a>{{ if lt (add $i 1) $len }}, {{ end }}
                   {{ end }}
                   for contributing this change!
-                </span>
+                </div>
                 {{ end }}
               </li>
               {{ end }}
@@ -196,7 +197,7 @@
           {{ partial "heading.html" (dict "text" "VRL Changelog" "level" 2) }}
         </div>
 
-        <div class="mt-6 prose dark:prose-invert max-w-none">
+        <div class="mt-6 prose dark:prose-invert max-w-none [&>ul]:mb-0 [&>ul]:mt-4 [&>ul]:min-w-0 [&>ul]:list-none [&>ul]:rounded-t-lg [&>ul]:border [&>ul]:border-gray-200 [&>ul]:border-b-0 [&>ul]:bg-gray-50/50 [&>ul]:px-4 [&>ul]:py-4 [&>ul]:shadow-sm dark:[&>ul]:border-gray-700 dark:[&>ul]:bg-gray-800/40 md:[&>ul]:px-5 [&>ul>li]:m-0 [&>ul+p]:mt-0 [&>ul+p]:rounded-b-lg [&>ul+p]:border [&>ul+p]:border-gray-200 [&>ul+p]:bg-gray-50/50 [&>ul+p]:px-4 [&>ul+p]:py-3 [&>ul+p]:text-sm [&>ul+p]:italic [&>ul+p]:shadow-sm dark:[&>ul+p]:border-gray-700 dark:[&>ul+p]:bg-gray-800/40 md:[&>ul+p]:px-5 [&_code]:max-w-full [&_code]:break-all [&_code]:whitespace-normal">
           {{ . | markdownify }}
         </div>
       </div>

--- a/website/layouts/releases/single.html
+++ b/website/layouts/releases/single.html
@@ -110,10 +110,10 @@
             {{ range $breakingTitled }}
             <li class="m-0 min-w-0 max-w-full">
               <a href="{{ (index $upgradeGuides 0).RelPermalink }}#{{ .anchor }}" class="group block overflow-hidden rounded-lg border border-gray-200 bg-gray-50/50 px-4 py-4 shadow-sm transition hover:border-gray-300 hover:bg-gray-100/70 focus:outline-none focus:ring-2 focus:ring-primary dark:border-gray-700 dark:bg-gray-800/40 dark:hover:border-gray-600 dark:hover:bg-gray-800/70 md:px-5">
-                <div class="prose dark:prose-invert max-w-none font-semibold text-dark group-hover:text-primary-dark dark:text-gray-100 dark:group-hover:text-primary [&>p]:m-0 [&_code]:break-all [&_code]:whitespace-normal">
+                <div class="prose dark:prose-invert max-w-none font-semibold text-dark group-hover:text-primary-dark dark:text-gray-100 dark:group-hover:text-primary [&>p]:m-0 [&_:not(pre)>code]:break-all [&_:not(pre)>code]:whitespace-normal">
                   {{ .title | markdownify }}
                 </div>
-                <div class="mt-2 prose dark:prose-invert max-w-none leading-relaxed text-gray-600 dark:text-gray-300 [&>p]:m-0 [&_code]:max-w-full [&_code]:break-all [&_code]:whitespace-normal">
+                <div class="mt-2 prose dark:prose-invert max-w-none leading-relaxed text-gray-600 dark:text-gray-300 [&>p]:m-0 [&_:not(pre)>code]:max-w-full [&_:not(pre)>code]:break-all [&_:not(pre)>code]:whitespace-normal">
                   {{ .description | markdownify }}
                 </div>
               </a>
@@ -139,7 +139,7 @@
             <ul class="mt-4 grid min-w-0 list-none gap-3 p-0">
               {{ range $changes }}
               <li class="m-0 min-w-0 max-w-full overflow-hidden rounded-lg border border-gray-200 bg-gray-50/50 px-4 py-4 shadow-sm dark:border-gray-700 dark:bg-gray-800/40 md:px-5">
-                <div class="prose dark:prose-invert max-w-none leading-relaxed [&_code]:max-w-full [&_code]:break-all [&_code]:whitespace-normal">
+                <div class="prose dark:prose-invert max-w-none leading-relaxed [&_:not(pre)>code]:max-w-full [&_:not(pre)>code]:break-all [&_:not(pre)>code]:whitespace-normal">
                   {{ .description | markdownify }}
                 </div>
                 {{ if gt (len .contributors) 0 }}
@@ -202,7 +202,7 @@
           {{ partial "heading.html" (dict "text" "VRL Changelog" "level" 2) }}
         </div>
 
-        <div class="vrl-changelog mt-6 prose dark:prose-invert max-w-none [&_code]:max-w-full [&_code]:break-all [&_code]:whitespace-normal">
+        <div class="vrl-changelog mt-6 prose dark:prose-invert max-w-none [&_:not(pre)>code]:max-w-full [&_:not(pre)>code]:break-all [&_:not(pre)>code]:whitespace-normal">
           {{ . | markdownify }}
         </div>
       </div>

--- a/website/layouts/releases/single.html
+++ b/website/layouts/releases/single.html
@@ -106,11 +106,16 @@
             {{ partial "heading.html" (dict "text" $breakingHeading "level" 3 "icon" false) }}
           </div>
 
-          <ul class="prose dark:prose-invert list-disc ml-6">
+          <ul class="mt-4 grid min-w-0 list-none gap-3 p-0">
             {{ range $breakingTitled }}
-            <li>
-              <a href="{{ (index $upgradeGuides 0).RelPermalink }}#{{ .anchor }}" class="text-primary-dark dark:text-primary hover:underline">
-                {{ .title | markdownify }}
+            <li class="m-0 min-w-0 max-w-full">
+              <a href="{{ (index $upgradeGuides 0).RelPermalink }}#{{ .anchor }}" class="group block overflow-hidden rounded-lg border border-gray-200 bg-gray-50/50 px-4 py-4 shadow-sm transition hover:border-gray-300 hover:bg-gray-100/70 focus:outline-none focus:ring-2 focus:ring-primary dark:border-gray-700 dark:bg-gray-800/40 dark:hover:border-gray-600 dark:hover:bg-gray-800/70 md:px-5">
+                <div class="prose dark:prose-invert max-w-none font-semibold text-dark group-hover:text-primary-dark dark:text-gray-100 dark:group-hover:text-primary [&>p]:m-0 [&_code]:break-all [&_code]:whitespace-normal">
+                  {{ .title | markdownify }}
+                </div>
+                <div class="mt-2 prose dark:prose-invert max-w-none leading-relaxed text-gray-600 dark:text-gray-300 [&>p]:m-0 [&_code]:max-w-full [&_code]:break-all [&_code]:whitespace-normal">
+                  {{ .description | markdownify }}
+                </div>
               </a>
             </li>
             {{ end }}


### PR DESCRIPTION
## Summary

### Motivation

Release pages can contain dozens of long changelog entries. Rendering them as a single bulleted list makes the boundaries between entries difficult to scan, especially when an entry spans multiple paragraphs.

### Changes

- Render Vector changelog entries as subtle bordered cards.
- Separate contributor credits into a card footer.
- Apply the same treatment to VRL entries and their PR attribution.
- Wrap long inline code labels on narrow screens.

### Follow-up

- Populate the existing per-entry `pr_numbers` release metadata during changelog generation. As in VRL's release tooling, this can be inferred by finding the commit that introduced each changelog fragment and resolving that commit to its merged GitHub pull request. Rendering those PR links on Vector entries is intentionally out of scope for this PR.

### References

N/A

## Vector configuration

N/A

## How did you test this PR?

- Regenerated the CUE-backed website data with `make cue-build`.
- Built the production site with `make production-build` (554 pages).
- Checked the template with Prettier and `git diff --check`.
- Verified Vector and VRL changelog cards in light mode, dark mode, and a mobile viewport.

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## Contributor Guidelines

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them. To catch issues early, add a `pre-push` hook ([template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#pre-push)) or run the following locally before pushing:
  - `make fmt`
  - `make check-clippy` (auto-fix with `make clippy-fix`)
  - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details on the [dd-rust-license-tool](https://github.com/vectordotdev/dd-rust-license-tool).
