### PR TITLE
chore(dev): add no-default-features Clippy target

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,9 +51,7 @@ reduction and improved data quality for observability infrastructure.
 When working on Vector's Rust codebase, follow this iterative development cycle:
 
 1. Make code changes
-2. Run `FEATURES="<features>" make check-clippy-no-default-features` to check the same
-   focused feature set used by the relevant tests. Use `make check-clippy` when a full
-   all-feature Clippy run is required.
+2. Run the appropriate Clippy command described under Rust Development below.
 3. Fix any issues found (use `make clippy-fix` for auto-fixes)
 4. Continue to next task or mark current task complete
 
@@ -79,14 +77,10 @@ times.
 
 If `cargo vdev run <config>` fails, fall back to `cargo run -- --config <config>`.
 
-For focused Clippy iteration, reuse the feature set selected for the relevant tests:
-
-```bash
-FEATURES="sources-file" make check-clippy-no-default-features
-```
-
-`FEATURES` is required for this target. It runs Clippy for the workspace and all targets with
-default features disabled; `make check-clippy` remains the full validation command.
+When a relevant test command explicitly sets `FEATURES`, run
+`make check-clippy-no-default-features` with that exact value. If a representative configuration
+exists, derive its features with `cargo vdev features <config>`. Do not infer features from file
+names; when no authoritative feature set is available, use `make check-clippy`.
 
 #### Running tests
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,9 @@ reduction and improved data quality for observability infrastructure.
 When working on Vector's Rust codebase, follow this iterative development cycle:
 
 1. Make code changes
-2. Run `make check-clippy` to check for linting issues
+2. Run `FEATURES="<features>" make check-clippy-no-default-features` to check the same
+   focused feature set used by the relevant tests. Use `make check-clippy` when a full
+   all-feature Clippy run is required.
 3. Fix any issues found (use `make clippy-fix` for auto-fixes)
 4. Continue to next task or mark current task complete
 
@@ -76,6 +78,15 @@ automatically selects the minimum set of features required by the configuration,
 times.
 
 If `cargo vdev run <config>` fails, fall back to `cargo run -- --config <config>`.
+
+For focused Clippy iteration, reuse the feature set selected for the relevant tests:
+
+```bash
+FEATURES="sources-file" make check-clippy-no-default-features
+```
+
+`FEATURES` is required for this target. It runs Clippy for the workspace and all targets with
+default features disabled; `make check-clippy` remains the full validation command.
 
 #### Running tests
 

--- a/Makefile
+++ b/Makefile
@@ -392,6 +392,8 @@ check-clippy: ## Check code with Clippy
 
 .PHONY: check-clippy-no-default-features
 check-clippy-no-default-features: ## Check code with Clippy using only FEATURES
+	@test -n "$(strip $(FEATURES))" || \
+		{ echo "FEATURES is required" >&2; exit 2; }
 	$(VDEV) check rust --no-default-features
 
 .PHONY: check-docs

--- a/Makefile
+++ b/Makefile
@@ -392,8 +392,7 @@ check-clippy: ## Check code with Clippy
 
 .PHONY: check-clippy-no-default-features
 check-clippy-no-default-features: ## Check code with Clippy using only FEATURES
-	cargo clippy --locked --workspace --all-targets \
-		--no-default-features --features "${FEATURES}"
+	$(VDEV) check rust --no-default-features
 
 .PHONY: check-docs
 check-docs: generate-vrl-docs ## Check that all /docs file are valid - vrl docs due to remap.functions.* references

--- a/Makefile
+++ b/Makefile
@@ -393,7 +393,7 @@ check-clippy: ## Check code with Clippy
 .PHONY: check-clippy-no-default-features
 check-clippy-no-default-features: ## Check code with Clippy using only FEATURES
 	cargo clippy --locked --workspace --all-targets \
-		--no-default-features --features ${FEATURES}
+		--no-default-features --features "${FEATURES}"
 
 .PHONY: check-docs
 check-docs: generate-vrl-docs ## Check that all /docs file are valid - vrl docs due to remap.functions.* references

--- a/Makefile
+++ b/Makefile
@@ -390,6 +390,11 @@ check-component-features: ## Check that all component features are setup properl
 check-clippy: ## Check code with Clippy
 	$(VDEV) check rust
 
+.PHONY: check-clippy-no-default-features
+check-clippy-no-default-features: ## Check code with Clippy using only FEATURES
+	cargo clippy --locked --workspace --all-targets \
+		--no-default-features --features ${FEATURES}
+
 .PHONY: check-docs
 check-docs: generate-vrl-docs ## Check that all /docs file are valid - vrl docs due to remap.functions.* references
 	$(VDEV) check docs


### PR DESCRIPTION
## Summary

### Motivation

The existing `make check-clippy` target checks the entire workspace with all features, which is unnecessarily expensive when iterating on a deliberately selected feature set.

### Changes

- Add `make check-clippy-no-default-features`.
- Delegate to the existing `vdev` Clippy wrapper with `--no-default-features`, retaining its workspace, all-target, and Cargo lock consistency checks.
- Document focused Clippy iteration in `AGENTS.md` using the same feature set as the relevant tests.
- Keep the existing full `make check-clippy` behavior unchanged.

### References

N/A

## Vector configuration

N/A

## How did you test this PR?

- `FEATURES= make check-clippy-no-default-features` (exits with status 2 before Clippy)
- `make -n FEATURES='sources-file transforms-remap' check-clippy-no-default-features`
- `FEATURES='sources-file transforms-remap' cargo vdev check rust --help`
- `cargo fmt --all -- --check`
- `git diff --check`

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.
