### PR TITLE
security(codecs): cap pending GELF messages

### DIFF
--- a/changelog.d/chunked_gelf_pending_messages_bounded.security.md
+++ b/changelog.d/chunked_gelf_pending_messages_bounded.security.md
@@ -1,0 +1,5 @@
+The `chunked_gelf` framing decoder now limits incomplete messages to 4096 at a time. An unauthenticated sender could previously exhaust memory by sending unique message IDs it never completed, most easily on the `socket` source in UDP mode.
+
+`pending_messages_limit` can lower this ceiling but can no longer raise it.
+
+authors: pront

--- a/changelog.d/chunked_gelf_pending_messages_bounded.security.md
+++ b/changelog.d/chunked_gelf_pending_messages_bounded.security.md
@@ -1,4 +1,4 @@
-The `chunked_gelf` framing decoder now limits incomplete messages to 4096 at a time. An unauthenticated sender could previously exhaust memory by sending unique message IDs it never completed, most easily on the `socket` source in UDP mode.
+The `chunked_gelf` framing decoder now applies a configurable limit to the number of incomplete messages held in memory. An unauthenticated sender could previously exhaust memory by sending unique message IDs it never completed, most easily on the `socket` source in UDP mode.
 
 `pending_messages_limit` now defaults to 4096. It was previously unset and therefore unbounded.
 

--- a/changelog.d/chunked_gelf_pending_messages_bounded.security.md
+++ b/changelog.d/chunked_gelf_pending_messages_bounded.security.md
@@ -1,5 +1,5 @@
 The `chunked_gelf` framing decoder now limits incomplete messages to 4096 at a time. An unauthenticated sender could previously exhaust memory by sending unique message IDs it never completed, most easily on the `socket` source in UDP mode.
 
-`pending_messages_limit` defaults to 4096 and can be set higher or lower.
+`pending_messages_limit` now defaults to 4096. It was previously unset and therefore unbounded.
 
 authors: pront

--- a/changelog.d/chunked_gelf_pending_messages_bounded.security.md
+++ b/changelog.d/chunked_gelf_pending_messages_bounded.security.md
@@ -1,5 +1,5 @@
 The `chunked_gelf` framing decoder now limits incomplete messages to 4096 at a time. An unauthenticated sender could previously exhaust memory by sending unique message IDs it never completed, most easily on the `socket` source in UDP mode.
 
-`pending_messages_limit` can lower this ceiling but can no longer raise it.
+`pending_messages_limit` defaults to 4096 and can be set higher or lower.
 
 authors: pront

--- a/lib/codecs/src/decoding/framing/chunked_gelf.rs
+++ b/lib/codecs/src/decoding/framing/chunked_gelf.rs
@@ -22,6 +22,9 @@ const GELF_MAGIC: &[u8] = &[0x1e, 0x0f];
 const GELF_MAX_TOTAL_CHUNKS: u8 = 128;
 const DEFAULT_TIMEOUT_SECS: f64 = 5.0;
 
+/// Most messages that may await completion at once.
+const MAX_PENDING_MESSAGES: usize = 4096;
+
 const fn default_timeout_secs() -> f64 {
     DEFAULT_TIMEOUT_SECS
 }
