### PR TITLE
chore(config): remove configurable derived annotations

### DIFF
--- a/docs/tutorials/sinks/1_basic_sink.md
+++ b/docs/tutorials/sinks/1_basic_sink.md
@@ -40,7 +40,6 @@ sink's behaviour.
 #[derive(Clone, Debug)]
 /// A basic sink that dumps its output to stdout.
 pub struct BasicConfig {
-    #[configurable(derived)]
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",

--- a/lib/codecs/src/encoding/config.rs
+++ b/lib/codecs/src/encoding/config.rs
@@ -64,10 +64,8 @@ where
 #[derive(Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct EncodingConfigWithFraming {
-    #[configurable(derived)]
     framing: Option<FramingConfig>,
 
-    #[configurable(derived)]
     encoding: EncodingConfig,
 }
 

--- a/lib/codecs/src/encoding/format/arrow.rs
+++ b/lib/codecs/src/encoding/format/arrow.rs
@@ -35,7 +35,6 @@ pub trait SchemaProvider: Send + Sync + std::fmt::Debug {
 pub struct ArrowStreamSerializerConfig {
     /// The Arrow schema to use for encoding
     #[serde(skip)]
-    #[configurable(derived)]
     pub schema: Option<arrow::datatypes::Schema>,
 
     /// Allow null values for non-nullable fields in the schema.
@@ -47,7 +46,6 @@ pub struct ArrowStreamSerializerConfig {
     /// When disabled (default), missing values for non-nullable fields results in encoding errors. This is to
     /// help ensure all required data is present before sending it to the sink.
     #[serde(default)]
-    #[configurable(derived)]
     pub allow_nullable_fields: bool,
 }
 

--- a/lib/codecs/src/encoding/format/parquet.rs
+++ b/lib/codecs/src/encoding/format/parquet.rs
@@ -118,12 +118,10 @@ pub struct ParquetSerializerConfig {
 
     /// Compression codec applied per column page inside the Parquet file.
     #[serde(default)]
-    #[configurable(derived)]
     pub compression: ParquetCompression,
 
     /// Controls how events with fields not present in the schema are handled.
     #[serde(default)]
-    #[configurable(derived)]
     pub schema_mode: ParquetSchemaMode,
 }
 

--- a/lib/vector-buffers/src/config.rs
+++ b/lib/vector-buffers/src/config.rs
@@ -227,7 +227,6 @@ pub enum BufferType {
         #[serde(flatten)]
         size: MemoryBufferSize,
 
-        #[configurable(derived)]
         #[serde(default)]
         when_full: WhenFull,
     },
@@ -250,7 +249,6 @@ pub enum BufferType {
         )]
         max_size: NonZeroU64,
 
-        #[configurable(derived)]
         #[serde(default)]
         when_full: WhenFull,
     },

--- a/lib/vector-config-macros/src/ast/container.rs
+++ b/lib/vector-config-macros/src/ast/container.rs
@@ -146,13 +146,7 @@ impl<'a> Container<'a> {
                                 !variant.attrs.skip_deserializing()
                                     && !variant.attrs.skip_serializing()
                             })
-                            .map(|variant| {
-                                Variant::from_ast(
-                                    variant,
-                                    tagging.clone(),
-                                    virtual_newtype.is_some(),
-                                )
-                            })
+                            .map(|variant| Variant::from_ast(variant, tagging.clone()))
                             .collect_darling_results(&mut accumulator);
 
                         // Check the generated variants for conformance. We do this at a per-variant and per-enum level.
