### PR TITLE
enhancement(sinks): validate encoder configs at sink validation time

### DIFF
--- a/lib/codecs/src/encoding/config.rs
+++ b/lib/codecs/src/encoding/config.rs
@@ -167,6 +167,18 @@ impl EncodingConfigWithFraming {
         let encoder = EncoderKind::Framed(Box::new(Encoder::<Framer>::new(framer, serializer)));
         Ok((self.transformer(), encoder))
     }
+
+    /// Validate that the configured serializer can be built.
+    ///
+    /// Delegates to [`EncodingConfig::validate`]: the serializer is built and
+    /// discarded to surface unbuildable codecs during pure config validation,
+    /// with the disk-bound protobuf codec assumed valid so validation stays
+    /// filesystem-free (it runs under `vector validate --no-environment`).
+    /// Building the framer is infallible, so there is nothing to validate on
+    /// the framing side.
+    pub fn validate(&self) -> vector_common::Result<()> {
+        self.encoding.validate()
+    }
 }
 
 /// The way a sink processes outgoing events.
@@ -333,6 +345,44 @@ mod test {
     fn validate_accepts_buildable_encoding() {
         let encoding = EncodingConfig::new(
             SerializerConfig::Json(JsonSerializerConfig::default()),
+            Default::default(),
+        );
+
+        assert!(encoding.validate().is_ok());
+    }
+
+    #[test]
+    fn validate_with_framing_rejects_unbuildable_encoding() {
+        let encoding = EncodingConfigWithFraming::new(
+            Some(FramingConfig::NewlineDelimited),
+            SerializerConfig::Avro {
+                avro: AvroSerializerOptions {
+                    schema: "not a valid avro schema".into(),
+                },
+            },
+            Default::default(),
+        );
+
+        let error = encoding.validate().unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("failed to build encoding serializer"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn validate_with_framing_skips_protobuf_encoding_that_reads_disk() {
+        let encoding = EncodingConfigWithFraming::new(
+            None,
+            SerializerConfig::Protobuf(ProtobufSerializerConfig {
+                protobuf: ProtobufSerializerOptions {
+                    desc_file: "/nonexistent/protobuf.desc".into(),
+                    message_type: "package.Message".into(),
+                    use_json_names: false,
+                },
+            }),
             Default::default(),
         );
 

--- a/lib/codecs/src/encoding/config.rs
+++ b/lib/codecs/src/encoding/config.rs
@@ -45,6 +45,26 @@ impl EncodingConfig {
     pub fn build(&self) -> vector_common::Result<Serializer> {
         self.encoding.build()
     }
+
+    /// Validate that the configured serializer can be built.
+    ///
+    /// Builds the serializer and discards it, surfacing unbuildable encodings
+    /// during pure config validation instead of at build time.
+    ///
+    /// The protobuf codec is skipped: building it reads the descriptor set
+    /// from `desc_file` on disk, and pure validation must stay
+    /// filesystem-free (it runs under `vector validate --no-environment`).
+    /// A protobuf descriptor that can't be loaded is caught by the
+    /// environment-dependent `build()` phase instead.
+    pub fn validate(&self) -> vector_common::Result<()> {
+        match self.config() {
+            SerializerConfig::Protobuf(_) => Ok(()),
+            _ => self
+                .build()
+                .map(|_| ())
+                .map_err(|error| format!("failed to build encoding serializer: {error}").into()),
+        }
+    }
 }
 
 impl<T> From<T> for EncodingConfig
@@ -176,6 +196,10 @@ mod test {
 
     use super::*;
     use crate::encoding::TimestampFormat;
+    use crate::encoding::{
+        AvroSerializerOptions, JsonSerializerConfig, ProtobufSerializerConfig,
+        ProtobufSerializerOptions,
+    };
 
     #[test]
     fn deserialize_encoding_config() {
@@ -262,5 +286,56 @@ mod test {
         );
         assert_eq!(transformer.except_fields(), &Some(vec!["ignore_me".into()]));
         assert_eq!(transformer.timestamp_format(), &Some(TimestampFormat::Unix));
+    }
+
+    #[test]
+    fn validate_skips_protobuf_encoding_that_reads_disk() {
+        // Building a protobuf serializer reads `desc_file` from disk; pure
+        // validation must stay filesystem-free, so the codec is assumed valid
+        // here and actually built (and failed) in the build phase.
+        let encoding = EncodingConfig::new(
+            SerializerConfig::Protobuf(ProtobufSerializerConfig {
+                protobuf: ProtobufSerializerOptions {
+                    desc_file: "/nonexistent/protobuf.desc".into(),
+                    message_type: "package.Message".into(),
+                    use_json_names: false,
+                },
+            }),
+            Default::default(),
+        );
+
+        assert!(encoding.validate().is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_unbuildable_encoding() {
+        // Avro's schema is inline JSON, so building it is filesystem-free and
+        // pure validation catches a malformed schema.
+        let encoding = EncodingConfig::new(
+            SerializerConfig::Avro {
+                avro: AvroSerializerOptions {
+                    schema: "not a valid avro schema".into(),
+                },
+            },
+            Default::default(),
+        );
+
+        let error = encoding.validate().unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("failed to build encoding serializer"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn validate_accepts_buildable_encoding() {
+        let encoding = EncodingConfig::new(
+            SerializerConfig::Json(JsonSerializerConfig::default()),
+            Default::default(),
+        );
+
+        assert!(encoding.validate().is_ok());
     }
 }

--- a/src/sinks/amqp/config.rs
+++ b/src/sinks/amqp/config.rs
@@ -169,6 +169,7 @@ impl ValidatedSink for AmqpSinkConfig {
             .connection_string
             .parse::<AMQPUri>()
             .map_err(|e| format!("Invalid connection string: {e}"))?;
+        self.encoding.validate()?;
         let exchange = self
             .exchange
             .clone()

--- a/src/sinks/aws_cloudwatch_logs/config.rs
+++ b/src/sinks/aws_cloudwatch_logs/config.rs
@@ -235,6 +235,7 @@ impl ValidatedSink for CloudwatchLogsSinkConfig {
                 .confine(&self.confinement, Self::NAME, "group_name")?;
         let batcher_settings = self.batch.into_batcher_settings()?;
         let headers = validate_headers(&self.request.headers)?;
+        self.encoding.validate()?;
 
         Ok(ValidatedCloudwatchLogs {
             group_template,

--- a/src/sinks/aws_kinesis/firehose/config.rs
+++ b/src/sinks/aws_kinesis/firehose/config.rs
@@ -146,6 +146,7 @@ impl ValidatedSink for KinesisFirehoseSinkConfig {
             .limit_max_bytes(MAX_PAYLOAD_SIZE)?
             .limit_max_events(MAX_PAYLOAD_EVENTS)?
             .into_batcher_settings()?;
+        self.base.encoding.validate()?;
 
         Ok(ValidatedKinesisFirehose { batch_settings })
     }

--- a/src/sinks/aws_kinesis/streams/config.rs
+++ b/src/sinks/aws_kinesis/streams/config.rs
@@ -141,6 +141,7 @@ impl ValidatedSink for KinesisStreamsSinkConfig {
             .limit_max_bytes(MAX_PAYLOAD_SIZE)?
             .limit_max_events(MAX_PAYLOAD_EVENTS)?
             .into_batcher_settings()?;
+        self.base.encoding.validate()?;
 
         Ok(ValidatedKinesisStreams { batch_settings })
     }

--- a/src/sinks/aws_s3/config.rs
+++ b/src/sinks/aws_s3/config.rs
@@ -254,6 +254,7 @@ impl ValidatedSink for S3SinkConfig {
     type Validated = ValidatedAwsS3;
 
     fn validate(&self) -> crate::Result<ValidatedAwsS3> {
+        self.encoding.validate()?;
         let batch_settings = self.batch.into_batcher_settings()?;
 
         let key_prefix = Template::try_from(self.key_prefix.clone())?.confine(

--- a/src/sinks/aws_s_s/sns/config.rs
+++ b/src/sinks/aws_s_s/sns/config.rs
@@ -101,6 +101,7 @@ impl ValidatedSink for SnsSinkConfig {
         )?;
         let message_deduplication_id =
             message_deduplication_id(self.base_config.message_deduplication_id.clone())?;
+        self.base_config.encoding.validate()?;
 
         Ok(ValidatedSnsSink {
             message_group_id,

--- a/src/sinks/aws_s_s/sqs/config.rs
+++ b/src/sinks/aws_s_s/sqs/config.rs
@@ -101,6 +101,7 @@ impl ValidatedSink for SqsSinkConfig {
         )?;
         let message_deduplication_id =
             message_deduplication_id(self.base_config.message_deduplication_id.clone())?;
+        self.base_config.encoding.validate()?;
 
         Ok(ValidatedSqsSink {
             message_group_id,

--- a/src/sinks/azure_blob/config.rs
+++ b/src/sinks/azure_blob/config.rs
@@ -406,6 +406,7 @@ impl ValidatedSink for AzureBlobSinkConfig {
     type Validated = ValidatedAzureBlob;
 
     fn validate(&self) -> crate::Result<ValidatedAzureBlob> {
+        self.encoding.validate()?;
         if self.blob_type == AzureBlobType::Append && !supports_append(self.compression) {
             // An error rather than a warning because of zlib: standard zlib decoders return only
             // the first block and report success, so the loss is invisible to the consumer.

--- a/src/sinks/console/config.rs
+++ b/src/sinks/console/config.rs
@@ -89,7 +89,7 @@ impl ValidatedSink for ConsoleSinkConfig {
     type Validated = ();
 
     fn validate(&self) -> crate::Result<()> {
-        Ok(())
+        self.encoding.validate()
     }
 
     async fn build(

--- a/src/sinks/doris/config.rs
+++ b/src/sinks/doris/config.rs
@@ -173,6 +173,7 @@ impl ValidatedSink for DorisConfig {
     type Validated = ValidatedDoris;
 
     fn validate(&self) -> crate::Result<ValidatedDoris> {
+        self.encoding.validate()?;
         if self.endpoints.is_empty() {
             return Err("No endpoints configured.'.".into());
         }

--- a/src/sinks/file/mod.rs
+++ b/src/sinks/file/mod.rs
@@ -263,6 +263,7 @@ impl ValidatedSink for FileSinkConfig {
     type Validated = ValidatedFileSink;
 
     fn validate(&self) -> crate::Result<ValidatedFileSink> {
+        self.encoding.validate()?;
         let transformer = self.encoding.transformer();
 
         // Pure path-confinement checks. `PathConfinement` itself is not

--- a/src/sinks/gcp/cloud_storage.rs
+++ b/src/sinks/gcp/cloud_storage.rs
@@ -278,6 +278,7 @@ impl ValidatedSink for GcsSinkConfig {
     type Validated = ValidatedGcsSink;
 
     fn validate(&self) -> crate::Result<ValidatedGcsSink> {
+        self.encoding.validate()?;
         let base_url = self.endpoint.append_path(&format!("{}/", self.bucket))?;
         let batch_settings = self.batch.into_batcher_settings()?;
         let key_prefix_template = self.key_prefix_template()?;

--- a/src/sinks/gcp/pubsub.rs
+++ b/src/sinks/gcp/pubsub.rs
@@ -139,6 +139,7 @@ impl ValidatedSink for PubsubConfig {
             .validate()?
             .limit_max_bytes(MAX_BATCH_PAYLOAD_SIZE)?
             .into_batch_settings()?;
+        self.encoding.validate()?;
 
         let transformer = self.encoding.transformer();
 

--- a/src/sinks/gcp_chronicle/chronicle_unstructured.rs
+++ b/src/sinks/gcp_chronicle/chronicle_unstructured.rs
@@ -325,6 +325,7 @@ impl ValidatedSink for ChronicleUnstructuredConfig {
         healthcheck_endpoint.parse::<Uri>()?;
 
         let batch_settings = self.batch.into_batcher_settings()?;
+        self.encoding.validate()?;
 
         Ok(ValidatedChronicleUnstructured {
             endpoint,

--- a/src/sinks/http/config.rs
+++ b/src/sinks/http/config.rs
@@ -316,6 +316,7 @@ impl ValidatedSink for HttpSinkConfig {
     type Validated = ValidatedHttp;
 
     fn validate(&self) -> crate::Result<ValidatedHttp> {
+        self.encoding.validate()?;
         let batch_settings = self.batch.validate()?.into_batcher_settings()?;
 
         let serializer_config = self.encoding.config().1;
@@ -707,6 +708,50 @@ mod tests {
             config.validate().is_err(),
             "relative static uri should fail validation"
         );
+    }
+
+    #[test]
+    fn validate_rejects_unbuildable_encoding() {
+        use crate::config::ValidatedSink;
+        let config: HttpSinkConfig = serde_yaml::from_str(
+            r#"
+            uri: "http://localhost:9000/endpoint"
+            encoding:
+              codec: avro
+              avro:
+                schema: "not a valid avro schema"
+            "#,
+        )
+        .unwrap();
+        let error = config.validate().unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("failed to build encoding serializer"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn validate_assumes_protobuf_encoding_valid_without_disk_access() {
+        use crate::config::ValidatedSink;
+        // The protobuf codec reads its descriptor set from `desc_file` on
+        // disk; pure validation must stay filesystem-free, so an unbuildable
+        // protobuf encoding is caught in the build phase instead.
+        let config: HttpSinkConfig = serde_yaml::from_str(
+            r#"
+            uri: "http://localhost:9000/endpoint"
+            encoding:
+              codec: protobuf
+              protobuf:
+                desc_file: "/nonexistent/protobuf.desc"
+                message_type: "package.Message"
+            "#,
+        )
+        .unwrap();
+        config
+            .validate()
+            .expect("protobuf encoding assumed valid without disk access");
     }
 
     #[test]

--- a/src/sinks/kafka/config.rs
+++ b/src/sinks/kafka/config.rs
@@ -346,6 +346,8 @@ impl ValidatedSink for KafkaSinkConfig {
             .topic
             .clone()
             .confine(&self.confinement, Self::NAME, "topic")?;
+        self.encoding.validate()?;
+
         Ok(ValidatedKafkaSink { topic })
     }
 

--- a/src/sinks/kafka/config.rs
+++ b/src/sinks/kafka/config.rs
@@ -390,6 +390,49 @@ mod tests {
     }
 
     #[test]
+    fn validate_assumes_protobuf_encoding_valid_without_disk_access() {
+        // The protobuf codec reads its descriptor set from `desc_file` on
+        // disk; pure validation must stay filesystem-free, so an unbuildable
+        // protobuf encoding is caught in the build phase instead.
+        let config: KafkaSinkConfig = serde_yaml::from_str(
+            r#"
+            bootstrap_servers: "localhost:9092"
+            topic: "test-topic"
+            encoding:
+                codec: protobuf
+                protobuf:
+                    desc_file: "/nonexistent/protobuf.desc"
+                    message_type: "package.Message"
+            "#,
+        )
+        .unwrap();
+        let validated = config.validate().expect("validation should succeed");
+        assert_eq!(validated.topic.to_string(), "test-topic");
+    }
+
+    #[test]
+    fn validate_rejects_unbuildable_encoding() {
+        let config: KafkaSinkConfig = serde_yaml::from_str(
+            r#"
+            bootstrap_servers: "localhost:9092"
+            topic: "test-topic"
+            encoding:
+                codec: avro
+                avro:
+                    schema: "not a valid avro schema"
+            "#,
+        )
+        .unwrap();
+        let error = config.validate().unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("failed to build encoding serializer"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
     fn confinement_rejects_unconfined_topic() {
         let template = Template::try_from("{{ topic }}").unwrap();
         let config = ConfinementConfig::default();

--- a/src/sinks/loki/config.rs
+++ b/src/sinks/loki/config.rs
@@ -278,6 +278,7 @@ impl ValidatedSink for LokiConfig {
                 settings
             }
         };
+        self.encoding.validate()?;
 
         let transformer = self.encoding.transformer();
 

--- a/src/sinks/mqtt/config.rs
+++ b/src/sinks/mqtt/config.rs
@@ -150,6 +150,7 @@ impl ValidatedSink for MqttSinkConfig {
                 }));
             }
         }
+        self.encoding.validate()?;
         let topic = self
             .topic
             .clone()

--- a/src/sinks/nats/config.rs
+++ b/src/sinks/nats/config.rs
@@ -206,6 +206,7 @@ impl ValidatedSink for NatsSinkConfig {
             .clone()
             .confine(&self.confinement, Self::NAME, "subject")?;
         let server_addresses = self.parse_server_addresses()?;
+        self.encoding.validate()?;
 
         if let Some(tls) = &self.tls {
             validate_tls_cert_key_pair(tls).context(ConfigSnafu)?;

--- a/src/sinks/papertrail.rs
+++ b/src/sinks/papertrail.rs
@@ -102,6 +102,7 @@ impl ValidatedSink for PapertrailConfig {
             .uri
             .port_u16()
             .ok_or_else(|| "A port is required for endpoint".to_string())?;
+        self.encoding.validate()?;
 
         let address = format!("{host}:{port}");
         let tls = Some(

--- a/src/sinks/pulsar/config.rs
+++ b/src/sinks/pulsar/config.rs
@@ -448,6 +448,7 @@ impl ValidatedSink for PulsarSinkConfig {
                 format!("Invalid Pulsar endpoint `{}`: missing host", self.endpoint).into(),
             );
         }
+        self.encoding.validate()?;
         let topic = self
             .topic
             .clone()

--- a/src/sinks/redis/config.rs
+++ b/src/sinks/redis/config.rs
@@ -234,6 +234,7 @@ impl ValidatedSink for RedisSinkConfig {
                 return Err(format!("`endpoint` is not a valid redis URL: {endpoint}").into());
             }
         }
+        self.encoding.validate()?;
         let batch_settings = self.batch.into_batcher_settings()?;
         Ok(ValidatedRedisSink {
             key,

--- a/src/sinks/socket.rs
+++ b/src/sinks/socket.rs
@@ -178,6 +178,7 @@ impl ValidatedSink for SocketSinkConfig {
         match &self.mode {
             Mode::Tcp(TcpMode { config, encoding }) => {
                 let (host, port) = config.parse_address()?;
+                encoding.validate()?;
                 let transformer = encoding.transformer();
                 Ok(ValidatedSocket::Tcp {
                     host,
@@ -195,6 +196,7 @@ impl ValidatedSink for SocketSinkConfig {
             }
             #[cfg(unix)]
             Mode::UnixStream(UnixMode { encoding, .. }) => {
+                encoding.validate()?;
                 let transformer = encoding.transformer();
                 Ok(ValidatedSocket::UnixStream { transformer })
             }
@@ -203,6 +205,7 @@ impl ValidatedSink for SocketSinkConfig {
             Mode::UnixDatagram(UnixMode { encoding, .. }) => {
                 cfg_if! {
                     if #[cfg(not(target_os = "macos"))] {
+                        encoding.validate()?;
                         let transformer = encoding.transformer();
                         Ok(ValidatedSocket::UnixDatagram { transformer })
                     }

--- a/src/sinks/socket.rs
+++ b/src/sinks/socket.rs
@@ -189,6 +189,7 @@ impl ValidatedSink for SocketSinkConfig {
                 // Mirror the pure host/port check from `UdpSinkConfig::build`
                 // so malformed addresses are rejected here instead.
                 config.parse_address()?;
+                encoding.validate()?;
                 let transformer = encoding.transformer();
                 Ok(ValidatedSocket::Udp { transformer })
             }

--- a/src/sinks/splunk_hec/logs/config.rs
+++ b/src/sinks/splunk_hec/logs/config.rs
@@ -213,6 +213,7 @@ impl HecLogsSinkConfig {
             .transpose()?;
 
         let batch_settings = self.batch.into_batcher_settings()?;
+        self.encoding.validate()?;
 
         Ok(ValidatedHecLogsSink {
             index,

--- a/src/sinks/webhdfs/config.rs
+++ b/src/sinks/webhdfs/config.rs
@@ -132,6 +132,7 @@ impl ValidatedSink for WebHdfsConfig {
     type Validated = ValidatedWebHdfs;
 
     fn validate(&self) -> crate::Result<ValidatedWebHdfs> {
+        self.encoding.validate()?;
         let batcher_settings = self.batch.into_batcher_settings()?;
         let confined_prefix = self.confined_prefix()?;
 

--- a/src/sinks/websocket/config.rs
+++ b/src/sinks/websocket/config.rs
@@ -70,6 +70,7 @@ impl ValidatedSink for WebSocketSinkConfig {
     fn validate(&self) -> crate::Result<ValidatedWebSocketSink> {
         let uri = WebSocketConnector::parse_uri(&self.common.uri)?;
         let transformer = self.encoding.transformer();
+        self.encoding.validate()?;
         Ok(ValidatedWebSocketSink { uri, transformer })
     }
 

--- a/src/sinks/websocket_server/config.rs
+++ b/src/sinks/websocket_server/config.rs
@@ -157,6 +157,7 @@ impl ValidatedSink for WebSocketListenerSinkConfig {
 
     fn validate(&self) -> crate::Result<ValidatedWebSocketListenerSink> {
         let transformer = self.encoding.transformer();
+        self.encoding.validate()?;
         // Custom-auth VRL compilation is deferred to `validate_with_context`, which
         // has the enrichment tables needed to resolve `get_enrichment_table_record!`.
         Ok(ValidatedWebSocketListenerSink { transformer })


### PR DESCRIPTION
## Summary
Validates sink encoder configs during pure sink validation, catching unbuildable codecs earlier; disk-bound protobuf is assumed valid and left to the build phase.

### References

## Vector configuration
NA

## How did you test this PR?
`make test SCOPE="validate"` (217 tests), codecs `encoding::config` tests, kafka sink tests, and the test modules of all 19 touched sinks pass; `make check-fmt` and `make check-clippy` clean (only pre-existing `codecs` otlp bench failure remains, reproducible on master).

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## Contributor Guidelines

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Before pushing, follow our [pre-push guidance](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#pre-push).
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.