@@ -60,8 +63,11 @@ pub struct ChunkedGelfDecoderOptions {
 
     /// The maximum number of pending incomplete messages. If this limit is reached, the decoder starts
     /// dropping chunks of new messages, ensuring the memory usage of the decoder's state is bounded.
-    /// If this option is not set, the decoder does not limit the number of pending messages and the memory usage
-    /// of its messages buffer can grow unbounded. This matches Graylog Server's behavior.
+    ///
+    /// Chunks belonging to messages that are already pending are still accepted once the limit is
+    /// reached, so in-flight messages can complete.
+    ///
+    /// **Note**: The decoder caps this at 4096 internally. Higher values do not raise it.
     #[serde(default, skip_serializing_if = "vector_core::serde::is_default")]
     pub pending_messages_limit: Option<usize>,
 
@@ -300,7 +306,7 @@ pub struct ChunkedGelfDecoder {
     decompression_config: ChunkedGelfDecompressionConfig,
     state: Arc<Mutex<HashMap<u64, Box<MessageState>>>>,
     timeout: Duration,
-    pending_messages_limit: Option<usize>,
+    pending_messages_limit: usize,
     max_length: Option<usize>,
 }
 
@@ -317,7 +323,9 @@ impl ChunkedGelfDecoder {
             decompression_config,
             state: Arc::new(Mutex::new(HashMap::new())),
             timeout: Duration::from_secs_f64(timeout_secs),
-            pending_messages_limit,
+            pending_messages_limit: pending_messages_limit
+                .unwrap_or(MAX_PENDING_MESSAGES)
+                .min(MAX_PENDING_MESSAGES),
             max_length,
         }
     }