@@ -211,13 +205,7 @@ impl<'a> Container<'a> {
                                 matches!(style, serde_ast::Style::Newtype);
                             let fields = fields
                                 .iter()
-                                .map(|field| {
-                                    Field::from_ast(
-                                        field,
-                                        virtual_newtype.is_some(),
-                                        is_newtype_wrapper_field,
-                                    )
-                                })
+                                .map(|field| Field::from_ast(field, is_newtype_wrapper_field))
                                 .collect_darling_results(&mut accumulator);
 
                             (Data::Struct(style.into(), fields), false)

--- a/lib/vector-config-macros/src/ast/field.rs
+++ b/lib/vector-config-macros/src/ast/field.rs
@@ -11,8 +11,8 @@ use vector_config_common::validation::Validation;
 use super::{
     LazyCustomAttribute, Metadata,
     util::{
-        err_field_implicit_transparent, err_field_missing_description,
-        find_delegated_serde_deser_ty, get_serde_default_value, try_extract_doc_title_description,
+        err_field_implicit_transparent, find_delegated_serde_deser_ty, get_serde_default_value,
+        try_extract_doc_title_description,
     },
 };
 
@@ -28,7 +28,6 @@ impl<'a> Field<'a> {
     /// Creates a new `Field<'a>` from the `serde`-derived information about the given field.
     pub fn from_ast(
         serde: &serde_ast::Field<'a>,
-        is_virtual_newtype: bool,
         is_newtype_wrapper_field: bool,
     ) -> darling::Result<Field<'a>> {
         let original = serde.original;
@@ -37,14 +36,7 @@ impl<'a> Field<'a> {
         let default_value = get_serde_default_value(&serde.ty, serde.attrs.default());
 
         Attributes::from_attributes(&original.attrs)
-            .and_then(|attrs| {
-                attrs.finalize(
-                    serde,
-                    &original.attrs,
-                    is_virtual_newtype,
-                    is_newtype_wrapper_field,
-                )
-            })
+            .and_then(|attrs| attrs.finalize(serde, &original.attrs, is_newtype_wrapper_field))
             .map(|attrs| Field {
                 original,
                 name,
@@ -265,7 +257,6 @@ impl ToTokens for Field<'_> {
 struct Attributes {
     title: Option<String>,
     description: Option<String>,
-    derived: SpannedValue<Flag>,
     transparent: SpannedValue<Flag>,
     deprecated: Option<Override<String>>,
     #[darling(skip)]
@@ -288,7 +279,6 @@ impl Attributes {
         mut self,
         field: &serde_ast::Field<'_>,
         forwarded_attrs: &[syn::Attribute],
-        is_virtual_newtype: bool,
         is_newtype_wrapper_field: bool,
     ) -> darling::Result<Self> {
         // Derive any of the necessary fields from the `serde` side of things.
@@ -309,59 +299,18 @@ impl Attributes {
         // We do this because the container -- struct or enum variant -- will itself be required to
         // have a description. We never show the description of unnamed fields, anyways, as we defer
         // to using the description of the container. Simply marking this field as transparent will
-        // keep the schema generation happy and avoid having to constantly specify `derived` or
-        // `transparent` all over the place.
+        // keep the schema generation happy and avoid having to constantly specify `transparent`
+        // all over the place.
         if is_newtype_wrapper_field {
-            // We additionally check here to see if transparent/derived as already set, as we want
-            // to throw an error if they are. As we're going to forcefully mark the field as
-            // transparent, there's no reason to allow setting derived/transparent manually, as it
-            // only leads to boilerplate and potential confusion.
+            // We additionally check here to see if transparent is already set, as we want to throw
+            // an error if it is. As we're going to forcefully mark the field as transparent,
+            // there's no reason to allow setting it manually, as it only leads to boilerplate and
+            // potential confusion.
             if self.transparent.is_present() {
                 return Err(err_field_implicit_transparent(&self.transparent.span()));
             }
 
-            if self.derived.is_present() {
-                return Err(err_field_implicit_transparent(&self.derived.span()));
-            }
-
             self.transparent = SpannedValue::new(Flag::present(), Span::call_site());
-        }
-
-        // If no description was provided for the field, it is typically an error. There are few situations when this is
-        // fine/valid, though:
-        //
-        // - the field is derived (`#[configurable(derived)]`)
-        // - the field is transparent (`#[configurable(transparent)]`)
-        // - the field is not visible (`#[serde(skip)]`, or `skip_serializing` plus `skip_deserializing`)
-        // - the field is flattened (`#[serde(flatten)]`)
-        // - the field is part of a virtual newtype
-        // - the field is part of a newtype wrapper (struct/enum variant with a single unnamed field)
-        //
-        // If the field is derived, it means we're taking the description/title from the `Configurable` implementation of
-        // the field type, which we can only do at runtime so we ignore it here. Similarly, if a field is transparent,
-        // we're explicitly saying that our container is meant to essentially take on the schema of the field, rather
-        // than the container being defined by the fields, if that makes sense. Derived and transparent fields are most
-        // common in newtype structs and newtype variants in enums, where they're a `(T)`, and so the container acts
-        // much like `T` itself.
-        //
-        // If the field is not visible, well, then, we're not inserting it in the schema and so requiring a description
-        // or title makes no sense. Similarly, if a field is flattened, that field also won't exist in the schema as
-        // we're lifting up all the fields from the type of the field itself, so again, requiring a description or title
-        // makes no sense.
-        //
-        // If the field is part of a virtual newtype, this means the container has instructed `serde` to
-        // (de)serialize it as some entirely different type. This means the original field will never show up in a
-        // schema, because the schema of the thing being (de)serialized is some `T`, not `ContainerType`. Simply put,
-        // like a field that is flattened or not visible, it makes no sense to require a description or title for fields
-        // in a virtual newtype.
-        if self.description.is_none()
-            && !self.derived.is_present()
-            && !self.transparent.is_present()
-            && self.visible
-            && !self.flatten
-            && !is_virtual_newtype
-        {
-            return Err(err_field_missing_description(&field.original));
         }
 
         // Try and find the delegated (de)serialization type for this field, if it exists.

--- a/lib/vector-config-macros/src/ast/util.rs
+++ b/lib/vector-config-macros/src/ast/util.rs
@@ -6,9 +6,8 @@ use syn::{
     spanned::Spanned, token::Comma,
 };
 
-const ERR_FIELD_MISSING_DESCRIPTION: &str = "field must have a description -- i.e. `/// This is a widget...` or `#[configurable(description = \"...\")] -- or derive it from the underlying type of the field by specifying `#[configurable(derived)]`";
 const ERR_FIELD_IMPLICIT_TRANSPARENT: &str =
-    "field in a newtype wrapper should not be manually marked as `derived`/`transparent`";
+    "field in a newtype wrapper should not be manually marked as `transparent`";
 
 pub fn try_extract_doc_title_description(
     attributes: &[Attribute],
@@ -139,10 +138,6 @@ fn group_doc_lines(ungrouped: &[String]) -> Vec<String> {
 
 fn none_if_empty(s: String) -> Option<String> {
     if s.is_empty() { None } else { Some(s) }
-}
-
-pub fn err_field_missing_description<T: Spanned>(field: &T) -> darling::Error {
-    darling::Error::custom(ERR_FIELD_MISSING_DESCRIPTION).with_span(field)
 }
 
 pub fn err_field_implicit_transparent<T: Spanned>(field: &T) -> darling::Error {

--- a/lib/vector-config-macros/src/ast/variant.rs
+++ b/lib/vector-config-macros/src/ast/variant.rs
@@ -23,7 +23,6 @@ impl<'a> Variant<'a> {
     pub fn from_ast(
         serde: &serde_ast::Variant<'a>,
         tagging: Tagging,
-        is_virtual_newtype: bool,
     ) -> darling::Result<Variant<'a>> {
         let original = serde.original;
         let name = serde.attrs.name().deserialize_name().to_string();
@@ -37,7 +36,7 @@ impl<'a> Variant<'a> {
         let fields = serde
             .fields
             .iter()
-            .map(|field| Field::from_ast(field, is_virtual_newtype, is_newtype_wrapper_field))
+            .map(|field| Field::from_ast(field, is_newtype_wrapper_field))
             .collect_darling_results(&mut accumulator);
 
         // If the enum overall is tagged (internal/adjacent) serde still allows one or more

--- a/lib/vector-config/tests/integration/smoke.rs
+++ b/lib/vector-config/tests/integration/smoke.rs
@@ -370,11 +370,9 @@ pub struct SimpleSinkConfig {
     #[serde(default = "default_simple_sink_endpoint")]
     endpoint: String,
 
-    #[configurable(derived)]
     #[serde(default = "default_simple_sink_batch")]
     batch: BatchConfig,
 
-    #[configurable(derived)]
     #[serde(default = "default_simple_sink_encoding")]
     encoding: Encoding,
 
@@ -425,7 +423,6 @@ fn default_simple_sink_endpoint() -> String {
 #[configurable(metadata(status = "stable"))]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub struct AwsBleepBloopSinkConfig {
-    #[configurable(derived)]
     #[serde(default)]
     auth: AwsAuthentication,
 
@@ -433,16 +430,14 @@ pub struct AwsBleepBloopSinkConfig {
     #[configurable(validation(pattern = "foo\\d+"))]
     folder_id: String,
 
-    #[configurable(derived)]
     #[serde(default = "default_aws_bleep_bloop_sink_batch")]
     batch: BatchConfig,
 
-    #[configurable(deprecated, derived)]
+    #[configurable(deprecated)]
     #[serde(default = "default_aws_bleep_bloop_sink_encoding")]
     encoding: Encoding,
 
     /// Overridden TLS description.
-    #[configurable(derived)]
     tls: Option<TlsEnableableConfig>,
 
     /// The partition key to use for each event.
@@ -624,7 +619,6 @@ pub struct GlobalOptions {
 #[derive(Clone)]
 #[configurable_component]
 pub struct VectorConfig {
-    #[configurable(derived)]
     global: GlobalOptions,
 
     /// Any configured sources.

--- a/lib/vector-core/src/config/global_options.rs
+++ b/lib/vector-core/src/config/global_options.rs
@@ -108,7 +108,6 @@ pub struct GlobalOptions {
     #[serde(default, skip_serializing_if = "crate::serde::is_default")]
     pub timezone: Option<TimeZone>,
 
-    #[configurable(derived)]
     #[serde(default, skip_serializing_if = "crate::serde::is_default")]
     #[configurable(metadata(docs::required = false))]
     pub proxy: ProxyConfig,

--- a/lib/vector-core/src/config/telemetry.rs
+++ b/lib/vector-core/src/config/telemetry.rs
@@ -79,7 +79,6 @@ cfg_if! {
 #[derive(Clone, Debug, Eq, PartialEq, Default)]
 #[serde(default)]
 pub struct Telemetry {
-    #[configurable(derived)]
     pub tags: Tags,
 }
 

--- a/lib/vector-core/src/event/metric/data.rs
+++ b/lib/vector-core/src/event/metric/data.rs
@@ -13,7 +13,6 @@ pub struct MetricData {
     #[serde(flatten)]
     pub time: MetricTime,
 
-    #[configurable(derived)]
     pub kind: MetricKind,
 
     #[serde(flatten)]

--- a/lib/vector-core/src/event/metric/series.rs
+++ b/lib/vector-core/src/event/metric/series.rs
@@ -12,7 +12,6 @@ pub struct MetricSeries {
     #[serde(flatten)]
     pub name: MetricName,
 
-    #[configurable(derived)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tags: Option<MetricTags>,
 }

--- a/lib/vector-core/src/event/metric/value.rs
+++ b/lib/vector-core/src/event/metric/value.rs
@@ -80,10 +80,7 @@ pub enum MetricValue {
     /// Sketches represent the data in a way that queries over it have bounded error guarantees without needing to hold
     /// every single sample in memory. They are also, typically, able to be merged with other sketches of the same type
     /// such that client-side _and_ server-side aggregation can be accomplished without loss of accuracy in the queries.
-    Sketch {
-        #[configurable(derived)]
-        sketch: MetricSketch,
-    },
+    Sketch { sketch: MetricSketch },
 }
 
 impl MetricValue {

--- a/src/amqp.rs
+++ b/src/amqp.rs
@@ -21,7 +21,6 @@ pub(crate) struct AmqpConfig {
     ))]
     pub(crate) connection_string: String,
 
-    #[configurable(derived)]
     pub(crate) tls: Option<crate::tls::TlsConfig>,
 }
 

--- a/src/common/mqtt.rs
+++ b/src/common/mqtt.rs
@@ -16,24 +16,20 @@ pub struct MqttCommonConfig {
     pub host: String,
 
     /// TCP port of the MQTT server to connect to.
-    #[configurable(derived)]
     #[serde(default = "default_port")]
     #[derivative(Default(value = "default_port()"))]
     pub port: u16,
 
     /// MQTT username.
     #[serde(default)]
-    #[configurable(derived)]
     pub user: Option<String>,
 
     /// MQTT password.
     #[serde(default)]
-    #[configurable(derived)]
     pub password: Option<String>,
 
     /// MQTT client ID.
     #[serde(default)]
-    #[configurable(derived)]
     pub client_id: Option<String>,
 
     /// Connection keep-alive interval.
@@ -47,7 +43,6 @@ pub struct MqttCommonConfig {
     pub max_packet_size: usize,
 
     /// TLS configuration.
-    #[configurable(derived)]
     pub tls: Option<TlsEnableableConfig>,
 }
 

--- a/src/common/websocket.rs
+++ b/src/common/websocket.rs
@@ -255,11 +255,9 @@ pub struct WebSocketCommonConfig {
     pub ping_timeout: Option<NonZeroU64>,
 
     /// TLS configuration.
-    #[configurable(derived)]
     pub tls: Option<TlsEnableableConfig>,
 
     /// HTTP Authentication.
-    #[configurable(derived)]
     pub auth: Option<Auth>,
 }
 

--- a/src/conditions/vrl.rs
+++ b/src/conditions/vrl.rs
@@ -23,7 +23,7 @@ pub struct VrlConfig {
     /// The VRL boolean expression.
     pub(crate) source: String,
 
-    #[configurable(derived, metadata(docs::hidden))]
+    #[configurable(metadata(docs::hidden))]
     #[serde(default, skip_serializing_if = "crate::serde::is_default")]
     pub(crate) runtime: VrlRuntime,
 }

--- a/src/config/builder.rs
+++ b/src/config/builder.rs
@@ -20,15 +20,12 @@ pub struct ConfigBuilder {
     pub global: GlobalOptions,
 
     #[cfg(feature = "api")]
-    #[configurable(derived)]
     #[serde(default)]
     pub api: api::Options,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub schema: schema::Options,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub healthchecks: HealthcheckOptions,
 

--- a/src/config/enrichment_table.rs
+++ b/src/config/enrichment_table.rs
@@ -24,10 +24,8 @@ where
 {
     #[serde(flatten)]
     pub inner: EnrichmentTables,
-    #[configurable(derived)]
     #[serde(default, skip_serializing_if = "vector_lib::serde::is_default")]
     pub graph: GraphConfig,
-    #[configurable(derived)]
     #[serde(
         default = "Inputs::<T>::default",
         skip_serializing_if = "Inputs::is_empty"

--- a/src/config/sink.rs
+++ b/src/config/sink.rs
@@ -66,11 +66,9 @@ pub struct SinkOuter<T>
 where
     T: Configurable + Serialize + 'static,
 {
-    #[configurable(derived)]
     #[serde(default, skip_serializing_if = "vector_lib::serde::is_default")]
     pub graph: GraphConfig,
 
-    #[configurable(derived)]
     pub inputs: Inputs<T>,
 
     /// The full URI to make HTTP healthcheck requests to.
@@ -80,15 +78,12 @@ where
     #[configurable(deprecated, metadata(docs::hidden), validation(format = "uri"))]
     pub healthcheck_uri: Option<UriSerde>,
 
-    #[configurable(derived)]
     #[serde(default, deserialize_with = "crate::serde::bool_or_struct")]
     pub healthcheck: SinkHealthcheckOptions,
 
-    #[configurable(derived)]
     #[serde(default, skip_serializing_if = "vector_lib::serde::is_default")]
     pub buffer: BufferConfig,
 
-    #[configurable(derived)]
     #[serde(default, skip_serializing_if = "vector_lib::serde::is_default")]
     pub proxy: ProxyConfig,
 

--- a/src/config/source.rs
+++ b/src/config/source.rs
@@ -53,11 +53,9 @@ impl<T: SourceConfig + 'static> From<T> for BoxedSource {
 #[configurable(metadata(docs::component_base_type = "source"))]
 #[derive(Clone, Debug)]
 pub struct SourceOuter {
-    #[configurable(derived)]
     #[serde(default, skip_serializing_if = "vector_lib::serde::is_default")]
     pub proxy: ProxyConfig,
 
-    #[configurable(derived)]
     #[serde(default, skip_serializing_if = "vector_lib::serde::is_default")]
     pub graph: GraphConfig,
 

--- a/src/config/transform.rs
+++ b/src/config/transform.rs
@@ -61,11 +61,9 @@ pub struct TransformOuter<T>
 where
     T: Configurable + Serialize + 'static,
 {
-    #[configurable(derived)]
     #[serde(default, skip_serializing_if = "vector_lib::serde::is_default")]
     pub graph: GraphConfig,
 
-    #[configurable(derived)]
     pub inputs: Inputs<T>,
 
     /// Enable CPU usage metrics for this transform.

--- a/src/enrichment_tables/file.rs
+++ b/src/enrichment_tables/file.rs
@@ -59,7 +59,6 @@ pub struct FileSettings {
     pub path: PathBuf,
 
     /// File encoding configuration.
-    #[configurable(derived)]
     pub encoding: Encoding,
 }
 
@@ -68,7 +67,6 @@ pub struct FileSettings {
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct FileConfig {
     /// File-specific settings.
-    #[configurable(derived)]
     pub file: FileSettings,
 
     /// Key/value pairs representing mapped log field names and types.

--- a/src/enrichment_tables/memory/config.rs
+++ b/src/enrichment_tables/memory/config.rs
@@ -66,25 +66,20 @@ pub struct MemoryConfig {
     #[serde(default)]
     pub log_namespace: Option<bool>,
     /// Configuration of internal metrics
-    #[configurable(derived)]
     #[serde(default)]
     pub internal_metrics: InternalMetricsConfig,
     /// Configuration for source functionality.
-    #[configurable(derived)]
     #[serde(skip_serializing_if = "vector_lib::serde::is_default")]
     pub source_config: Option<MemorySourceConfig>,
     /// Field in the incoming value used as the TTL override.
-    #[configurable(derived)]
     #[serde(default)]
     pub ttl_field: OptionalValuePath,
     /// Behavior for memory table state on configuration reload.
-    #[configurable(derived)]
     #[serde(default)]
     pub reload_behavior: ReloadBehavior,
 
     /// Set to make the table act as a probabilistic filter instead of storing original values. This
     /// will prevent reading values from the table - found keys will have empty value.
-    #[configurable(derived)]
     #[serde(default)]
     pub filter: Option<TableFilter>,
 

--- a/src/enrichment_tables/memory/cuckoo_table.rs
+++ b/src/enrichment_tables/memory/cuckoo_table.rs
@@ -112,7 +112,6 @@ pub struct CuckooMemoryConfig {
     #[serde(default = "default_cuckoo_counter_bits")]
     pub counter_bits: NonZeroUsize,
     /// Field in the incoming value used as the counter increment override.
-    #[configurable(derived)]
     #[serde(default)]
     pub counter_field: OptionalValuePath,
     /// The amount to increment the counter by on every insertion. Negative values are allowed.
@@ -126,7 +125,6 @@ pub struct CuckooMemoryConfig {
     ///
     /// If table `reload_behavior` is set to `clear-state` and this is set, the persisted state will
     /// still be read after reload.
-    #[configurable(derived)]
     #[serde(default)]
     pub persistence_path: Option<PathBuf>,
     /// The interval used for exporting data.

--- a/src/http.rs
+++ b/src/http.rs
@@ -574,7 +574,6 @@ pub struct KeepaliveConfig {
     /// will send keepalive probes after the specified idle time has elapsed, detecting and
     /// closing connections where the remote peer has disappeared without sending a FIN or
     /// RST packet (for example, due to an abrupt machine failure or network partition).
-    #[configurable(derived)]
     #[serde(default)]
     pub tcp_keepalive: Option<TcpKeepaliveConfig>,
 }

--- a/src/kafka.rs
+++ b/src/kafka.rs
@@ -43,10 +43,8 @@ pub enum KafkaCompression {
 #[configurable_component]
 #[derive(Clone, Debug, Default)]
 pub struct KafkaAuthConfig {
-    #[configurable(derived)]
     pub(crate) sasl: Option<KafkaSaslConfig>,
 
-    #[configurable(derived)]
     pub(crate) tls: Option<TlsEnableableConfig>,
 }
 

--- a/src/nats.rs
+++ b/src/nats.rs
@@ -35,28 +35,18 @@ NATS [documentation][nats_auth_docs]. For TLS client certificate authentication 
 ))]
 pub enum NatsAuthConfig {
     /// Username/password authentication.
-    UserPassword {
-        #[configurable(derived)]
-        user_password: NatsAuthUserPassword,
-    },
+    UserPassword { user_password: NatsAuthUserPassword },
 
     /// Token authentication.
-    Token {
-        #[configurable(derived)]
-        token: NatsAuthToken,
-    },
+    Token { token: NatsAuthToken },
 
     /// Credentials file authentication. (JWT-based)
     CredentialsFile {
-        #[configurable(derived)]
         credentials_file: NatsAuthCredentialsFile,
     },
 
     /// NKey authentication.
-    Nkey {
-        #[configurable(derived)]
-        nkey: NatsAuthNKey,
-    },
+    Nkey { nkey: NatsAuthNKey },
 }
 
 impl std::fmt::Display for NatsAuthConfig {

--- a/src/providers/http.rs
+++ b/src/providers/http.rs
@@ -42,7 +42,6 @@ pub struct HttpConfig {
     /// URL for the HTTP provider.
     url: Option<Url>,
 
-    #[configurable(derived)]
     request: RequestConfig,
 
     /// How often to poll the provider, in seconds.
@@ -51,12 +50,10 @@ pub struct HttpConfig {
     #[serde(flatten)]
     tls_options: Option<TlsConfig>,
 
-    #[configurable(derived)]
     #[serde(default, skip_serializing_if = "crate::serde::is_default")]
     proxy: ProxyConfig,
 
     /// Which config format expected to be loaded
-    #[configurable(derived)]
     config_format: Format,
 
     /// Enable environment variable interpolation

--- a/src/secrets/aws_secrets_manager.rs
+++ b/src/secrets/aws_secrets_manager.rs
@@ -29,14 +29,11 @@ pub struct AwsSecretsManagerBackend {
     pub secret_id: String,
 
     #[serde(flatten)]
-    #[configurable(derived)]
     pub region: RegionOrEndpoint,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub auth: AwsAuthentication,
 
-    #[configurable(derived)]
     pub tls: Option<TlsConfig>,
 }
 

--- a/src/sinks/amqp/config.rs
+++ b/src/sinks/amqp/config.rs
@@ -81,10 +81,8 @@ pub struct AmqpSinkConfig {
     #[serde(flatten)]
     pub(crate) connection: AmqpConfig,
 
-    #[configurable(derived)]
     pub(crate) encoding: EncodingConfig,
 
-    #[configurable(derived)]
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
@@ -96,7 +94,6 @@ pub struct AmqpSinkConfig {
     #[serde(default = "default_max_channels")]
     pub(crate) max_channels: u32,
 
-    #[configurable(derived)]
     #[serde(flatten)]
     pub confinement: ConfinementConfig,
 }

--- a/src/sinks/appsignal/config.rs
+++ b/src/sinks/appsignal/config.rs
@@ -52,26 +52,20 @@ pub(super) struct AppsignalConfig {
     #[configurable(metadata(docs::examples = "${APPSIGNAL_PUSH_API_KEY}"))]
     push_api_key: SensitiveString,
 
-    #[configurable(derived)]
     #[serde(default = "Compression::gzip_default")]
     compression: Compression,
 
-    #[configurable(derived)]
     #[serde(default)]
     batch: BatchConfig<AppsignalDefaultBatchSettings>,
 
-    #[configurable(derived)]
     #[serde(default)]
     request: TowerRequestConfig,
 
-    #[configurable(derived)]
     tls: Option<TlsEnableableConfig>,
 
-    #[configurable(derived)]
     #[serde(default, skip_serializing_if = "crate::serde::is_default")]
     encoding: Transformer,
 
-    #[configurable(derived)]
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
@@ -79,7 +73,6 @@ pub(super) struct AppsignalConfig {
     )]
     acknowledgements: AcknowledgementsConfig,
 
-    #[configurable(derived)]
     #[serde(default)]
     retry_strategy: RetryStrategy,
 }

--- a/src/sinks/aws_cloudwatch_logs/config.rs
+++ b/src/sinks/aws_cloudwatch_logs/config.rs
@@ -129,26 +129,20 @@ pub struct CloudwatchLogsSinkConfig {
     #[serde(default = "crate::serde::default_true")]
     pub create_missing_stream: bool,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub retention: Retention,
 
-    #[configurable(derived)]
     pub encoding: EncodingConfig,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub compression: Compression,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub batch: BatchConfig<CloudwatchLogsDefaultBatchSettings>,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub request: RequestConfig,
 
-    #[configurable(derived)]
     pub tls: Option<TlsConfig>,
 
     /// The ARN of an [IAM role][iam_role] to assume at startup.
@@ -158,11 +152,9 @@ pub struct CloudwatchLogsSinkConfig {
     #[configurable(metadata(docs::hidden))]
     pub assume_role: Option<String>,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub auth: AwsAuthentication,
 
-    #[configurable(derived)]
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
@@ -174,21 +166,18 @@ pub struct CloudwatchLogsSinkConfig {
     ///
     /// [arn]: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference-arns.html
     /// [kms_key]: https://docs.aws.amazon.com/kms/latest/developerguide/overview.html
-    #[configurable(derived)]
     #[serde(default)]
     pub kms_key: Option<String>,
 
     /// The Key-value pairs to be applied as [tags][tags] to the log group and stream.
     ///
     /// [tags]: https://docs.aws.amazon.com/whitepapers/latest/tagging-best-practices/what-are-tags.html
-    #[configurable(derived)]
     #[serde(default)]
     #[configurable(metadata(
         docs::additional_props_description = "A tag represented as a key-value pair"
     ))]
     pub tags: Option<HashMap<String, String>>,
 
-    #[configurable(derived)]
     #[serde(flatten)]
     pub confinement: ConfinementConfig,
 }

--- a/src/sinks/aws_cloudwatch_metrics/mod.rs
+++ b/src/sinks/aws_cloudwatch_metrics/mod.rs
@@ -84,19 +84,15 @@ pub struct CloudWatchMetricsSinkConfig {
     #[serde(flatten)]
     pub region: RegionOrEndpoint,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub compression: Compression,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub batch: BatchConfig<CloudWatchMetricsDefaultBatchSettings>,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub request: TowerRequestConfig<CloudWatchMetricsTowerRequestConfigDefaults>,
 
-    #[configurable(derived)]
     pub tls: Option<TlsConfig>,
 
     /// The ARN of an [IAM role][iam_role] to assume at startup.
@@ -106,11 +102,9 @@ pub struct CloudWatchMetricsSinkConfig {
     #[configurable(metadata(docs::hidden))]
     assume_role: Option<String>,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub auth: AwsAuthentication,
 
-    #[configurable(derived)]
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",

--- a/src/sinks/aws_kinesis/config.rs
+++ b/src/sinks/aws_kinesis/config.rs
@@ -30,24 +30,18 @@ pub struct KinesisSinkBaseConfig {
     pub stream_name: String,
 
     #[serde(flatten)]
-    #[configurable(derived)]
     pub region: RegionOrEndpoint,
 
-    #[configurable(derived)]
     pub encoding: EncodingConfig,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub compression: Compression,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub request: TowerRequestConfig,
 
-    #[configurable(derived)]
     pub tls: Option<TlsConfig>,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub auth: AwsAuthentication,
 
@@ -55,7 +49,6 @@ pub struct KinesisSinkBaseConfig {
     #[serde(default)]
     pub request_retry_partial: bool,
 
-    #[configurable(derived)]
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",

--- a/src/sinks/aws_kinesis/firehose/config.rs
+++ b/src/sinks/aws_kinesis/firehose/config.rs
@@ -72,7 +72,6 @@ pub struct KinesisFirehoseSinkConfig {
     #[serde(flatten)]
     pub base: KinesisSinkBaseConfig,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub batch: BatchConfig<KinesisFirehoseDefaultBatchSettings>,
 }

--- a/src/sinks/aws_kinesis/streams/config.rs
+++ b/src/sinks/aws_kinesis/streams/config.rs
@@ -67,7 +67,6 @@ pub struct KinesisStreamsSinkConfig {
     #[serde(flatten)]
     pub base: KinesisSinkBaseConfig,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub batch: BatchConfig<KinesisDefaultBatchSettings>,
 }

--- a/src/sinks/aws_s3/config.rs
+++ b/src/sinks/aws_s3/config.rs
@@ -134,7 +134,6 @@ pub struct S3SinkConfig {
     /// instead of the standard per-event framing-based encoding. The columnar format handles
     /// its own internal compression, so the top-level `compression` setting is bypassed.
     #[cfg(feature = "codecs-parquet")]
-    #[configurable(derived)]
     #[serde(default)]
     pub batch_encoding: Option<S3BatchEncoding>,
 
@@ -144,26 +143,20 @@ pub struct S3SinkConfig {
     ///
     /// Some cloud storage API clients and browsers handle decompression transparently, so
     /// depending on how they are accessed, files may not always appear to be compressed.
-    #[configurable(derived)]
     #[serde(default = "Compression::gzip_default")]
     pub compression: Compression,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub batch: BatchConfig<BulkSizeBasedDefaultBatchSettings>,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub request: TowerRequestConfig,
 
-    #[configurable(derived)]
     pub tls: Option<TlsConfig>,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub auth: AwsAuthentication,
 
-    #[configurable(derived)]
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
@@ -171,7 +164,6 @@ pub struct S3SinkConfig {
     )]
     pub acknowledgements: AcknowledgementsConfig,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub timezone: Option<TimeZone>,
 
@@ -185,7 +177,6 @@ pub struct S3SinkConfig {
     ///
     /// By default, the sink only retries attempts it deems possible to retry.
     /// These settings extend the default behavior.
-    #[configurable(derived)]
     #[serde(default, skip_serializing_if = "vector_lib::serde::is_default")]
     pub retry_strategy: RetryStrategy,
 

--- a/src/sinks/aws_s_s/config.rs
+++ b/src/sinks/aws_s_s/config.rs
@@ -27,7 +27,6 @@ pub(super) enum BuildError {
 #[derive(Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub(super) struct BaseSSSinkConfig {
-    #[configurable(derived)]
     pub(super) encoding: EncodingConfig,
 
     /// The tag that specifies that a message belongs to a specific message group.
@@ -43,11 +42,9 @@ pub(super) struct BaseSSSinkConfig {
     /// [deduplication_id_docs]: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/using-messagededuplicationid-property.html
     pub(super) message_deduplication_id: Option<String>,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub(super) request: TowerRequestConfig,
 
-    #[configurable(derived)]
     pub(super) tls: Option<TlsConfig>,
 
     /// The ARN of an [IAM role][iam_role] to assume at startup.
@@ -57,11 +54,9 @@ pub(super) struct BaseSSSinkConfig {
     #[configurable(metadata(docs::hidden))]
     pub(super) assume_role: Option<String>,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub(super) auth: AwsAuthentication,
 
-    #[configurable(derived)]
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",

--- a/src/sinks/axiom/config.rs
+++ b/src/sinks/axiom/config.rs
@@ -100,31 +100,25 @@ pub struct AxiomConfig {
 
     /// Configuration for the URL or regional edge endpoint.
     #[serde(flatten)]
-    #[configurable(derived)]
     pub endpoint: UrlOrRegion,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub request: RequestConfig,
 
     /// The compression algorithm to use.
-    #[configurable(derived)]
     #[serde(default = "Compression::zstd_default")]
     pub compression: Compression,
 
     /// The TLS settings for the connection.
     ///
     /// Optional, constrains TLS settings for this sink.
-    #[configurable(derived)]
     pub tls: Option<TlsConfig>,
 
     /// The batch settings for the sink.
-    #[configurable(derived)]
     #[serde(default)]
     pub batch: BatchConfig<RealtimeSizeBasedDefaultBatchSettings>,
 
     /// Controls how acknowledgements are handled for this sink.
-    #[configurable(derived)]
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
@@ -132,7 +126,6 @@ pub struct AxiomConfig {
     )]
     pub acknowledgements: AcknowledgementsConfig,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub retry_strategy: RetryStrategy,
 

--- a/src/sinks/azure_blob/config.rs
+++ b/src/sinks/azure_blob/config.rs
@@ -99,7 +99,6 @@ pub enum AzureBlobType {
 #[derive(Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct AzureBlobSinkConfig {
-    #[configurable(derived)]
     #[serde(default)]
     pub auth: Option<AzureAuthentication>,
 
@@ -240,7 +239,6 @@ pub struct AzureBlobSinkConfig {
     /// the block is appended twice. Setting `request.retry_attempts` to `0` disables sink-level
     /// retries, but it does not give at-most-once delivery — upstream retries and resending
     /// sources can still produce duplicates.
-    #[configurable(derived)]
     #[serde(default)]
     pub blob_type: AzureBlobType,
 
@@ -253,7 +251,6 @@ pub struct AzureBlobSinkConfig {
     ///
     /// Some cloud storage API clients and browsers handle decompression transparently, so
     /// depending on how they are accessed, files may not always appear to be compressed.
-    #[configurable(derived)]
     #[serde(default = "Compression::gzip_default")]
     pub compression: Compression,
 
@@ -294,15 +291,12 @@ pub struct AzureBlobSinkConfig {
     #[serde(default)]
     pub metadata: Option<HashMap<String, String>>,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub batch: BatchConfig<BulkSizeBasedDefaultBatchSettings>,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub request: TowerRequestConfig<AzureBlobTowerRequestConfigDefaults>,
 
-    #[configurable(derived)]
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
@@ -310,7 +304,6 @@ pub struct AzureBlobSinkConfig {
     )]
     pub(super) acknowledgements: AcknowledgementsConfig,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub tls: Option<AzureBlobTlsConfig>,
 

--- a/src/sinks/azure_logs_ingestion/config.rs
+++ b/src/sinks/azure_logs_ingestion/config.rs
@@ -64,7 +64,6 @@ pub struct AzureLogsIngestionConfig {
     #[configurable(metadata(docs::examples = "Custom-MyTable"))]
     pub stream_name: String,
 
-    #[configurable(derived)]
     pub auth: AzureAuthentication,
 
     /// [Token scope][token_scope] for dedicated Azure regions.
@@ -86,22 +85,17 @@ pub struct AzureLogsIngestionConfig {
     #[serde(default = "default_timestamp_field")]
     pub timestamp_field: String,
 
-    #[configurable(derived)]
     #[serde(default, skip_serializing_if = "crate::serde::is_default")]
     pub encoding: Transformer,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub batch: BatchConfig<RealtimeSizeBasedDefaultBatchSettings>,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub request: TowerRequestConfig,
 
-    #[configurable(derived)]
     pub tls: Option<TlsConfig>,
 
-    #[configurable(derived)]
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
@@ -109,7 +103,6 @@ pub struct AzureLogsIngestionConfig {
     )]
     pub acknowledgements: AcknowledgementsConfig,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub retry_strategy: RetryStrategy,
 }

--- a/src/sinks/blackhole/config.rs
+++ b/src/sinks/blackhole/config.rs
@@ -41,7 +41,6 @@ pub struct BlackholeConfig {
     #[configurable(metadata(docs::examples = 1000))]
     pub rate: Option<usize>,
 
-    #[configurable(derived)]
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",

--- a/src/sinks/clickhouse/config.rs
+++ b/src/sinks/clickhouse/config.rs
@@ -117,11 +117,9 @@ pub struct ClickhouseConfig {
     #[serde(default)]
     pub insert_random_shard: bool,
 
-    #[configurable(derived)]
     #[serde(default = "Compression::gzip_default")]
     pub compression: Compression,
 
-    #[configurable(derived)]
     #[serde(default, skip_serializing_if = "crate::serde::is_default")]
     pub encoding: Transformer,
 
@@ -129,25 +127,19 @@ pub struct ClickhouseConfig {
     ///
     /// When specified, events are encoded together as a single batch.
     /// This is mutually exclusive with per-event encoding based on the `format` field.
-    #[configurable(derived)]
     #[serde(default)]
     pub batch_encoding: Option<ClickhouseBatchEncoding>,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub batch: BatchConfig<RealtimeSizeBasedDefaultBatchSettings>,
 
-    #[configurable(derived)]
     pub auth: Option<Auth>,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub request: TowerRequestConfig,
 
-    #[configurable(derived)]
     pub tls: Option<TlsConfig>,
 
-    #[configurable(derived)]
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
@@ -155,11 +147,9 @@ pub struct ClickhouseConfig {
     )]
     pub acknowledgements: AcknowledgementsConfig,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub query_settings: QuerySettingsConfig,
 
-    #[configurable(derived)]
     #[serde(flatten)]
     pub confinement: ConfinementConfig,
 }

--- a/src/sinks/console/config.rs
+++ b/src/sinks/console/config.rs
@@ -43,14 +43,12 @@ pub enum Target {
 #[derive(Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct ConsoleSinkConfig {
-    #[configurable(derived)]
     #[serde(default = "default_target")]
     pub target: Target,
 
     #[serde(flatten)]
     pub encoding: EncodingConfigWithFraming,
 
-    #[configurable(derived)]
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",

--- a/src/sinks/databend/config.rs
+++ b/src/sinks/databend/config.rs
@@ -62,34 +62,27 @@ pub struct DatabendConfig {
     pub database: Option<String>,
 
     /// The username and password to authenticate with. Overrides the username and password in DSN.
-    #[configurable(derived)]
     pub auth: Option<Auth>,
 
     /// The table that data is inserted into.
     #[configurable(metadata(docs::examples = "mytable"))]
     pub table: String,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub missing_field_as: DatabendMissingFieldAS,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub encoding: DatabendEncodingConfig,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub compression: DatabendCompression,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub batch: BatchConfig<RealtimeSizeBasedDefaultBatchSettings>,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub request: TowerRequestConfig,
 
-    #[configurable(derived)]
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",

--- a/src/sinks/databricks_zerobus/config.rs
+++ b/src/sinks/databricks_zerobus/config.rs
@@ -93,7 +93,6 @@ pub struct ZerobusStreamOptions {
     pub server_lack_of_ack_timeout_ms: u64,
 
     /// Arrow IPC compression for Flight payloads. Defaults to no compression.
-    #[configurable(derived)]
     #[serde(default, skip_serializing_if = "crate::serde::is_default")]
     pub compression: Compression,
 }
@@ -162,7 +161,6 @@ pub struct ZerobusSinkConfig {
     /// principal and grant it permissions to write to the target table.
     ///
     /// [zerobus_service_principal]: https://docs.databricks.com/aws/en/ingestion/zerobus-ingest#create-a-service-principal-and-grant-permissions
-    #[configurable(derived)]
     pub auth: DatabricksAuthentication,
 
     /// Custom identifier appended to the `user-agent` header sent to Databricks.
@@ -173,19 +171,15 @@ pub struct ZerobusSinkConfig {
     #[configurable(metadata(docs::examples = "my-service/1.2"))]
     pub user_agent: Option<String>,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub stream_options: ZerobusStreamOptions,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub batch: BatchConfig<RealtimeSizeBasedDefaultBatchSettings>,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub request: TowerRequestConfig,
 
-    #[configurable(derived)]
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",

--- a/src/sinks/datadog/events/config.rs
+++ b/src/sinks/datadog/events/config.rs
@@ -36,11 +36,9 @@ pub struct DatadogEventsConfig {
     #[serde(flatten)]
     pub dd_common: LocalDatadogCommonConfig,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub request: TowerRequestConfig,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub retry_strategy: RetryStrategy,
 }

--- a/src/sinks/datadog/logs/config.rs
+++ b/src/sinks/datadog/logs/config.rs
@@ -56,20 +56,16 @@ pub struct DatadogLogsConfig {
     #[serde(flatten)]
     pub local_dd_common: LocalDatadogCommonConfig,
 
-    #[configurable(derived)]
     #[derivative(Default(value = "default_compression()"))]
     #[serde(default = "default_compression")]
     pub compression: Option<Compression>,
 
-    #[configurable(derived)]
     #[serde(default, skip_serializing_if = "crate::serde::is_default")]
     pub encoding: Transformer,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub batch: BatchConfig<DatadogLogsDefaultBatchSettings>,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub request: RequestConfig,
 

--- a/src/sinks/datadog/metrics/config.rs
+++ b/src/sinks/datadog/metrics/config.rs
@@ -183,11 +183,9 @@ pub struct DatadogMetricsConfig {
     #[serde(default)]
     pub series_api_version: SeriesApiVersion,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub batch: BatchConfig<DatadogMetricsDefaultBatchSettings>,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub request: TowerRequestConfig,
 }

--- a/src/sinks/datadog/mod.rs
+++ b/src/sinks/datadog/mod.rs
@@ -75,11 +75,9 @@ pub struct LocalDatadogCommonConfig {
     #[configurable(metadata(docs::examples = "ef8d5de700e7989468166c40fc8a0ccd"))]
     pub default_api_key: Option<SensitiveString>,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub tls: Option<TlsEnableableConfig>,
 
-    #[configurable(derived)]
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",

--- a/src/sinks/datadog/traces/config.rs
+++ b/src/sinks/datadog/traces/config.rs
@@ -60,15 +60,12 @@ pub struct DatadogTracesConfig {
     #[serde(flatten)]
     pub local_dd_common: LocalDatadogCommonConfig,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub compression: Option<Compression>,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub batch: BatchConfig<DatadogTracesDefaultBatchSettings>,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub request: TowerRequestConfig,
 }

--- a/src/sinks/doris/config.rs
+++ b/src/sinks/doris/config.rs
@@ -80,27 +80,21 @@ pub struct DorisConfig {
     #[serde(default = "default_max_retries")]
     pub max_retries: isize,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub batch: BatchConfig<RealtimeSizeBasedDefaultBatchSettings>,
 
-    #[configurable(derived)]
     pub auth: Option<Auth>,
 
     #[serde(default)]
-    #[configurable(derived)]
     pub request: TowerRequestConfig,
 
-    #[configurable(derived)]
     pub tls: Option<TlsConfig>,
 
     /// Options for determining the health of Doris endpoints.
     #[serde(default)]
-    #[configurable(derived)]
     #[serde(rename = "distribution")]
     pub endpoint_health: Option<HealthConfig>,
 
-    #[configurable(derived)]
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
@@ -108,7 +102,6 @@ pub struct DorisConfig {
     )]
     pub acknowledgements: AcknowledgementsConfig,
 
-    #[configurable(derived)]
     #[serde(flatten)]
     pub confinement: ConfinementConfig,
 }

--- a/src/sinks/elasticsearch/config.rs
+++ b/src/sinks/elasticsearch/config.rs
@@ -111,7 +111,6 @@ pub struct ElasticsearchConfig {
     ///
     /// Amazon OpenSearch Serverless requires this option to be set to `auto` (the default).
     #[serde(default)]
-    #[configurable(derived)]
     pub api_version: ElasticsearchApiVersion,
 
     /// Whether or not to send the `type` field to Elasticsearch.
@@ -149,26 +148,20 @@ pub struct ElasticsearchConfig {
     pub pipeline: Option<String>,
 
     #[serde(default)]
-    #[configurable(derived)]
     pub mode: ElasticsearchMode,
 
     #[serde(default)]
-    #[configurable(derived)]
     pub compression: Compression,
 
     #[serde(skip_serializing_if = "crate::serde::is_default", default)]
-    #[configurable(derived)]
     pub encoding: Transformer,
 
     #[serde(default)]
-    #[configurable(derived)]
     pub batch: BatchConfig<RealtimeSizeBasedDefaultBatchSettings>,
 
     #[serde(default)]
-    #[configurable(derived)]
     pub request: RequestConfig,
 
-    #[configurable(derived)]
     pub auth: Option<ElasticsearchAuthConfig>,
 
     /// Custom parameters to add to the query string for each HTTP request sent to Elasticsearch.
@@ -178,7 +171,6 @@ pub struct ElasticsearchConfig {
     pub query: Option<QueryParameters>,
 
     #[serde(default)]
-    #[configurable(derived)]
     #[cfg(feature = "aws-core")]
     pub aws: Option<crate::aws::RegionOrEndpoint>,
 
@@ -187,11 +179,9 @@ pub struct ElasticsearchConfig {
     pub opensearch_service_type: OpenSearchServiceType,
 
     #[serde(default)]
-    #[configurable(derived)]
     pub tls: Option<TlsConfig>,
 
     #[serde(default)]
-    #[configurable(derived)]
     #[serde(rename = "distribution")]
     pub endpoint_health: Option<HealthConfig>,
 
@@ -200,15 +190,12 @@ pub struct ElasticsearchConfig {
     // `DataStreamConfig` into the `mode` enum variants. Doing so would remove them from the root
     // of the config here and thus any post serde config parsing manual error prone logic.
     #[serde(alias = "normal", default)]
-    #[configurable(derived)]
     pub bulk: BulkConfig,
 
     #[serde(default)]
-    #[configurable(derived)]
     pub data_stream: Option<DataStreamConfig>,
 
     #[serde(default)]
-    #[configurable(derived)]
     pub metrics: Option<MetricToLogConfig>,
 
     #[serde(
@@ -216,10 +203,8 @@ pub struct ElasticsearchConfig {
         deserialize_with = "crate::serde::bool_or_struct",
         skip_serializing_if = "crate::serde::is_default"
     )]
-    #[configurable(derived)]
     pub acknowledgements: AcknowledgementsConfig,
 
-    #[configurable(derived)]
     #[serde(flatten)]
     pub confinement: ConfinementConfig,
 }

--- a/src/sinks/file/mod.rs
+++ b/src/sinks/file/mod.rs
@@ -98,11 +98,9 @@ pub struct FileSinkConfig {
     #[serde(flatten)]
     pub encoding: EncodingConfigWithFraming,
 
-    #[configurable(derived)]
     #[serde(default, skip_serializing_if = "crate::serde::is_default")]
     pub compression: Compression,
 
-    #[configurable(derived)]
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
@@ -110,15 +108,12 @@ pub struct FileSinkConfig {
     )]
     pub acknowledgements: AcknowledgementsConfig,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub timezone: Option<TimeZone>,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub internal_metrics: FileInternalMetricsConfig,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub truncate: FileTruncateConfig,
 }

--- a/src/sinks/gcp/cloud_storage.rs
+++ b/src/sinks/gcp/cloud_storage.rs
@@ -153,7 +153,6 @@ pub struct GcsSinkConfig {
     ///
     /// Some cloud storage API clients and browsers handle decompression transparently, so
     /// depending on how they are accessed, files may not always appear to be compressed.
-    #[configurable(derived)]
     #[serde(default)]
     compression: Compression,
 
@@ -182,7 +181,6 @@ pub struct GcsSinkConfig {
     #[configurable(metadata(docs::examples = "no-transform"))]
     cache_control: Option<String>,
 
-    #[configurable(derived)]
     #[serde(default)]
     batch: BatchConfig<BulkSizeBasedDefaultBatchSettings>,
 
@@ -192,17 +190,14 @@ pub struct GcsSinkConfig {
     #[serde(default = "default_endpoint")]
     endpoint: HttpEndpoint,
 
-    #[configurable(derived)]
     #[serde(default)]
     request: TowerRequestConfig<GcsTowerRequestConfigDefaults>,
 
     #[serde(flatten)]
     auth: GcpAuthConfig,
 
-    #[configurable(derived)]
     tls: Option<TlsConfig>,
 
-    #[configurable(derived)]
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
@@ -210,7 +205,6 @@ pub struct GcsSinkConfig {
     )]
     acknowledgements: AcknowledgementsConfig,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub timezone: Option<TimeZone>,
 

--- a/src/sinks/gcp/pubsub.rs
+++ b/src/sinks/gcp/pubsub.rs
@@ -77,22 +77,17 @@ pub struct PubsubConfig {
     #[serde(default, flatten)]
     pub auth: GcpAuthConfig,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub batch: BatchConfig<PubsubDefaultBatchSettings>,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub request: TowerRequestConfig,
 
-    #[configurable(derived)]
     encoding: EncodingConfig,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub tls: Option<TlsConfig>,
 
-    #[configurable(derived)]
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",

--- a/src/sinks/gcp/stackdriver/logs/config.rs
+++ b/src/sinks/gcp/stackdriver/logs/config.rs
@@ -93,22 +93,17 @@ pub(super) struct StackdriverConfig {
     #[serde(flatten)]
     pub(super) auth: GcpAuthConfig,
 
-    #[configurable(derived)]
     #[serde(default, skip_serializing_if = "crate::serde::is_default")]
     pub(super) encoding: Transformer,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub(super) batch: BatchConfig<RealtimeSizeBasedDefaultBatchSettings>,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub(super) request: TowerRequestConfig<StackdriverTowerRequestConfigDefaults>,
 
-    #[configurable(derived)]
     pub(super) tls: Option<TlsConfig>,
 
-    #[configurable(derived)]
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
@@ -116,11 +111,9 @@ pub(super) struct StackdriverConfig {
     )]
     acknowledgements: AcknowledgementsConfig,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub retry_strategy: RetryStrategy,
 
-    #[configurable(derived)]
     #[serde(flatten)]
     pub confinement: ConfinementConfig,
 }

--- a/src/sinks/gcp/stackdriver/metrics/config.rs
+++ b/src/sinks/gcp/stackdriver/metrics/config.rs
@@ -64,18 +64,14 @@ pub struct StackdriverConfig {
     #[serde(default = "default_metric_namespace_value")]
     pub(super) default_namespace: String,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub(super) request: TowerRequestConfig<StackdriverMetricsTowerRequestConfigDefaults>,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub(super) batch: BatchConfig<StackdriverMetricsDefaultBatchSettings>,
 
-    #[configurable(derived)]
     pub(super) tls: Option<TlsConfig>,
 
-    #[configurable(derived)]
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
@@ -83,7 +79,6 @@ pub struct StackdriverConfig {
     )]
     pub(super) acknowledgements: AcknowledgementsConfig,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub retry_strategy: RetryStrategy,
 }

--- a/src/sinks/gcp_chronicle/chronicle_unstructured.rs
+++ b/src/sinks/gcp_chronicle/chronicle_unstructured.rs
@@ -189,7 +189,6 @@ pub struct ChronicleUnstructuredConfig {
     pub endpoint: Option<HttpEndpoint>,
 
     /// The GCP region to use.
-    #[configurable(derived)]
     #[configurable(required_one_of = "region_or_endpoint")]
     pub region: Option<Region>,
 
@@ -214,22 +213,17 @@ pub struct ChronicleUnstructuredConfig {
     #[serde(flatten)]
     pub auth: GcpAuthConfig,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub batch: BatchConfig<ChronicleUnstructuredDefaultBatchSettings>,
 
-    #[configurable(derived)]
     pub encoding: EncodingConfig,
 
     #[serde(default)]
-    #[configurable(derived)]
     pub compression: ChronicleCompression,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub request: TowerRequestConfig<ChronicleUnstructuredTowerRequestConfigDefaults>,
 
-    #[configurable(derived)]
     pub tls: Option<TlsConfig>,
 
     /// The type of log entries in a request.
@@ -245,7 +239,6 @@ pub struct ChronicleUnstructuredConfig {
     #[configurable(metadata(docs::examples = "VECTOR_DEV"))]
     pub fallback_log_type: Option<String>,
 
-    #[configurable(derived)]
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",

--- a/src/sinks/greptimedb/logs/config.rs
+++ b/src/sinks/greptimedb/logs/config.rs
@@ -91,11 +91,9 @@ pub struct GreptimeDBLogsConfig {
     pub password: Option<SensitiveString>,
     /// Set http compression encoding for the request
     /// Default to none, `gzip` or `zstd` is supported.
-    #[configurable(derived)]
     #[serde(default = "Compression::gzip_default")]
     pub compression: Compression,
 
-    #[configurable(derived)]
     #[serde(default, skip_serializing_if = "crate::serde::is_default")]
     pub encoding: Transformer,
 
@@ -113,18 +111,14 @@ pub struct GreptimeDBLogsConfig {
     ))]
     pub extra_headers: Option<HashMap<String, String>>,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub(crate) batch: BatchConfig<GreptimeDBDefaultBatchSettings>,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub request: TowerRequestConfig,
 
-    #[configurable(derived)]
     pub tls: Option<TlsConfig>,
 
-    #[configurable(derived)]
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
@@ -132,7 +126,6 @@ pub struct GreptimeDBLogsConfig {
     )]
     pub acknowledgements: AcknowledgementsConfig,
 
-    #[configurable(derived)]
     #[serde(flatten)]
     pub confinement: ConfinementConfig,
 }

--- a/src/sinks/greptimedb/metrics/config.rs
+++ b/src/sinks/greptimedb/metrics/config.rs
@@ -59,15 +59,12 @@ pub struct GreptimeDBMetricsConfig {
     #[serde(default)]
     pub grpc_compression: GrpcCompression,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub request: TowerRequestConfig,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub(crate) batch: BatchConfig<GreptimeDBDefaultBatchSettings>,
 
-    #[configurable(derived)]
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
@@ -75,7 +72,6 @@ pub struct GreptimeDBMetricsConfig {
     )]
     pub acknowledgements: AcknowledgementsConfig,
 
-    #[configurable(derived)]
     pub tls: Option<TlsConfig>,
 
     /// Use Greptime's prefixed naming for time index and value columns.

--- a/src/sinks/honeycomb/config.rs
+++ b/src/sinks/honeycomb/config.rs
@@ -52,24 +52,19 @@ pub struct HoneycombConfig {
     // but this limits us in how we can do our healthcheck.
     dataset: String,
 
-    #[configurable(derived)]
     #[serde(default)]
     batch: BatchConfig<HoneycombDefaultBatchSettings>,
 
-    #[configurable(derived)]
     #[serde(default)]
     request: TowerRequestConfig,
 
-    #[configurable(derived)]
     #[serde(default, skip_serializing_if = "crate::serde::is_default")]
     encoding: Transformer,
 
     /// The compression algorithm to use.
-    #[configurable(derived)]
     #[serde(default = "Compression::zstd_default")]
     compression: Compression,
 
-    #[configurable(derived)]
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
@@ -77,7 +72,6 @@ pub struct HoneycombConfig {
     )]
     acknowledgements: AcknowledgementsConfig,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub retry_strategy: RetryStrategy,
 }

--- a/src/sinks/http/config.rs
+++ b/src/sinks/http/config.rs
@@ -59,10 +59,8 @@ pub struct HttpSinkConfig {
     #[serde(default)]
     pub method: HttpMethod,
 
-    #[configurable(derived)]
     pub auth: Option<Auth>,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub compression: Compression,
 
@@ -87,18 +85,14 @@ pub struct HttpSinkConfig {
     #[serde(default)]
     pub payload_suffix: String,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub batch: BatchConfig<RealtimeSizeBasedDefaultBatchSettings>,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub request: RequestConfig,
 
-    #[configurable(derived)]
     pub tls: Option<TlsConfig>,
 
-    #[configurable(derived)]
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
@@ -106,7 +100,6 @@ pub struct HttpSinkConfig {
     )]
     pub acknowledgements: AcknowledgementsConfig,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub retry_strategy: RetryStrategy,
 

--- a/src/sinks/humio/logs.rs
+++ b/src/sinks/humio/logs.rs
@@ -61,7 +61,6 @@ pub struct HumioLogsConfig {
     /// Typically the filename the logs originated from. Maps to `@source` in Humio.
     pub source: Option<Template>,
 
-    #[configurable(derived)]
     pub encoding: EncodingConfig,
 
     /// The type of events sent to this sink. Humio uses this as the name of the parser to use to ingest the data.
@@ -109,26 +108,21 @@ pub struct HumioLogsConfig {
     ))]
     pub index: Option<Template>,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub compression: Compression,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub request: TowerRequestConfig,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub batch: BatchConfig<SplunkHecDefaultBatchSettings>,
 
-    #[configurable(derived)]
     pub tls: Option<TlsConfig>,
 
     /// Overrides the name of the log field used to retrieve the nanosecond-enabled timestamp to send to Humio.
     #[serde(default = "timestamp_nanos_key")]
     pub timestamp_nanos_key: Option<String>,
 
-    #[configurable(derived)]
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",

--- a/src/sinks/humio/metrics.rs
+++ b/src/sinks/humio/metrics.rs
@@ -120,22 +120,17 @@ pub struct HumioMetricsConfig {
     ))]
     index: Option<Template>,
 
-    #[configurable(derived)]
     #[serde(default)]
     compression: Compression,
 
-    #[configurable(derived)]
     #[serde(default)]
     request: TowerRequestConfig,
 
-    #[configurable(derived)]
     #[serde(default)]
     batch: BatchConfig<SplunkHecDefaultBatchSettings>,
 
-    #[configurable(derived)]
     tls: Option<TlsConfig>,
 
-    #[configurable(derived)]
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",

--- a/src/sinks/influxdb/logs.rs
+++ b/src/sinks/influxdb/logs.rs
@@ -150,22 +150,17 @@ pub struct InfluxDbLogsConfig {
     #[configurable(metadata(docs::minimal = true))]
     pub token: Option<SensitiveString>,
 
-    #[configurable(derived)]
     #[serde(skip_serializing_if = "crate::serde::is_default", default)]
     pub encoding: Transformer,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub batch: BatchConfig<InfluxDbLogsDefaultBatchSettings>,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub request: TowerRequestConfig,
 
-    #[configurable(derived)]
     pub tls: Option<TlsConfig>,
 
-    #[configurable(derived)]
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",

--- a/src/sinks/influxdb/metrics.rs
+++ b/src/sinks/influxdb/metrics.rs
@@ -155,11 +155,9 @@ pub struct InfluxDbConfig {
     #[configurable(metadata(docs::minimal = true))]
     pub token: Option<SensitiveString>,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub batch: BatchConfig<InfluxDbDefaultBatchSettings>,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub request: TowerRequestConfig,
 
@@ -168,14 +166,12 @@ pub struct InfluxDbConfig {
     #[configurable(metadata(docs::examples = "example_tags()"))]
     pub tags: Option<HashMap<String, String>>,
 
-    #[configurable(derived)]
     pub tls: Option<TlsConfig>,
 
     /// The list of quantiles to calculate when sending distribution metrics.
     #[serde(default = "default_summary_quantiles")]
     pub quantiles: Vec<f64>,
 
-    #[configurable(derived)]
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",

--- a/src/sinks/kafka/config.rs
+++ b/src/sinks/kafka/config.rs
@@ -64,19 +64,15 @@ pub struct KafkaSinkConfig {
     #[configurable(metadata(docs::examples = "%my_topic"))]
     pub key_field: Option<ConfigTargetPath>,
 
-    #[configurable(derived)]
     pub encoding: EncodingConfig,
 
     // These batching options will **not** override librdkafka_options values.
-    #[configurable(derived)]
     #[serde(default)]
     pub batch: BatchConfig<NoDefaultsBatchSettings>,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub compression: KafkaCompression,
 
-    #[configurable(derived)]
     #[serde(flatten)]
     pub auth: KafkaAuthConfig,
 
@@ -125,7 +121,6 @@ pub struct KafkaSinkConfig {
     #[configurable(metadata(docs::examples = "headers"))]
     pub headers_key: Option<ConfigTargetPath>,
 
-    #[configurable(derived)]
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
@@ -133,7 +128,6 @@ pub struct KafkaSinkConfig {
     )]
     pub acknowledgements: AcknowledgementsConfig,
 
-    #[configurable(derived)]
     #[serde(flatten)]
     pub confinement: ConfinementConfig,
 }

--- a/src/sinks/keep/config.rs
+++ b/src/sinks/keep/config.rs
@@ -41,19 +41,15 @@ pub struct KeepConfig {
     #[configurable(metadata(docs::examples = "keepappkey"))]
     api_key: SensitiveString,
 
-    #[configurable(derived)]
     #[serde(default)]
     batch: BatchConfig<KeepDefaultBatchSettings>,
 
-    #[configurable(derived)]
     #[serde(default)]
     request: TowerRequestConfig,
 
-    #[configurable(derived)]
     #[serde(default, skip_serializing_if = "crate::serde::is_default")]
     encoding: Transformer,
 
-    #[configurable(derived)]
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
@@ -61,7 +57,6 @@ pub struct KeepConfig {
     )]
     acknowledgements: AcknowledgementsConfig,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub retry_strategy: RetryStrategy,
 }

--- a/src/sinks/loki/config.rs
+++ b/src/sinks/loki/config.rs
@@ -41,7 +41,6 @@ pub struct LokiConfig {
     #[serde(default = "default_loki_path")]
     pub path: String,
 
-    #[configurable(derived)]
     pub encoding: EncodingConfig,
 
     /// The [tenant ID][tenant_id] to specify in requests to Loki.
@@ -104,25 +103,19 @@ pub struct LokiConfig {
     #[serde(default = "default_compression")]
     pub compression: Compression,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub out_of_order_action: OutOfOrderAction,
 
-    #[configurable(derived)]
     pub auth: Option<Auth>,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub request: TowerRequestConfig,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub batch: BatchConfig<LokiDefaultBatchSettings>,
 
-    #[configurable(derived)]
     pub tls: Option<TlsConfig>,
 
-    #[configurable(derived)]
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
@@ -130,7 +123,6 @@ pub struct LokiConfig {
     )]
     acknowledgements: AcknowledgementsConfig,
 
-    #[configurable(derived)]
     #[serde(flatten)]
     pub confinement: ConfinementConfig,
 }

--- a/src/sinks/mezmo.rs
+++ b/src/sinks/mezmo.rs
@@ -67,7 +67,6 @@ pub struct MezmoConfig {
     #[configurable(metadata(docs::examples = "tag2"))]
     tags: Option<Vec<UnconfinedTemplate>>,
 
-    #[configurable(derived)]
     #[serde(default, skip_serializing_if = "crate::serde::is_default")]
     pub encoding: Transformer,
 
@@ -81,15 +80,12 @@ pub struct MezmoConfig {
     #[configurable(metadata(docs::examples = "staging"))]
     default_env: String,
 
-    #[configurable(derived)]
     #[serde(default)]
     batch: BatchConfig<RealtimeSizeBasedDefaultBatchSettings>,
 
-    #[configurable(derived)]
     #[serde(default)]
     request: TowerRequestConfig,
 
-    #[configurable(derived)]
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",

--- a/src/sinks/mqtt/config.rs
+++ b/src/sinks/mqtt/config.rs
@@ -35,10 +35,8 @@ pub struct MqttSinkConfig {
     #[serde(default = "default_retain")]
     pub retain: bool,
 
-    #[configurable(derived)]
     pub encoding: EncodingConfig,
 
-    #[configurable(derived)]
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
@@ -46,11 +44,9 @@ pub struct MqttSinkConfig {
     )]
     pub acknowledgements: AcknowledgementsConfig,
 
-    #[configurable(derived)]
     #[serde(default = "default_qos")]
     pub quality_of_service: MqttQoS,
 
-    #[configurable(derived)]
     #[serde(flatten)]
     pub confinement: ConfinementConfig,
 }

--- a/src/sinks/nats/config.rs
+++ b/src/sinks/nats/config.rs
@@ -55,7 +55,6 @@ impl NatsHeaderConfig {
 #[serde(deny_unknown_fields)]
 pub struct JetStreamConfig {
     /// Whether to enable Jetstream.
-    #[configurable(derived)]
     #[serde(default)]
     pub enabled: bool,
 
@@ -82,10 +81,8 @@ impl From<bool> for JetStreamConfig {
 #[derive(Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct NatsSinkConfig {
-    #[configurable(derived)]
     pub(super) encoding: EncodingConfig,
 
-    #[configurable(derived)]
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
@@ -127,13 +124,10 @@ pub struct NatsSinkConfig {
     ))]
     pub(super) url: String,
 
-    #[configurable(derived)]
     pub(super) tls: Option<TlsEnableableConfig>,
 
-    #[configurable(derived)]
     pub(super) auth: Option<NatsAuthConfig>,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub(super) request: TowerRequestConfig<NatsTowerRequestConfigDefaults>,
 
@@ -142,7 +136,6 @@ pub struct NatsSinkConfig {
     /// If set, the `subject` must belong to an existing JetStream stream.
     ///
     /// [jetstream]: https://docs.nats.io/nats-concepts/jetstream
-    #[configurable(derived)]
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
@@ -150,7 +143,6 @@ pub struct NatsSinkConfig {
     )]
     pub(super) jetstream: JetStreamConfig,
 
-    #[configurable(derived)]
     #[serde(flatten)]
     pub confinement: ConfinementConfig,
 }

--- a/src/sinks/new_relic/config.rs
+++ b/src/sinks/new_relic/config.rs
@@ -87,29 +87,22 @@ pub struct NewRelicConfig {
     #[configurable(metadata(docs::examples = "${NEW_RELIC_ACCOUNT_KEY}"))]
     pub account_id: SensitiveString,
 
-    #[configurable(derived)]
     pub region: Option<NewRelicRegion>,
 
-    #[configurable(derived)]
     pub api: NewRelicApi,
 
-    #[configurable(derived)]
     #[serde(default = "Compression::gzip_default")]
     pub compression: Compression,
 
-    #[configurable(derived)]
     #[serde(default, skip_serializing_if = "crate::serde::is_default")]
     pub encoding: Transformer,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub batch: BatchConfig<NewRelicDefaultBatchSettings>,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub request: TowerRequestConfig,
 
-    #[configurable(derived)]
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",

--- a/src/sinks/opentelemetry/mod.rs
+++ b/src/sinks/opentelemetry/mod.rs
@@ -15,7 +15,6 @@ use crate::{
 #[derive(Clone, Debug)]
 pub struct OpenTelemetryConfig {
     /// Protocol configuration
-    #[configurable(derived)]
     protocol: Protocol,
 }
 

--- a/src/sinks/papertrail.rs
+++ b/src/sinks/papertrail.rs
@@ -27,13 +27,10 @@ pub struct PapertrailConfig {
     #[configurable(metadata(docs::examples = "logs.papertrailapp.com:12345"))]
     endpoint: UriSerde,
 
-    #[configurable(derived)]
     encoding: EncodingConfig,
 
-    #[configurable(derived)]
     keepalive: Option<TcpKeepaliveConfig>,
 
-    #[configurable(derived)]
     tls: Option<TlsEnableableConfig>,
 
     /// Configures the send buffer size using the `SO_SNDBUF` option on the socket.
@@ -44,7 +41,6 @@ pub struct PapertrailConfig {
     #[serde(default = "default_process")]
     process: UnconfinedTemplate,
 
-    #[configurable(derived)]
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",

--- a/src/sinks/postgres/config.rs
+++ b/src/sinks/postgres/config.rs
@@ -63,15 +63,12 @@ pub struct PostgresConfig {
     /// can be defined at a database level to change the behavior of the insert operation on specific tables.
     /// Alternatively, setting `max_events` batch setting to `1` will make each event to be inserted independently,
     /// so events that trigger a constraint violation will not affect the rest of the events.
-    #[configurable(derived)]
     #[serde(default)]
     pub batch: BatchConfig<RealtimeSizeBasedDefaultBatchSettings>,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub request: TowerRequestConfig,
 
-    #[configurable(derived)]
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",

--- a/src/sinks/prometheus/exporter.rs
+++ b/src/sinks/prometheus/exporter.rs
@@ -79,10 +79,8 @@ pub struct PrometheusExporterConfig {
     #[configurable(metadata(docs::examples = "192.160.0.10:9598"))]
     pub address: SocketAddr,
 
-    #[configurable(derived)]
     pub auth: Option<Auth>,
 
-    #[configurable(derived)]
     pub tls: Option<TlsEnableableConfig>,
 
     /// Default buckets to use for aggregating [distribution][dist_metric_docs] metrics into histograms.
@@ -132,7 +130,6 @@ pub struct PrometheusExporterConfig {
     #[serde(default)]
     pub suppress_timestamp: bool,
 
-    #[configurable(derived)]
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",

--- a/src/sinks/prometheus/remote_write/config.rs
+++ b/src/sinks/prometheus/remote_write/config.rs
@@ -29,7 +29,6 @@ use crate::{
 #[derive(Clone, Copy, Debug, Derivative)]
 #[derivative(Default)]
 pub struct RemoteWriteBatchConfig {
-    #[configurable(derived)]
     #[serde(flatten)]
     pub batch_settings: BatchConfig<PrometheusRemoteWriteDefaultBatchSettings>,
 
@@ -78,11 +77,9 @@ pub struct RemoteWriteConfig {
     #[serde(default = "crate::sinks::prometheus::default_summary_quantiles")]
     pub quantiles: Vec<f64>,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub batch: RemoteWriteBatchConfig,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub request: RemoteWriteRequestConfig,
 
@@ -103,17 +100,13 @@ pub struct RemoteWriteConfig {
     #[configurable(metadata(docs::required = false))]
     pub expire_metrics_secs: Option<f64>,
 
-    #[configurable(derived)]
     pub tls: Option<TlsConfig>,
 
-    #[configurable(derived)]
     pub auth: Option<PrometheusRemoteWriteAuth>,
 
     #[cfg(feature = "aws-config")]
-    #[configurable(derived)]
     pub aws: Option<crate::aws::RegionOrEndpoint>,
 
-    #[configurable(derived)]
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
@@ -121,16 +114,13 @@ pub struct RemoteWriteConfig {
     )]
     pub acknowledgements: AcknowledgementsConfig,
 
-    #[configurable(derived)]
     #[serde(default = "default_compression")]
     #[derivative(Default(value = "default_compression()"))]
     pub compression: Compression,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub retry_strategy: RetryStrategy,
 
-    #[configurable(derived)]
     #[serde(flatten)]
     pub confinement: ConfinementConfig,
 }

--- a/src/sinks/pulsar/config.rs
+++ b/src/sinks/pulsar/config.rs
@@ -62,21 +62,16 @@ pub struct PulsarSinkConfig {
     /// If omitted, no properties will be written.
     pub properties_key: Option<OptionalTargetPath>,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub(crate) batch: PulsarBatchConfig,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub compression: PulsarCompression,
 
-    #[configurable(derived)]
     pub encoding: EncodingConfig,
 
-    #[configurable(derived)]
     pub(crate) auth: Option<PulsarAuthConfig>,
 
-    #[configurable(derived)]
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
@@ -84,15 +79,12 @@ pub struct PulsarSinkConfig {
     )]
     pub acknowledgements: AcknowledgementsConfig,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub connection_retry_options: Option<CustomConnectionRetryOptions>,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub(crate) tls: Option<PulsarTlsOptions>,
 
-    #[configurable(derived)]
     #[serde(flatten)]
     pub confinement: ConfinementConfig,
 }
@@ -134,7 +126,6 @@ pub(crate) struct PulsarAuthConfig {
     #[configurable(metadata(docs::examples = "123456789"))]
     token: Option<SensitiveString>,
 
-    #[configurable(derived)]
     oauth2: Option<OAuth2Config>,
 }
 

--- a/src/sinks/redis/config.rs
+++ b/src/sinks/redis/config.rs
@@ -122,18 +122,14 @@ impl SinkBatchSettings for RedisDefaultBatchSettings {
 #[derive(Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct RedisSinkConfig {
-    #[configurable(derived)]
     pub(super) encoding: EncodingConfig,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub(super) data_type: DataTypeConfig,
 
-    #[configurable(derived)]
     #[serde(alias = "list")]
     pub(super) list_option: Option<ListOption>,
 
-    #[configurable(derived)]
     #[serde(alias = "sorted_set")]
     pub(super) sorted_set_option: Option<SortedSetOption>,
 
@@ -152,7 +148,6 @@ pub struct RedisSinkConfig {
     #[configurable]
     pub(super) sentinel_service: Option<String>,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub(super) sentinel_connect: Option<SentinelConnectionSettings>,
 
@@ -161,15 +156,12 @@ pub struct RedisSinkConfig {
     #[configurable(metadata(docs::examples = "syslog:{{ app }}", docs::examples = "vector"))]
     pub(super) key: Template,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub(super) batch: BatchConfig<RedisDefaultBatchSettings>,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub(super) request: TowerRequestConfig<RedisTowerRequestConfigDefaults>,
 
-    #[configurable(derived)]
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
@@ -177,7 +169,6 @@ pub struct RedisSinkConfig {
     )]
     pub(super) acknowledgements: AcknowledgementsConfig,
 
-    #[configurable(derived)]
     #[serde(flatten)]
     pub confinement: ConfinementConfig,
 }
@@ -310,11 +301,9 @@ impl RedisSinkConfig {
 #[derive(Clone, Debug, Default)]
 #[serde(deny_unknown_fields)]
 pub struct SentinelConnectionSettings {
-    #[configurable(derived)]
     #[serde(default)]
     pub tls: MaybeTlsMode,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub connections: Option<RedisConnectionSettings>,
 }

--- a/src/sinks/sematext/logs.rs
+++ b/src/sinks/sematext/logs.rs
@@ -33,7 +33,6 @@ use crate::{
 #[derive(Clone, Debug)]
 pub struct SematextLogsConfig {
     #[serde(default = "super::default_region")]
-    #[configurable(derived)]
     region: Region,
 
     /// The endpoint to send data to.
@@ -49,19 +48,15 @@ pub struct SematextLogsConfig {
     #[configurable(metadata(docs::examples = "some-sematext-token"))]
     token: SensitiveString,
 
-    #[configurable(derived)]
     #[serde(skip_serializing_if = "crate::serde::is_default", default)]
     pub encoding: Transformer,
 
-    #[configurable(derived)]
     #[serde(default)]
     request: TowerRequestConfig,
 
-    #[configurable(derived)]
     #[serde(default)]
     batch: BatchConfig<RealtimeSizeBasedDefaultBatchSettings>,
 
-    #[configurable(derived)]
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",

--- a/src/sinks/sematext/metrics.rs
+++ b/src/sinks/sematext/metrics.rs
@@ -69,7 +69,6 @@ pub struct SematextMetricsConfig {
     pub default_namespace: String,
 
     #[serde(default = "super::default_region")]
-    #[configurable(derived)]
     pub region: Region,
 
     /// The endpoint to send data to.
@@ -84,15 +83,12 @@ pub struct SematextMetricsConfig {
     #[configurable(metadata(docs::examples = "some-sematext-token"))]
     pub token: SensitiveString,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub(self) batch: BatchConfig<SematextMetricsDefaultBatchSettings>,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub request: TowerRequestConfig,
 
-    #[configurable(derived)]
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",

--- a/src/sinks/socket.rs
+++ b/src/sinks/socket.rs
@@ -23,7 +23,6 @@ pub struct SocketSinkConfig {
     #[serde(flatten)]
     pub mode: Mode,
 
-    #[configurable(derived)]
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
@@ -72,7 +71,6 @@ pub struct UdpMode {
     #[serde(flatten)]
     config: UdpSinkConfig,
 
-    #[configurable(derived)]
     encoding: EncodingConfig,
 }
 

--- a/src/sinks/splunk_hec/logs/config.rs
+++ b/src/sinks/splunk_hec/logs/config.rs
@@ -99,25 +99,19 @@ pub struct HecLogsSinkConfig {
     ))]
     pub source: Option<Template>,
 
-    #[configurable(derived)]
     pub encoding: EncodingConfig,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub compression: Compression,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub batch: BatchConfig<SplunkHecDefaultBatchSettings>,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub request: TowerRequestConfig,
 
-    #[configurable(derived)]
     pub tls: Option<TlsConfig>,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub acknowledgements: HecClientAcknowledgementsConfig,
 
@@ -150,11 +144,9 @@ pub struct HecLogsSinkConfig {
     #[serde(default)]
     pub auto_extract_timestamp: Option<bool>,
 
-    #[configurable(derived)]
     #[serde(default = "default_endpoint_target")]
     pub endpoint_target: EndpointTarget,
 
-    #[configurable(derived)]
     #[serde(flatten)]
     pub confinement: ConfinementConfig,
 }

--- a/src/sinks/splunk_hec/metrics/config.rs
+++ b/src/sinks/splunk_hec/metrics/config.rs
@@ -108,26 +108,20 @@ pub struct HecMetricsSinkConfig {
     ))]
     pub source: Option<Template>,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub compression: Compression,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub batch: BatchConfig<SplunkHecDefaultBatchSettings>,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub request: TowerRequestConfig,
 
-    #[configurable(derived)]
     pub tls: Option<TlsConfig>,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub acknowledgements: HecClientAcknowledgementsConfig,
 
-    #[configurable(derived)]
     #[serde(flatten)]
     pub confinement: crate::template::ConfinementConfig,
 }

--- a/src/sinks/statsd/config.rs
+++ b/src/sinks/statsd/config.rs
@@ -48,11 +48,9 @@ pub struct StatsdSinkConfig {
     #[serde(flatten)]
     pub mode: Mode,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub batch: BatchConfig<StatsdDefaultBatchSettings>,
 
-    #[configurable(derived)]
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",

--- a/src/sinks/util/adaptive_concurrency/tests.rs
+++ b/src/sinks/util/adaptive_concurrency/tests.rs
@@ -78,7 +78,6 @@ struct LimitParams {
     /// The level above which more requests will be denied.
     limit: Option<usize>,
 
-    #[configurable(derived)]
     #[serde(default)]
     action: Action,
 }
@@ -125,19 +124,15 @@ struct TestParams {
     #[serde(default)]
     jitter: f64,
 
-    #[configurable(derived)]
     #[serde(default)]
     concurrency_limit_params: LimitParams,
 
-    #[configurable(derived)]
     #[serde(default)]
     rate: LimitParams,
 
-    #[configurable(derived)]
     #[serde(default = "default_concurrency")]
     concurrency: Concurrency,
 
-    #[configurable(derived)]
     #[serde(default)]
     adaptive_concurrency: AdaptiveConcurrencySettings,
 }
@@ -154,10 +149,8 @@ const fn default_concurrency() -> Concurrency {
 #[configurable_component(sink("test_arc", "Test (adaptive concurrency)."))]
 #[derive(Clone, Debug, Default)]
 pub struct TestConfig {
-    #[configurable(derived)]
     request: TowerRequestConfig,
 
-    #[configurable(derived)]
     params: TestParams,
 
     // The statistics collected by running a test must be local to that

--- a/src/sinks/util/service.rs
+++ b/src/sinks/util/service.rs
@@ -111,7 +111,6 @@ impl TowerRequestConfigDefaults for GlobalTowerRequestConfigDefaults {}
 #[configurable_component]
 #[derive(Clone, Copy, Debug)]
 pub struct TowerRequestConfig<D: TowerRequestConfigDefaults = GlobalTowerRequestConfigDefaults> {
-    #[configurable(derived)]
     #[serde(default = "default_concurrency::<D>")]
     #[serde(skip_serializing_if = "concurrency_is_default::<D>")]
     pub concurrency: Concurrency,
@@ -156,11 +155,9 @@ pub struct TowerRequestConfig<D: TowerRequestConfigDefaults = GlobalTowerRequest
     #[serde(default = "default_retry_initial_backoff_secs::<D>")]
     pub retry_initial_backoff_secs: NonZeroU64,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub retry_jitter_mode: JitterMode,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub adaptive_concurrency: AdaptiveConcurrencySettings,
 

--- a/src/sinks/util/service/net/tcp.rs
+++ b/src/sinks/util/service/net/tcp.rs
@@ -15,10 +15,8 @@ use crate::dns;
 #[configurable_component]
 #[derive(Clone, Debug)]
 pub struct TcpConnectorConfig {
-    #[configurable(derived)]
     address: HostAndPort,
 
-    #[configurable(derived)]
     keepalive: Option<TcpKeepaliveConfig>,
 
     /// The size of the socket's send buffer.
@@ -28,7 +26,6 @@ pub struct TcpConnectorConfig {
     #[configurable(metadata(docs::examples = 65536))]
     send_buffer_size: Option<usize>,
 
-    #[configurable(derived)]
     tls: Option<TlsEnableableConfig>,
 }
 

--- a/src/sinks/util/service/net/udp.rs
+++ b/src/sinks/util/service/net/udp.rs
@@ -11,7 +11,6 @@ use crate::{dns, net};
 #[configurable_component]
 #[derive(Clone, Debug)]
 pub struct UdpConnectorConfig {
-    #[configurable(derived)]
     address: HostAndPort,
 
     /// The size of the socket's send buffer.

--- a/src/sinks/util/tcp.rs
+++ b/src/sinks/util/tcp.rs
@@ -64,10 +64,8 @@ pub struct TcpSinkConfig {
     #[configurable(metadata(docs::examples = "https://somehost:5000"))]
     address: String,
 
-    #[configurable(derived)]
     keepalive: Option<TcpKeepaliveConfig>,
 
-    #[configurable(derived)]
     tls: Option<TlsEnableableConfig>,
 
     /// The size of the socket's send buffer.

--- a/src/sinks/vector/config.rs
+++ b/src/sinks/vector/config.rs
@@ -80,26 +80,21 @@ pub struct VectorConfig {
     /// This option is mutually exclusive with `address`. Set exactly one of
     /// `address` or `routing`.
     #[serde(default)]
-    #[configurable(derived)]
     #[configurable(required_one_of = "address_or_routing")]
     routing: Option<RoutingConfig>,
 
     /// Compression algorithm for requests.
     ///
     /// Supports `"none"`, `"gzip"`, or `"zstd"`.
-    #[configurable(derived)]
     #[serde(default)]
     compression: VectorCompression,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub batch: BatchConfig<RealtimeEventBasedDefaultBatchSettings>,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub request: TowerRequestConfig,
 
-    #[configurable(derived)]
     #[serde(default)]
     tls: Option<TlsEnableableConfig>,
 
@@ -109,11 +104,9 @@ pub struct VectorConfig {
     /// frames on idle connections so that a pooled connection to a downstream Vector instance that
     /// has gone away (crashed, restarted, or cut off by a network partition) is detected and evicted
     /// before it is reused, ensuring retries always go to a live connection.
-    #[configurable(derived)]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     keepalive: Option<VectorKeepaliveConfig>,
 
-    #[configurable(derived)]
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
@@ -187,7 +180,6 @@ struct RoutingConfig {
     ///
     /// This option is only used when `strategy` is set to `load_balance`.
     #[serde(default)]
-    #[configurable(derived)]
     health: Option<HealthConfig>,
 }
 

--- a/src/sinks/webhdfs/config.rs
+++ b/src/sinks/webhdfs/config.rs
@@ -66,15 +66,12 @@ pub struct WebHdfsConfig {
     #[serde(flatten)]
     pub encoding: EncodingConfigWithFraming,
 
-    #[configurable(derived)]
     #[serde(default = "Compression::gzip_default")]
     pub compression: Compression,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub batch: BatchConfig<BulkSizeBasedDefaultBatchSettings>,
 
-    #[configurable(derived)]
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",

--- a/src/sinks/websocket/config.rs
+++ b/src/sinks/websocket/config.rs
@@ -22,10 +22,8 @@ pub struct WebSocketSinkConfig {
     #[serde(flatten)]
     pub common: WebSocketCommonConfig,
 
-    #[configurable(derived)]
     pub encoding: EncodingConfig,
 
-    #[configurable(derived)]
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",

--- a/src/sinks/websocket_server/buffering.rs
+++ b/src/sinks/websocket_server/buffering.rs
@@ -33,7 +33,6 @@ pub struct MessageBufferingConfig {
     #[serde(default, skip_serializing_if = "crate::serde::is_default")]
     pub message_id_path: Option<ConfigValuePath>,
 
-    #[configurable(derived)]
     pub client_ack_config: Option<BufferingAckConfig>,
 }
 
@@ -44,7 +43,6 @@ pub struct MessageBufferingConfig {
 #[configurable_component]
 #[derive(Clone, Debug, Derivative)]
 pub struct BufferingAckConfig {
-    #[configurable(derived)]
     #[derivative(Default(value = "default_decoding()"))]
     #[serde(default = "default_decoding")]
     pub ack_decoding: DeserializerConfig,
@@ -53,7 +51,6 @@ pub struct BufferingAckConfig {
     /// the message.
     pub message_id_path: ConfigValuePath,
 
-    #[configurable(derived)]
     #[serde(default = "default_client_key_config")]
     pub client_key: ClientKeyConfig,
 }

--- a/src/sinks/websocket_server/config.rs
+++ b/src/sinks/websocket_server/config.rs
@@ -25,17 +25,13 @@ pub struct WebSocketListenerSinkConfig {
     #[configurable(metadata(docs::examples = "localhost:80"))]
     pub address: SocketAddr,
 
-    #[configurable(derived)]
     pub tls: Option<TlsEnableableConfig>,
 
-    #[configurable(derived)]
     pub encoding: EncodingConfig,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub subprotocol: SubProtocolConfig,
 
-    #[configurable(derived)]
     #[serde(
         default,
         deserialize_with = "crate::serde::bool_or_struct",
@@ -43,14 +39,11 @@ pub struct WebSocketListenerSinkConfig {
     )]
     pub acknowledgements: AcknowledgementsConfig,
 
-    #[configurable(derived)]
     pub message_buffering: Option<MessageBufferingConfig>,
 
-    #[configurable(derived)]
     pub auth: Option<HttpServerAuthConfig>,
 
     /// Configuration of internal metrics
-    #[configurable(derived)]
     #[serde(default)]
     pub internal_metrics: InternalMetricsConfig,
 }

--- a/src/sources/amqp.rs
+++ b/src/sources/amqp.rs
@@ -89,17 +89,14 @@ pub struct AmqpSourceConfig {
     #[serde(default)]
     pub log_namespace: Option<bool>,
 
-    #[configurable(derived)]
     #[serde(default = "default_framing_message_based")]
     #[derivative(Default(value = "default_framing_message_based()"))]
     pub(crate) framing: FramingConfig,
 
-    #[configurable(derived)]
     #[serde(default = "default_decoding")]
     #[derivative(Default(value = "default_decoding()"))]
     pub(crate) decoding: DeserializerConfig,
 
-    #[configurable(derived)]
     #[serde(default, deserialize_with = "bool_or_struct")]
     pub(crate) acknowledgements: SourceAcknowledgementsConfig,
 

--- a/src/sources/aws_kinesis_firehose/mod.rs
+++ b/src/sources/aws_kinesis_firehose/mod.rs
@@ -63,7 +63,6 @@ pub struct AwsKinesisFirehoseConfig {
     ///
     /// If set to `true`, when incoming requests contains an access key sent by AWS Firehose, it is kept in the
     /// event secrets as "aws_kinesis_firehose_access_key".
-    #[configurable(derived)]
     store_access_key: bool,
 
     /// The compression scheme to use for decompressing records within the Firehose message.
@@ -80,18 +79,14 @@ pub struct AwsKinesisFirehoseConfig {
     #[serde(default)]
     record_compression: Compression,
 
-    #[configurable(derived)]
     tls: Option<TlsEnableableConfig>,
 
-    #[configurable(derived)]
     #[serde(default = "default_framing_message_based")]
     framing: FramingConfig,
 
-    #[configurable(derived)]
     #[serde(default = "default_decoding")]
     decoding: DeserializerConfig,
 
-    #[configurable(derived)]
     #[serde(default, deserialize_with = "bool_or_struct")]
     acknowledgements: SourceAcknowledgementsConfig,
 
@@ -100,7 +95,6 @@ pub struct AwsKinesisFirehoseConfig {
     #[serde(default)]
     log_namespace: Option<bool>,
 
-    #[configurable(derived)]
     #[serde(default)]
     keepalive: KeepaliveConfig,
 

--- a/src/sources/aws_s3/mod.rs
+++ b/src/sources/aws_s3/mod.rs
@@ -119,21 +119,17 @@ pub struct AwsS3Config {
     #[configurable(metadata(docs::hidden))]
     assume_role: Option<String>,
 
-    #[configurable(derived)]
     #[serde(default)]
     auth: AwsAuthentication,
 
     /// Multiline aggregation configuration.
     ///
     /// If not specified, multiline aggregation is disabled.
-    #[configurable(derived)]
     multiline: Option<MultilineConfig>,
 
-    #[configurable(derived)]
     #[serde(default, deserialize_with = "bool_or_struct")]
     acknowledgements: SourceAcknowledgementsConfig,
 
-    #[configurable(derived)]
     tls_options: Option<TlsConfig>,
 
     /// The namespace to use for logs. This overrides the global setting.
@@ -141,12 +137,10 @@ pub struct AwsS3Config {
     #[serde(default)]
     log_namespace: Option<bool>,
 
-    #[configurable(derived)]
     #[serde(default = "default_framing")]
     #[derivative(Default(value = "default_framing()"))]
     pub framing: FramingConfig,
 
-    #[configurable(derived)]
     #[serde(default = "default_decoding")]
     #[derivative(Default(value = "default_decoding()"))]
     pub decoding: DeserializerConfig,

--- a/src/sources/aws_s3/sqs.rs
+++ b/src/sources/aws_s3/sqs.rs
@@ -166,21 +166,18 @@ pub(super) struct Config {
     #[configurable(metadata(docs::examples = 1))]
     pub(super) max_number_of_messages: u32,
 
-    #[configurable(derived)]
     #[serde(default)]
     #[derivative(Default)]
     pub(super) tls_options: Option<TlsConfig>,
 
     // Client timeout configuration for SQS operations. Take care when configuring these settings
     // to allow enough time for the polling interval configured in `poll_secs`.
-    #[configurable(derived)]
     #[derivative(Default)]
     #[serde(default)]
     #[serde(flatten)]
     pub(super) timeout: Option<AwsTimeout>,
 
     /// Configuration for deferring events to another queue based on their age.
-    #[configurable(derived)]
     pub(super) deferred: Option<DeferredConfig>,
 }
 

--- a/src/sources/aws_sqs/config.rs
+++ b/src/sources/aws_sqs/config.rs
@@ -27,7 +27,6 @@ pub struct AwsSqsConfig {
     #[serde(flatten)]
     pub region: RegionOrEndpoint,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub auth: AwsAuthentication,
 
@@ -81,21 +80,17 @@ pub struct AwsSqsConfig {
     /// processing them.
     pub client_concurrency: Option<NonZeroUsize>,
 
-    #[configurable(derived)]
     #[serde(default = "default_framing_message_based")]
     #[derivative(Default(value = "default_framing_message_based()"))]
     pub framing: FramingConfig,
 
-    #[configurable(derived)]
     #[serde(default = "default_decoding")]
     #[derivative(Default(value = "default_decoding()"))]
     pub decoding: DeserializerConfig,
 
-    #[configurable(derived)]
     #[serde(default, deserialize_with = "bool_or_struct")]
     pub acknowledgements: SourceAcknowledgementsConfig,
 
-    #[configurable(derived)]
     pub tls: Option<TlsConfig>,
 
     /// The namespace to use for logs. This overrides the global setting.

--- a/src/sources/datadog_agent/mod.rs
+++ b/src/sources/datadog_agent/mod.rs
@@ -140,22 +140,17 @@ pub struct DatadogAgentConfig {
     #[configurable(metadata(docs::hidden))]
     log_namespace: Option<bool>,
 
-    #[configurable(derived)]
     tls: Option<TlsEnableableConfig>,
 
-    #[configurable(derived)]
     #[serde(default = "default_framing_message_based")]
     framing: FramingConfig,
 
-    #[configurable(derived)]
     #[serde(default = "default_decoding")]
     decoding: DeserializerConfig,
 
-    #[configurable(derived)]
     #[serde(default, deserialize_with = "bool_or_struct")]
     acknowledgements: SourceAcknowledgementsConfig,
 
-    #[configurable(derived)]
     #[serde(default)]
     keepalive: KeepaliveConfig,
 

--- a/src/sources/demo_logs.rs
+++ b/src/sources/demo_logs.rs
@@ -62,12 +62,10 @@ pub struct DemoLogsConfig {
     ))]
     pub format: OutputFormat,
 
-    #[configurable(derived)]
     #[derivative(Default(value = "default_framing_message_based()"))]
     #[serde(default = "default_framing_message_based")]
     pub framing: FramingConfig,
 
-    #[configurable(derived)]
     #[derivative(Default(value = "default_decoding()"))]
     #[serde(default = "default_decoding")]
     pub decoding: DeserializerConfig,

--- a/src/sources/dnstap/tcp.rs
+++ b/src/sources/dnstap/tcp.rs
@@ -28,10 +28,8 @@ use crate::{
 #[configurable_component]
 #[derive(Clone, Debug)]
 pub struct TcpConfig {
-    #[configurable(derived)]
     address: SocketListenAddr,
 
-    #[configurable(derived)]
     keepalive: Option<TcpKeepaliveConfig>,
 
     /// The timeout before a connection is forcefully closed during shutdown.
@@ -50,10 +48,8 @@ pub struct TcpConfig {
     #[serde(default = "default_port_key")]
     pub port_key: OptionalValuePath,
 
-    #[configurable(derived)]
     permit_origin: Option<IpAllowlistConfig>,
 
-    #[configurable(derived)]
     tls: Option<TlsSourceConfig>,
 
     /// The size of the receive buffer used for each connection.

--- a/src/sources/docker_logs/mod.rs
+++ b/src/sources/docker_logs/mod.rs
@@ -165,10 +165,8 @@ pub struct DockerLogsConfig {
     /// Multiline aggregation configuration.
     ///
     /// If not specified, multiline aggregation is disabled.
-    #[configurable(derived)]
     multiline: Option<MultilineConfig>,
 
-    #[configurable(derived)]
     tls: Option<DockerTlsConfig>,
 
     /// The namespace to use for logs. This overrides the global setting.

--- a/src/sources/exec/mod.rs
+++ b/src/sources/exec/mod.rs
@@ -44,13 +44,10 @@ mod tests;
 #[derive(Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct ExecConfig {
-    #[configurable(derived)]
     pub mode: Mode,
 
-    #[configurable(derived)]
     pub scheduled: Option<ScheduledConfig>,
 
-    #[configurable(derived)]
     pub streaming: Option<StreamingConfig>,
 
     /// The command to run, plus any arguments required.
@@ -79,10 +76,8 @@ pub struct ExecConfig {
     #[serde(default = "default_maximum_buffer_size")]
     pub maximum_buffer_size_bytes: usize,
 
-    #[configurable(derived)]
     framing: Option<FramingConfig>,
 
-    #[configurable(derived)]
     #[serde(default = "default_decoding")]
     decoding: DeserializerConfig,
 

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -99,7 +99,6 @@ pub struct FileConfig {
     pub ignore_checkpoints: Option<bool>,
 
     #[serde(default = "default_read_from")]
-    #[configurable(derived)]
     pub read_from: ReadFromConfig,
 
     /// Ignore files with a data modification date older than the specified number of seconds.
@@ -162,7 +161,6 @@ pub struct FileConfig {
     #[configurable(metadata(docs::human_name = "Glob Minimum Cooldown"))]
     pub glob_minimum_cooldown_ms: Duration,
 
-    #[configurable(derived)]
     #[serde(alias = "fingerprinting", default)]
     fingerprint: FingerprintConfig,
 
@@ -187,7 +185,6 @@ pub struct FileConfig {
     /// Multiline aggregation configuration.
     ///
     /// If not specified, multiline aggregation is disabled.
-    #[configurable(derived)]
     #[serde(default)]
     pub multiline: Option<MultilineConfig>,
 
@@ -220,11 +217,9 @@ pub struct FileConfig {
     #[configurable(metadata(docs::examples = "\r\n"))]
     pub line_delimiter: String,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub encoding: Option<EncodingConfig>,
 
-    #[configurable(derived)]
     #[serde(default, deserialize_with = "bool_or_struct")]
     acknowledgements: SourceAcknowledgementsConfig,
 
@@ -233,7 +228,6 @@ pub struct FileConfig {
     #[serde(default)]
     log_namespace: Option<bool>,
 
-    #[configurable(derived)]
     #[serde(default)]
     internal_metrics: FileInternalMetricsConfig,
 

--- a/src/sources/file_descriptors/file_descriptor.rs
+++ b/src/sources/file_descriptors/file_descriptor.rs
@@ -34,10 +34,8 @@ pub struct FileDescriptorSourceConfig {
     /// By default, the [global `host_key` option](https://vector.dev/docs/reference/configuration//global-options#log_schema.host_key) is used.
     pub host_key: Option<OptionalValuePath>,
 
-    #[configurable(derived)]
     pub framing: Option<FramingConfig>,
 
-    #[configurable(derived)]
     #[serde(default = "default_decoding")]
     pub decoding: DeserializerConfig,
 

--- a/src/sources/file_descriptors/stdin.rs
+++ b/src/sources/file_descriptors/stdin.rs
@@ -33,10 +33,8 @@ pub struct StdinConfig {
     /// [global_host_key]: https://vector.dev/docs/reference/configuration/global-options/#log_schema.host_key
     pub host_key: Option<OptionalValuePath>,
 
-    #[configurable(derived)]
     pub framing: Option<FramingConfig>,
 
-    #[configurable(derived)]
     #[serde(default = "default_decoding")]
     pub decoding: DeserializerConfig,
 

--- a/src/sources/fluent/mod.rs
+++ b/src/sources/fluent/mod.rs
@@ -164,17 +164,14 @@ mod deser {
 #[derive(Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct FluentTcpConfig {
-    #[configurable(derived)]
     address: SocketListenAddr,
 
     /// The maximum number of TCP connections that are allowed at any given time.
     #[configurable(metadata(docs::type_unit = "connections"))]
     connection_limit: Option<u32>,
 
-    #[configurable(derived)]
     keepalive: Option<TcpKeepaliveConfig>,
 
-    #[configurable(derived)]
     pub permit_origin: Option<IpAllowlistConfig>,
 
     /// The size of the receive buffer used for each connection.
@@ -192,10 +189,8 @@ pub struct FluentTcpConfig {
     #[configurable(metadata(docs::type_unit = "seconds"))]
     tls_handshake_timeout_secs: Option<NonZeroU64>,
 
-    #[configurable(derived)]
     tls: Option<TlsSourceConfig>,
 
-    #[configurable(derived)]
     #[serde(default, deserialize_with = "bool_or_struct")]
     acknowledgements: SourceAcknowledgementsConfig,
 }

--- a/src/sources/gcp_pubsub.rs
+++ b/src/sources/gcp_pubsub.rs
@@ -146,7 +146,6 @@ pub struct PubsubConfig {
     #[serde(flatten)]
     pub auth: GcpAuthConfig,
 
-    #[configurable(derived)]
     pub tls: Option<TlsConfig>,
 
     /// The maximum number of concurrent stream connections to open at once.
@@ -210,17 +209,14 @@ pub struct PubsubConfig {
     #[serde(default)]
     pub log_namespace: Option<bool>,
 
-    #[configurable(derived)]
     #[serde(default = "default_framing_message_based")]
     #[derivative(Default(value = "default_framing_message_based()"))]
     pub framing: FramingConfig,
 
-    #[configurable(derived)]
     #[serde(default = "default_decoding")]
     #[derivative(Default(value = "default_decoding()"))]
     pub decoding: DeserializerConfig,
 
-    #[configurable(derived)]
     #[serde(default, deserialize_with = "bool_or_struct")]
     pub acknowledgements: SourceAcknowledgementsConfig,
 }

--- a/src/sources/heroku_logs.rs
+++ b/src/sources/heroku_logs.rs
@@ -69,21 +69,16 @@ pub struct LogplexConfig {
     #[configurable(metadata(docs::examples = "*"))]
     query_parameters: Vec<String>,
 
-    #[configurable(derived)]
     tls: Option<TlsEnableableConfig>,
 
-    #[configurable(derived)]
     auth: Option<HttpServerAuthConfig>,
 
-    #[configurable(derived)]
     #[serde(default = "default_framing_message_based")]
     framing: FramingConfig,
 
-    #[configurable(derived)]
     #[serde(default = "default_decoding")]
     decoding: DeserializerConfig,
 
-    #[configurable(derived)]
     #[serde(default, deserialize_with = "bool_or_struct")]
     acknowledgements: SourceAcknowledgementsConfig,
 
@@ -92,7 +87,6 @@ pub struct LogplexConfig {
     #[serde(default)]
     log_namespace: Option<bool>,
 
-    #[configurable(derived)]
     #[serde(default)]
     keepalive: KeepaliveConfig,
 }

--- a/src/sources/host_metrics/mod.rs
+++ b/src/sources/host_metrics/mod.rs
@@ -125,24 +125,19 @@ pub struct HostMetricsConfig {
     #[serde(default = "default_namespace")]
     pub namespace: Option<String>,
 
-    #[configurable(derived)]
     #[derivative(Default(value = "default_cgroups_config()"))]
     #[serde(default = "default_cgroups_config")]
     pub cgroups: Option<CGroupsConfig>,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub disk: disk::DiskConfig,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub filesystem: filesystem::FilesystemConfig,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub network: network::NetworkConfig,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub process: process::ProcessConfig,
 }

--- a/src/sources/http_client/client.rs
+++ b/src/sources/http_client/client.rs
@@ -91,12 +91,10 @@ pub struct HttpClientConfig {
     #[configurable(metadata(docs::examples = "query_examples()"))]
     pub query: QueryParameters,
 
-    #[configurable(derived)]
     #[serde(default = "default_decoding")]
     pub decoding: DeserializerConfig,
 
     /// Framing to use in the decoding.
-    #[configurable(derived)]
     #[serde(default = "default_framing_message_based")]
     pub framing: FramingConfig,
 
@@ -124,11 +122,9 @@ pub struct HttpClientConfig {
     pub body: Option<ParameterValue>,
 
     /// TLS configuration.
-    #[configurable(derived)]
     pub tls: Option<TlsConfig>,
 
     /// HTTP Authentication.
-    #[configurable(derived)]
     pub auth: Option<Auth>,
 
     /// The namespace to use for logs. This overrides the global setting.

--- a/src/sources/http_server.rs
+++ b/src/sources/http_server.rs
@@ -76,7 +76,6 @@ pub struct SimpleHttpConfig {
     /// When using the `custom` strategy, the VRL program may write `%field = value` to enrich
     /// authenticated events. These metadata fields are injected into the event body (legacy
     /// namespace) or under `http_server.<field>` in event metadata (Vector namespace).
-    #[configurable(derived)]
     auth: Option<HttpServerAuthConfig>,
 
     /// Whether or not to treat the configured `path` as an absolute path.
@@ -116,16 +115,12 @@ pub struct SimpleHttpConfig {
     #[serde(default = "default_http_response_code")]
     response_code: StatusCode,
 
-    #[configurable(derived)]
     tls: Option<TlsEnableableConfig>,
 
-    #[configurable(derived)]
     framing: Option<FramingConfig>,
 
-    #[configurable(derived)]
     decoding: Option<DeserializerConfig>,
 
-    #[configurable(derived)]
     #[serde(default, deserialize_with = "bool_or_struct")]
     acknowledgements: SourceAcknowledgementsConfig,
 
@@ -134,7 +129,6 @@ pub struct SimpleHttpConfig {
     #[serde(default)]
     log_namespace: Option<bool>,
 
-    #[configurable(derived)]
     #[serde(default)]
     keepalive: KeepaliveConfig,
 }

--- a/src/sources/internal_metrics.rs
+++ b/src/sources/internal_metrics.rs
@@ -35,7 +35,6 @@ pub struct InternalMetricsConfig {
     #[configurable(metadata(docs::human_name = "Scrape Interval"))]
     pub scrape_interval_secs: Duration,
 
-    #[configurable(derived)]
     pub tags: TagsConfig,
 
     /// Overrides the default namespace for the metrics emitted by the source.

--- a/src/sources/journald.rs
+++ b/src/sources/journald.rs
@@ -204,7 +204,6 @@ pub struct JournaldConfig {
     #[serde(default)]
     pub journal_namespace: Option<String>,
 
-    #[configurable(derived)]
     #[serde(default, deserialize_with = "bool_or_struct")]
     acknowledgements: SourceAcknowledgementsConfig,
 

--- a/src/sources/kafka.rs
+++ b/src/sources/kafka.rs
@@ -230,22 +230,18 @@ pub struct KafkaSourceConfig {
     /// transparently by the underlying client library and does not require this option.
     ///
     /// Payloads are decompressed before `framing` and `decoding` are applied.
-    #[configurable(derived)]
     #[configurable(metadata(docs::advanced))]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     decompression: Option<DecompressionConfig>,
 
-    #[configurable(derived)]
     #[serde(default = "default_framing_message_based")]
     #[derivative(Default(value = "default_framing_message_based()"))]
     framing: FramingConfig,
 
-    #[configurable(derived)]
     #[serde(default = "default_decoding")]
     #[derivative(Default(value = "default_decoding()"))]
     decoding: DeserializerConfig,
 
-    #[configurable(derived)]
     #[serde(default, deserialize_with = "bool_or_struct")]
     acknowledgements: SourceAcknowledgementsConfig,
 
@@ -254,7 +250,6 @@ pub struct KafkaSourceConfig {
     #[serde(default)]
     log_namespace: Option<bool>,
 
-    #[configurable(derived)]
     #[serde(default)]
     metrics: Metrics,
 }

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -156,14 +156,11 @@ pub struct Config {
     #[configurable(metadata(docs::human_name = "Data Directory"))]
     data_dir: Option<PathBuf>,
 
-    #[configurable(derived)]
     #[serde(alias = "annotation_fields")]
     pod_annotation_fields: pod_metadata_annotator::FieldsSpec,
 
-    #[configurable(derived)]
     namespace_annotation_fields: namespace_metadata_annotator::FieldsSpec,
 
-    #[configurable(derived)]
     node_annotation_fields: node_metadata_annotator::FieldsSpec,
 
     /// A list of glob patterns to include while reading the files.
@@ -174,7 +171,6 @@ pub struct Config {
     #[configurable(metadata(docs::examples = "**/exclude/**"))]
     exclude_paths_glob_patterns: Vec<PathBuf>,
 
-    #[configurable(derived)]
     #[serde(default = "default_read_from")]
     read_from: ReadFromConfig,
 
@@ -231,7 +227,6 @@ pub struct Config {
     ///
     /// This option has no effect if `max_merged_line_bytes` is not set.
     #[serde(default)]
-    #[configurable(derived)]
     max_merged_line_action: OversizedAction,
 
     /// The number of lines to read for generating the checksum.
@@ -289,7 +284,6 @@ pub struct Config {
     #[serde(default)]
     log_namespace: Option<bool>,
 
-    #[configurable(derived)]
     #[serde(default)]
     internal_metrics: FileInternalMetricsConfig,
 

--- a/src/sources/logstash.rs
+++ b/src/sources/logstash.rs
@@ -41,16 +41,12 @@ use crate::{
 #[configurable_component(source("logstash", "Collect logs from a Logstash agent."))]
 #[derive(Clone, Debug)]
 pub struct LogstashConfig {
-    #[configurable(derived)]
     address: SocketListenAddr,
 
-    #[configurable(derived)]
     keepalive: Option<TcpKeepaliveConfig>,
 
-    #[configurable(derived)]
     pub permit_origin: Option<IpAllowlistConfig>,
 
-    #[configurable(derived)]
     tls: Option<TlsSourceConfig>,
 
     /// The size of the receive buffer used for each connection.
@@ -70,7 +66,6 @@ pub struct LogstashConfig {
     #[configurable(metadata(docs::type_unit = "seconds"))]
     tls_handshake_timeout_secs: Option<NonZeroU64>,
 
-    #[configurable(derived)]
     #[serde(default, deserialize_with = "bool_or_struct")]
     acknowledgements: SourceAcknowledgementsConfig,
 

--- a/src/sources/mqtt/config.rs
+++ b/src/sources/mqtt/config.rs
@@ -33,17 +33,14 @@ pub struct MqttSourceConfig {
     pub common: MqttCommonConfig,
 
     /// MQTT topic or topics from which messages are to be read.
-    #[configurable(derived)]
     #[serde(default = "default_topic")]
     #[derivative(Default(value = "default_topic()"))]
     pub topic: OneOrMany<String>,
 
-    #[configurable(derived)]
     #[serde(default = "default_framing_message_based")]
     #[derivative(Default(value = "default_framing_message_based()"))]
     pub framing: FramingConfig,
 
-    #[configurable(derived)]
     #[serde(default = "default_decoding")]
     #[derivative(Default(value = "default_decoding()"))]
     pub decoding: DeserializerConfig,

--- a/src/sources/nats/config.rs
+++ b/src/sources/nats/config.rs
@@ -87,7 +87,6 @@ pub struct JetStreamConfig {
     pub consumer: String,
 
     #[serde(default)]
-    #[configurable(derived)]
     pub batch_config: BatchConfig,
 }
 
@@ -136,18 +135,14 @@ pub struct NatsSourceConfig {
     #[serde(default)]
     pub log_namespace: Option<bool>,
 
-    #[configurable(derived)]
     pub tls: Option<TlsEnableableConfig>,
 
-    #[configurable(derived)]
     pub auth: Option<NatsAuthConfig>,
 
-    #[configurable(derived)]
     #[serde(default = "default_framing_message_based")]
     #[derivative(Default(value = "default_framing_message_based()"))]
     pub framing: FramingConfig,
 
-    #[configurable(derived)]
     #[serde(default = "default_decoding")]
     #[derivative(Default(value = "default_decoding()"))]
     pub decoding: DeserializerConfig,
@@ -168,7 +163,6 @@ pub struct NatsSourceConfig {
     #[derivative(Default(value = "default_subscription_capacity()"))]
     pub subscriber_capacity: usize,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub jetstream: Option<JetStreamConfig>,
 }

--- a/src/sources/nginx_metrics/mod.rs
+++ b/src/sources/nginx_metrics/mod.rs
@@ -85,10 +85,8 @@ pub struct NginxMetricsConfig {
     #[serde(default = "default_namespace")]
     namespace: String,
 
-    #[configurable(derived)]
     tls: Option<TlsConfig>,
 
-    #[configurable(derived)]
     auth: Option<Auth>,
 }
 

--- a/src/sources/okta/client.rs
+++ b/src/sources/okta/client.rs
@@ -74,7 +74,6 @@ pub struct OktaConfig {
     pub since: Option<u64>,
 
     /// TLS configuration.
-    #[configurable(derived)]
     pub tls: Option<TlsConfig>,
 
     /// The namespace to use for logs. This overrides the global setting.

--- a/src/sources/opentelemetry/config.rs
+++ b/src/sources/opentelemetry/config.rs
@@ -114,13 +114,10 @@ impl OtlpDecodingConfig {
 #[derive(Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct OpentelemetryConfig {
-    #[configurable(derived)]
     pub grpc: GrpcConfig,
 
-    #[configurable(derived)]
     pub http: HttpConfig,
 
-    #[configurable(derived)]
     #[serde(default, deserialize_with = "bool_or_struct")]
     pub acknowledgements: SourceAcknowledgementsConfig,
 
@@ -173,11 +170,9 @@ pub struct GrpcConfig {
     #[configurable(metadata(docs::examples = "0.0.0.0:4317", docs::examples = "localhost:4317"))]
     pub address: SocketAddr,
 
-    #[configurable(derived)]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tls: Option<TlsEnableableConfig>,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub keepalive: GrpcKeepaliveConfig,
 }
@@ -202,11 +197,9 @@ pub struct HttpConfig {
     #[configurable(metadata(docs::examples = "0.0.0.0:4318", docs::examples = "localhost:4318"))]
     pub address: SocketAddr,
 
-    #[configurable(derived)]
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tls: Option<TlsEnableableConfig>,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub keepalive: KeepaliveConfig,
 

--- a/src/sources/postgresql_metrics.rs
+++ b/src/sources/postgresql_metrics.rs
@@ -167,7 +167,6 @@ pub struct PostgresqlMetricsConfig {
     #[serde(default = "default_namespace")]
     namespace: String,
 
-    #[configurable(derived)]
     tls: Option<PostgresqlMetricsTlsConfig>,
 }
 

--- a/src/sources/prometheus/pushgateway.rs
+++ b/src/sources/prometheus/pushgateway.rs
@@ -48,17 +48,13 @@ pub struct PrometheusPushgatewayConfig {
     #[configurable(metadata(docs::examples = "0.0.0.0:9091"))]
     address: SocketAddr,
 
-    #[configurable(derived)]
     tls: Option<TlsEnableableConfig>,
 
-    #[configurable(derived)]
     auth: Option<HttpServerAuthConfig>,
 
-    #[configurable(derived)]
     #[serde(default, deserialize_with = "bool_or_struct")]
     acknowledgements: SourceAcknowledgementsConfig,
 
-    #[configurable(derived)]
     #[serde(default)]
     keepalive: KeepaliveConfig,
 

--- a/src/sources/prometheus/remote_write.rs
+++ b/src/sources/prometheus/remote_write.rs
@@ -56,21 +56,17 @@ pub struct PrometheusRemoteWriteConfig {
     #[configurable(metadata(docs::examples = "/remote-write"))]
     path: String,
 
-    #[configurable(derived)]
     tls: Option<TlsEnableableConfig>,
 
-    #[configurable(derived)]
     auth: Option<HttpServerAuthConfig>,
 
     /// Defines the behavior for handling conflicting metric metadata.
     #[serde(default)]
     metadata_conflict_strategy: MetadataConflictStrategy,
 
-    #[configurable(derived)]
     #[serde(default, deserialize_with = "bool_or_struct")]
     acknowledgements: SourceAcknowledgementsConfig,
 
-    #[configurable(derived)]
     #[serde(default)]
     keepalive: KeepaliveConfig,
 

--- a/src/sources/prometheus/scrape.rs
+++ b/src/sources/prometheus/scrape.rs
@@ -92,10 +92,8 @@ pub struct PrometheusScrapeConfig {
     #[configurable(metadata(docs::examples = "query_example()"))]
     query: QueryParameters,
 
-    #[configurable(derived)]
     tls: Option<TlsConfig>,
 
-    #[configurable(derived)]
     auth: Option<Auth>,
 }
 

--- a/src/sources/pulsar.rs
+++ b/src/sources/pulsar.rs
@@ -75,23 +75,18 @@ pub struct PulsarSourceConfig {
     /// Max count of messages in a batch.
     batch_size: Option<u32>,
 
-    #[configurable(derived)]
     auth: Option<AuthConfig>,
 
-    #[configurable(derived)]
     dead_letter_queue_policy: Option<DeadLetterQueuePolicy>,
 
-    #[configurable(derived)]
     #[serde(default = "default_framing_message_based")]
     #[derivative(Default(value = "default_framing_message_based()"))]
     framing: FramingConfig,
 
-    #[configurable(derived)]
     #[serde(default = "default_decoding")]
     #[derivative(Default(value = "default_decoding()"))]
     decoding: DeserializerConfig,
 
-    #[configurable(derived)]
     #[serde(default, deserialize_with = "bool_or_struct")]
     acknowledgements: SourceAcknowledgementsConfig,
 
@@ -100,7 +95,6 @@ pub struct PulsarSourceConfig {
     #[serde(default)]
     log_namespace: Option<bool>,
 
-    #[configurable(derived)]
     #[serde(default)]
     tls: Option<TlsOptions>,
 }
@@ -130,10 +124,7 @@ enum AuthConfig {
     },
 
     /// OAuth authentication.
-    OAuth {
-        #[configurable(derived)]
-        oauth2: OAuth2Config,
-    },
+    OAuth { oauth2: OAuth2Config },
 }
 
 /// OAuth2-specific authentication configuration.

--- a/src/sources/redis/mod.rs
+++ b/src/sources/redis/mod.rs
@@ -53,7 +53,6 @@ pub enum DataTypeConfig {
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
 #[serde(deny_unknown_fields, rename_all = "lowercase")]
 pub struct ListOption {
-    #[configurable(derived)]
     method: Method,
 }
 
@@ -96,7 +95,6 @@ pub struct RedisSourceConfig {
     #[serde(default)]
     data_type: DataTypeConfig,
 
-    #[configurable(derived)]
     list: Option<ListOption>,
 
     /// The Redis URL to connect to.
@@ -117,12 +115,10 @@ pub struct RedisSourceConfig {
     #[configurable(metadata(docs::examples = "redis_key"))]
     redis_key: Option<OptionalValuePath>,
 
-    #[configurable(derived)]
     #[serde(default = "default_framing_message_based")]
     #[derivative(Default(value = "default_framing_message_based()"))]
     framing: FramingConfig,
 
-    #[configurable(derived)]
     #[serde(default = "default_decoding")]
     #[derivative(Default(value = "default_decoding()"))]
     decoding: DeserializerConfig,

--- a/src/sources/socket/tcp.rs
+++ b/src/sources/socket/tcp.rs
@@ -26,10 +26,8 @@ use crate::{
 #[configurable_component]
 #[derive(Clone, Debug)]
 pub struct TcpConfig {
-    #[configurable(derived)]
     address: SocketListenAddr,
 
-    #[configurable(derived)]
     keepalive: Option<TcpKeepaliveConfig>,
 
     /// The timeout before a connection is forcefully closed during shutdown.
@@ -59,10 +57,8 @@ pub struct TcpConfig {
     #[serde(default = "default_port_key")]
     port_key: OptionalValuePath,
 
-    #[configurable(derived)]
     pub permit_origin: Option<IpAllowlistConfig>,
 
-    #[configurable(derived)]
     tls: Option<TlsSourceConfig>,
 
     /// The size of the receive buffer used for each connection.
@@ -87,10 +83,8 @@ pub struct TcpConfig {
     #[configurable(metadata(docs::type_unit = "connections"))]
     pub connection_limit: Option<u32>,
 
-    #[configurable(derived)]
     pub(super) framing: Option<FramingConfig>,
 
-    #[configurable(derived)]
     #[serde(default = "default_decoding")]
     pub(super) decoding: DeserializerConfig,
 

--- a/src/sources/socket/udp.rs
+++ b/src/sources/socket/udp.rs
@@ -40,7 +40,6 @@ use crate::{
 #[serde(deny_unknown_fields)]
 #[derive(Clone, Debug)]
 pub struct UdpConfig {
-    #[configurable(derived)]
     address: SocketListenAddr,
 
     /// List of IPv4 multicast groups to join on socket's binding process.
@@ -106,10 +105,8 @@ pub struct UdpConfig {
     #[configurable(metadata(docs::type_unit = "bytes"))]
     receive_buffer_bytes: Option<usize>,
 
-    #[configurable(derived)]
     pub(super) framing: Option<FramingConfig>,
 
-    #[configurable(derived)]
     #[serde(default = "default_decoding")]
     pub(super) decoding: DeserializerConfig,
 

--- a/src/sources/socket/unix.rs
+++ b/src/sources/socket/unix.rs
@@ -54,11 +54,9 @@ pub struct UnixConfig {
     #[serde(default = "default_host_key")]
     pub host_key: OptionalValuePath,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub framing: Option<FramingConfig>,
 
-    #[configurable(derived)]
     #[serde(default = "default_decoding")]
     pub decoding: DeserializerConfig,
 

--- a/src/sources/splunk_hec/mod.rs
+++ b/src/sources/splunk_hec/mod.rs
@@ -122,10 +122,8 @@ pub struct SplunkConfig {
     /// event metadata and preferentially used if the event is sent to a Splunk HEC sink.
     store_hec_token: bool,
 
-    #[configurable(derived)]
     tls: Option<TlsEnableableConfig>,
 
-    #[configurable(derived)]
     #[serde(deserialize_with = "bool_or_struct")]
     acknowledgements: HecAcknowledgementsConfig,
 
@@ -134,7 +132,6 @@ pub struct SplunkConfig {
     #[serde(default)]
     log_namespace: Option<bool>,
 
-    #[configurable(derived)]
     #[serde(default)]
     keepalive: KeepaliveConfig,
 
@@ -148,7 +145,6 @@ pub struct SplunkConfig {
     /// The VRL codec can access HEC envelope metadata, such as host, sourcetype, and,
     /// channel, and the authentication token via `%splunk_hec.*` paths and
     /// `get_secret!("splunk_hec_token")` before the program executes.
-    #[configurable(derived)]
     #[serde(default)]
     pub event: CodecConfig,
 
@@ -158,7 +154,6 @@ pub struct SplunkConfig {
     /// codec instead of being emitted as a single event. Decode failures are
     /// swallowed and do not return an error to the Splunk client. When unset, the
     /// endpoint preserves its existing behavior of one event per request body.
-    #[configurable(derived)]
     #[serde(default)]
     pub raw: CodecConfig,
 }
@@ -172,7 +167,6 @@ pub struct CodecConfig {
     ///
     /// Only used when `decoding` is also set. Defaults to a per-codec choice
     /// (typically `bytes`) that produces one event per payload.
-    #[configurable(derived)]
     #[serde(default)]
     pub framing: Option<FramingConfig>,
 
@@ -182,7 +176,6 @@ pub struct CodecConfig {
     /// behavior. When set, the endpoint-selected payload is processed through
     /// `framing` and `decoding`, and a single payload can fan out to multiple
     /// events.
-    #[configurable(derived)]
     #[serde(default)]
     pub decoding: Option<DeserializerConfig>,
 }

--- a/src/sources/static_metrics.rs
+++ b/src/sources/static_metrics.rs
@@ -42,7 +42,6 @@ pub struct StaticMetricsConfig {
     #[serde(default = "default_namespace")]
     pub namespace: String,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub metrics: Vec<StaticMetricConfig>,
 }

--- a/src/sources/statsd/mod.rs
+++ b/src/sources/statsd/mod.rs
@@ -82,18 +82,15 @@ pub enum ConversionUnit {
 #[configurable_component]
 #[derive(Clone, Debug)]
 pub struct UdpConfig {
-    #[configurable(derived)]
     address: SocketListenAddr,
 
     /// The size of the receive buffer used for each connection.
     receive_buffer_bytes: Option<usize>,
 
     #[serde(default = "default_sanitize")]
-    #[configurable(derived)]
     sanitize: bool,
 
     #[serde(default = "default_convert_to")]
-    #[configurable(derived)]
     convert_to: ConversionUnit,
 }
 
@@ -113,16 +110,12 @@ impl UdpConfig {
 #[configurable_component]
 #[derive(Clone, Debug)]
 pub struct TcpConfig {
-    #[configurable(derived)]
     address: SocketListenAddr,
 
-    #[configurable(derived)]
     keepalive: Option<TcpKeepaliveConfig>,
 
-    #[configurable(derived)]
     pub permit_origin: Option<IpAllowlistConfig>,
 
-    #[configurable(derived)]
     #[serde(default)]
     tls: Option<TlsSourceConfig>,
 
@@ -153,11 +146,9 @@ pub struct TcpConfig {
     /// - All whitespace is replaced with "_"
     /// - All non alphanumeric characters (A-Z, a-z, 0-9, _, or -) are removed.
     #[serde(default = "default_sanitize")]
-    #[configurable(derived)]
     sanitize: bool,
 
     #[serde(default = "default_convert_to")]
-    #[configurable(derived)]
     convert_to: ConversionUnit,
 }
 

--- a/src/sources/statsd/unix.rs
+++ b/src/sources/statsd/unix.rs
@@ -27,11 +27,9 @@ pub struct UnixConfig {
     pub path: PathBuf,
 
     #[serde(default = "default_sanitize")]
-    #[configurable(derived)]
     pub sanitize: bool,
 
     #[serde(default = "default_convert_to")]
-    #[configurable(derived)]
     pub convert_to: ConversionUnit,
 }
 

--- a/src/sources/syslog.rs
+++ b/src/sources/syslog.rs
@@ -80,16 +80,12 @@ pub struct SyslogConfig {
 pub enum Mode {
     /// Listen on TCP.
     Tcp {
-        #[configurable(derived)]
         address: SocketListenAddr,
 
-        #[configurable(derived)]
         keepalive: Option<TcpKeepaliveConfig>,
 
-        #[configurable(derived)]
         permit_origin: Option<IpAllowlistConfig>,
 
-        #[configurable(derived)]
         tls: Option<TlsSourceConfig>,
 
         /// The size of the receive buffer used for each connection.
@@ -112,7 +108,6 @@ pub enum Mode {
 
     /// Listen on UDP.
     Udp {
-        #[configurable(derived)]
         address: SocketListenAddr,
 
         /// The size of the receive buffer used for the listening socket.

--- a/src/sources/util/multiline_config.rs
+++ b/src/sources/util/multiline_config.rs
@@ -32,7 +32,6 @@ pub struct MultilineConfig {
     /// Aggregation mode.
     ///
     /// This setting must be configured in conjunction with `condition_pattern`.
-    #[configurable(derived)]
     pub mode: line_agg::Mode,
 
     /// The maximum amount of time to wait for the next additional line, in milliseconds.

--- a/src/sources/vector/mod.rs
+++ b/src/sources/vector/mod.rs
@@ -133,15 +133,12 @@ pub struct VectorConfig {
     /// It _must_ include a port.
     pub address: SocketAddr,
 
-    #[configurable(derived)]
     #[serde(default)]
     tls: Option<TlsEnableableConfig>,
 
-    #[configurable(derived)]
     #[serde(default, deserialize_with = "bool_or_struct")]
     acknowledgements: SourceAcknowledgementsConfig,
 
-    #[configurable(derived)]
     #[serde(default)]
     keepalive: GrpcKeepaliveConfig,
 

--- a/src/sources/websocket/config.rs
+++ b/src/sources/websocket/config.rs
@@ -82,12 +82,10 @@ pub struct WebSocketConfig {
     pub common: WebSocketCommonConfig,
 
     /// Decoder to use on each received message.
-    #[configurable(derived)]
     #[serde(default = "default_decoding")]
     pub decoding: DeserializerConfig,
 
     /// Framing to use in the decoding.
-    #[configurable(derived)]
     #[serde(default = "default_framing_message_based")]
     pub framing: FramingConfig,
 

--- a/src/sources/windows_event_log/config.rs
+++ b/src/sources/windows_event_log/config.rs
@@ -193,7 +193,6 @@ pub struct WindowsEventLogConfig {
     /// When disabled (default), checkpoints are updated immediately after reading
     /// events, which may result in data loss if Vector crashes before events are
     /// delivered to sinks.
-    #[configurable(derived)]
     #[serde(default, deserialize_with = "bool_or_struct")]
     pub acknowledgements: SourceAcknowledgementsConfig,
 }

--- a/src/test_util/mock/transforms/noop.rs
+++ b/src/test_util/mock/transforms/noop.rs
@@ -17,7 +17,6 @@ use crate::config::{GenerateConfig, OutputId, TransformConfig, TransformContext}
 #[configurable_component(transform("test_noop", "Test (no-op)"))]
 #[derive(Clone, Debug)]
 pub struct NoopTransformConfig {
-    #[configurable(derived)]
     transform_type: TransformType,
 
     /// Optional per-event/array delay, in milliseconds.

--- a/src/transforms/aggregate/config.rs
+++ b/src/transforms/aggregate/config.rs
@@ -24,7 +24,6 @@ pub struct AggregateConfig {
     ///
     /// Some of the functions may only function on incremental and some only on absolute metrics.
     #[serde(default = "default_mode")]
-    #[configurable(derived)]
     pub mode: AggregationMode,
 }
 

--- a/src/transforms/aws_ec2_metadata.rs
+++ b/src/transforms/aws_ec2_metadata.rs
@@ -133,7 +133,6 @@ pub struct Ec2Metadata {
     #[derivative(Default(value = "default_refresh_timeout_secs()"))]
     refresh_timeout_secs: Duration,
 
-    #[configurable(derived)]
     #[serde(default, skip_serializing_if = "crate::serde::is_default")]
     proxy: ProxyConfig,
 

--- a/src/transforms/dedupe/config.rs
+++ b/src/transforms/dedupe/config.rs
@@ -22,15 +22,12 @@ use crate::{
 #[derive(Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct DedupeConfig {
-    #[configurable(derived)]
     #[serde(default)]
     pub fields: Option<FieldMatchConfig>,
 
-    #[configurable(derived)]
     #[serde(default = "default_cache_config")]
     pub cache: CacheConfig,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub time_settings: Option<TimedCacheConfig>,
 }

--- a/src/transforms/filter.rs
+++ b/src/transforms/filter.rs
@@ -21,7 +21,6 @@ use crate::{
 #[derive(Clone, Debug)]
 #[serde(deny_unknown_fields)]
 pub struct FilterConfig {
-    #[configurable(derived)]
     /// The condition that every input event is matched against.
     ///
     /// If an event is matched by the condition, it is forwarded. Otherwise, the event is dropped.

--- a/src/transforms/incremental_to_absolute.rs
+++ b/src/transforms/incremental_to_absolute.rs
@@ -24,7 +24,6 @@ pub struct IncrementalToAbsoluteConfig {
     ///
     /// By default, incremental metrics are evicted after 5 minutes of not being updated. The next
     /// incremental value will be reset.
-    #[configurable(derived)]
     #[serde(default)]
     pub cache: NormalizerConfig<IncrementalToAbsoluteDefaultNormalizerSettings>,
 }

--- a/src/transforms/log_to_metric.rs
+++ b/src/transforms/log_to_metric.rs
@@ -84,7 +84,6 @@ pub struct CounterConfig {
     #[serde(default = "default_increment_by_value")]
     pub increment_by_value: bool,
 
-    #[configurable(derived)]
     #[serde(default = "default_kind")]
     pub kind: MetricKind,
 }
@@ -116,7 +115,6 @@ pub struct MetricConfig {
     #[configurable(metadata(docs::additional_props_description = "A metric tag."))]
     pub tags: Option<IndexMap<UnconfinedTemplate, TagConfig>>,
 
-    #[configurable(derived)]
     #[serde(flatten)]
     pub metric: MetricTypeConfig,
 }

--- a/src/transforms/lua/v2/mod.rs
+++ b/src/transforms/lua/v2/mod.rs
@@ -94,7 +94,6 @@ pub struct LuaConfig {
     #[configurable(metadata(docs::human_name = "Search Directories"))]
     search_dirs: Vec<PathBuf>,
 
-    #[configurable(derived)]
     hooks: HooksConfig,
 
     /// A list of timers which should be configured and executed periodically.

--- a/src/transforms/remap.rs
+++ b/src/transforms/remap.rs
@@ -154,11 +154,11 @@ pub struct RemapConfig {
     #[configurable(metadata(docs::human_name = "Reroute Dropped Events"))]
     pub reroute_dropped: bool,
 
-    #[configurable(derived, metadata(docs::hidden))]
+    #[configurable(metadata(docs::hidden))]
     #[serde(default)]
     pub runtime: VrlRuntime,
 
-    #[configurable(derived, metadata(docs::hidden))]
+    #[configurable(metadata(docs::hidden))]
     #[serde(skip)]
     #[derivative(Debug = "ignore")]
     /// Cache can't be `BTreeMap` or `HashMap` because of `TableRegistry`, which doesn't allow us to inspect tables inside it.

--- a/src/transforms/tag_cardinality_limit/config.rs
+++ b/src/transforms/tag_cardinality_limit/config.rs
@@ -25,7 +25,6 @@ pub struct Config {
     pub global: Inner,
 
     /// Controls how tag tracking state is partitioned across metrics.
-    #[configurable(derived)]
     #[serde(default)]
     pub tracking_scope: TrackingScope,
 
@@ -39,15 +38,13 @@ pub struct Config {
     /// When unset (default), there is no cap and the transform tracks all pairs it
     /// encounters. In `global` tracking scope mode, this limit still applies (the
     /// metric key is set to `None` unless there is a per-metric override).
-    #[configurable(derived)]
     #[serde(default)]
     pub max_tracked_keys: Option<usize>,
 
     /// Tag cardinality limits configuration per metric name.
-    #[configurable(
-        derived,
-        metadata(docs::additional_props_description = "An individual metric configuration.")
-    )]
+    #[configurable(metadata(
+        docs::additional_props_description = "An individual metric configuration."
+    ))]
     #[serde(default)]
     pub per_metric_limits: HashMap<String, PerMetricConfig>,
 
@@ -57,10 +54,9 @@ pub struct Config {
     ///
     /// See the "Per-tag overrides" section under "How it works" for a worked example
     /// and the precedence rules.
-    #[configurable(
-        derived,
-        metadata(docs::additional_props_description = "An individual tag configuration.")
-    )]
+    #[configurable(metadata(
+        docs::additional_props_description = "An individual tag configuration."
+    ))]
     #[serde(default)]
     pub per_tag_limits: HashMap<String, PerTagConfig>,
 }
@@ -89,14 +85,12 @@ pub struct Inner {
     #[serde(default = "default_value_limit")]
     pub value_limit: usize,
 
-    #[configurable(derived)]
     #[serde(default = "default_limit_exceeded_action")]
     pub limit_exceeded_action: LimitExceededAction,
 
     #[serde(flatten)]
     pub mode: Mode,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub internal_metrics: InternalMetricsConfig,
 }
@@ -147,10 +141,9 @@ pub struct PerMetricConfig {
     /// are inherited from the enclosing per-metric configuration, except
     /// `cache_size_per_key`, which can be overridden per tag in probabilistic mode.
     /// Tags not listed here use the per-metric configuration.
-    #[configurable(
-        derived,
-        metadata(docs::additional_props_description = "An individual tag configuration.")
-    )]
+    #[configurable(metadata(
+        docs::additional_props_description = "An individual tag configuration."
+    ))]
     #[serde(default)]
     pub per_tag_limits: HashMap<String, PerTagConfig>,
 
@@ -168,14 +161,12 @@ pub struct OverrideInner {
     #[serde(default = "default_value_limit")]
     pub value_limit: usize,
 
-    #[configurable(derived)]
     #[serde(default = "default_limit_exceeded_action")]
     pub limit_exceeded_action: LimitExceededAction,
 
     #[serde(flatten)]
     pub mode: OverrideMode,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub internal_metrics: InternalMetricsConfig,
 }
@@ -235,7 +226,6 @@ impl OverrideMode {
 #[configurable_component]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct PerTagConfig {
-    #[configurable(derived)]
     #[serde(flatten)]
     pub mode: PerTagMode,
 }

--- a/src/transforms/throttle/config.rs
+++ b/src/transforms/throttle/config.rs
@@ -57,7 +57,6 @@ pub struct ThrottleConfig {
     /// A logical condition used to exclude events from sampling.
     pub exclude: Option<AnyCondition>,
 
-    #[configurable(derived)]
     #[serde(default)]
     pub internal_metrics: ThrottleInternalMetricsConfig,
 }


### PR DESCRIPTION
## Summary

### Motivation

`#[configurable(derived)]` only bypassed the macro-time field-description check. It was not emitted into metadata or consulted during schema generation, which already falls back to the field type's documentation.

### Changes

- remove the field-description compile-time requirement and the `derived` macro option
- remove all `derived` annotations from configuration fields
- simplify the now-unused virtual-newtype parsing plumbing

## Vector configuration

Not applicable. The generated schema and component documentation remain unchanged.

## How did you test this PR?

- generated component documentation from clean `master` and this branch; tracked output is identical
- normalized generated configuration schemas from clean `master` and this branch are identical
- `cargo test -p vector-config` (56 passed)
- `cargo fmt --all`

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment in the `changelog.d` directory.
- [x] No. A changelog fragment is not required.
