### PR TITLE
chore(release): remove whats_next from generated release cue

### DIFF
--- a/vdev/src/commands/release/generate_cue.rs
+++ b/vdev/src/commands/release/generate_cue.rs
@@ -456,8 +456,6 @@ fn render_release_cue(version: &Version, changelog: &[ChangelogEntry]) -> String
         releases: \"{version}\": {{
         \tdate:     \"{date}\"
 
-        \twhats_next: []
-
         \tchangelog: [
         {changelog_block}
         \t]
@@ -737,7 +735,6 @@ mod tests {
 
         assert!(out.starts_with("package metadata\n"));
         assert!(out.contains("releases: \"0.99.0\":"));
-        assert!(out.contains("\twhats_next: []\n"));
         assert!(out.contains("\t\t\ttype: \"feat\"\n"));
         assert!(out.contains("\t\t\t\tAdds a thing.\n"));
         assert!(out.contains("\t\t\t\tMulti-line.\n"));

--- a/website/cue/reference/releases.cue
+++ b/website/cue/reference/releases.cue
@@ -50,7 +50,7 @@ releases: {
 		commits?: [#Commit, ...#Commit]
 		changelog: [#ChangeLogEntry, ...#ChangeLogEntry] | *[]
 		vrl_changelog?: string
-		whats_next: #Any | *[]
+		whats_next?: [...{title: string, description: string}]
 	}
 
 	{[Version=string]: #Release & {version: Version}}

--- a/website/cue/reference/releases/0.21.0.cue
+++ b/website/cue/reference/releases/0.21.0.cue
@@ -57,20 +57,6 @@ releases: "0.21.0": {
 				for a preview of how this will work.
 				"""
 		},
-		{
-			type: "fix"
-			scopes: ["vrl"]
-			breaking: true
-			description: """
-				VRL now has lexical scoping for blocks. This means that variables defined inside of a block in VRL (e.g.
-				an `if` condition block) are no longer accessible from outside of this block. This breaking change
-				was done to support VRL's forthcoming iteration feature which requires it.
-
-				See the [upgrade guide](/highlights/2022-03-22-0-21-0-upgrade-guide#vrl-lexical-scoping) for how to
-				migrate your VRL programs.
-				"""
-			pr_numbers: [12017]
-		},
 	]
 
 	description: """
@@ -115,6 +101,20 @@ releases: "0.21.0": {
 				implementation in the future once it stabilizes.
 				"""
 			pr_numbers: [11554]
+		},
+		{
+			type: "fix"
+			scopes: ["vrl"]
+			breaking: true
+			description: """
+				VRL now has lexical scoping for blocks. This means that variables defined inside of a block in VRL (e.g.
+				an `if` condition block) are no longer accessible from outside of this block. This breaking change
+				was done to support VRL's forthcoming iteration feature which requires it.
+
+				See the [upgrade guide](/highlights/2022-03-22-0-21-0-upgrade-guide#vrl-lexical-scoping) for how to
+				migrate your VRL programs.
+				"""
+			pr_numbers: [12017]
 		},
 		{
 			type: "enhancement"


### PR DESCRIPTION
## Summary
Remove the `whats_next` field from the generated release cue file and make it optional in the release schema.

Fixing the type of `whats_next` also exposed a bug in `website/cue/reference/releases/0.21.0.cue` which had to be fixed

### References
NA

## Vector configuration
NA

## How did you test this PR?
Ran `./scripts/cue.sh vet` and the `vdev` release cue unit tests.

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.