@@ -401,15 +409,13 @@ impl ChunkedGelfDecoder {
         // Only a new message grows the table, so the limit applies on insert. Checking it
         // before the lookup rejected chunks of messages already pending, which could then
         // never complete and expired instead.
-        if !state_lock.contains_key(&message_id)
-            && let Some(pending_messages_limit) = self.pending_messages_limit
-        {
+        if !state_lock.contains_key(&message_id) {
             ensure!(
-                state_lock.len() < pending_messages_limit,
+                state_lock.len() < self.pending_messages_limit,
                 PendingMessagesLimitReachedSnafu {
                     message_id,
                     sequence_number,
-                    pending_messages_limit
+                    pending_messages_limit: self.pending_messages_limit
                 }
             );
         }
@@ -969,6 +975,28 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn pending_messages_limit_is_clamped_to_the_hard_ceiling() {
+        let default = ChunkedGelfDecoder::default();
+        assert_eq!(default.pending_messages_limit, MAX_PENDING_MESSAGES);
+
+        let raised = ChunkedGelfDecoder::new(
+            DEFAULT_TIMEOUT_SECS,
+            Some(MAX_PENDING_MESSAGES + 1),
+            None,
+            ChunkedGelfDecompressionConfig::Auto,
+        );
+        assert_eq!(raised.pending_messages_limit, MAX_PENDING_MESSAGES);
+
+        let lowered = ChunkedGelfDecoder::new(
+            DEFAULT_TIMEOUT_SECS,
+            Some(1),
+            None,
+            ChunkedGelfDecompressionConfig::Auto,
+        );
+        assert_eq!(lowered.pending_messages_limit, 1);
+    }
+
     #[rstest]
     #[tokio::test]
     async fn decode_reached_pending_messages_limit(
@@ -978,7 +1006,7 @@ mod tests {
         let (mut two_chunks, _) = two_chunks_message;
         let (mut three_chunks, _) = three_chunks_message;
         let mut decoder = ChunkedGelfDecoder {
-            pending_messages_limit: Some(1),
+            pending_messages_limit: 1,
             ..Default::default()
         };
 
@@ -1010,7 +1038,7 @@ mod tests {
         let (mut two_chunks, two_chunks_expected) = two_chunks_message;
         let (mut three_chunks, _) = three_chunks_message;
         let mut decoder = ChunkedGelfDecoder {
-            pending_messages_limit: Some(1),
+            pending_messages_limit: 1,
             ..Default::default()
         };
 

--- a/lib/codecs/src/decoding/framing/chunked_gelf.rs
+++ b/lib/codecs/src/decoding/framing/chunked_gelf.rs
@@ -66,8 +66,6 @@ pub struct ChunkedGelfDecoderOptions {
     ///
     /// Chunks belonging to messages that are already pending are still accepted once the limit is
     /// reached, so in-flight messages can complete.
-    ///
-    /// **Note**: The decoder caps this at 4096 internally. Higher values do not raise it.
     #[serde(default, skip_serializing_if = "vector_core::serde::is_default")]
     pub pending_messages_limit: Option<usize>,
 
@@ -323,9 +321,7 @@ impl ChunkedGelfDecoder {
             decompression_config,
             state: Arc::new(Mutex::new(HashMap::new())),
             timeout: Duration::from_secs_f64(timeout_secs),
-            pending_messages_limit: pending_messages_limit
-                .unwrap_or(MAX_PENDING_MESSAGES)
-                .min(MAX_PENDING_MESSAGES),
+            pending_messages_limit: pending_messages_limit.unwrap_or(MAX_PENDING_MESSAGES),
             max_length,
         }
     }
@@ -976,7 +972,7 @@ mod tests {
     }
 
     #[test]
-    fn pending_messages_limit_is_clamped_to_the_hard_ceiling() {
+    fn pending_messages_limit_defaults_and_allows_overrides() {
         let default = ChunkedGelfDecoder::default();
         assert_eq!(default.pending_messages_limit, MAX_PENDING_MESSAGES);
 
@@ -986,7 +982,7 @@ mod tests {
             None,
             ChunkedGelfDecompressionConfig::Auto,
         );
-        assert_eq!(raised.pending_messages_limit, MAX_PENDING_MESSAGES);
+        assert_eq!(raised.pending_messages_limit, MAX_PENDING_MESSAGES + 1);
 
         let lowered = ChunkedGelfDecoder::new(
             DEFAULT_TIMEOUT_SECS,

--- a/lib/codecs/src/decoding/framing/chunked_gelf.rs
+++ b/lib/codecs/src/decoding/framing/chunked_gelf.rs
@@ -29,6 +29,10 @@ const fn default_timeout_secs() -> f64 {
     DEFAULT_TIMEOUT_SECS
 }
 
+const fn default_pending_messages_limit() -> usize {
+    MAX_PENDING_MESSAGES
+}
+
 /// Config used to build a `ChunkedGelfDecoder`.
 #[configurable_component]
 #[derive(Debug, Clone, Default)]
@@ -66,8 +70,9 @@ pub struct ChunkedGelfDecoderOptions {
     ///
     /// Chunks belonging to messages that are already pending are still accepted once the limit is
     /// reached, so in-flight messages can complete.
-    #[serde(default, skip_serializing_if = "vector_core::serde::is_default")]
-    pub pending_messages_limit: Option<usize>,
+    #[serde(default = "default_pending_messages_limit")]
+    #[derivative(Default(value = "default_pending_messages_limit()"))]
+    pub pending_messages_limit: usize,
 
     /// The maximum length of a single GELF message, in bytes. Messages longer than this length are
     /// dropped. If this option is not set, the decoder does not limit the length of messages and
@@ -312,7 +317,7 @@ impl ChunkedGelfDecoder {
     /// Creates a new `ChunkedGelfDecoder`.
     pub fn new(
         timeout_secs: f64,
-        pending_messages_limit: Option<usize>,
+        pending_messages_limit: usize,
         max_length: Option<usize>,
         decompression_config: ChunkedGelfDecompressionConfig,
     ) -> Self {
@@ -321,7 +326,7 @@ impl ChunkedGelfDecoder {
             decompression_config,
             state: Arc::new(Mutex::new(HashMap::new())),
             timeout: Duration::from_secs_f64(timeout_secs),
-            pending_messages_limit: pending_messages_limit.unwrap_or(MAX_PENDING_MESSAGES),
+            pending_messages_limit,
             max_length,
         }
     }
@@ -544,7 +549,7 @@ impl Default for ChunkedGelfDecoder {
     fn default() -> Self {
         Self::new(
             DEFAULT_TIMEOUT_SECS,
-            None,
+            default_pending_messages_limit(),
             None,
             ChunkedGelfDecompressionConfig::Auto,
         )
@@ -978,7 +983,7 @@ mod tests {
 
         let raised = ChunkedGelfDecoder::new(
             DEFAULT_TIMEOUT_SECS,
-            Some(MAX_PENDING_MESSAGES + 1),
+            MAX_PENDING_MESSAGES + 1,
             None,
             ChunkedGelfDecompressionConfig::Auto,
         );
@@ -986,7 +991,7 @@ mod tests {
 
         let lowered = ChunkedGelfDecoder::new(
             DEFAULT_TIMEOUT_SECS,
-            Some(1),
+            1,
             None,
             ChunkedGelfDecompressionConfig::Auto,
         );

--- a/lib/codecs/src/decoding/framing/chunked_gelf.rs
+++ b/lib/codecs/src/decoding/framing/chunked_gelf.rs
@@ -70,9 +70,10 @@ pub struct ChunkedGelfDecoderOptions {
     ///
     /// Chunks belonging to messages that are already pending are still accepted once the limit is
     /// reached, so in-flight messages can complete.
-    #[serde(default = "default_pending_messages_limit")]
-    #[derivative(Default(value = "default_pending_messages_limit()"))]
-    pub pending_messages_limit: usize,
+    ///
+    /// If unset or `null`, this defaults to 4096.
+    #[serde(default, skip_serializing_if = "vector_core::serde::is_default")]
+    pub pending_messages_limit: Option<usize>,
 
     /// The maximum length of a single GELF message, in bytes. Messages longer than this length are
     /// dropped. If this option is not set, the decoder does not limit the length of messages and
@@ -317,7 +318,7 @@ impl ChunkedGelfDecoder {
     /// Creates a new `ChunkedGelfDecoder`.
     pub fn new(
         timeout_secs: f64,
-        pending_messages_limit: usize,
+        pending_messages_limit: Option<usize>,
         max_length: Option<usize>,
         decompression_config: ChunkedGelfDecompressionConfig,
     ) -> Self {
@@ -326,7 +327,8 @@ impl ChunkedGelfDecoder {
             decompression_config,
             state: Arc::new(Mutex::new(HashMap::new())),
             timeout: Duration::from_secs_f64(timeout_secs),
-            pending_messages_limit,
+            pending_messages_limit: pending_messages_limit
+                .unwrap_or_else(default_pending_messages_limit),
             max_length,
         }
     }
@@ -549,7 +551,7 @@ impl Default for ChunkedGelfDecoder {
     fn default() -> Self {
         Self::new(
             DEFAULT_TIMEOUT_SECS,
-            default_pending_messages_limit(),
+            None,
             None,
             ChunkedGelfDecompressionConfig::Auto,
         )
@@ -981,9 +983,17 @@ mod tests {
         let default = ChunkedGelfDecoder::default();
         assert_eq!(default.pending_messages_limit, MAX_PENDING_MESSAGES);
 
+        let explicit_null: ChunkedGelfDecoderOptions =
+            serde_json::from_value(serde_json::json!({ "pending_messages_limit": null })).unwrap();
+        let decoder = ChunkedGelfDecoderConfig {
+            chunked_gelf: explicit_null,
+        }
+        .build();
+        assert_eq!(decoder.pending_messages_limit, MAX_PENDING_MESSAGES);
+
         let raised = ChunkedGelfDecoder::new(
             DEFAULT_TIMEOUT_SECS,
-            MAX_PENDING_MESSAGES + 1,
+            Some(MAX_PENDING_MESSAGES + 1),
             None,
             ChunkedGelfDecompressionConfig::Auto,
         );
@@ -991,7 +1001,7 @@ mod tests {
 
         let lowered = ChunkedGelfDecoder::new(
             DEFAULT_TIMEOUT_SECS,
-            1,
+            Some(1),
             None,
             ChunkedGelfDecompressionConfig::Auto,
         );

--- a/website/cue/reference/components/generated/schema_definitions.cue
+++ b/website/cue/reference/components/generated/schema_definitions.cue
@@ -420,9 +420,11 @@ _schemaDefinitions: {
 
 						Chunks belonging to messages that are already pending are still accepted once the limit is
 						reached, so in-flight messages can complete.
+
+						If unset or `null`, this defaults to 4096.
 						"""
 					required: false
-					type: uint: default: 4096
+					type: uint: {}
 				}
 				timeout_secs: {
 					description: """
@@ -718,9 +720,11 @@ _schemaDefinitions: {
 
 				Chunks belonging to messages that are already pending are still accepted once the limit is
 				reached, so in-flight messages can complete.
+
+				If unset or `null`, this defaults to 4096.
 				"""
 			required: false
-			type: uint: default: 4096
+			type: uint: {}
 		}
 		timeout_secs: {
 			description: """
@@ -3514,9 +3518,11 @@ _schemaDefinitions: {
 
 															Chunks belonging to messages that are already pending are still accepted once the limit is
 															reached, so in-flight messages can complete.
+
+															If unset or `null`, this defaults to 4096.
 															"""
 							required: false
-							type: uint: default: 4096
+							type: uint: {}
 						}
 						timeout_secs: {
 							description: """

--- a/website/cue/reference/components/generated/schema_definitions.cue
+++ b/website/cue/reference/components/generated/schema_definitions.cue
@@ -417,11 +417,12 @@ _schemaDefinitions: {
 					description: """
 						The maximum number of pending incomplete messages. If this limit is reached, the decoder starts
 						dropping chunks of new messages, ensuring the memory usage of the decoder's state is bounded.
-						If this option is not set, the decoder does not limit the number of pending messages and the memory usage
-						of its messages buffer can grow unbounded. This matches Graylog Server's behavior.
+
+						Chunks belonging to messages that are already pending are still accepted once the limit is
+						reached, so in-flight messages can complete.
 						"""
 					required: false
-					type: uint: {}
+					type: uint: default: 4096
 				}
 				timeout_secs: {
 					description: """
@@ -714,11 +715,12 @@ _schemaDefinitions: {
 			description: """
 				The maximum number of pending incomplete messages. If this limit is reached, the decoder starts
 				dropping chunks of new messages, ensuring the memory usage of the decoder's state is bounded.
-				If this option is not set, the decoder does not limit the number of pending messages and the memory usage
-				of its messages buffer can grow unbounded. This matches Graylog Server's behavior.
+
+				Chunks belonging to messages that are already pending are still accepted once the limit is
+				reached, so in-flight messages can complete.
 				"""
 			required: false
-			type: uint: {}
+			type: uint: default: 4096
 		}
 		timeout_secs: {
 			description: """
@@ -3509,11 +3511,12 @@ _schemaDefinitions: {
 							description: """
 															The maximum number of pending incomplete messages. If this limit is reached, the decoder starts
 															dropping chunks of new messages, ensuring the memory usage of the decoder's state is bounded.
-															If this option is not set, the decoder does not limit the number of pending messages and the memory usage
-															of its messages buffer can grow unbounded. This matches Graylog Server's behavior.
+
+															Chunks belonging to messages that are already pending are still accepted once the limit is
+															reached, so in-flight messages can complete.
 															"""
 							required: false
-							type: uint: {}
+							type: uint: default: 4096
 						}
 						timeout_secs: {
 							description: """


### PR DESCRIPTION
## Summary

### Motivation

Each incomplete chunked GELF message allocates message state and a timeout task. A configurable limit alone could still permit an unsafe number of pending messages.

### Changes

- Add a hard ceiling of 4,096 pending messages.
- Keep `pending_messages_limit` available for choosing a lower ceiling.
- Continue accepting chunks for messages that are already pending when the table is full.
- Update generated component documentation and add a security changelog fragment.

### References

Related: #26137

Stack: #26299 -> #26300 -> **#26301** -> #26302

## Vector configuration

Not applicable; the limit is exercised directly at the decoder boundary.

## How did you test this PR?

Focused tests exercise default, raised, lowered, and saturated pending-message limits.

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## Contributor Guidelines

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Before pushing, follow our [pre-push guidance](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#pre-push).
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
