### PR TITLE
fix(ci): make awaiting-author label removal idempotent

### DIFF
--- a/.github/workflows/remove_waiting_author.yml
+++ b/.github/workflows/remove_waiting_author.yml
@@ -7,17 +7,29 @@ on:
   pull_request_target:
     types: [synchronize, review_requested]
 
-  pull_request:
-    types: [synchronize, review_requested]
-
 jobs:
   remove_label:
     if: "contains(github.event.pull_request.labels.*.name, 'meta: awaiting author')"
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: actions-ecosystem/action-remove-labels@2ce5d41b4b6aa8503e285553f75ed56e0a40bae0 # v1.3.0
+      - name: Remove label
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          labels: "meta: awaiting author"
-          fail_on_error: true
+          script: |
+            const labelName = 'meta: awaiting author';
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                name: labelName,
+              });
+              core.info(`Removed "${labelName}" label from PR #${context.issue.number}`);
+            } catch (err) {
+              if (err.status === 404) {
+                core.info(`Label "${labelName}" already absent from PR #${context.issue.number}, skipping`);
+              } else {
+                throw err;
+              }
+            }


### PR DESCRIPTION
## Summary

### Motivation

The awaiting-author label workflow runs for both `pull_request_target` and `pull_request`. For fork PRs, a single update therefore starts two jobs from the same labeled event snapshot: the target-context job can remove the label, while the ordinary pull-request job has a read-only token and fails with `Resource not accessible by integration`.

Closely spaced events can also attempt to remove the same label concurrently.

### Changes

- Run label removal only in the writable `pull_request_target` context.
- Remove the label through the GitHub API and treat an already-absent label as a successful no-op while preserving all other failures.
- Remove the unnecessary repository checkout.

### References

Related: https://github.com/vectordotdev/vector/actions/runs/33088523835/job/98865681573?pr=25627

## Vector configuration

N/A — this changes a GitHub Actions workflow only.

## How did you test this PR?

- Parsed the updated workflow as YAML.
- Ran `git diff --check`.
- Installed the exact workflow in `vectordotdev/ci-sandbox` and pushed two updates rapidly while the test PR had the awaiting-author label.
- The first run removed the label successfully and the concurrent second run observed that it was already absent; both runs completed successfully.

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.
