### PR TITLE
chore(build): align component feature names

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -680,9 +680,9 @@ codecs-opentelemetry = ["vector-lib/opentelemetry"]
 codecs-syslog = ["vector-lib/syslog"]
 
 # Secrets
-secrets = ["secrets-aws-secrets-manager"]
+secrets = ["secrets-aws_secrets_manager"]
 
-secrets-aws-secrets-manager = ["aws-core", "dep:aws-sdk-secretsmanager"]
+secrets-aws_secrets_manager = ["aws-core", "dep:aws-sdk-secretsmanager"]
 
 # Sources
 sources = ["sources-logs", "sources-metrics"]
@@ -782,10 +782,10 @@ sources-opentelemetry = [
   "sources-vector",
 ]
 sources-postgresql_metrics = ["dep:postgres-openssl", "dep:tokio-postgres"]
-sources-prometheus = ["sources-prometheus-scrape", "sources-prometheus-remote-write", "sources-prometheus-pushgateway"]
-sources-prometheus-scrape = ["sinks-prometheus", "sources-utils-http-client", "vector-lib/prometheus"]
-sources-prometheus-remote-write = ["sinks-prometheus", "sources-utils-http", "vector-lib/prometheus"]
-sources-prometheus-pushgateway = ["sinks-prometheus", "sources-utils-http", "vector-lib/prometheus"]
+sources-prometheus = ["sources-prometheus_scrape", "sources-prometheus_remote_write", "sources-prometheus_pushgateway"]
+sources-prometheus_scrape = ["sinks-prometheus", "sources-utils-http-client", "vector-lib/prometheus"]
+sources-prometheus_remote_write = ["sinks-prometheus", "sources-utils-http", "vector-lib/prometheus"]
+sources-prometheus_pushgateway = ["sinks-prometheus", "sources-utils-http", "vector-lib/prometheus"]
 sources-pulsar = ["dep:pulsar"]
 sources-redis = ["dep:redis"]
 sources-socket = ["sources-utils-net", "tokio-util/net"]
@@ -825,7 +825,7 @@ transforms-logs = [
   "transforms-reduce",
   "transforms-remap",
   "transforms-route",
-  "transforms-exclusive-route",
+  "transforms-exclusive_route",
   "transforms-sample",
   "transforms-throttle",
   "transforms-trace_to_log"
@@ -856,7 +856,7 @@ transforms-metric_to_log = []
 transforms-reduce = ["transforms-impl-reduce"]
 transforms-remap = []
 transforms-route = []
-transforms-exclusive-route = []
+transforms-exclusive_route = []
 transforms-sample = ["transforms-impl-sample"]
 transforms-tag_cardinality_limit = ["dep:bloomy", "dep:hashbrown"]
 transforms-throttle = ["dep:governor"]
@@ -886,7 +886,7 @@ sinks-logs = [
   "sinks-clickhouse",
   "sinks-console",
   "sinks-databend",
-  "sinks-databricks-zerobus",
+  "sinks-databricks_zerobus",
   "sinks-datadog_events",
   "sinks-datadog_logs",
   "sinks-datadog_traces",
@@ -918,7 +918,7 @@ sinks-logs = [
   "sinks-vector",
   "sinks-webhdfs",
   "sinks-websocket",
-  "sinks-websocket-server",
+  "sinks-websocket_server",
 ]
 sinks-metrics = [
   "sinks-appsignal",
@@ -954,7 +954,7 @@ sinks-chronicle = []
 sinks-clickhouse = ["dep:nom", "dep:rust_decimal", "codecs-arrow"]
 sinks-console = []
 sinks-databend = ["dep:databend-client"]
-sinks-databricks-zerobus = ["dep:databricks-zerobus-ingest-sdk", "codecs-arrow", "arrow/ipc_compression"]
+sinks-databricks_zerobus = ["dep:databricks-zerobus-ingest-sdk", "codecs-arrow", "arrow/ipc_compression"]
 sinks-datadog_events = []
 sinks-datadog_logs = []
 sinks-datadog_metrics = ["protobuf-build", "dep:prost", "dep:prost-reflect"]
@@ -991,7 +991,7 @@ sinks-statsd = ["sinks-utils-udp", "tokio-util/net"]
 sinks-utils-udp = []
 sinks-vector = ["sinks-utils-udp", "dep:tonic", "protobuf-build", "dep:prost"]
 sinks-websocket = ["dep:tokio-tungstenite"]
-sinks-websocket-server = ["dep:tokio-tungstenite", "sources-utils-http-auth", "sources-utils-http-error", "sources-utils-http-prelude"]
+sinks-websocket_server = ["dep:tokio-tungstenite", "sources-utils-http-auth", "sources-utils-http-error", "sources-utils-http-prelude"]
 sinks-webhdfs = ["dep:opendal"]
 
 # Identifies that the build is a nightly build

--- a/src/internal_events/mod.rs
+++ b/src/internal_events/mod.rs
@@ -117,8 +117,8 @@ mod parser;
 mod postgresql_metrics;
 mod process;
 #[cfg(any(
-    feature = "sources-prometheus-scrape",
-    feature = "sources-prometheus-remote-write",
+    feature = "sources-prometheus_scrape",
+    feature = "sources-prometheus_remote_write",
     feature = "sinks-prometheus"
 ))]
 mod prometheus;
