### PR TITLE
docs: modernize community support guidance

### DIFF
--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,113 +1,45 @@
 # Support
 
-Vector is a growing open source project with a variety of people willing to help
-you through various mediums.
+Vector is an open source project supported by its maintainers and community on
+a best-effort basis. See our [community response expectations][response] for
+information about how pull requests, issues, and discussions are prioritized.
 
-Take a look at those mediums listed at <https://vector.dev/community>
+## Where to ask
 
-## How to ask a question about Vector
+- For questions, troubleshooting, and general proposals, start a
+  [GitHub Discussion][discussions].
+- For a reproducible bug, open a [bug report][bug-report].
+- For a feature proposal, open a [feature request][feature-request].
+- For contribution guidance, see [CONTRIBUTING.md][contributing].
+- For community conversation, join [Discord][discord]. The maintainers do not
+  actively monitor Discord for support requests.
 
-Framing your question well and providing the right level of details will improve your chances of getting
-your question answered. Here are some tips:
+If you are unsure whether you have found a bug, start a discussion. It can be
+continued in an issue if an actionable problem is identified.
 
-### Before asking
+## Before posting
 
-Check the [Vector documentation](https://vector.dev/docs/) first to see if it answers your question. If you use a search
-engine
-and provide a query like the following
-`site:vector.dev releases`, you might get better results than the built-in search.
-If your question is about [VRL](https://vector.dev/docs/reference/vrl/#learn), you can also try out
-the [VRL playground][vrl_playground].
+Check the [Vector documentation][documentation] and search existing issues and
+discussions. Someone may have already reported the same behavior or answered
+the same question.
 
-If the docs do not answer your question, try the following:
+## Help us investigate
 
-* Use the search feature on [GitHub][vector], to search for keywords related to your issue. It is
-  quite possible someone has
-already asked your question before. This is especially useful if you have a specific error message
-you are observing.
-* You can also search [Discord][discord] threads. Note that the #support channel is no longer active because we migrated
-  to GitHub Issues/Discussions.
+Include the information relevant to your question or report:
 
-### Provide details
+- Your Vector version and the versions of related services.
+- The relevant Vector configuration, with sensitive information removed.
+- How Vector is deployed and the surrounding architecture.
+- What you expected to happen and what happened instead.
+- Complete error messages, relevant logs, and reproduction steps.
 
-Essential details to include:
+Use fenced code blocks for configurations and logs, and review all content for
+sensitive information before posting it publicly.
 
-* Errors: for each error, please provide the full error message snippet, and
-  details such as where the error is observed, at what stage in the process
-  (e.g. at boot time, after some specific condition etc.).
-* What is the version of Vector (and the Helm chart if deploying via Helm) and
-  the versions of any other systems in use (like Elasticsearch, NATS, etc.).
-* What is your Vector configuration. See the below section on [how to format
-  your config](#formatting).
-* How are you [deploying](https://vector.dev/docs/setup/deployment/) Vector?
-* What is your complete deployment architecture? For example: I have Logstash
-  agents sending to Vector over syslog that is being forwarded to Loki.
-
-Situation specific (not exhaustive):
-
-* Did it occur after upgrading to a new version of Vector?
-* Are you trying out Vector for the first time, or did you have a previous
-  working configuration?
-
-These are just some examples of questions that may or may not apply to your
-situation.
-
-### Formatting
-
-When providing snippets of configuration files, or log messages, format these with backticks to
-improve the legibility for readers.
-
-#### Blocks
-
-Blocks should be formatted with three backticks (\`\`\`)
-
-This should be used for any configuration snippets of Vector, Helm values, etc.
-and for Vector console log messages.
-
-See the [markdown documentation](https://www.markdownguide.org/basic-syntax/#fenced-code-blocks)
-for an explanation.
-
-For example:
-
-[sinks.sink0]
-
-inputs = ["source0"]
-
-target = "stdout"
-
-type = "console"
-
-should be written as
-
-```toml
-[sinks.sink0]
-inputs = ["source0"]
-target = "stdout"
-type = "console"
-```
-
-#### Single word or phrase
-
-Formatting things like component names, versions etc. is done with single
-backticks (\`) around the word or phrase.
-
-This is less critical but also helps readability a lot and is greatly
-appreciated.
-
-See the [markdown documentation](https://www.markdownguide.org/basic-syntax/#code)
-for an explanation.
-
-For example:
-
-> We upgraded from v24 to 25.1 and are seeing the following error output from
-> kafka.
-
-should be written as
-
-> We upgraded from `v0.24.0` to `v0.25.1` and are seeing the following error
-> output from the `kafka` sink.
-
+[bug-report]: https://github.com/vectordotdev/vector/issues/new?template=bug.yml
+[contributing]: ../CONTRIBUTING.md
+[discussions]: https://github.com/vectordotdev/vector/discussions/new?category=q-a
 [discord]: https://chat.vector.dev
-[discussions]: https://github.com/vectordotdev/vector/discussions
-[vector]: https://github.com/vectordotdev/vector
-[vrl_playground]: https://playground.vrl.dev
+[documentation]: https://vector.dev/docs/
+[feature-request]: https://github.com/vectordotdev/vector/issues/new?template=feature.yml
+[response]: ../COMMUNITY_RESPONSE_EXPECTATIONS.md

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -1,18 +1,11 @@
 # Support
 
-Vector is an open source project supported by its maintainers and community on
-a best-effort basis. See our [community response expectations][response] for
-information about how pull requests, issues, and discussions are prioritized.
+For questions and troubleshooting, start a [GitHub Discussion][discussions].
+For reproducible bugs, open a [bug report][bug-report].
 
-## Where to ask
-
-- For questions, troubleshooting, and general proposals, start a
-  [GitHub Discussion][discussions].
-- For a reproducible bug, open a [bug report][bug-report].
-- For a feature proposal, open a [feature request][feature-request].
-- For contribution guidance, see [CONTRIBUTING.md][contributing].
-- For community conversation, join [Discord][discord]. The maintainers do not
-  actively monitor Discord for support requests.
+See the [Vector community page][community] for other community and support
+channels. See our [community response expectations][response] for information
+about how pull requests, issues, and discussions are prioritized.
 
 If you are unsure whether you have found a bug, start a discussion. It can be
 continued in an issue if an actionable problem is identified.
@@ -37,9 +30,7 @@ Use fenced code blocks for configurations and logs, and review all content for
 sensitive information before posting it publicly.
 
 [bug-report]: https://github.com/vectordotdev/vector/issues/new?template=bug.yml
-[contributing]: ../CONTRIBUTING.md
+[community]: https://vector.dev/community/
 [discussions]: https://github.com/vectordotdev/vector/discussions/new?category=q-a
-[discord]: https://chat.vector.dev
 [documentation]: https://vector.dev/docs/
-[feature-request]: https://github.com/vectordotdev/vector/issues/new?template=feature.yml
 [response]: ../COMMUNITY_RESPONSE_EXPECTATIONS.md

--- a/website/content/en/community/_index.md
+++ b/website/content/en/community/_index.md
@@ -20,11 +20,7 @@ description: >
 
 ## Discord
 
-Join our [Discord server][discord].
-
-The Discord server is meant for connecting with other Vector users and fostering community conversations.
-
-The Vector team does not actively monitor the Discord channels. The best way to reach out to the Vector team directly is through GitHub.
+Join our [Discord server][discord] for peer-to-peer conversations with other Vector users. Discord is not an official support channel and is not actively monitored by the Vector team. For questions and help, use [GitHub Discussions][vector_discussions].
 
 ## FAQ
 

--- a/website/content/en/community/_index.md
+++ b/website/content/en/community/_index.md
@@ -11,7 +11,7 @@ description: >
 * For questions and help: [Create a Vector GitHub Discussions][vector_discussions]
 
 * For bug reports: [Create a Vector GitHub issue][vector_bug_report]
-* For feedback on pull requests, ping the Vector team directly on GitHub with `@vectordotdev/vector`
+* For information about how pull requests are prioritized, see [Community response expectations][response_expectations]
 
 ### VRL
 
@@ -83,6 +83,8 @@ Vector has adopted the Rust community model and practices for engaging with peop
 [linux]: https://www.kernel.org
 
 [oss]: https://github.com/vectordotdev/vector
+
+[response_expectations]: https://github.com/vectordotdev/vector/blob/master/COMMUNITY_RESPONSE_EXPECTATIONS.md
 
 [rust_community]: https://www.rust-lang.org/community
 

--- a/website/content/en/community/_index.md
+++ b/website/content/en/community/_index.md
@@ -34,13 +34,7 @@ Find us on [X][vector_x].
 
 ### How do I contribute to Vector?
 
-Vector is [open source][oss] and welcomes contributions. A few guidelines to help you get started:
-
-1. Read our [contribution guide][contribution].
-
-2. Start with [good first issues][first_issues].
-
-3. Use [GitHub Discussions][vector_discussions] if you have any questions. We are happy to help!
+Vector is [open source][oss] and welcomes contributions. See our [contribution guide][contribution] or explore [good first issues][first_issues] to get started.
 
 ### What is Vector's governance model?
 

--- a/website/content/en/community/_index.md
+++ b/website/content/en/community/_index.md
@@ -26,10 +26,6 @@ The Discord server is meant for connecting with other Vector users and fostering
 
 The Vector team does not actively monitor the Discord channels. The best way to reach out to the Vector team directly is through GitHub.
 
-## X
-
-Find us on [X][vector_x].
-
 ## FAQ
 
 ### How do I contribute to Vector?
@@ -59,8 +55,6 @@ Vector has adopted the Rust community model and practices for engaging with peop
 1. [Rust Language Organization][rust_lang]
 
 2. [Rust community standards][rust_community]
-
-[vector_x]: https://x.com/vectordotdev
 
 [discord]: https://chat.vector.dev
 


### PR DESCRIPTION
## Summary

Modernize the GitHub support guide and align the website Community page with
the community response expectations.

### Motivation

The existing support guide duplicates community channel details and contains
outdated guidance. The website also asks contributors to ping the Vector team
for pull request feedback, which no longer matches the documented process.

### Changes

- keep GitHub's support guide focused on routing and useful diagnostic details
- use the website Community page as the source for community and support channels
- replace the pull request team-ping guidance with a link to the community response expectations

## How did you test this PR?

- `make check-markdown`
- `make generate-docs`
- `make serve` and verify `/community/`

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [x] Yes
- [ ] No
