### PR TITLE
chore: simplify pull request contributor guidance

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,12 +23,10 @@ Changes to CI, website, playground and similar are generally not considered user
 
 - Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
 - Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
-- Some CI checks run only after we manually approve them. To catch issues early, add a `pre-push` hook ([template](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#Pre-push)) or run the following locally before pushing:
+- Before pushing, run:
   - `make fmt`
   - `make check-clippy` (auto-fix with `make clippy-fix`)
   - `make test`
 - After a review is requested, please avoid force pushes to help us review incrementally.
   - Feel free to push as many commits as you want. They will be squashed into one before merging.
   - For example, you can run `git merge origin master` and `git push`.
-- If this PR introduces changes Vector dependencies (modifies `Cargo.lock`), please
-  run `make build-licenses` to regenerate the [license inventory](https://github.com/vectordotdev/vrl/blob/main/LICENSE-3rdparty.csv) and commit the changes (if any). More details on the [dd-rust-license-tool](https://crates.io/crates/dd-rust-license-tool).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,10 +23,7 @@ Changes to CI, website, playground and similar are generally not considered user
 
 - Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
 - Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
-- Before pushing, run:
-  - `make fmt`
-  - `make check-clippy` (auto-fix with `make clippy-fix`)
-  - `make test`
+- Before pushing, follow our [pre-push guidance](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#pre-push).
 - After a review is requested, please avoid force pushes to help us review incrementally.
   - Feel free to push as many commits as you want. They will be squashed into one before merging.
   - For example, you can run `git merge origin master` and `git push`.


### PR DESCRIPTION
## Summary

Simplify the contributor guidance in the pull request template by linking to the contribution guide instead of copying its local-check commands. Remove the dependency-license reminder because the contribution guide already documents the `make build-licenses` workflow.

### References

N/A

## Vector configuration

N/A

## How did you test this PR?

- `markdownlint-cli2 .github/PULL_REQUEST_TEMPLATE.md`
- `git diff --check`

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.
