### PR TITLE
fix(codecs): handle single-chunk GELF messages directly

### DIFF
--- a/lib/codecs/src/decoding/framing/chunked_gelf.rs
+++ b/lib/codecs/src/decoding/framing/chunked_gelf.rs
@@ -369,6 +369,34 @@ impl ChunkedGelfDecoder {
             }
         );
 
+        // A lone chunk is already complete, but it cannot reuse the ID of a pending message.
+        if total_chunks == 1 {
+            if let Some(max_length) = self.max_length
+                && chunk.len() > max_length
+            {
+                return Err(ChunkedGelfDecoderError::MaxLengthExceed {
+                    message_id,
+                    sequence_number,
+                    length: chunk.len(),
+                    max_length,
+                });
+            }
+
+            // Copy before taking the shared-state lock, then keep the lock from the ID check
+            // through return so another decoder clone cannot insert this ID between them.
+            let chunk = Bytes::copy_from_slice(&chunk);
+            let state_lock = self.state.lock().expect("poisoned lock");
+            if let Some(message_state) = state_lock.get(&message_id) {
+                return Err(ChunkedGelfDecoderError::TotalChunksMismatch {
+                    message_id,
+                    sequence_number,
+                    original_total_chunks: message_state.total_chunks,
+                    received_total_chunks: total_chunks,
+                });
+            }
+            return Ok(Some(chunk));
+        }
+
         let mut state_lock = self.state.lock().expect("poisoned lock");
 
         // Only a new message grows the table, so the limit applies on insert. Checking it
@@ -1045,6 +1073,23 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn a_lone_chunk_does_not_retain_the_source_buffer() {
+        let mut chunk = create_chunk(1u64, 0u8, 1u8, &"foo");
+        let source_range = chunk.as_ptr_range();
+        let mut decoder = ChunkedGelfDecoder::default();
+
+        let frame = decoder
+            .decode_eof(&mut chunk)
+            .unwrap()
+            .expect("the lone chunk must complete");
+
+        assert!(
+            !source_range.contains(&frame.as_ptr()),
+            "the returned frame must not alias the decoder's input buffer"
+        );
+    }
+
+    #[tokio::test]
     async fn finish_assembles_the_final_chunk_in_sequence() {
         let mut state = Box::new(MessageState::new(3, tokio::spawn(async {})));
         state.add_chunk(0, Bytes::from_static(b"foo"));
@@ -1082,6 +1127,34 @@ mod tests {
                 received_total_chunks: 3,
             }
         ));
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn a_lone_chunk_cannot_reuse_a_pending_message_id(
+        two_chunks_message: ([BytesMut; 2], String),
+    ) {
+        let (mut chunks, expected) = two_chunks_message;
+        let mut decoder = ChunkedGelfDecoder::default();
+
+        assert!(decoder.decode_eof(&mut chunks[0]).unwrap().is_none());
+
+        let mut lone_chunk = create_chunk(1u64, 0u8, 1u8, &"other");
+        let error = decoder
+            .decode_eof(&mut lone_chunk)
+            .expect_err("a pending message already owns this ID");
+        assert!(matches!(
+            downcast_framing_error(&error),
+            ChunkedGelfDecoderError::TotalChunksMismatch {
+                message_id: 1,
+                sequence_number: 0,
+                original_total_chunks: 2,
+                received_total_chunks: 1,
+            }
+        ));
+
+        let frame = decoder.decode_eof(&mut chunks[1]).unwrap();
+        assert_eq!(frame, Some(Bytes::from(expected)));
     }
 
     #[rstest]

--- a/lib/codecs/src/decoding/framing/chunked_gelf.rs
+++ b/lib/codecs/src/decoding/framing/chunked_gelf.rs
@@ -140,28 +140,30 @@ impl MessageState {
         self.chunks[sequence_number as usize] = Bytes::copy_from_slice(&chunk);
     }
 
