### PR TITLE
fix(docker_logs source): stabilize container exclusion test

### DIFF
--- a/src/sources/docker_logs/tests.rs
+++ b/src/sources/docker_logs/tests.rs
@@ -550,9 +550,10 @@ mod integration_tests {
             .clone();
 
         assert_source_compliance(&SOURCE_TAGS, async {
-            let will_be_read = "12";
+            let included0_message = "included 0";
+            let included1_message = "included 1";
 
-            let prefix = "vector_test_exclude_containers";
+            let prefix = format!("vector_test_exclude_containers_{}", uuid::Uuid::new_v4());
             let included0 = format!("{}_{}", prefix, "include0");
             let included1 = format!("{}_{}", prefix, "include1");
             let excluded0 = format!("{}_{}", prefix, "excluded0");
@@ -560,31 +561,36 @@ mod integration_tests {
             let docker = docker(None, None).unwrap();
 
             let out = source_with_config(DockerLogsConfig {
-                include_containers: Some(vec![prefix.to_owned()]),
+                include_containers: Some(vec![prefix]),
                 exclude_containers: Some(vec![excluded0.to_owned()]),
                 ..DockerLogsConfig::default()
             })
             .await;
 
-            let id0 = container_log_n(1, &excluded0, None, "will not be read", &docker).await;
-            let id1 = container_log_n(1, &included0, None, will_be_read, &docker).await;
-            let id2 = container_log_n(1, &included1, None, will_be_read, &docker).await;
+            let id0 = container_log_n(1, &excluded0, None, "excluded", &docker).await;
+            let id1 = container_log_n(1, &included0, None, included0_message, &docker).await;
+            let id2 = container_log_n(1, &included1, None, included1_message, &docker).await;
             tokio::time::sleep(Duration::from_secs(1)).await;
             let events = collect_ready(out).await;
             container_remove(&id0, &docker).await;
             container_remove(&id1, &docker).await;
             container_remove(&id2, &docker).await;
 
-            assert_eq!(events.len(), 2);
-
             let definition = schema_definitions.unwrap();
-            definition.assert_valid_for_event(&events[0]);
-
             let message_key = log_schema().message_key().unwrap().to_string();
-            assert_eq!(events[0].as_log()[&message_key], will_be_read.into());
+            // Docker can replay logs around container discovery and reconnects. This test verifies
+            // include/exclude filtering rather than exactly-once delivery.
+            let messages = events
+                .iter()
+                .map(|event| {
+                    definition.assert_valid_for_event(event);
+                    event.as_log()[&message_key].as_str().unwrap()
+                })
+                .unique()
+                .sorted()
+                .collect_vec();
 
-            definition.assert_valid_for_event(&events[1]);
-            assert_eq!(events[1].as_log()[message_key], will_be_read.into());
+            assert_eq!(messages, vec![included0_message, included1_message]);
         })
         .await;
     }


### PR DESCRIPTION
## Summary

### Motivation

The `exclude_containers_legacy_namespace` integration test assumes exactly-once log delivery and expects exactly two events. Docker can replay logs around container discovery and reconnect boundaries, causing the test to receive duplicate included events even though container filtering is working correctly.

The test also uses fixed container names, which can collide with containers left by retries or concurrent runs.

### Changes

- Generate a unique container-name prefix for each test invocation.
- Give the two included containers distinct log messages.
- Validate every received event against the expected schema.
- Assert the unique received messages match both included containers, while still rejecting the excluded container's message.

### References

Related: https://github.com/vectordotdev/vector/actions/runs/33198814185/job/98944198247
Related: https://github.com/vectordotdev/vector/actions/runs/33101263773/job/98621831221

## Vector configuration

Not applicable; this only changes an existing integration test.

## How did you test this PR?

- `cargo fmt --all -- --check`
- `git diff --check`
- `make check-clippy` checked Vector and the changed all-features test target without diagnostics, but the Cargo wrapper stopped making progress after the visible workspace checks and was interrupted.
- `cargo vdev int run docker-logs` was attempted, but Docker Desktop blocked execution before the test because it requires Datadog organization sign-in.

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## Contributor Guidelines

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them. To catch issues early, add a `pre-push` hook ([template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#pre-push)) or run the following locally before pushing:
  - `make fmt`
  - `make check-clippy` (auto-fix with `make clippy-fix`)
  - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details on the [dd-rust-license-tool](https://crates.io/crates/dd-rust-license-tool).
