### PR TITLE
docs: define community response expectations

### DIFF
--- a/COMMUNITY_RESPONSE_EXPECTATIONS.md
+++ b/COMMUNITY_RESPONSE_EXPECTATIONS.md
@@ -1,0 +1,47 @@
+# Community response expectations
+
+Vector is maintained by a small team alongside a growing community. We review
+GitHub activity on a best-effort basis, guided by maintainer availability,
+impact, urgency, and the readiness of each contribution.
+
+These are expectations, not service-level guarantees. Response and review times
+will vary.
+
+## Pull requests
+
+Pull requests are our highest priority for community response.
+
+We want to eventually merge all sound contributions. Small, focused, and
+ready-to-review pull requests are generally easier to pick up. Clear motivation,
+passing checks, appropriate tests and documentation, and resolved review threads
+all help a contribution move forward.
+
+Review order is not strictly chronological. Maintainers may prioritize changes
+based on user impact, regressions, release needs, technical risk, and available
+expertise.
+
+More complex changes will generally require more discussion and review. Large
+changes, new components, and breaking changes should therefore be discussed in
+an issue before substantial implementation begins.
+
+If a pull request has received no maintainer activity for some time, a polite
+ping to `@vectordotdev/vector` is welcome.
+
+## Issues
+
+Issues are reviewed and prioritized on a best-effort basis. Reports with a
+clear reproduction, relevant configuration, logs, and version information are
+easier to investigate.
+
+Maintainers may prioritize regressions, broadly impactful bugs, and issues that
+are ready to act on. An issue remaining open does not mean that work has been
+scheduled.
+
+## Discussions
+
+GitHub Discussions is the primary place for questions, troubleshooting, and
+general proposals. Responses may come from maintainers or other community
+members, and response times will vary.
+
+If a discussion identifies a confirmed bug or actionable change, it may be
+continued in an issue or pull request.

--- a/COMMUNITY_RESPONSE_EXPECTATIONS.md
+++ b/COMMUNITY_RESPONSE_EXPECTATIONS.md
@@ -24,8 +24,9 @@ More complex changes will generally require more discussion and review. Large
 changes, new components, and breaking changes should therefore be discussed in
 an issue before substantial implementation begins.
 
-If a pull request has received no maintainer activity for some time, a polite
-ping to `@vectordotdev/vector` is welcome.
+If a pull request has received no maintainer activity for some time, leave a
+comment on the pull request. Maintainers can take a look as they work through
+the backlog.
 
 ## Issues
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -164,6 +164,10 @@ relevant to your PR. This command is defined in the
 
 ### GitHub Pull Requests
 
+Please see [Community response expectations](COMMUNITY_RESPONSE_EXPECTATIONS.md)
+for information about how maintainers prioritize pull requests, issues, and
+discussions.
+
 Once your changes are ready you must submit your branch as a [pull request](https://github.com/vectordotdev/vector/pulls).
 
 #### Reviews & Approvals


### PR DESCRIPTION
## Summary

Define best-effort response expectations for community pull requests, issues,
and discussions, with pull requests called out as the highest priority.

### Motivation

Set clearer expectations for community contributions.

Related: https://github.com/vectordotdev/vector/discussions/26049#discussioncomment-17924432

## Does this PR include user facing changes?

- [ ] Yes
- [x] No