@@ -150,7 +150,7 @@ mod udp;
 mod unix;
 #[cfg(any(feature = "sources-websocket", feature = "sinks-websocket"))]
 mod websocket;
-#[cfg(feature = "sinks-websocket-server")]
+#[cfg(feature = "sinks-websocket_server")]
 mod websocket_server;
 #[cfg(feature = "transforms-window")]
 mod window;
@@ -267,8 +267,8 @@ pub(crate) use self::parser::*;
 #[cfg(feature = "sources-postgresql_metrics")]
 pub(crate) use self::postgresql_metrics::*;
 #[cfg(any(
-    feature = "sources-prometheus-scrape",
-    feature = "sources-prometheus-remote-write",
+    feature = "sources-prometheus_scrape",
+    feature = "sources-prometheus_remote_write",
     feature = "sinks-prometheus"
 ))]
 pub(crate) use self::prometheus::*;
@@ -296,7 +296,7 @@ pub(crate) use self::throttle::*;
 pub(crate) use self::unix::*;
 #[cfg(any(feature = "sources-websocket", feature = "sinks-websocket"))]
 pub(crate) use self::websocket::*;
-#[cfg(feature = "sinks-websocket-server")]
+#[cfg(feature = "sinks-websocket_server")]
 pub(crate) use self::websocket_server::*;
 #[cfg(feature = "transforms-window")]
 pub(crate) use self::window::*;

--- a/src/internal_events/prometheus.rs
+++ b/src/internal_events/prometheus.rs
@@ -1,9 +1,9 @@
 #![allow(dead_code)] // TODO requires optional feature compilation
 
-#[cfg(feature = "sources-prometheus-scrape")]
+#[cfg(feature = "sources-prometheus_scrape")]
 use std::borrow::Cow;
 
-#[cfg(feature = "sources-prometheus-scrape")]
+#[cfg(feature = "sources-prometheus_scrape")]
 use vector_lib::prometheus::parser::ParserError;
 use vector_lib::{
     NamedInternalEvent, counter,
@@ -12,7 +12,7 @@ use vector_lib::{
     },
 };
 
-#[cfg(feature = "sources-prometheus-scrape")]
+#[cfg(feature = "sources-prometheus_scrape")]
 #[derive(Debug, NamedInternalEvent)]
 pub struct PrometheusParseError<'a> {
     pub error: ParserError,
@@ -20,7 +20,7 @@ pub struct PrometheusParseError<'a> {
     pub body: Cow<'a, str>,
 }
 