-    fn is_complete(&self) -> bool {
-        self.chunks_bitmap.count_ones() == self.total_chunks as u32
+    /// Callers must have ruled out a duplicate, which would not raise the count.
+    fn is_final_missing_chunk(&self) -> bool {
+        self.chunks_bitmap.count_ones() + 1 == self.total_chunks as u32
     }
 
     fn current_length(&self) -> usize {
         self.current_length
     }
 
-    /// Peak is ~2x the message: a contiguous destination coexists with the chunks it copies
-    /// from. Reserving exactly keeps a growing buffer from adding slack on top of that.
-    fn retrieve_message(&mut self) -> Option<Bytes> {
-        if !self.is_complete() {
-            return None;
-        }
-
+    fn finish(mut self: Box<Self>, sequence_number: u8, final_chunk: Bytes) -> Bytes {
         self.timeout_task.abort();
-        let mut message = BytesMut::with_capacity(self.current_length);
-        for chunk in &mut self.chunks[0..self.total_chunks as usize] {
-            message.extend_from_slice(chunk);
-            *chunk = Bytes::new();
+        let mut message = BytesMut::with_capacity(self.current_length + final_chunk.len());
+        for (index, chunk) in self.chunks[0..self.total_chunks as usize]
+            .iter_mut()
+            .enumerate()
+        {
+            if index == sequence_number as usize {
+                message.extend_from_slice(&final_chunk);
+            } else {
+                message.extend_from_slice(chunk);
+                *chunk = Bytes::new();
+            }
         }
-        Some(message.freeze())
+        message.freeze()
     }
 }
 
@@ -423,6 +425,29 @@ impl ChunkedGelfDecoder {
             return Ok(None);
         }
 
+        // Remove a complete message before assembling it. The final chunk goes straight into
+        // the output, so it needs neither an intermediate copy nor shared state during assembly.
+        if message_state.is_final_missing_chunk() {
+            let length = message_state.current_length().saturating_add(chunk.len());
+            if let Some(max_length) = self.max_length
+                && length > max_length
+            {
+                if let Some(dropped) = state_lock.remove(&message_id) {
+                    dropped.timeout_task.abort();
+                }
+                return Err(ChunkedGelfDecoderError::MaxLengthExceed {
+                    message_id,
+                    sequence_number,
+                    length,
+                    max_length,
+                });
+            }
+
+            let message_state = state_lock.remove(&message_id).expect("entry must exist");
+            drop(state_lock);
+            return Ok(Some(message_state.finish(sequence_number, chunk)));
+        }
+
         message_state.add_chunk(sequence_number, chunk);
 
         if let Some(max_length) = self.max_length {
@@ -442,12 +467,7 @@ impl ChunkedGelfDecoder {
             }
         }
 
-        if let Some(message) = message_state.retrieve_message() {
-            state_lock.remove(&message_id);
-            Ok(Some(message))
-        } else {
-            Ok(None)
-        }
+        Ok(None)
     }
 
     /// Decode a GELF message that may be chunked or not. The source bytes are expected to be
@@ -1025,22 +1045,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn retrieve_message_releases_chunks_while_assembling() {
-        // Does not lower the 2x peak, just shortens how long the source side is held.
-        let mut state = MessageState::new(2, tokio::spawn(async {}));
+    async fn finish_assembles_the_final_chunk_in_sequence() {
+        let mut state = Box::new(MessageState::new(3, tokio::spawn(async {})));
         state.add_chunk(0, Bytes::from_static(b"foo"));
-        state.add_chunk(1, Bytes::from_static(b"bar"));
+        state.add_chunk(2, Bytes::from_static(b"baz"));
 
-        let message = state
-            .retrieve_message()
-            .expect("message should be complete");
+        let message = state.finish(1, Bytes::from_static(b"bar"));
 
-        assert_eq!(message, Bytes::from_static(b"foobar"));
-        assert!(
-            state.chunks[..2].iter().all(Bytes::is_empty),
-            "each chunk must be released as it is copied"
-        );
-        assert_eq!(state.current_length(), 6);
+        assert_eq!(message, Bytes::from_static(b"foobarbaz"));
     }
 
     #[rstest]

--- a/lib/codecs/src/decoding/framing/chunked_gelf.rs
+++ b/lib/codecs/src/decoding/framing/chunked_gelf.rs
@@ -150,7 +150,6 @@ impl MessageState {
     }
 
     fn finish(mut self: Box<Self>, sequence_number: u8, final_chunk: Bytes) -> Bytes {
-        self.timeout_task.abort();
         let mut message = BytesMut::with_capacity(self.current_length + final_chunk.len());
         for (index, chunk) in self.chunks[0..self.total_chunks as usize]
             .iter_mut()
@@ -444,6 +443,10 @@ impl ChunkedGelfDecoder {
             }
 
             let message_state = state_lock.remove(&message_id).expect("entry must exist");
+            // Abort while the message ID is still protected. Otherwise another decoder clone
+            // can reuse the ID before the old timeout is canceled, and that callback can remove
+            // the new message.
+            message_state.timeout_task.abort();
             drop(state_lock);
             return Ok(Some(message_state.finish(sequence_number, chunk)));
         }

--- a/lib/codecs/src/decoding/framing/chunked_gelf.rs
+++ b/lib/codecs/src/decoding/framing/chunked_gelf.rs
@@ -393,8 +393,12 @@ impl ChunkedGelfDecoder {
             let timeout = self.timeout;
             let timeout_handle = tokio::spawn(async move {
                 tokio::time::sleep(timeout).await;
+                let timeout_task_id = tokio::task::id();
                 let mut state_lock = state.lock().expect("poisoned lock");
-                if state_lock.remove(&message_id).is_some() {
+                let owns_message = state_lock
+                    .get(&message_id)
+                    .is_some_and(|message| message.timeout_task.id() == timeout_task_id);
+                if owns_message && state_lock.remove(&message_id).is_some() {
                     warn!(
                         message_id = message_id,
                         timeout_secs = timeout.as_secs_f64(),


### PR DESCRIPTION
## Summary

### Motivation

A one-chunk GELF message is already complete, but the decoder sent it through the pending-message path. That created unnecessary state and made message-ID ownership harder to enforce.

### Changes

- Decode one-chunk messages without creating pending state or a timeout task.
- Detach returned and retained payloads from the decoder input buffer.
- Reject a one-chunk message that reuses the ID of a pending multi-chunk message.

### References

Related: #26137

Stack: #26299 -> **#26300** -> #26301 -> #26302

## Vector configuration

Not applicable; the decoder behavior is exercised directly.

## How did you test this PR?

Focused tests exercise source-buffer ownership and pending message-ID reuse.

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## Contributor Guidelines

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Before pushing, follow our [pre-push guidance](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#pre-push).
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
