### PR TITLE
chore(events): mark legacy Protobuf fields as deprecated

### DIFF
--- a/lib/vector-core/proto/event.proto
+++ b/lib/vector-core/proto/event.proto
@@ -3,6 +3,10 @@ package event;
 
 import "google/protobuf/timestamp.proto";
 
+// Deprecated fields remain declared for wire compatibility, which prevents
+// their field numbers from being reused. If a deprecated field is removed, its
+// number must be added to a reserved statement in the containing message.
+
 message EventArray {
   oneof events {
     LogArray logs = 1;
@@ -32,8 +36,8 @@ message EventWrapper {
 }
 
 message Log {
-  // Deprecated, use value instead
-  map<string, Value> fields = 1;
+  // Deprecated, use value instead.
+  map<string, Value> fields = 1 [deprecated = true];
   Value value = 2;
   Value metadata = 3 [deprecated = true];
   Metadata metadata_full = 4;
@@ -99,7 +103,8 @@ message Metadata {
 message Metric {
   string name = 1;
   google.protobuf.Timestamp timestamp = 2;
-  map<string, string> tags_v1 = 3;
+  // Deprecated, use tags_v2 instead.
+  map<string, string> tags_v1 = 3 [deprecated = true];
   map<string, TagValues> tags_v2 = 20;
   enum Kind {
     Incremental = 0;
@@ -110,12 +115,12 @@ message Metric {
     Counter counter = 5;
     Gauge gauge = 6;
     Set set = 7;
-    Distribution1 distribution1 = 8;
-    AggregatedHistogram1 aggregated_histogram1 = 9;
-    AggregatedSummary1 aggregated_summary1 = 10;
+    Distribution1 distribution1 = 8 [deprecated = true];
+    AggregatedHistogram1 aggregated_histogram1 = 9 [deprecated = true];
+    AggregatedSummary1 aggregated_summary1 = 10 [deprecated = true];
     Distribution2 distribution2 = 12;
-    AggregatedHistogram2 aggregated_histogram2 = 13;
-    AggregatedSummary2 aggregated_summary2 = 14;
+    AggregatedHistogram2 aggregated_histogram2 = 13 [deprecated = true];
+    AggregatedSummary2 aggregated_summary2 = 14 [deprecated = true];
     Sketch sketch = 15;
     AggregatedHistogram3 aggregated_histogram3 = 16;
     AggregatedSummary3 aggregated_summary3 = 17;

--- a/lib/vector-core/src/event/proto.rs
+++ b/lib/vector-core/src/event/proto.rs
@@ -93,8 +93,8 @@ impl From<Trace> for Event {
 }
 
 impl From<Log> for super::LogEvent {
+    #[allow(deprecated)]
     fn from(log: Log) -> Self {
-        #[allow(deprecated)]
         let metadata = log
             .metadata_full
             .map(Into::into)
@@ -145,6 +145,7 @@ impl From<Trace> for super::TraceEvent {
 }
 
 impl From<MetricValue> for super::MetricValue {
+    #[allow(deprecated)]
     fn from(value: MetricValue) -> Self {
         match value {
             MetricValue::Counter(counter) => Self::Counter {
@@ -205,6 +206,7 @@ impl From<MetricValue> for super::MetricValue {
 }
 
 impl From<Metric> for super::Metric {
+    #[allow(deprecated)]
     fn from(metric: Metric) -> Self {
         let kind = match metric.kind() {
             metric::Kind::Incremental => super::MetricKind::Incremental,
@@ -252,7 +254,6 @@ impl From<Metric> for super::Metric {
 
         let value = super::MetricValue::from(metric.value.unwrap());
 
-        #[allow(deprecated)]
         let metadata = metric
             .metadata_full
             .map(Into::into)


### PR DESCRIPTION
## Summary

### Motivation

The event Protobuf descriptor does not currently distinguish several historical compatibility fields from the current wire model. That makes it difficult to expose the Protobuf model as the basis for native JSON without also advertising obsolete representations.

### Changes

- Mark `Log.fields` and `Metric.tags_v1` as deprecated.
- Mark the superseded distribution, histogram, and summary metric variants as deprecated.
- Document that deprecated fields remain declared to prevent field-number reuse and must be reserved if eventually removed.
- Scope Rust deprecation allowances to the compatibility conversion paths that intentionally decode these fields.

No fields, field numbers, encoding behavior, or compatibility paths are removed.

### References

Related: #18779

## Vector configuration

Not applicable; this changes the event Protobuf schema annotations only.

## How did you test this PR?

- `protoc` descriptor generation and inspection confirmed the expected fields carry `deprecated: true`.
- `cargo check -p vector-core`
- `cargo test -p vector-core event::proto::tests` — 5 passed
- `make check-clippy`
- `make fmt`

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## Contributor Guidelines

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Some CI checks run only after we manually approve them. To catch issues early, add a `pre-push` hook ([template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push)) or run the following locally before pushing:
  - `make fmt`
  - `make check-clippy` (auto-fix with `make clippy-fix`)
  - `make test`
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can `git merge origin master` and `git push`.
- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details on the [dd-rust-license-tool](https://crates.io/crates/dd-rust-license-tool).