-#[cfg(feature = "sources-prometheus-scrape")]
+#[cfg(feature = "sources-prometheus_scrape")]
 impl InternalEvent for PrometheusParseError<'_> {
     fn emit(self) {
         error!(

--- a/src/secrets/mod.rs
+++ b/src/secrets/mod.rs
@@ -9,7 +9,7 @@ use crate::{
     signal,
 };
 
-#[cfg(feature = "secrets-aws-secrets-manager")]
+#[cfg(feature = "secrets-aws_secrets_manager")]
 mod aws_secrets_manager;
 mod directory;
 mod exec;
@@ -67,7 +67,7 @@ pub enum SecretBackends {
     Exec(exec::ExecBackend),
 
     /// AWS Secrets Manager.
-    #[cfg(feature = "secrets-aws-secrets-manager")]
+    #[cfg(feature = "secrets-aws_secrets_manager")]
     AwsSecretsManager(aws_secrets_manager::AwsSecretsManagerBackend),
 
     /// Test.
@@ -82,7 +82,7 @@ impl vector_lib::configurable::NamedComponent for SecretBackends {
             Self::File(config) => config.get_component_name(),
             Self::Directory(config) => config.get_component_name(),
             Self::Exec(config) => config.get_component_name(),
-            #[cfg(feature = "secrets-aws-secrets-manager")]
+            #[cfg(feature = "secrets-aws_secrets_manager")]
             Self::AwsSecretsManager(config) => config.get_component_name(),
             Self::Test(config) => config.get_component_name(),
         }

--- a/src/sinks/mod.rs
+++ b/src/sinks/mod.rs
@@ -38,7 +38,7 @@ pub mod clickhouse;
 pub mod console;
 #[cfg(feature = "sinks-databend")]
 pub mod databend;
-#[cfg(feature = "sinks-databricks-zerobus")]
+#[cfg(feature = "sinks-databricks_zerobus")]
 pub mod databricks_zerobus;
 #[cfg(any(
     feature = "sinks-datadog_events",
@@ -116,7 +116,7 @@ pub mod vector;
 pub mod webhdfs;
 #[cfg(feature = "sinks-websocket")]
 pub mod websocket;
-#[cfg(feature = "sinks-websocket-server")]
+#[cfg(feature = "sinks-websocket_server")]
 pub mod websocket_server;
 
 pub use vector_lib::{config::Input, sink::VectorSink};

--- a/src/sinks/prometheus/remote_write/mod.rs
+++ b/src/sinks/prometheus/remote_write/mod.rs
@@ -23,7 +23,7 @@ mod tests;
 #[cfg(all(test, feature = "prometheus-integration-tests"))]
 mod integration_tests;
 
-#[cfg(all(test, feature = "sources-prometheus-remote-write"))]
+#[cfg(all(test, feature = "sources-prometheus_remote_write"))]
 pub use config::RemoteWriteConfig;
 
 #[cfg(feature = "aws-core")]

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -71,9 +71,9 @@ pub mod opentelemetry;
 #[cfg(feature = "sources-postgresql_metrics")]
 pub mod postgresql_metrics;
 #[cfg(any(
-    feature = "sources-prometheus-scrape",
-    feature = "sources-prometheus-remote-write",
-    feature = "sources-prometheus-pushgateway"
+    feature = "sources-prometheus_scrape",
+    feature = "sources-prometheus_remote_write",
+    feature = "sources-prometheus_pushgateway"
 ))]
 pub mod prometheus;
 #[cfg(feature = "sources-pulsar")]

--- a/src/sources/prometheus/mod.rs
+++ b/src/sources/prometheus/mod.rs
@@ -1,15 +1,15 @@
 pub(crate) mod parser;
 
-#[cfg(feature = "sources-prometheus-pushgateway")]
+#[cfg(feature = "sources-prometheus_pushgateway")]
 mod pushgateway;
-#[cfg(feature = "sources-prometheus-remote-write")]
+#[cfg(feature = "sources-prometheus_remote_write")]
 mod remote_write;
-#[cfg(feature = "sources-prometheus-scrape")]
+#[cfg(feature = "sources-prometheus_scrape")]
 mod scrape;
 
-#[cfg(feature = "sources-prometheus-pushgateway")]
+#[cfg(feature = "sources-prometheus_pushgateway")]
 pub use pushgateway::PrometheusPushgatewayConfig;
-#[cfg(feature = "sources-prometheus-remote-write")]
+#[cfg(feature = "sources-prometheus_remote_write")]
 pub use remote_write::PrometheusRemoteWriteConfig;
-#[cfg(feature = "sources-prometheus-scrape")]
+#[cfg(feature = "sources-prometheus_scrape")]
 pub use scrape::PrometheusScrapeConfig;

--- a/src/sources/prometheus/parser.rs
+++ b/src/sources/prometheus/parser.rs
@@ -1,8 +1,8 @@
-#[cfg(feature = "sources-prometheus-remote-write")]
+#[cfg(feature = "sources-prometheus_remote_write")]
 use super::remote_write::MetadataConflictStrategy;
 use chrono::{DateTime, TimeZone, Utc};
 use vector_lib::prometheus::parser::{GroupKind, MetricGroup, ParserError};
-#[cfg(feature = "sources-prometheus-remote-write")]
+#[cfg(feature = "sources-prometheus_remote_write")]
 use vector_lib::prometheus::parser::{
     MetadataConflictStrategy as ParserMetadataConflictStrategy, proto,
 };
@@ -21,13 +21,13 @@ fn utc_timestamp(timestamp: Option<i64>, default: DateTime<Utc>) -> DateTime<Utc
         .unwrap_or(default)
 }
 
