### PR TITLE
chore(release): add COSE announcement to GitHub release notes

### DIFF
--- a/vdev/src/commands/release/github.rs
+++ b/vdev/src/commands/release/github.rs
@@ -32,7 +32,9 @@ impl Cli {
                 "--title",
                 &format!("v{version}"),
                 "--notes",
-                &format!("[View release notes](https://vector.dev/releases/{version})"),
+                &format!(
+                    "The [COSE team](https://opensource.datadoghq.com/about/#the-community-open-source-engineering-team) is excited to announce version `{version}`! 🚀\n\n[View release notes](https://vector.dev/releases/{version})"
+                ),
             ]
             .map(String::from)
             .into_iter()


### PR DESCRIPTION
## Summary
Prepend the COSE team announcement to the GitHub release notes body generated by `vdev release github`. The notes now open with the announcement line before the existing "View release notes" link. The version stays dynamic (resolved from the crate version at release time).

### References
NA

## Vector configuration
NA

## How did you test this PR?
Ran `cargo check -p vdev` and `cargo clippy -p vdev` — both clean.

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.
