### PR TITLE
chore(website): show release authors and PRs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13145,7 +13145,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vdev"
-version = "0.3.15"
+version = "0.3.16"
 dependencies = [
  "anyhow",
  "cfg-if",

--- a/vdev/Cargo.toml
+++ b/vdev/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vdev"
-version = "0.3.15"
+version = "0.3.16"
 edition = "2024"
 authors = ["Vector Contributors <vector@datadoghq.com>"]
 license = "MPL-2.0"

--- a/vdev/src/commands/release/generate_cue.rs
+++ b/vdev/src/commands/release/generate_cue.rs
@@ -9,6 +9,8 @@ use std::{
 use anyhow::{Context, Result, anyhow, bail};
 use chrono::Utc;
 use semver::Version;
+#[cfg(not(test))]
+use serde::Deserialize;
 use serde_json::json;
 
 use crate::commands::changelog::FRAGMENT_TYPES;
@@ -88,7 +90,7 @@ pub(super) fn run(new_version: &Version) -> Result<PathBuf> {
     // breaking fragments.
 
     let changelog_dir = repo_root.join(CHANGELOG_DIR);
-    let changelog_entries = read_changelog_fragments(&changelog_dir)?;
+    let changelog_entries = read_changelog_fragments(&repo_root, &changelog_dir)?;
 
     // Validate + render everything IN MEMORY before touching disk, so a validation
     // failure doesn't leave a partial CUE file behind (which would then trip the
@@ -288,9 +290,16 @@ struct ChangelogEntry {
     cue_type: String,
     breaking: bool,
     description: String,
+    pr_numbers: Vec<u64>,
     contributors: Vec<String>,
     /// For `*.breaking.md` fragments, the structured upgrade-guide details.
     breaking_details: Option<BreakingDetails>,
+}
+
+#[cfg(not(test))]
+#[derive(Deserialize)]
+struct PullRequest {
+    number: u64,
 }
 
 #[derive(Debug, Clone)]
@@ -304,10 +313,14 @@ struct BreakingDetails {
     migration: String,
 }
 
-fn read_changelog_fragments(dir: &Path) -> Result<Vec<ChangelogEntry>> {
+fn read_changelog_fragments(repo_root: &Path, dir: &Path) -> Result<Vec<ChangelogEntry>> {
     if !dir.is_dir() {
         return Ok(Vec::new());
     }
+
+    #[cfg(not(test))]
+    ensure_full_git_history(repo_root)?;
+
     let mut entries = Vec::new();
     let mut paths: Vec<PathBuf> = fs::read_dir(dir)?
         .filter_map(|e| e.ok().map(|e| e.path()))
@@ -316,7 +329,10 @@ fn read_changelog_fragments(dir: &Path) -> Result<Vec<ChangelogEntry>> {
         .collect();
     paths.sort();
     for path in paths {
-        let entry = parse_changelog_fragment(&path)?;
+        let mut entry = parse_changelog_fragment(&path)?;
+        entry
+            .pr_numbers
+            .push(lookup_pull_request(repo_root, &path)?);
         entries.push(entry);
     }
     Ok(entries)
@@ -363,6 +379,7 @@ fn parse_changelog_fragment(path: &Path) -> Result<ChangelogEntry> {
             cue_type: cue_type.to_string(),
             breaking,
             description: summary,
+            pr_numbers: Vec::new(),
             contributors,
             breaking_details: Some(details),
         });
@@ -372,9 +389,118 @@ fn parse_changelog_fragment(path: &Path) -> Result<ChangelogEntry> {
         cue_type: cue_type.to_string(),
         breaking,
         description: body.trim().to_string(),
+        pr_numbers: Vec::new(),
         contributors,
         breaking_details: None,
     })
+}
+
+/// Find the merged PR that introduced a changelog fragment. The adding commit
+/// remains available after release preparation deletes the fragment, so the
+/// same lookup can also be used when backfilling release metadata.
+#[cfg(not(test))]
+fn lookup_pull_request(repo_root: &Path, fragment_path: &Path) -> Result<u64> {
+    let relative_path = fragment_path.strip_prefix(repo_root).with_context(|| {
+        format!(
+            "Fragment path {} is outside the repository root {}",
+            fragment_path.display(),
+            repo_root.display()
+        )
+    })?;
+    let relative_path = relative_path.to_str().ok_or_else(|| {
+        anyhow!(
+            "Fragment path is not valid UTF-8: {}",
+            fragment_path.display()
+        )
+    })?;
+
+    let commit = run_command(
+        "git",
+        &[
+            "log",
+            "-1",
+            "--format=%H",
+            "--diff-filter=A",
+            "--follow",
+            "--",
+            relative_path,
+        ],
+        repo_root,
+    )?;
+    let commit = commit.trim();
+    if commit.is_empty() {
+        bail!(
+            "Could not find the commit that added {relative_path}; cannot determine its pull request."
+        );
+    }
+
+    let output = run_command(
+        "gh",
+        &[
+            "pr",
+            "list",
+            "--repo",
+            "vectordotdev/vector",
+            "--state",
+            "merged",
+            "--search",
+            commit,
+            "--json",
+            "number",
+            "--limit",
+            "2",
+        ],
+        repo_root,
+    )?;
+    let pull_requests: Vec<PullRequest> = serde_json::from_str(&output)
+        .with_context(|| format!("Could not parse GitHub PR lookup for commit {commit}"))?;
+
+    match pull_requests.as_slice() {
+        [pull_request] => Ok(pull_request.number),
+        [] => bail!("No merged GitHub PR found for commit {commit} that added {relative_path}."),
+        _ => bail!(
+            "Multiple merged GitHub PRs found for commit {commit} that added {relative_path}."
+        ),
+    }
+}
+
+#[cfg(not(test))]
+fn ensure_full_git_history(repo_root: &Path) -> Result<()> {
+    let is_shallow = run_command("git", &["rev-parse", "--is-shallow-repository"], repo_root)?;
+    if is_shallow.trim() == "true" {
+        bail!(
+            "Release generation requires full Git history to find the PRs that introduced changelog fragments."
+        );
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+fn lookup_pull_request(_: &Path, _: &Path) -> Result<u64> {
+    // Unit tests exercise local parsing and rendering. A release dry run checks
+    // the real GitHub lookup without requiring network access in unit tests.
+    Ok(42)
+}
+
+#[cfg(not(test))]
+fn run_command(cmd: &str, args: &[&str], cwd: &Path) -> Result<String> {
+    let display = format!("{cmd} {}", args.join(" "));
+    let output = Command::new(cmd)
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .with_context(|| format!("Failed to run `{display}`"))?;
+
+    if !output.status.success() {
+        bail!(
+            "`{display}` failed (exit {}):\n{}{}",
+            output.status,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
 }
 
 /// Split off the trailing `authors: <handles...>` line, returning the body preceding it
@@ -484,6 +610,10 @@ fn render_changelog(entries: &[ChangelogEntry]) -> String {
                 writeln!(s, "\t\t\t\t{line}").unwrap();
             }
             s.push_str("\t\t\t\t\"\"\"#\n");
+            if !e.pr_numbers.is_empty() {
+                let json_prs = serde_json::to_string(&e.pr_numbers).unwrap();
+                writeln!(s, "\t\t\tpr_numbers: {json_prs}").unwrap();
+            }
             if !e.contributors.is_empty() {
                 let json_contribs = serde_json::to_string(&e.contributors).unwrap();
                 writeln!(s, "\t\t\tcontributors: {json_contribs}").unwrap();
@@ -667,7 +797,7 @@ mod tests {
         .unwrap();
         fs::write(dir.join("sec.security.md"), "Patched a CVE.\n").unwrap();
 
-        let entries = read_changelog_fragments(dir).unwrap();
+        let entries = read_changelog_fragments(dir, dir).unwrap();
         assert_eq!(entries.len(), 3);
 
         // Sorted by filename
@@ -681,6 +811,7 @@ mod tests {
         );
         assert!(feat.description.starts_with("Adds a thing."));
         assert!(!feat.description.contains("authors:"));
+        assert_eq!(feat.pr_numbers, vec![42]);
 
         // Breaking fragments must be marked as such and carry structured details.
         let breaking = &entries[1];
@@ -700,7 +831,7 @@ mod tests {
     fn read_changelog_fragments_rejects_unknown_type() {
         let tmp = tempfile::tempdir().unwrap();
         fs::write(tmp.path().join("foo.bogus.md"), "x").unwrap();
-        assert!(read_changelog_fragments(tmp.path()).is_err());
+        assert!(read_changelog_fragments(tmp.path(), tmp.path()).is_err());
     }
 
     #[test]
@@ -710,6 +841,7 @@ mod tests {
                 cue_type: "feat".into(),
                 breaking: false,
                 description: "Adds a thing.\nMulti-line.".into(),
+                pr_numbers: vec![123],
                 contributors: vec!["alice".into()],
                 breaking_details: None,
             },
@@ -717,6 +849,7 @@ mod tests {
                 cue_type: "fix".into(),
                 breaking: false,
                 description: "Fixed it.".into(),
+                pr_numbers: vec![],
                 contributors: vec![],
                 breaking_details: None,
             },
@@ -724,6 +857,7 @@ mod tests {
                 cue_type: "chore".into(),
                 breaking: true,
                 description: "Removed legacy thing.".into(),
+                pr_numbers: vec![456],
                 contributors: vec![],
                 breaking_details: Some(BreakingDetails {
                     title: "Legacy thing removed".into(),
@@ -742,6 +876,8 @@ mod tests {
         assert!(out.contains("\t\t\t\tAdds a thing.\n"));
         assert!(out.contains("\t\t\t\tMulti-line.\n"));
         assert!(out.contains("contributors: [\"alice\"]"));
+        assert!(out.contains("pr_numbers: [123]"));
+        assert!(out.contains("pr_numbers: [456]"));
         assert!(out.contains("\t\t\ttype: \"fix\"\n"));
         assert!(out.contains("\t\t\ttype: \"chore\"\n"));
         assert!(out.contains("\t\t\tbreaking: true\n"));

--- a/vdev/src/commands/release/generate_cue.rs
+++ b/vdev/src/commands/release/generate_cue.rs
@@ -18,6 +18,12 @@ const RELEASES_DIR: &str = "website/cue/reference/releases";
 const CHANGELOG_DIR: &str = "changelog.d";
 const HIGHLIGHTS_DIR: &str = "website/content/en/highlights";
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum PullRequestMetadata {
+    Optional,
+    Required,
+}
+
 /// Generate the release CUE file (and, if there are breaking fragments, the upgrade guide)
 /// for the given version. Handy for testing the changelog pipeline without running the
 /// full `release prepare` flow.
@@ -34,7 +40,7 @@ pub struct Cli {
 
 impl Cli {
     pub fn exec(self) -> Result<()> {
-        run(&self.version)?;
+        run(&self.version, PullRequestMetadata::Optional)?;
         Ok(())
     }
 }
@@ -43,7 +49,10 @@ impl Cli {
 ///
 /// Pure generation: does not touch `changelog.d/`. Callers that want the fragments retired
 /// after a successful release run should call [`retire_all_fragments`] afterward.
-pub(super) fn run(new_version: &Version) -> Result<PathBuf> {
+pub(super) fn run(
+    new_version: &Version,
+    pull_request_metadata: PullRequestMetadata,
+) -> Result<PathBuf> {
     let repo_root = paths::find_repo_root()?;
     env::set_current_dir(&repo_root)?;
 
@@ -88,7 +97,8 @@ pub(super) fn run(new_version: &Version) -> Result<PathBuf> {
     // breaking fragments.
 
     let changelog_dir = repo_root.join(CHANGELOG_DIR);
-    let changelog_entries = read_changelog_fragments(&repo_root, &changelog_dir)?;
+    let changelog_entries =
+        read_changelog_fragments(&repo_root, &changelog_dir, pull_request_metadata)?;
 
     // Validate + render everything IN MEMORY before touching disk, so a validation
     // failure doesn't leave a partial CUE file behind (which would then trip the
@@ -305,13 +315,19 @@ struct BreakingDetails {
     migration: String,
 }
 
-fn read_changelog_fragments(repo_root: &Path, dir: &Path) -> Result<Vec<ChangelogEntry>> {
+fn read_changelog_fragments(
+    repo_root: &Path,
+    dir: &Path,
+    pull_request_metadata: PullRequestMetadata,
+) -> Result<Vec<ChangelogEntry>> {
     if !dir.is_dir() {
         return Ok(Vec::new());
     }
 
     #[cfg(not(test))]
-    ensure_full_git_history(repo_root)?;
+    if pull_request_metadata == PullRequestMetadata::Required {
+        ensure_full_git_history(repo_root)?;
+    }
 
     let mut entries = Vec::new();
     let mut paths: Vec<PathBuf> = fs::read_dir(dir)?
@@ -322,7 +338,7 @@ fn read_changelog_fragments(repo_root: &Path, dir: &Path) -> Result<Vec<Changelo
     paths.sort();
     for path in paths {
         let mut entry = parse_changelog_fragment(&path)?;
-        entry.pr_numbers = lookup_pull_requests(repo_root, &path)?;
+        entry.pr_numbers = lookup_pull_requests(repo_root, &path, pull_request_metadata)?;
         entries.push(entry);
     }
     Ok(entries)
@@ -385,11 +401,23 @@ fn parse_changelog_fragment(path: &Path) -> Result<ChangelogEntry> {
     })
 }
 
-/// Find every PR that added or edited a changelog fragment from each commit's
-/// `... (#12345)` title. Deletion commits are excluded so this also works after
-/// release preparation removes the fragment.
+/// Find every PR that added or edited the current lifetime of a changelog fragment
+/// from each commit's `... (#12345)` title. Deletion commits are excluded so this
+/// also works after release preparation removes the fragment.
 #[cfg(not(test))]
-fn lookup_pull_requests(repo_root: &Path, fragment_path: &Path) -> Result<Vec<u64>> {
+fn lookup_pull_requests(
+    repo_root: &Path,
+    fragment_path: &Path,
+    pull_request_metadata: PullRequestMetadata,
+) -> Result<Vec<u64>> {
+    lookup_pull_requests_from_git(repo_root, fragment_path, pull_request_metadata)
+}
+
+fn lookup_pull_requests_from_git(
+    repo_root: &Path,
+    fragment_path: &Path,
+    pull_request_metadata: PullRequestMetadata,
+) -> Result<Vec<u64>> {
     let relative_path = fragment_path.strip_prefix(repo_root).with_context(|| {
         format!(
             "Fragment path {} is outside the repository root {}",
@@ -404,41 +432,78 @@ fn lookup_pull_requests(repo_root: &Path, fragment_path: &Path) -> Result<Vec<u6
         )
     })?;
 
-    let commit_titles = run_command(
+    let addition_commits = run_command(
         "git",
         &[
             "log",
-            "--format=%s",
-            "--diff-filter=AM",
+            "--format=%H",
+            "--diff-filter=A",
             "--follow",
             "--",
             relative_path,
         ],
         repo_root,
     )?;
-    if commit_titles.trim().is_empty() {
-        bail!(
-            "Could not find commits that added or edited {relative_path}; cannot determine its pull requests."
-        );
-    }
+    let Some(latest_addition) = addition_commits.lines().next() else {
+        return match pull_request_metadata {
+            PullRequestMetadata::Optional => Ok(Vec::new()),
+            PullRequestMetadata::Required => bail!(
+                "Could not find the commit that added {relative_path}; cannot determine its pull requests."
+            ),
+        };
+    };
 
-    parse_pull_request_numbers(&commit_titles).with_context(|| {
-        format!("Could not determine every PR that added or edited {relative_path}")
-    })
+    let commit_history = run_command(
+        "git",
+        &[
+            "log",
+            "--format=%H%x09%s",
+            "--diff-filter=AMR",
+            "--follow",
+            "--",
+            relative_path,
+        ],
+        repo_root,
+    )?;
+
+    parse_pull_request_history(&commit_history, latest_addition, pull_request_metadata)
+        .with_context(|| {
+            format!("Could not determine every PR that added or edited {relative_path}")
+        })
 }
 
-fn parse_pull_request_numbers(commit_titles: &str) -> Result<Vec<u64>> {
+fn parse_pull_request_history(
+    commit_history: &str,
+    latest_addition: &str,
+    pull_request_metadata: PullRequestMetadata,
+) -> Result<Vec<u64>> {
     let mut numbers = Vec::new();
-    for commit_title in commit_titles
+    for line in commit_history
         .lines()
-        .filter(|title| !title.trim().is_empty())
+        .filter(|line| !line.trim().is_empty())
     {
-        let number = parse_pull_request_number(commit_title)?;
-        if !numbers.contains(&number) {
-            numbers.push(number);
+        let (commit, title) = line
+            .split_once('\t')
+            .ok_or_else(|| anyhow!("Malformed git log entry `{line}`"))?;
+
+        match parse_pull_request_number(title) {
+            Ok(number) if !numbers.contains(&number) => numbers.push(number),
+            Ok(_) => {}
+            Err(_) if pull_request_metadata == PullRequestMetadata::Optional => {}
+            Err(error) => return Err(error.context(format!("Commit {commit}: `{title}`"))),
+        }
+
+        if commit == latest_addition {
+            return Ok(numbers);
         }
     }
-    Ok(numbers)
+
+    match pull_request_metadata {
+        PullRequestMetadata::Optional => Ok(Vec::new()),
+        PullRequestMetadata::Required => {
+            bail!("Could not find latest addition commit {latest_addition} in the fragment history")
+        }
+    }
 }
 
 fn parse_pull_request_number(commit_title: &str) -> Result<u64> {
@@ -467,12 +532,11 @@ fn ensure_full_git_history(repo_root: &Path) -> Result<()> {
 }
 
 #[cfg(test)]
-fn lookup_pull_requests(_: &Path, _: &Path) -> Result<Vec<u64>> {
+fn lookup_pull_requests(_: &Path, _: &Path, _: PullRequestMetadata) -> Result<Vec<u64>> {
     // Unit tests exercise local parsing and rendering without requiring a Git repository.
     Ok(vec![42])
 }
 
-#[cfg(not(test))]
 fn run_command(cmd: &str, args: &[&str], cwd: &Path) -> Result<String> {
     let display = format!("{cmd} {}", args.join(" "));
     let output = Command::new(cmd)
@@ -744,15 +808,116 @@ mod tests {
 
     #[test]
     fn parses_and_deduplicates_pull_requests_from_commit_titles() {
-        let titles = indoc::indoc! {"
-            fix(foo): adjust bar (#23456)
-            feat(foo): add bar (#12345)
-            feat(foo): add bar (#12345)
+        let history = indoc::indoc! {"
+            c3	fix(foo): adjust bar (#23456)
+            c2	feat(foo): add bar (#12345)
+            c1	feat(foo): add bar (#12345)
         "};
         assert_eq!(
-            parse_pull_request_numbers(titles).unwrap(),
+            parse_pull_request_history(history, "c1", PullRequestMetadata::Required).unwrap(),
             vec![23456, 12345]
         );
+    }
+
+    #[test]
+    fn pull_request_history_stops_at_latest_addition() {
+        let history = indoc::indoc! {"
+            current-edit	fix(foo): adjust bar (#300)
+            current-add	feat(foo): add bar (#298)
+            old-edit	fix(foo): old adjustment (#120)
+            old-add	feat(foo): old addition (#119)
+        "};
+
+        assert_eq!(
+            parse_pull_request_history(history, "current-add", PullRequestMetadata::Required,)
+                .unwrap(),
+            vec![300, 298]
+        );
+    }
+
+    #[test]
+    fn pull_request_lookup_includes_renamed_fragment_commit() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = tmp.path();
+        let changelog_dir = repo.join("changelog.d");
+        fs::create_dir(&changelog_dir).unwrap();
+
+        run_command("git", &["init", "--quiet"], repo).unwrap();
+        run_command("git", &["config", "core.hooksPath", "/dev/null"], repo).unwrap();
+        run_command("git", &["config", "user.name", "Vector Test"], repo).unwrap();
+        run_command("git", &["config", "user.email", "vector@example.com"], repo).unwrap();
+        run_command("git", &["config", "commit.gpgsign", "false"], repo).unwrap();
+
+        let original = changelog_dir.join("original.enhancement.md");
+        let renamed = changelog_dir.join("renamed.enhancement.md");
+        fs::write(
+            &original,
+            "Original entry.\nIt documents the first behavior.\nIt includes migration details.\n",
+        )
+        .unwrap();
+        run_command("git", &["add", "changelog.d/original.enhancement.md"], repo).unwrap();
+        run_command(
+            "git",
+            &["commit", "--quiet", "-m", "feat(foo): add entry (#100)"],
+            repo,
+        )
+        .unwrap();
+
+        run_command(
+            "git",
+            &[
+                "mv",
+                "changelog.d/original.enhancement.md",
+                "changelog.d/renamed.enhancement.md",
+            ],
+            repo,
+        )
+        .unwrap();
+        fs::write(
+            &renamed,
+            "Original entry.\nIt documents the first behavior.\nIt includes migration details.\nOne more detail.\n",
+        )
+        .unwrap();
+        run_command("git", &["add", "changelog.d/renamed.enhancement.md"], repo).unwrap();
+        run_command(
+            "git",
+            &[
+                "commit",
+                "--quiet",
+                "-m",
+                "fix(foo): rename and edit entry (#101)",
+            ],
+            repo,
+        )
+        .unwrap();
+
+        assert_eq!(
+            lookup_pull_requests_from_git(repo, &renamed, PullRequestMetadata::Required).unwrap(),
+            vec![101, 100]
+        );
+    }
+
+    #[test]
+    fn optional_pull_request_metadata_skips_unmerged_commits() {
+        let history = indoc::indoc! {"
+            edit	fix(foo): adjust bar
+            add	feat(foo): add bar (#12345)
+        "};
+
+        assert_eq!(
+            parse_pull_request_history(history, "add", PullRequestMetadata::Optional).unwrap(),
+            vec![12345]
+        );
+        assert!(parse_pull_request_history(history, "add", PullRequestMetadata::Required).is_err());
+    }
+
+    #[test]
+    fn optional_pull_request_metadata_tolerates_missing_history() {
+        assert_eq!(
+            parse_pull_request_history("", "missing", PullRequestMetadata::Optional).unwrap(),
+            Vec::<u64>::new()
+        );
+        assert!(parse_pull_request_history("", "missing", PullRequestMetadata::Required).is_err());
     }
 
     #[test]
@@ -815,7 +980,7 @@ mod tests {
         .unwrap();
         fs::write(dir.join("sec.security.md"), "Patched a CVE.\n").unwrap();
 
-        let entries = read_changelog_fragments(dir, dir).unwrap();
+        let entries = read_changelog_fragments(dir, dir, PullRequestMetadata::Optional).unwrap();
         assert_eq!(entries.len(), 3);
 
         // Sorted by filename
@@ -849,7 +1014,10 @@ mod tests {
     fn read_changelog_fragments_rejects_unknown_type() {
         let tmp = tempfile::tempdir().unwrap();
         fs::write(tmp.path().join("foo.bogus.md"), "x").unwrap();
-        assert!(read_changelog_fragments(tmp.path(), tmp.path()).is_err());
+        assert!(
+            read_changelog_fragments(tmp.path(), tmp.path(), PullRequestMetadata::Optional)
+                .is_err()
+        );
     }
 
     #[test]

--- a/vdev/src/commands/release/generate_cue.rs
+++ b/vdev/src/commands/release/generate_cue.rs
@@ -9,8 +9,6 @@ use std::{
 use anyhow::{Context, Result, anyhow, bail};
 use chrono::Utc;
 use semver::Version;
-#[cfg(not(test))]
-use serde::Deserialize;
 use serde_json::json;
 
 use crate::commands::changelog::FRAGMENT_TYPES;
@@ -296,12 +294,6 @@ struct ChangelogEntry {
     breaking_details: Option<BreakingDetails>,
 }
 
-#[cfg(not(test))]
-#[derive(Deserialize)]
-struct PullRequest {
-    number: u64,
-}
-
 #[derive(Debug, Clone)]
 struct BreakingDetails {
     title: String,
@@ -395,9 +387,9 @@ fn parse_changelog_fragment(path: &Path) -> Result<ChangelogEntry> {
     })
 }
 
-/// Find the merged PR that introduced a changelog fragment. The adding commit
-/// remains available after release preparation deletes the fragment, so the
-/// same lookup can also be used when backfilling release metadata.
+/// Find the PR that introduced a changelog fragment from the adding commit's
+/// `... (#12345)` title. The commit remains available after release preparation
+/// deletes the fragment, so the same lookup can also backfill release metadata.
 #[cfg(not(test))]
 fn lookup_pull_request(repo_root: &Path, fragment_path: &Path) -> Result<u64> {
     let relative_path = fragment_path.strip_prefix(repo_root).with_context(|| {
@@ -414,12 +406,12 @@ fn lookup_pull_request(repo_root: &Path, fragment_path: &Path) -> Result<u64> {
         )
     })?;
 
-    let commit = run_command(
+    let commit_title = run_command(
         "git",
         &[
             "log",
             "-1",
-            "--format=%H",
+            "--format=%s",
             "--diff-filter=A",
             "--follow",
             "--",
@@ -427,41 +419,30 @@ fn lookup_pull_request(repo_root: &Path, fragment_path: &Path) -> Result<u64> {
         ],
         repo_root,
     )?;
-    let commit = commit.trim();
-    if commit.is_empty() {
+    let commit_title = commit_title.trim();
+    if commit_title.is_empty() {
         bail!(
             "Could not find the commit that added {relative_path}; cannot determine its pull request."
         );
     }
 
-    let output = run_command(
-        "gh",
-        &[
-            "pr",
-            "list",
-            "--repo",
-            "vectordotdev/vector",
-            "--state",
-            "merged",
-            "--search",
-            commit,
-            "--json",
-            "number",
-            "--limit",
-            "2",
-        ],
-        repo_root,
-    )?;
-    let pull_requests: Vec<PullRequest> = serde_json::from_str(&output)
-        .with_context(|| format!("Could not parse GitHub PR lookup for commit {commit}"))?;
+    parse_pull_request_number(commit_title).with_context(|| {
+        format!("Could not determine the PR that added {relative_path} from commit title `{commit_title}`")
+    })
+}
 
-    match pull_requests.as_slice() {
-        [pull_request] => Ok(pull_request.number),
-        [] => bail!("No merged GitHub PR found for commit {commit} that added {relative_path}."),
-        _ => bail!(
-            "Multiple merged GitHub PRs found for commit {commit} that added {relative_path}."
-        ),
-    }
+fn parse_pull_request_number(commit_title: &str) -> Result<u64> {
+    let number = commit_title
+        .trim()
+        .strip_suffix(')')
+        .and_then(|title| title.rsplit_once("(#"))
+        .map(|(_, number)| number)
+        .filter(|number| !number.is_empty() && number.bytes().all(|byte| byte.is_ascii_digit()))
+        .ok_or_else(|| anyhow!("Commit title must end with `(#<PR number>)`"))?;
+
+    number
+        .parse()
+        .with_context(|| format!("Invalid PR number in commit title `{commit_title}`"))
 }
 
 #[cfg(not(test))]
@@ -477,8 +458,7 @@ fn ensure_full_git_history(repo_root: &Path) -> Result<()> {
 
 #[cfg(test)]
 fn lookup_pull_request(_: &Path, _: &Path) -> Result<u64> {
-    // Unit tests exercise local parsing and rendering. A release dry run checks
-    // the real GitHub lookup without requiring network access in unit tests.
+    // Unit tests exercise local parsing and rendering without requiring a Git repository.
     Ok(42)
 }
 
@@ -743,6 +723,21 @@ fn render_upgrade_guide(date: &str, version: &Version, breaking: &[&BreakingDeta
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parses_pull_request_from_commit_title() {
+        assert_eq!(
+            parse_pull_request_number("feat(foo): add bar (#12345)").unwrap(),
+            12345
+        );
+    }
+
+    #[test]
+    fn rejects_commit_title_without_pull_request_suffix() {
+        assert!(parse_pull_request_number("feat(foo): add bar").is_err());
+        assert!(parse_pull_request_number("feat(foo): add bar (#abc)").is_err());
+        assert!(parse_pull_request_number("feat(foo): add bar (#123) trailing").is_err());
+    }
 
     #[test]
     fn bump_type_patch_minor_major() {

--- a/vdev/src/commands/release/generate_cue.rs
+++ b/vdev/src/commands/release/generate_cue.rs
@@ -322,9 +322,7 @@ fn read_changelog_fragments(repo_root: &Path, dir: &Path) -> Result<Vec<Changelo
     paths.sort();
     for path in paths {
         let mut entry = parse_changelog_fragment(&path)?;
-        entry
-            .pr_numbers
-            .push(lookup_pull_request(repo_root, &path)?);
+        entry.pr_numbers = lookup_pull_requests(repo_root, &path)?;
         entries.push(entry);
     }
     Ok(entries)
@@ -387,11 +385,11 @@ fn parse_changelog_fragment(path: &Path) -> Result<ChangelogEntry> {
     })
 }
 
-/// Find the PR that introduced a changelog fragment from the adding commit's
-/// `... (#12345)` title. The commit remains available after release preparation
-/// deletes the fragment, so the same lookup can also backfill release metadata.
+/// Find every PR that added or edited a changelog fragment from each commit's
+/// `... (#12345)` title. Deletion commits are excluded so this also works after
+/// release preparation removes the fragment.
 #[cfg(not(test))]
-fn lookup_pull_request(repo_root: &Path, fragment_path: &Path) -> Result<u64> {
+fn lookup_pull_requests(repo_root: &Path, fragment_path: &Path) -> Result<Vec<u64>> {
     let relative_path = fragment_path.strip_prefix(repo_root).with_context(|| {
         format!(
             "Fragment path {} is outside the repository root {}",
@@ -406,29 +404,41 @@ fn lookup_pull_request(repo_root: &Path, fragment_path: &Path) -> Result<u64> {
         )
     })?;
 
-    let commit_title = run_command(
+    let commit_titles = run_command(
         "git",
         &[
             "log",
-            "-1",
             "--format=%s",
-            "--diff-filter=A",
+            "--diff-filter=AM",
             "--follow",
             "--",
             relative_path,
         ],
         repo_root,
     )?;
-    let commit_title = commit_title.trim();
-    if commit_title.is_empty() {
+    if commit_titles.trim().is_empty() {
         bail!(
-            "Could not find the commit that added {relative_path}; cannot determine its pull request."
+            "Could not find commits that added or edited {relative_path}; cannot determine its pull requests."
         );
     }
 
-    parse_pull_request_number(commit_title).with_context(|| {
-        format!("Could not determine the PR that added {relative_path} from commit title `{commit_title}`")
+    parse_pull_request_numbers(&commit_titles).with_context(|| {
+        format!("Could not determine every PR that added or edited {relative_path}")
     })
+}
+
+fn parse_pull_request_numbers(commit_titles: &str) -> Result<Vec<u64>> {
+    let mut numbers = Vec::new();
+    for commit_title in commit_titles
+        .lines()
+        .filter(|title| !title.trim().is_empty())
+    {
+        let number = parse_pull_request_number(commit_title)?;
+        if !numbers.contains(&number) {
+            numbers.push(number);
+        }
+    }
+    Ok(numbers)
 }
 
 fn parse_pull_request_number(commit_title: &str) -> Result<u64> {
@@ -457,9 +467,9 @@ fn ensure_full_git_history(repo_root: &Path) -> Result<()> {
 }
 
 #[cfg(test)]
-fn lookup_pull_request(_: &Path, _: &Path) -> Result<u64> {
+fn lookup_pull_requests(_: &Path, _: &Path) -> Result<Vec<u64>> {
     // Unit tests exercise local parsing and rendering without requiring a Git repository.
-    Ok(42)
+    Ok(vec![42])
 }
 
 #[cfg(not(test))]
@@ -729,6 +739,19 @@ mod tests {
         assert_eq!(
             parse_pull_request_number("feat(foo): add bar (#12345)").unwrap(),
             12345
+        );
+    }
+
+    #[test]
+    fn parses_and_deduplicates_pull_requests_from_commit_titles() {
+        let titles = indoc::indoc! {"
+            fix(foo): adjust bar (#23456)
+            feat(foo): add bar (#12345)
+            feat(foo): add bar (#12345)
+        "};
+        assert_eq!(
+            parse_pull_request_numbers(titles).unwrap(),
+            vec![23456, 12345]
         );
     }
 

--- a/vdev/src/commands/release/prepare.rs
+++ b/vdev/src/commands/release/prepare.rs
@@ -216,7 +216,10 @@ impl Prepare {
     // Step 6
     fn generate_release_cue(&self) -> Result<()> {
         debug!("generate_release_cue");
-        generate_cue::run(&self.new_vector_version)?;
+        generate_cue::run(
+            &self.new_vector_version,
+            generate_cue::PullRequestMetadata::Required,
+        )?;
         generate_cue::retire_all_fragments()?;
 
         self.append_vrl_changelog_to_release_cue()?;

--- a/website/assets/css/style.css
+++ b/website/assets/css/style.css
@@ -155,18 +155,23 @@
   margin: 0;
 }
 
-/* VRL release entries end with linked PR and author attribution. */
-.vrl-changelog > ul:has(+ p a[href*="github.com/vectordotdev/vrl/pull/"] ~ a[href^="https://github.com/"]) {
+/* VRL release entries end with a paragraph linking both the author and PR. */
+.vrl-changelog > ul:has(+ p a[href*="github.com/vectordotdev/vrl/pull/"] ~ a[href^="https://github.com/"]:not([href*="/pull/"])),
+.vrl-changelog > ul:has(+ p a[href^="https://github.com/"]:not([href*="/pull/"]) ~ a[href*="github.com/vectordotdev/vrl/pull/"]) {
   @apply mb-0 mt-4 min-w-0 list-none rounded-t-lg border border-b-0 border-gray-200 bg-gray-50/50 px-4 py-4 shadow-sm md:px-5;
 }
-.vrl-changelog > ul:has(+ p a[href*="github.com/vectordotdev/vrl/pull/"] ~ a[href^="https://github.com/"]) > li {
+.vrl-changelog > ul:has(+ p a[href*="github.com/vectordotdev/vrl/pull/"] ~ a[href^="https://github.com/"]:not([href*="/pull/"])) > li,
+.vrl-changelog > ul:has(+ p a[href^="https://github.com/"]:not([href*="/pull/"]) ~ a[href*="github.com/vectordotdev/vrl/pull/"]) > li {
   @apply m-0;
 }
-.vrl-changelog > ul + p:has(a[href*="github.com/vectordotdev/vrl/pull/"] ~ a[href^="https://github.com/"]) {
+.vrl-changelog > ul + p:has(a[href*="github.com/vectordotdev/vrl/pull/"] ~ a[href^="https://github.com/"]:not([href*="/pull/"])),
+.vrl-changelog > ul + p:has(a[href^="https://github.com/"]:not([href*="/pull/"]) ~ a[href*="github.com/vectordotdev/vrl/pull/"]) {
   @apply mt-0 rounded-b-lg border border-gray-200 bg-gray-50/50 px-4 py-3 text-sm italic shadow-sm md:px-5;
 }
-.dark .vrl-changelog > ul:has(+ p a[href*="github.com/vectordotdev/vrl/pull/"] ~ a[href^="https://github.com/"]),
-.dark .vrl-changelog > ul + p:has(a[href*="github.com/vectordotdev/vrl/pull/"] ~ a[href^="https://github.com/"]) {
+.dark .vrl-changelog > ul:has(+ p a[href*="github.com/vectordotdev/vrl/pull/"] ~ a[href^="https://github.com/"]:not([href*="/pull/"])),
+.dark .vrl-changelog > ul:has(+ p a[href^="https://github.com/"]:not([href*="/pull/"]) ~ a[href*="github.com/vectordotdev/vrl/pull/"]),
+.dark .vrl-changelog > ul + p:has(a[href*="github.com/vectordotdev/vrl/pull/"] ~ a[href^="https://github.com/"]:not([href*="/pull/"])),
+.dark .vrl-changelog > ul + p:has(a[href^="https://github.com/"]:not([href*="/pull/"]) ~ a[href*="github.com/vectordotdev/vrl/pull/"]) {
   @apply border-gray-700 bg-gray-800/40;
 }
 

--- a/website/cue/reference/releases/0.58.0.cue
+++ b/website/cue/reference/releases/0.58.0.cue
@@ -540,7 +540,7 @@ releases: "0.58.0": {
 			description: #"""
 				Sink `endpoint` options now require an absolute URL that includes a host. Endpoints without a scheme are defaulted to `https://` (for example `endpoint: "localhost:8080"` becomes `https://localhost:8080`). Previously, partial or empty endpoints (for example `endpoint: ""` or `endpoint: "localhost:8080"` without a scheme) were accepted at configuration load and only failed when the sink attempted to send data, or were silently completed with a default scheme and host. Empty, host-less, or non-`http(s)` endpoints (for example `endpoint: ""`, `endpoint: "/path"`, or `endpoint: "ftp://example.com"`) are now rejected at configuration load with a clear error, including with `vector validate --no-environment`. This affects the `appsignal`, `azure_logs_ingestion`, `datadog_events`, `datadog_logs`, `datadog_metrics`, `datadog_traces`, `elasticsearch`, `gcp_cloud_storage`, `gcp_pubsub`, `gcp_stackdriver_logs`, `gcp_stackdriver_metrics`, `honeycomb`, `humio`, `influxdb`, `loki`, `prometheus_remote_write`, `sematext`, `splunk_hec`, and `webhdfs` sinks.
 				"""#
-			pr_numbers: [26116]
+			pr_numbers: [26195, 26177, 26180, 26152, 26130, 26116]
 			contributors: ["thomasqueirozb"]
 		},
 		{
@@ -558,7 +558,7 @@ releases: "0.58.0": {
 			description: #"""
 				Fixed the `tls.server_name` option so that it is used for certificate hostname verification in addition to SNI. Previously, on the OpenSSL path (used by HTTP-based sinks such as `datadog_logs`), the certificate was still verified against the connection URL host, causing a "hostname mismatch" verification failure when `server_name` differed from the endpoint host. The override applies only to the upstream destination, so an HTTPS forward proxy's own certificate is verified against the proxy host.
 				"""#
-			pr_numbers: [25881]
+			pr_numbers: [25899, 25881]
 			contributors: ["gwenaskell"]
 		},
 		{

--- a/website/cue/reference/releases/0.58.0.cue
+++ b/website/cue/reference/releases/0.58.0.cue
@@ -11,6 +11,7 @@ releases: "0.58.0": {
 			description: #"""
 				Added common internal HTTP metrics to the connector used by AWS sinks.
 				"""#
+			pr_numbers: [25508]
 			contributors: ["gwenaskell"]
 		},
 		{
@@ -18,6 +19,7 @@ releases: "0.58.0": {
 			description: #"""
 				Propagate FIPS endpoint setting to STS AssumeRole clients. When `AWS_USE_FIPS_ENDPOINT=true` is configured, Vector now correctly uses FIPS endpoints for STS operations (e.g., `sts-fips.<region>.amazonaws.com`) in addition to the primary service client.
 				"""#
+			pr_numbers: [25232]
 			contributors: ["hligit"]
 		},
 		{
@@ -26,6 +28,7 @@ releases: "0.58.0": {
 				Allow explicit null values in JSON and YAML configuration files to load without being converted
 				through TOML.
 				"""#
+			pr_numbers: [25981]
 			contributors: ["pront"]
 		},
 		{
@@ -35,6 +38,7 @@ releases: "0.58.0": {
 				
 				The `azure_blob` sink now supports a `metadata` option, which sets [custom blob metadata](https://learn.microsoft.com/rest/api/storageservices/set-blob-metadata) (`x-ms-meta-*`) on every created blob (parity with the `metadata` option on the `gcp_cloud_storage` sink).
 				"""#
+			pr_numbers: [25545]
 			contributors: ["danielku15"]
 		},
 		{
@@ -42,6 +46,7 @@ releases: "0.58.0": {
 			description: #"""
 				The `redis` source configured with `data_type = "channel"` now automatically reconnects and re-subscribes after the Redis connection drops (for example, on a Redis restart or a transient network blip), instead of silently stopping until Vector is restarted. Reconnect attempts use exponential backoff (capped at 30s) and emit `component_errors_total` on failures and `connection_established_total` on recovery.
 				"""#
+			pr_numbers: [25892]
 			contributors: ["gibranbadrul"]
 		},
 		{
@@ -55,6 +60,7 @@ releases: "0.58.0": {
 				metrics for the lifetime of the sink; be aware this can result in unbounded memory growth if
 				metric series cardinality is unbounded.
 				"""#
+			pr_numbers: [26041]
 			contributors: ["valerypetrov"]
 		},
 		{
@@ -67,6 +73,7 @@ releases: "0.58.0": {
 				
 				Additionally fixed a panic when `expire_metrics_secs: 0` was set.
 				"""#
+			pr_numbers: [25214]
 			contributors: ["GreyLilac09"]
 		},
 		{
@@ -91,6 +98,7 @@ releases: "0.58.0": {
 				}
 				```
 				"""#
+			pr_numbers: [25404]
 			contributors: ["kimjune01"]
 		},
 		{
@@ -98,6 +106,7 @@ releases: "0.58.0": {
 			description: #"""
 				Added cuckoo filter support for the `memory` enrichment table to provide an efficient way to store and check for the presence of keys with a low memory footprint, at the cost of false positives.
 				"""#
+			pr_numbers: [25143]
 			contributors: ["esensar", "Quad9DNS"]
 		},
 		{
@@ -105,6 +114,7 @@ releases: "0.58.0": {
 			description: #"""
 				Added bloom filter support for `memory` enrichment table, similar to cuckoo filter, providing a simple and efficient way to store and check the presence of keys with a low memory footprint at the cost of false positives, but with fewer features than cuckoo filter.
 				"""#
+			pr_numbers: [25154]
 			contributors: ["esensar", "Quad9DNS"]
 		},
 		{
@@ -112,6 +122,7 @@ releases: "0.58.0": {
 			description: #"""
 				The `datadog_agent` source now accepts LLM Observability (LLMObs) telemetry at `/api/v2/llmobs`. When `multiple_outputs` is enabled, LLMObs span events are available as log events on the `llmobs` output port.
 				"""#
+			pr_numbers: [25636]
 			contributors: ["ronitanilkumar"]
 		},
 		{
@@ -122,6 +133,7 @@ releases: "0.58.0": {
 				When `oversized_action` is set to `truncate`, frames that exceed the configured `max_length` are truncated to the maximum
 				allowed size, and the remainder of the oversized frame is discarded up to the next delimiter.
 				"""#
+			pr_numbers: [25567]
 			contributors: ["vparfonov"]
 		},
 		{
@@ -137,6 +149,7 @@ releases: "0.58.0": {
 				can truncate the combined result. Note that `max_line_bytes` still applies at the file level
 				and always drops individual lines exceeding it; file-level truncation is not yet supported.
 				"""#
+			pr_numbers: [25567]
 			contributors: ["vparfonov"]
 		},
 		{
@@ -144,6 +157,7 @@ releases: "0.58.0": {
 			description: #"""
 				The `mqtt` sink and source now honor the configured `tls.alpn_protocols` option instead of always advertising the hardcoded `mqtt` ALPN protocol. This allows connecting to endpoints that require a specific ALPN protocol name, such as AWS IoT Core over port 443 which requires `x-amzn-mqtt-ca`. When `tls.alpn_protocols` is not set, the previous `mqtt` default is preserved.
 				"""#
+			pr_numbers: [25807]
 			contributors: ["frank-hivewatch"]
 		},
 		{
@@ -151,6 +165,7 @@ releases: "0.58.0": {
 			description: #"""
 				Fixed generated configuration schemas for overlapping untagged enum variants, allowing values accepted by `serde` to validate correctly.
 				"""#
+			pr_numbers: [25828]
 			contributors: ["bruceg"]
 		},
 		{
@@ -185,6 +200,7 @@ releases: "0.58.0": {
 				      codec: json
 				```
 				"""#
+			pr_numbers: [26177]
 			contributors: ["thomasqueirozb"]
 		},
 		{
@@ -192,6 +208,7 @@ releases: "0.58.0": {
 			description: #"""
 				Allows hyphens in the `<backend name>` portion of the `SECRET[<backend name>.<secret name>]` collector regex. Before, a backend name containing a hyphen (e.g., `my-backend`) would fail to match, leaving the literal `SECRET[...]` string in the resolved config instead of the secret value.
 				"""#
+			pr_numbers: [25896]
 			contributors: ["maklean"]
 		},
 		{
@@ -199,6 +216,7 @@ releases: "0.58.0": {
 			description: #"""
 				Added missing "httpProtocol" field to dnstap source events.
 				"""#
+			pr_numbers: [25887]
 			contributors: ["esensar", "Quad9DNS"]
 		},
 		{
@@ -207,6 +225,7 @@ releases: "0.58.0": {
 				Dynamic `loki` sink label and structured metadata values no longer require a literal prefix or
 				`dangerously_allow_unconfined_template_resolution`. Template keys and tenant IDs remain confined.
 				"""#
+			pr_numbers: [26176]
 			contributors: ["pront"]
 		},
 		{
@@ -215,6 +234,7 @@ releases: "0.58.0": {
 				Dynamic `aws_cloudwatch_logs` sink `stream_name` templates no longer require a literal prefix or
 				`dangerously_allow_unconfined_template_resolution`. `group_name` remains confined.
 				"""#
+			pr_numbers: [26188]
 			contributors: ["pront"]
 		},
 		{
@@ -223,6 +243,7 @@ releases: "0.58.0": {
 				Reduce transforms using the `sum` merge strategy now return an error instead of panicking when
 				floating-point addition would produce NaN.
 				"""#
+			pr_numbers: [26022]
 			contributors: ["pront"]
 		},
 		{
@@ -230,6 +251,7 @@ releases: "0.58.0": {
 			description: #"""
 				The `sematext_logs` sink no longer panics when the `token` cannot be parsed as a template (e.g., `{{ }}`). It now fails configuration validation with a clear error instead of crashing at startup.
 				"""#
+			pr_numbers: [26180]
 			contributors: ["thomasqueirozb"]
 		},
 		{
@@ -241,6 +263,7 @@ releases: "0.58.0": {
 				Vector namespace, or into the event body in the legacy namespace, without overwriting existing
 				fields.
 				"""#
+			pr_numbers: [25935]
 			contributors: ["petere-datadog"]
 		},
 		{
@@ -249,6 +272,7 @@ releases: "0.58.0": {
 				The `aws_s3` source can now retrieve objects from S3 Requester Pays buckets by setting
 				`request_payer: requester`.
 				"""#
+			pr_numbers: [26028]
 			contributors: ["vibe"]
 		},
 		{
@@ -257,6 +281,7 @@ releases: "0.58.0": {
 				The `ssekms_key_id` option in the `aws_s3` sink now respects the configured timezone when the
 				value is a template containing time components, matching the existing behavior of `key_prefix`.
 				"""#
+			pr_numbers: [26141]
 			contributors: ["thomasqueirozb"]
 		},
 		{
@@ -264,6 +289,7 @@ releases: "0.58.0": {
 			description: #"""
 				Fix Azure Blob Storage uploads larger than 4 MiB when using an account-key connection string. These uploads could send all data blocks successfully but fail with a 403 while completing the upload because the final request's body length was missing during Shared Key signing. Vector now sets the body length before signing that request.
 				"""#
+			pr_numbers: [25978]
 			contributors: ["ArunPiduguDD"]
 		},
 		{
@@ -276,6 +302,7 @@ releases: "0.58.0": {
 				validation. Microsoft ends support for the sink's underlying Data Collector API in September
 				2026.
 				"""#
+			pr_numbers: [26152]
 			contributors: ["pront"]
 		},
 		{
@@ -286,6 +313,7 @@ releases: "0.58.0": {
 			description: #"""
 				The deprecated `buffer_byte_size` and `buffer_events` gauge metrics have been removed.
 				"""#
+			pr_numbers: [26153]
 			contributors: ["pront"]
 		},
 		{
@@ -293,6 +321,7 @@ releases: "0.58.0": {
 			description: #"""
 				Fixed two problems with the `chunked_gelf` framing decoder's limits. `pending_messages_limit` was applied to every chunk rather than only to new messages, so once the limit was reached even chunks of messages already pending were rejected and those messages could never complete. Separately, dropping a message for exceeding `max_length` left its timeout task running, so `pending_messages_limit` bounded the pending message count but not the number of live tasks.
 				"""#
+			pr_numbers: [26162]
 			contributors: ["pront"]
 		},
 		{
@@ -300,6 +329,7 @@ releases: "0.58.0": {
 			description: #"""
 				Fixed a panic in the `chunked_gelf` framing decoder when a one-byte message arrived with trace-level logging enabled, which caused the source to fail. Such a message is now passed on for the decoder to reject, as it would any other malformed payload.
 				"""#
+			pr_numbers: [26162]
 			contributors: ["pront"]
 		},
 		{
@@ -316,6 +346,7 @@ releases: "0.58.0": {
 				
 				This configuration now reports `sources.broken: invalid type: string "not-a-number", expected f64`.
 				"""#
+			pr_numbers: [25981]
 			contributors: ["pront"]
 		},
 		{
@@ -324,6 +355,7 @@ releases: "0.58.0": {
 				Encode `resource.<type>` metric tags as resources when using a V2 `datadog_metrics`
 				sink, preserving Datadog Agent resources such as `database_instance`.
 				"""#
+			pr_numbers: [25973]
 			contributors: ["tessneau"]
 		},
 		{
@@ -331,6 +363,7 @@ releases: "0.58.0": {
 			description: #"""
 				After a crash, affected `disk_v2` buffers could incorrectly appear full, block new events, and stall recovery. Vector now restores buffer usage correctly on restart so the pipeline can continue processing.
 				"""#
+			pr_numbers: [25845]
 			contributors: ["graphcareful"]
 		},
 		{
@@ -338,6 +371,7 @@ releases: "0.58.0": {
 			description: #"""
 				Fixed a `disk_v2` buffer bug where a record too large to write (one whose encoded size exceeds the buffer's maximum record size) caused the buffer writer to return an unrecoverable error, which tore down the entire Vector topology and stopped the process. The writer now drops just that record and continues: the record's finalizers are resolved with the default `Dropped` status (which sources with end-to-end acknowledgement treat as `Delivered`, so they ack or checkpoint rather than redelivering the un-writable record), an error is logged, and the drop is counted via the `buffer_discarded_events_total` and `buffer_discarded_bytes_total` metrics (with `intentional="false"`). Every other record and the buffer itself are unaffected.
 				"""#
+			pr_numbers: [25795]
 			contributors: ["graphcareful"]
 		},
 		{
@@ -345,6 +379,7 @@ releases: "0.58.0": {
 			description: #"""
 				Prevent disk buffers from stalling by publishing flushed writer progress before notifying readers.
 				"""#
+			pr_numbers: [25872]
 			contributors: ["graphcareful"]
 		},
 		{
@@ -353,6 +388,7 @@ releases: "0.58.0": {
 				Fix deserialization of `aggregated_histogram` bucket `upper_limit` when the value is provided as
 				an integer instead of a float.
 				"""#
+			pr_numbers: [26031]
 			contributors: ["dd-sebastien-lb"]
 		},
 		{
@@ -360,6 +396,7 @@ releases: "0.58.0": {
 			description: #"""
 				`gcp_stackdriver_logs` label templates are now unconfined; they were previously overly constrained.
 				"""#
+			pr_numbers: [25976]
 			contributors: ["pront"]
 		},
 		{
@@ -371,6 +408,7 @@ releases: "0.58.0": {
 				The deprecated `encoding` option has been removed from the `http_server` source
 				and its deprecated `http` alias. Configurations using it now fail validation.
 				"""#
+			pr_numbers: [26082]
 			contributors: ["pront"]
 		},
 		{
@@ -382,6 +420,7 @@ releases: "0.58.0": {
 				The deprecated `namespace` option has been removed from the `influxdb_logs` sink. It has been
 				deprecated since v0.24.0 in favor of `measurement`. Configurations using it now fail validation.
 				"""#
+			pr_numbers: [26108]
 			contributors: ["thomasqueirozb"]
 		},
 		{
@@ -392,6 +431,7 @@ releases: "0.58.0": {
 				configured settings, matching the previous behavior. The `version` field will be required in a
 				future release.
 				"""#
+			pr_numbers: [26093]
 			contributors: ["thomasqueirozb"]
 		},
 		{
@@ -403,6 +443,7 @@ releases: "0.58.0": {
 				`gzip`, `zlib`, and `zstd`, and zstd decompression supports custom dictionaries via
 				`dictionary_path`. Payloads are decompressed before framing and decoding are applied.
 				"""#
+			pr_numbers: [26024]
 			contributors: ["cjford"]
 		},
 		{
@@ -412,6 +453,7 @@ releases: "0.58.0": {
 				
 				On this fallback path, Vector still populates `pod_name`, `pod_namespace`, and `container_name`. The path segment that is usually a Pod UID is exposed as `pod_log_directory_id` (not `pod_uid`), because for static pods it can be a config hash instead of the API Pod UID. Users who want UID semantics can remap the field.
 				"""#
+			pr_numbers: [25834]
 			contributors: ["vparfonov"]
 		},
 		{
@@ -419,6 +461,7 @@ releases: "0.58.0": {
 			description: #"""
 				Explicitly log when components are gracefully shut down.
 				"""#
+			pr_numbers: [25974]
 			contributors: ["clementd-dd"]
 		},
 		{
@@ -430,6 +473,7 @@ releases: "0.58.0": {
 				The deprecated `logdna` sink alias has been removed. It was renamed to `mezmo` in v0.29.0.
 				Configurations using `type: logdna` now fail validation.
 				"""#
+			pr_numbers: [26114]
 			contributors: ["thomasqueirozb"]
 		},
 		{
@@ -437,6 +481,7 @@ releases: "0.58.0": {
 			description: #"""
 				The `logstash` source no longer runs out of memory and crashes on rare problematic compressed frames, such as one containing an extremely large number of events. Additionally, events received before a malformed frame inside a compressed payload are now delivered instead of being silently discarded along with the malformed frame.
 				"""#
+			pr_numbers: [26129]
 			contributors: ["pront"]
 		},
 		{
@@ -444,6 +489,7 @@ releases: "0.58.0": {
 			description: #"""
 				The `logstash` source now rejects frames larger than the configured maximum instead of buffering them indefinitely; previously, a sender could declare an extremely large frame and force the source to hold its bytes in memory until it ran out of memory. The limit is controlled by the existing `--max-decompressed-size-bytes` option (default 100 MiB).
 				"""#
+			pr_numbers: [26129]
 			contributors: ["pront"]
 		},
 		{
@@ -454,6 +500,7 @@ releases: "0.58.0": {
 				instead of forcing every tag into one form. The `lua` transform continues to support only
 				`single` and `full`.
 				"""#
+			pr_numbers: [25376]
 			contributors: ["kaarolch"]
 		},
 		{
@@ -461,6 +508,7 @@ releases: "0.58.0": {
 			description: #"""
 				The OTLP codec's serializer now supports native Vector `Metric` events for `Counter`, `Gauge`, `AggregatedHistogram`, and `AggregatedSummary` values, converting them into the OTLP `Sum`, `Gauge`, `Histogram`, and `Summary` protobuf types respectively. Previously, encoding a native metric event with the OTLP serializer always failed.
 				"""#
+			pr_numbers: [25738]
 			contributors: ["petere-datadog"]
 		},
 		{
@@ -468,6 +516,7 @@ releases: "0.58.0": {
 			description: #"""
 				Fixed an issue where unusually deeply nested event data or metadata could make disk buffers unreadable or cause vector-to-vector pipelines to retry indefinitely. Vector now detects affected events before buffering or sending while leaving safely nested events unchanged. When when_full = "overflow" is configured, the original event is routed intact to the overflow stage regardless of buffer occupancy; otherwise, only the affected event is dropped.
 				"""#
+			pr_numbers: [26099]
 			contributors: ["connoryy", "ganelo", "EricaJ6", "jonodera97"]
 		},
 		{
@@ -475,6 +524,7 @@ releases: "0.58.0": {
 			description: #"""
 				Prevent configured HTTP proxy credentials from being sent in the `Authorization` header to origin servers for plaintext `http://` requests; they are now sent only in `Proxy-Authorization`.
 				"""#
+			pr_numbers: [26095]
 			contributors: ["pront"]
 		},
 		{
@@ -482,6 +532,7 @@ releases: "0.58.0": {
 			description: #"""
 				Fixed the `vector_security_confinement_disabled` internal metric disappearing after the metric idle timeout (300 seconds by default) while a sink was still running with `dangerously_allow_unconfined_template_resolution` enabled. The gauge is now owned by the topology and held for the lifetime of each sink, and refreshed on configuration reload, so alerts watching this metric no longer silently stop firing.
 				"""#
+			pr_numbers: [25910]
 			contributors: ["thomasqueirozb"]
 		},
 		{
@@ -489,6 +540,7 @@ releases: "0.58.0": {
 			description: #"""
 				Sink `endpoint` options now require an absolute URL that includes a host. Endpoints without a scheme are defaulted to `https://` (for example `endpoint: "localhost:8080"` becomes `https://localhost:8080`). Previously, partial or empty endpoints (for example `endpoint: ""` or `endpoint: "localhost:8080"` without a scheme) were accepted at configuration load and only failed when the sink attempted to send data, or were silently completed with a default scheme and host. Empty, host-less, or non-`http(s)` endpoints (for example `endpoint: ""`, `endpoint: "/path"`, or `endpoint: "ftp://example.com"`) are now rejected at configuration load with a clear error, including with `vector validate --no-environment`. This affects the `appsignal`, `azure_logs_ingestion`, `datadog_events`, `datadog_logs`, `datadog_metrics`, `datadog_traces`, `elasticsearch`, `gcp_cloud_storage`, `gcp_pubsub`, `gcp_stackdriver_logs`, `gcp_stackdriver_metrics`, `honeycomb`, `humio`, `influxdb`, `loki`, `prometheus_remote_write`, `sematext`, `splunk_hec`, and `webhdfs` sinks.
 				"""#
+			pr_numbers: [26116]
 			contributors: ["thomasqueirozb"]
 		},
 		{
@@ -498,6 +550,7 @@ releases: "0.58.0": {
 				
 				Previously, TLS handshakes on these sources had no timeout: a client that opened a TCP connection and never completed (or never started) the TLS handshake would hold its slot against `connection_limit` indefinitely, since neither TCP keepalive nor `max_connection_duration_secs` are evaluated until after the handshake succeeds. This could let misbehaving or unresponsive clients gradually exhaust the connection limit and block legitimate traffic. The new setting is unset by default, preserving prior behavior.
 				"""#
+			pr_numbers: [26126]
 			contributors: ["vladimir-dd"]
 		},
 		{
@@ -505,6 +558,7 @@ releases: "0.58.0": {
 			description: #"""
 				Fixed the `tls.server_name` option so that it is used for certificate hostname verification in addition to SNI. Previously, on the OpenSSL path (used by HTTP-based sinks such as `datadog_logs`), the certificate was still verified against the connection URL host, causing a "hostname mismatch" verification failure when `server_name` differed from the endpoint host. The override applies only to the upstream destination, so an HTTPS forward proxy's own certificate is verified against the proxy host.
 				"""#
+			pr_numbers: [25881]
 			contributors: ["gwenaskell"]
 		},
 		{
@@ -517,6 +571,7 @@ releases: "0.58.0": {
 				the hostname (or immediately adjacent to it without a path separator). Previously,
 				such templates built successfully but silently dropped every event at render time.
 				"""#
+			pr_numbers: [25886]
 			contributors: ["thomasqueirozb"]
 		},
 		{
@@ -524,6 +579,7 @@ releases: "0.58.0": {
 			description: #"""
 				Fix a panic in Vector when a sink endpoint or URI contains a non-numeric port (e.g. `http://localhost:notaport`). Malformed URIs now produce a validation error instead of crashing Vector.
 				"""#
+			pr_numbers: [26083]
 			contributors: ["thomasqueirozb"]
 		},
 		{
@@ -536,6 +592,7 @@ releases: "0.58.0": {
 				prefix. Any source using `framing.method = "varint_length_delimited"` was affected once the stream
 				exceeded the 8 KiB read buffer, unless the frame size happened to tile that buffer exactly.
 				"""#
+			pr_numbers: [26169]
 			contributors: ["meirdev"]
 		},
 		{
@@ -549,6 +606,7 @@ releases: "0.58.0": {
 				remains valid, but it now resolves to `https://127.0.0.1:9870`; previously the underlying
 				WebHDFS client resolved to `http://127.0.0.1:9870`
 				"""#
+			pr_numbers: [26177]
 			contributors: ["thomasqueirozb"]
 		},
 		{
@@ -556,6 +614,7 @@ releases: "0.58.0": {
 			description: #"""
 				The `databricks_zerobus` sink now has OTel v2 compatibility.
 				"""#
+			pr_numbers: [25831]
 			contributors: ["yorickvanzweeden"]
 		},
 	]
@@ -567,16 +626,16 @@ releases: "0.58.0": {
 		
 		- The `parse_aws_vpc_flow_log` function now recognizes all fields introduced in AWS VPC Flow Logs versions 7 through 11, including the v7 ECS metadata fields, v8 `reject_reason`, v9 `resource_id`, v10 `encryption_status`, and the v11 tag/interface/next-hop fields.
 		
-		[PR #1879](https://github.com/vectordotdev/vrl/pull/1879) by [@avestuk](https://github.com/avestuk)
+		Thanks to [avestuk](https://github.com/avestuk) for contributing PR [#1879](https://github.com/vectordotdev/vrl/pull/1879)!
 		
 		#### Fixes
 		
 		- Fixed `round`'s type definition, which previously always claimed to return an integer even though it returns a float for float inputs.
 		
-		[PR #1862](https://github.com/vectordotdev/vrl/pull/1862) by [@thomasqueirozb](https://github.com/thomasqueirozb)
+		Thanks to [thomasqueirozb](https://github.com/thomasqueirozb) for contributing PR [#1862](https://github.com/vectordotdev/vrl/pull/1862)!
 		- Prevent float arithmetic that produces NaN from panicking or silently returning zero. Such operations now return a runtime error.
 		
-		[PR #1890](https://github.com/vectordotdev/vrl/pull/1890) by [@pront](https://github.com/pront)
+		Thanks to [pront](https://github.com/pront) for contributing PR [#1890](https://github.com/vectordotdev/vrl/pull/1890)!
 		
 		"""#
 }

--- a/website/layouts/partials/releases/changelog-attribution.html
+++ b/website/layouts/partials/releases/changelog-attribution.html
@@ -1,0 +1,24 @@
+{{- $contributors := .contributors -}}
+{{- $prNumbers := .pr_numbers -}}
+{{- if or (gt (len $contributors) 0) (gt (len $prNumbers) 0) }}
+<div class="mt-3 overflow-x-auto border-t border-gray-200 pt-3 text-sm italic text-gray-600 dark:border-gray-700 dark:text-gray-300">
+  {{- if gt (len $contributors) 0 }}
+    {{- printf "Thanks to " -}}
+    {{- range $i, $contributor := $contributors }}
+      {{- $username := replace $contributor "@" "" }}
+      {{- $profile := printf "https://github.com/%s" $username }}
+      {{- if gt $i 0 }}{{ printf ", " }}{{ end -}}
+      <a href="{{ $profile }}" class="text-primary-dark hover:text-secondary dark:text-primary dark:hover:text-secondary" rel="noopener" target="_blank">{{ $username }}</a>
+    {{- end }}
+    {{- if gt (len $prNumbers) 0 }}{{ printf " for contributing %s " (cond (eq (len $prNumbers) 1) "PR" "PRs") }}{{ else }}{{ printf " for contributing this change!" }}{{ end -}}
+  {{- else }}
+    {{- printf "%s " (cond (eq (len $prNumbers) 1) "PR" "PRs") -}}
+  {{- end }}
+  {{- range $i, $prNumber := $prNumbers }}
+    {{- if gt $i 0 }}{{ printf ", " }}{{ end -}}
+    {{- $prLink := printf "https://github.com/vectordotdev/vector/pull/%v" $prNumber -}}
+    <a href="{{ $prLink }}" class="text-primary-dark hover:text-secondary dark:text-primary dark:hover:text-secondary" rel="noopener" target="_blank">#{{ $prNumber }}</a>
+  {{- end -}}
+  {{- if gt (len $prNumbers) 0 }}!{{ end -}}
+</div>
+{{- end }}

--- a/website/layouts/releases/single.html
+++ b/website/layouts/releases/single.html
@@ -109,8 +109,8 @@
           <ul class="mt-4 grid min-w-0 list-none gap-3 p-0">
             {{ range $breakingTitled }}
             <li class="m-0 min-w-0 max-w-full overflow-hidden rounded-lg border border-gray-200 bg-gray-50/50 px-4 py-4 shadow-sm dark:border-gray-700 dark:bg-gray-800/40 md:px-5">
-              <a href="{{ (index $upgradeGuides 0).RelPermalink }}#{{ .anchor }}" class="block focus:outline-none focus:ring-2 focus:ring-primary">
-                <div class="prose dark:prose-invert max-w-none font-semibold text-dark hover:text-primary-dark dark:text-gray-100 dark:hover:text-primary [&>p]:m-0 [&_:not(pre)>code]:break-all [&_:not(pre)>code]:whitespace-normal">
+              <a href="{{ (index $upgradeGuides 0).RelPermalink }}#{{ .anchor }}" class="group block underline decoration-primary/50 underline-offset-4 focus:outline-none focus:ring-2 focus:ring-primary hover:decoration-secondary">
+                <div class="prose dark:prose-invert max-w-none font-semibold [&>p]:m-0 [&>p]:text-primary-dark group-hover:[&>p]:text-secondary dark:[&>p]:text-primary dark:group-hover:[&>p]:text-secondary [&_:not(pre)>code]:break-all [&_:not(pre)>code]:whitespace-normal">
                   {{ .title | markdownify }}
                 </div>
               </a>

--- a/website/layouts/releases/single.html
+++ b/website/layouts/releases/single.html
@@ -108,15 +108,16 @@
 
           <ul class="mt-4 grid min-w-0 list-none gap-3 p-0">
             {{ range $breakingTitled }}
-            <li class="m-0 min-w-0 max-w-full">
-              <a href="{{ (index $upgradeGuides 0).RelPermalink }}#{{ .anchor }}" class="group block overflow-hidden rounded-lg border border-gray-200 bg-gray-50/50 px-4 py-4 shadow-sm transition hover:border-gray-300 hover:bg-gray-100/70 focus:outline-none focus:ring-2 focus:ring-primary dark:border-gray-700 dark:bg-gray-800/40 dark:hover:border-gray-600 dark:hover:bg-gray-800/70 md:px-5">
-                <div class="prose dark:prose-invert max-w-none font-semibold text-dark group-hover:text-primary-dark dark:text-gray-100 dark:group-hover:text-primary [&>p]:m-0 [&_:not(pre)>code]:break-all [&_:not(pre)>code]:whitespace-normal">
+            <li class="m-0 min-w-0 max-w-full overflow-hidden rounded-lg border border-gray-200 bg-gray-50/50 px-4 py-4 shadow-sm dark:border-gray-700 dark:bg-gray-800/40 md:px-5">
+              <a href="{{ (index $upgradeGuides 0).RelPermalink }}#{{ .anchor }}" class="block focus:outline-none focus:ring-2 focus:ring-primary">
+                <div class="prose dark:prose-invert max-w-none font-semibold text-dark hover:text-primary-dark dark:text-gray-100 dark:hover:text-primary [&>p]:m-0 [&_:not(pre)>code]:break-all [&_:not(pre)>code]:whitespace-normal">
                   {{ .title | markdownify }}
                 </div>
-                <div class="mt-2 prose dark:prose-invert max-w-none leading-relaxed text-gray-600 dark:text-gray-300 [&>p]:m-0 [&_:not(pre)>code]:max-w-full [&_:not(pre)>code]:break-all [&_:not(pre)>code]:whitespace-normal">
-                  {{ .description | markdownify }}
-                </div>
               </a>
+              <div class="mt-2 prose dark:prose-invert max-w-none leading-relaxed [&_:not(pre)>code]:max-w-full [&_:not(pre)>code]:break-all [&_:not(pre)>code]:whitespace-normal">
+                {{ .description | markdownify }}
+              </div>
+              {{ partial "releases/changelog-attribution.html" . }}
             </li>
             {{ end }}
           </ul>
@@ -142,18 +143,7 @@
                 <div class="prose dark:prose-invert max-w-none leading-relaxed [&_:not(pre)>code]:max-w-full [&_:not(pre)>code]:break-all [&_:not(pre)>code]:whitespace-normal">
                   {{ .description | markdownify }}
                 </div>
-                {{ if gt (len .contributors) 0 }}
-                <div class="mt-3 overflow-x-auto border-t border-gray-200 pt-3 text-sm italic text-gray-600 dark:border-gray-700 dark:text-gray-300">
-                  Thanks to
-                  {{ $len := len .contributors }}
-                  {{ range $i, $contributor := .contributors }}
-                    {{ $username := replace $contributor "@" "" }}
-                    {{ $profile := printf "https://github.com/%s" $username }}
-                    <a href="{{ $profile }}" class="text-primary-dark hover:text-secondary dark:text-primary dark:hover:text-secondary" rel="noopener" target="_blank">{{ $contributor }}</a>{{ if lt (add $i 1) $len }}, {{ end }}
-                  {{ end }}
-                  for contributing this change!
-                </div>
-                {{ end }}
+                {{ partial "releases/changelog-attribution.html" . }}
               </li>
               {{ end }}
             </ul>


### PR DESCRIPTION
## Summary

### Motivation

Release changelog entries currently present contributor and pull-request information inconsistently, making the release pages harder to scan. Keeping this attribution in generated metadata also avoids losing it when changelog fragments are deleted during release preparation.

### Changes

- Infer Vector PR numbers from the `(#12345)` suffix on every commit that added or edited a changelog fragment.
- Reject shallow repositories where the required history is unavailable.
- Backfill contributor and PR metadata for Vector 0.58.0.
- Use consistent cards and attribution wording across breaking changes, regular Vector entries, and the embedded VRL changelog.
- Bump `vdev` from 0.3.15 to 0.3.16.

### References

Related: #26241

## Vector configuration

N/A — website and release tooling only.

## How did you test this PR?

- `cargo test -p vdev generate_cue` (26 tests)
- `make check-clippy`
- `make -C website cue-build cargo-data production-build`
- Rendered 0.58.0 locally and visually checked Vector, breaking-change, and VRL entries
- Checked 0.57.0 to confirm older VRL attribution retains its card styling

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## Contributor Guidelines

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out regarding this PR.
- Some CI checks run only after manual approval.
- After review is requested, avoid force pushes so incremental review history is preserved.