-#[cfg(any(test, feature = "sources-prometheus-scrape"))]
+#[cfg(any(test, feature = "sources-prometheus_scrape"))]
 pub(super) fn parse_text(packet: &str) -> Result<Vec<Event>, ParserError> {
     vector_lib::prometheus::parser::parse_text(packet)
         .map(|group| reparse_groups(group, vec![], false, false))
 }
 
-#[cfg(any(test, feature = "sources-prometheus-pushgateway"))]
+#[cfg(any(test, feature = "sources-prometheus_pushgateway"))]
 pub(super) fn parse_text_with_overrides(
     packet: &str,
     tag_overrides: impl IntoIterator<Item = (String, String)> + Clone,
@@ -43,7 +43,7 @@ fn parse_text_with_nan_filtering(packet: &str) -> Result<Vec<Event>, ParserError
         .map(|group| reparse_groups(group, vec![], false, true))
 }
 
-#[cfg(feature = "sources-prometheus-remote-write")]
+#[cfg(feature = "sources-prometheus_remote_write")]
 pub(super) fn parse_request(
     request: proto::WriteRequest,
     metadata_conflict_strategy: MetadataConflictStrategy,
@@ -203,7 +203,7 @@ fn reparse_groups(
     result
 }
 
-#[cfg(feature = "sources-prometheus-remote-write")]
+#[cfg(feature = "sources-prometheus_remote_write")]
 impl From<MetadataConflictStrategy> for ParserMetadataConflictStrategy {
     fn from(strategy: MetadataConflictStrategy) -> Self {
         match strategy {

--- a/src/sources/util/mod.rs
+++ b/src/sources/util/mod.rs
@@ -18,7 +18,7 @@ pub mod grpc;
 pub mod http;
 #[cfg(any(
     feature = "sources-http_client",
-    feature = "sources-prometheus-scrape",
+    feature = "sources-prometheus_scrape",
     feature = "sources-okta"
 ))]
 pub mod http_client;
@@ -66,8 +66,8 @@ pub use self::http::add_headers;
 #[cfg(feature = "sources-utils-http-query")]
 pub use self::http::add_query_parameters;
 #[cfg(any(
-    feature = "sources-prometheus-scrape",
-    feature = "sources-prometheus-remote-write",
+    feature = "sources-prometheus_scrape",
+    feature = "sources-prometheus_remote_write",
     feature = "sources-utils-http-encoding"
 ))]
 pub use self::http::decompress_body;

--- a/src/transforms/mod.rs
+++ b/src/transforms/mod.rs
@@ -13,7 +13,7 @@ pub mod aggregate;
 pub mod aws_ec2_metadata;
 #[cfg(feature = "transforms-delay")]
 pub mod delay;
-#[cfg(feature = "transforms-exclusive-route")]
+#[cfg(feature = "transforms-exclusive_route")]
 mod exclusive_route;
 #[cfg(feature = "transforms-filter")]
 pub mod filter;

--- a/website/content/en/guides/aws/aws-secrets-manager.md
+++ b/website/content/en/guides/aws/aws-secrets-manager.md
@@ -16,7 +16,7 @@ Before you begin, ensure you have:
 - An AWS account with access to AWS Secrets Manager.
 - Appropriate AWS IAM permissions to read secrets.
 - Vector v0.38.0 or higher installed.
-- Vector compiled with the `secrets-aws-secrets-manager` feature (enabled by default in most distributions).
+- Vector compiled with the `secrets-aws_secrets_manager` feature (enabled by default in most distributions).
 
 ## Setting up AWS Secrets Manager
 


### PR DESCRIPTION
## Summary

### Motivation

Component Cargo features normally follow `sources-<component>`, `transforms-<component>`, and `sinks-<component>`, using the component type name verbatim. A small set of older features used additional hyphenation, which prevents development tooling from deriving the feature name directly from a Vector configuration.

### Changes

- Rename the affected Cargo features to use their component type names.
- Update the corresponding Rust `cfg(feature = ...)` checks.

### References

Related: #26209

## Vector configuration

Not applicable.

## How did you test this PR?

- `cargo fmt --all -- --check`
- `CARGO_NET_OFFLINE=true cargo check -p vector --no-default-features --features secrets-aws_secrets_manager,sources-prometheus_scrape,sources-prometheus_remote_write,sources-prometheus_pushgateway,transforms-exclusive_route,sinks-databricks_zerobus,sinks-websocket_server`

## Is this a breaking change?

- [x] Yes
- [ ] No

The old Cargo feature names are removed. Source builds that select them directly must use the renamed features.

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

