### PR TITLE
security(codecs): cap buffered GELF payload

### DIFF
--- a/changelog.d/chunked_gelf_buffered_payload_bounded.security.md
+++ b/changelog.d/chunked_gelf_buffered_payload_bounded.security.md
@@ -1,0 +1,5 @@
+The `chunked_gelf` framing decoder now limits the payload buffered across incomplete messages to 128 MiB. An unauthenticated sender could previously exhaust memory by sending chunks for messages it never completed, most easily on the `socket` source in UDP mode.
+
+`max_length` can lower the per-message ceiling but can no longer raise it above the aggregate limit.
+
+authors: pront

--- a/changelog.d/chunked_gelf_buffered_payload_bounded.security.md
+++ b/changelog.d/chunked_gelf_buffered_payload_bounded.security.md
@@ -1,5 +1,5 @@
 The `chunked_gelf` framing decoder now limits the payload buffered across incomplete messages to 128 MiB. An unauthenticated sender could previously exhaust memory by sending chunks for messages it never completed, most easily on the `socket` source in UDP mode.
 
-`max_length` can lower the per-message ceiling but can no longer raise it above the aggregate limit.
+`max_length` can lower the per-message ceiling. Setting it above 128 MiB raises both the per-message ceiling and the aggregate limit to that value.
 
 authors: pront

--- a/changelog.d/chunked_gelf_pending_messages_bounded.security.md
+++ b/changelog.d/chunked_gelf_pending_messages_bounded.security.md
@@ -1,0 +1,5 @@
+The `chunked_gelf` framing decoder now limits incomplete messages to 4096 at a time. An unauthenticated sender could previously exhaust memory by sending unique message IDs it never completed, most easily on the `socket` source in UDP mode.
+
+`pending_messages_limit` can lower this ceiling but can no longer raise it.
+
+authors: pront

--- a/changelog.d/chunked_gelf_pending_messages_bounded.security.md
+++ b/changelog.d/chunked_gelf_pending_messages_bounded.security.md
@@ -1,5 +1,5 @@
 The `chunked_gelf` framing decoder now limits incomplete messages to 4096 at a time. An unauthenticated sender could previously exhaust memory by sending unique message IDs it never completed, most easily on the `socket` source in UDP mode.
 
-`pending_messages_limit` defaults to 4096 and can be set higher or lower.
+`pending_messages_limit` now defaults to 4096. It was previously unset and therefore unbounded.
 
 authors: pront

--- a/changelog.d/chunked_gelf_pending_messages_bounded.security.md
+++ b/changelog.d/chunked_gelf_pending_messages_bounded.security.md
@@ -1,5 +1,5 @@
 The `chunked_gelf` framing decoder now limits incomplete messages to 4096 at a time. An unauthenticated sender could previously exhaust memory by sending unique message IDs it never completed, most easily on the `socket` source in UDP mode.
 
-`pending_messages_limit` can lower this ceiling but can no longer raise it.
+`pending_messages_limit` defaults to 4096 and can be set higher or lower.
 
 authors: pront

--- a/lib/codecs/src/decoding/framing/chunked_gelf.rs
+++ b/lib/codecs/src/decoding/framing/chunked_gelf.rs
@@ -22,6 +22,9 @@ const GELF_MAGIC: &[u8] = &[0x1e, 0x0f];
 const GELF_MAX_TOTAL_CHUNKS: u8 = 128;
 const DEFAULT_TIMEOUT_SECS: f64 = 5.0;
 
+/// Most messages that may await completion at once.
+const MAX_PENDING_MESSAGES: usize = 4096;
+
 const fn default_timeout_secs() -> f64 {
     DEFAULT_TIMEOUT_SECS
 }
@@ -60,8 +63,11 @@ pub struct ChunkedGelfDecoderOptions {
 
     /// The maximum number of pending incomplete messages. If this limit is reached, the decoder starts
     /// dropping chunks of new messages, ensuring the memory usage of the decoder's state is bounded.
-    /// If this option is not set, the decoder does not limit the number of pending messages and the memory usage
-    /// of its messages buffer can grow unbounded. This matches Graylog Server's behavior.
+    ///
+    /// Chunks belonging to messages that are already pending are still accepted once the limit is
+    /// reached, so in-flight messages can complete.
+    ///
+    /// **Note**: The decoder caps this at 4096 internally. Higher values do not raise it.
     #[serde(default, skip_serializing_if = "vector_core::serde::is_default")]
     pub pending_messages_limit: Option<usize>,
 
@@ -300,7 +306,7 @@ pub struct ChunkedGelfDecoder {
     decompression_config: ChunkedGelfDecompressionConfig,
     state: Arc<Mutex<HashMap<u64, Box<MessageState>>>>,
     timeout: Duration,
-    pending_messages_limit: Option<usize>,
+    pending_messages_limit: usize,
     max_length: Option<usize>,
 }
 
@@ -317,7 +323,9 @@ impl ChunkedGelfDecoder {
             decompression_config,
             state: Arc::new(Mutex::new(HashMap::new())),
             timeout: Duration::from_secs_f64(timeout_secs),
-            pending_messages_limit,
+            pending_messages_limit: pending_messages_limit
+                .unwrap_or(MAX_PENDING_MESSAGES)
+                .min(MAX_PENDING_MESSAGES),
             max_length,
         }
     }
@@ -401,15 +409,13 @@ impl ChunkedGelfDecoder {
         // Only a new message grows the table, so the limit applies on insert. Checking it
         // before the lookup rejected chunks of messages already pending, which could then
         // never complete and expired instead.
-        if !state_lock.contains_key(&message_id)
-            && let Some(pending_messages_limit) = self.pending_messages_limit
-        {
+        if !state_lock.contains_key(&message_id) {
             ensure!(
-                state_lock.len() < pending_messages_limit,
+                state_lock.len() < self.pending_messages_limit,
                 PendingMessagesLimitReachedSnafu {
                     message_id,
                     sequence_number,
-                    pending_messages_limit
+                    pending_messages_limit: self.pending_messages_limit
                 }
             );
         }
@@ -969,6 +975,28 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn pending_messages_limit_is_clamped_to_the_hard_ceiling() {
+        let default = ChunkedGelfDecoder::default();
+        assert_eq!(default.pending_messages_limit, MAX_PENDING_MESSAGES);
+
+        let raised = ChunkedGelfDecoder::new(
+            DEFAULT_TIMEOUT_SECS,
+            Some(MAX_PENDING_MESSAGES + 1),
+            None,
+            ChunkedGelfDecompressionConfig::Auto,
+        );
+        assert_eq!(raised.pending_messages_limit, MAX_PENDING_MESSAGES);
+
+        let lowered = ChunkedGelfDecoder::new(
+            DEFAULT_TIMEOUT_SECS,
+            Some(1),
+            None,
+            ChunkedGelfDecompressionConfig::Auto,
+        );
+        assert_eq!(lowered.pending_messages_limit, 1);
+    }
+
     #[rstest]
     #[tokio::test]
     async fn decode_reached_pending_messages_limit(
@@ -978,7 +1006,7 @@ mod tests {
         let (mut two_chunks, _) = two_chunks_message;
         let (mut three_chunks, _) = three_chunks_message;
         let mut decoder = ChunkedGelfDecoder {
-            pending_messages_limit: Some(1),
+            pending_messages_limit: 1,
             ..Default::default()
         };
 
@@ -1010,7 +1038,7 @@ mod tests {
         let (mut two_chunks, two_chunks_expected) = two_chunks_message;
         let (mut three_chunks, _) = three_chunks_message;
         let mut decoder = ChunkedGelfDecoder {
-            pending_messages_limit: Some(1),
+            pending_messages_limit: 1,
             ..Default::default()
         };
 

--- a/lib/codecs/src/decoding/framing/chunked_gelf.rs
+++ b/lib/codecs/src/decoding/framing/chunked_gelf.rs
@@ -25,8 +25,8 @@ const DEFAULT_TIMEOUT_SECS: f64 = 5.0;
 /// Most messages that may await completion at once.
 const MAX_PENDING_MESSAGES: usize = 4096;
 
-/// Most chunk payload held across all incomplete messages. Aggregate, so it also bounds one.
-const MAX_BUFFERED_PAYLOAD: usize = 128 * 1024 * 1024;
+/// Default maximum chunk payload held across all incomplete messages.
+const DEFAULT_MAX_BUFFERED_PAYLOAD: usize = 128 * 1024 * 1024;
 
 const fn default_timeout_secs() -> f64 {
     DEFAULT_TIMEOUT_SECS
@@ -86,8 +86,8 @@ pub struct ChunkedGelfDecoderOptions {
     /// This limit takes into account only the message payload. GELF header bytes are excluded from the calculation.
     /// The message payload is the concatenation of all chunk payloads.
     ///
-    /// **Note**: The decoder also caps the payload buffered across *all* incomplete messages
-    /// at 128 MiB, so no chunked message can exceed that whatever this is set to.
+    /// The decoder also limits the payload buffered across *all* incomplete messages to 128 MiB by
+    /// default. Setting this above 128 MiB raises that aggregate limit to the same value.
     ///
     /// An unchunked message is never buffered, so neither limit applies to it; its size is
     /// bounded by whatever the source accepts as one frame.
@@ -354,6 +354,7 @@ pub struct ChunkedGelfDecoder {
     timeout: Duration,
     pending_messages_limit: usize,
     max_length: usize,
+    max_buffered_payload: usize,
 }
 
 impl ChunkedGelfDecoder {
@@ -364,15 +365,15 @@ impl ChunkedGelfDecoder {
         max_length: Option<usize>,
         decompression_config: ChunkedGelfDecompressionConfig,
     ) -> Self {
+        let max_length = max_length.unwrap_or(DEFAULT_MAX_BUFFERED_PAYLOAD);
         Self {
             bytes_decoder: BytesDecoder::new(),
             decompression_config,
             state: Arc::new(Mutex::new(PendingMessages::new())),
             timeout: Duration::from_secs_f64(timeout_secs),
             pending_messages_limit,
-            max_length: max_length
-                .unwrap_or(MAX_BUFFERED_PAYLOAD)
-                .min(MAX_BUFFERED_PAYLOAD),
+            max_length,
+            max_buffered_payload: max_length.max(DEFAULT_MAX_BUFFERED_PAYLOAD),
         }
     }
 
@@ -473,11 +474,11 @@ impl ChunkedGelfDecoder {
                 }
             );
             ensure!(
-                pending.buffered_payload.saturating_add(chunk_len) <= MAX_BUFFERED_PAYLOAD,
+                pending.buffered_payload.saturating_add(chunk_len) <= self.max_buffered_payload,
                 BufferedPayloadLimitReachedSnafu {
                     message_id,
                     sequence_number,
-                    limit: MAX_BUFFERED_PAYLOAD,
+                    limit: self.max_buffered_payload,
                 }
             );
         }
@@ -554,12 +555,12 @@ impl ChunkedGelfDecoder {
 
         // A message that cannot advance would otherwise retain its allocation until timeout.
         // Discard only that message and refund the payload it already held.
-        if pending.buffered_payload.saturating_add(chunk_len) > MAX_BUFFERED_PAYLOAD {
+        if pending.buffered_payload.saturating_add(chunk_len) > self.max_buffered_payload {
             pending.discard(message_id);
             return Err(ChunkedGelfDecoderError::BufferedPayloadLimitReached {
                 message_id,
                 sequence_number,
-                limit: MAX_BUFFERED_PAYLOAD,
+                limit: self.max_buffered_payload,
             });
         }
 
@@ -1137,7 +1138,7 @@ mod tests {
     async fn new_message_is_rejected_before_exceeding_the_payload_limit() {
         let mut chunk = create_chunk(1u64, 0u8, 2u8, &vec![b'x'; 1024]);
         let mut decoder = ChunkedGelfDecoder::default();
-        let already_buffered = MAX_BUFFERED_PAYLOAD - 1;
+        let already_buffered = DEFAULT_MAX_BUFFERED_PAYLOAD - 1;
         decoder.state.lock().unwrap().buffered_payload = already_buffered;
 
         let error = decoder
@@ -1149,7 +1150,7 @@ mod tests {
             ChunkedGelfDecoderError::BufferedPayloadLimitReached {
                 message_id: 1,
                 sequence_number: 0,
-                limit: MAX_BUFFERED_PAYLOAD,
+                limit: DEFAULT_MAX_BUFFERED_PAYLOAD,
             }
         ));
         let pending = decoder.state.lock().unwrap();
@@ -1169,7 +1170,7 @@ mod tests {
         let mut unrelated = create_chunk(3u64, 0u8, 3u8, &"bar");
         assert!(decoder.decode_eof(&mut unrelated).unwrap().is_none());
 
-        decoder.state.lock().unwrap().buffered_payload = MAX_BUFFERED_PAYLOAD;
+        decoder.state.lock().unwrap().buffered_payload = DEFAULT_MAX_BUFFERED_PAYLOAD;
         let error = decoder
             .decode_eof(&mut chunks[1].clone())
             .expect_err("the chunk must be refused");
@@ -1181,7 +1182,7 @@ mod tests {
         let pending = decoder.state.lock().unwrap();
         assert!(!pending.messages.contains_key(&2));
         assert!(pending.messages.contains_key(&3));
-        assert_eq!(pending.buffered_payload, MAX_BUFFERED_PAYLOAD - 3);
+        assert_eq!(pending.buffered_payload, DEFAULT_MAX_BUFFERED_PAYLOAD - 3);
     }
 
     #[tokio::test]
@@ -1192,7 +1193,7 @@ mod tests {
             None,
             ChunkedGelfDecompressionConfig::Auto,
         );
-        decoder.state.lock().unwrap().buffered_payload = MAX_BUFFERED_PAYLOAD;
+        decoder.state.lock().unwrap().buffered_payload = DEFAULT_MAX_BUFFERED_PAYLOAD;
 
         let mut chunk = create_chunk(u64::MAX, 0u8, 1u8, &"foo");
         assert_eq!(
@@ -1202,7 +1203,7 @@ mod tests {
 
         let pending = decoder.state.lock().unwrap();
         assert!(pending.messages.is_empty());
-        assert_eq!(pending.buffered_payload, MAX_BUFFERED_PAYLOAD);
+        assert_eq!(pending.buffered_payload, DEFAULT_MAX_BUFFERED_PAYLOAD);
     }
 
     #[rstest]
@@ -1213,7 +1214,7 @@ mod tests {
 
         assert!(decoder.decode_eof(&mut chunks[0]).unwrap().is_none());
         assert!(decoder.decode_eof(&mut chunks[1]).unwrap().is_none());
-        decoder.state.lock().unwrap().buffered_payload = MAX_BUFFERED_PAYLOAD;
+        decoder.state.lock().unwrap().buffered_payload = DEFAULT_MAX_BUFFERED_PAYLOAD;
 
         assert_eq!(
             decoder.decode_eof(&mut chunks[2]).unwrap(),
@@ -1222,7 +1223,7 @@ mod tests {
 
         let pending = decoder.state.lock().unwrap();
         assert!(pending.messages.is_empty());
-        assert_eq!(pending.buffered_payload, MAX_BUFFERED_PAYLOAD - 6);
+        assert_eq!(pending.buffered_payload, DEFAULT_MAX_BUFFERED_PAYLOAD - 6);
     }
 
     #[rstest]
@@ -1239,7 +1240,7 @@ mod tests {
         );
 
         assert!(decoder.decode_eof(&mut chunks[0]).unwrap().is_none());
-        decoder.state.lock().unwrap().buffered_payload = MAX_BUFFERED_PAYLOAD;
+        decoder.state.lock().unwrap().buffered_payload = DEFAULT_MAX_BUFFERED_PAYLOAD;
 
         let error = decoder
             .decode_eof(&mut chunks[1])
@@ -1255,21 +1256,26 @@ mod tests {
 
         let pending = decoder.state.lock().unwrap();
         assert!(pending.messages.is_empty());
-        assert_eq!(pending.buffered_payload, MAX_BUFFERED_PAYLOAD - 3);
+        assert_eq!(pending.buffered_payload, DEFAULT_MAX_BUFFERED_PAYLOAD - 3);
     }
 
     #[test]
-    fn max_length_only_tightens_the_payload_ceiling() {
+    fn max_length_adjusts_the_per_message_and_aggregate_limits() {
         let default = ChunkedGelfDecoder::default();
-        assert_eq!(default.max_length, MAX_BUFFERED_PAYLOAD);
+        assert_eq!(default.max_length, DEFAULT_MAX_BUFFERED_PAYLOAD);
+        assert_eq!(default.max_buffered_payload, DEFAULT_MAX_BUFFERED_PAYLOAD);
 
         let raised = ChunkedGelfDecoder::new(
             DEFAULT_TIMEOUT_SECS,
             default_pending_messages_limit(),
-            Some(MAX_BUFFERED_PAYLOAD + 1),
+            Some(DEFAULT_MAX_BUFFERED_PAYLOAD + 1),
             ChunkedGelfDecompressionConfig::Auto,
         );
-        assert_eq!(raised.max_length, MAX_BUFFERED_PAYLOAD);
+        assert_eq!(raised.max_length, DEFAULT_MAX_BUFFERED_PAYLOAD + 1);
+        assert_eq!(
+            raised.max_buffered_payload,
+            DEFAULT_MAX_BUFFERED_PAYLOAD + 1
+        );
 
         let lowered = ChunkedGelfDecoder::new(
             DEFAULT_TIMEOUT_SECS,
@@ -1278,6 +1284,35 @@ mod tests {
             ChunkedGelfDecompressionConfig::Auto,
         );
         assert_eq!(lowered.max_length, 2);
+        assert_eq!(lowered.max_buffered_payload, DEFAULT_MAX_BUFFERED_PAYLOAD);
+    }
+
+    #[tokio::test]
+    async fn raised_max_length_raises_the_aggregate_limit() {
+        let mut decoder = ChunkedGelfDecoder::new(
+            DEFAULT_TIMEOUT_SECS,
+            default_pending_messages_limit(),
+            Some(DEFAULT_MAX_BUFFERED_PAYLOAD + 1),
+            ChunkedGelfDecompressionConfig::Auto,
+        );
+        decoder.state.lock().unwrap().buffered_payload = DEFAULT_MAX_BUFFERED_PAYLOAD;
+
+        let mut first = create_chunk(1, 0, 2, &"x");
+        assert!(decoder.decode_eof(&mut first).unwrap().is_none());
+        assert_eq!(
+            decoder.state.lock().unwrap().buffered_payload,
+            DEFAULT_MAX_BUFFERED_PAYLOAD + 1
+        );
+
+        let mut second = create_chunk(1, 1, 2, &"y");
+        assert_eq!(
+            decoder.decode_eof(&mut second).unwrap(),
+            Some(Bytes::from_static(b"xy"))
+        );
+        assert_eq!(
+            decoder.state.lock().unwrap().buffered_payload,
+            DEFAULT_MAX_BUFFERED_PAYLOAD
+        );
     }
 
     #[test]

--- a/lib/codecs/src/decoding/framing/chunked_gelf.rs
+++ b/lib/codecs/src/decoding/framing/chunked_gelf.rs
@@ -66,8 +66,6 @@ pub struct ChunkedGelfDecoderOptions {
     ///
     /// Chunks belonging to messages that are already pending are still accepted once the limit is
     /// reached, so in-flight messages can complete.
-    ///
-    /// **Note**: The decoder caps this at 4096 internally. Higher values do not raise it.
     #[serde(default, skip_serializing_if = "vector_core::serde::is_default")]
     pub pending_messages_limit: Option<usize>,
 
@@ -323,9 +321,7 @@ impl ChunkedGelfDecoder {
             decompression_config,
             state: Arc::new(Mutex::new(HashMap::new())),
             timeout: Duration::from_secs_f64(timeout_secs),
-            pending_messages_limit: pending_messages_limit
-                .unwrap_or(MAX_PENDING_MESSAGES)
-                .min(MAX_PENDING_MESSAGES),
+            pending_messages_limit: pending_messages_limit.unwrap_or(MAX_PENDING_MESSAGES),
             max_length,
         }
     }
@@ -976,7 +972,7 @@ mod tests {
     }
 
     #[test]
-    fn pending_messages_limit_is_clamped_to_the_hard_ceiling() {
+    fn pending_messages_limit_defaults_and_allows_overrides() {
         let default = ChunkedGelfDecoder::default();
         assert_eq!(default.pending_messages_limit, MAX_PENDING_MESSAGES);
 
@@ -986,7 +982,7 @@ mod tests {
             None,
             ChunkedGelfDecompressionConfig::Auto,
         );
-        assert_eq!(raised.pending_messages_limit, MAX_PENDING_MESSAGES);
+        assert_eq!(raised.pending_messages_limit, MAX_PENDING_MESSAGES + 1);
 
         let lowered = ChunkedGelfDecoder::new(
             DEFAULT_TIMEOUT_SECS,

--- a/lib/codecs/src/decoding/framing/chunked_gelf.rs
+++ b/lib/codecs/src/decoding/framing/chunked_gelf.rs
@@ -36,6 +36,10 @@ const fn default_pending_messages_limit() -> usize {
     MAX_PENDING_MESSAGES
 }
 
+const fn default_max_length() -> Option<usize> {
+    Some(DEFAULT_MAX_BUFFERED_PAYLOAD)
+}
+
 /// Config used to build a `ChunkedGelfDecoder`.
 #[configurable_component]
 #[derive(Debug, Clone, Default)]
@@ -92,7 +96,11 @@ pub struct ChunkedGelfDecoderOptions {
     ///
     /// An unchunked message is never buffered, so neither limit applies to it; its size is
     /// bounded by whatever the source accepts as one frame.
-    #[serde(default, skip_serializing_if = "vector_core::serde::is_default")]
+    #[derivative(Default(value = "default_max_length()"))]
+    #[serde(
+        default = "default_max_length",
+        skip_serializing_if = "vector_core::serde::is_default"
+    )]
     pub max_length: Option<usize>,
 
     /// Decompression configuration for GELF messages.
@@ -1293,6 +1301,19 @@ mod tests {
 
     #[test]
     fn max_length_adjusts_the_per_message_and_aggregate_limits() {
+        let omitted: ChunkedGelfDecoderOptions = serde_json::from_value(serde_json::json!({}))
+            .expect("the default options must deserialize");
+        assert_eq!(omitted.max_length, default_max_length());
+
+        let explicit_null: ChunkedGelfDecoderOptions =
+            serde_json::from_value(serde_json::json!({ "max_length": null }))
+                .expect("an explicit null must deserialize");
+        let explicit_null = ChunkedGelfDecoderConfig {
+            chunked_gelf: explicit_null,
+        }
+        .build();
+        assert_eq!(explicit_null.max_length, DEFAULT_MAX_BUFFERED_PAYLOAD);
+
         let default = ChunkedGelfDecoder::default();
         assert_eq!(default.max_length, DEFAULT_MAX_BUFFERED_PAYLOAD);
         assert_eq!(default.max_buffered_payload, DEFAULT_MAX_BUFFERED_PAYLOAD);

--- a/lib/codecs/src/decoding/framing/chunked_gelf.rs
+++ b/lib/codecs/src/decoding/framing/chunked_gelf.rs
@@ -29,6 +29,10 @@ const fn default_timeout_secs() -> f64 {
     DEFAULT_TIMEOUT_SECS
 }
 
+const fn default_pending_messages_limit() -> usize {
+    MAX_PENDING_MESSAGES
+}
+
 /// Config used to build a `ChunkedGelfDecoder`.
 #[configurable_component]
 #[derive(Debug, Clone, Default)]
@@ -66,8 +70,9 @@ pub struct ChunkedGelfDecoderOptions {
     ///
     /// Chunks belonging to messages that are already pending are still accepted once the limit is
     /// reached, so in-flight messages can complete.
-    #[serde(default, skip_serializing_if = "vector_core::serde::is_default")]
-    pub pending_messages_limit: Option<usize>,
+    #[serde(default = "default_pending_messages_limit")]
+    #[derivative(Default(value = "default_pending_messages_limit()"))]
+    pub pending_messages_limit: usize,
 
     /// The maximum length of a single GELF message, in bytes. Messages longer than this length are
     /// dropped. If this option is not set, the decoder does not limit the length of messages and
@@ -312,7 +317,7 @@ impl ChunkedGelfDecoder {
     /// Creates a new `ChunkedGelfDecoder`.
     pub fn new(
         timeout_secs: f64,
-        pending_messages_limit: Option<usize>,
+        pending_messages_limit: usize,
         max_length: Option<usize>,
         decompression_config: ChunkedGelfDecompressionConfig,
     ) -> Self {
@@ -321,7 +326,7 @@ impl ChunkedGelfDecoder {
             decompression_config,
             state: Arc::new(Mutex::new(HashMap::new())),
             timeout: Duration::from_secs_f64(timeout_secs),
-            pending_messages_limit: pending_messages_limit.unwrap_or(MAX_PENDING_MESSAGES),
+            pending_messages_limit,
             max_length,
         }
     }
@@ -544,7 +549,7 @@ impl Default for ChunkedGelfDecoder {
     fn default() -> Self {
         Self::new(
             DEFAULT_TIMEOUT_SECS,
-            None,
+            default_pending_messages_limit(),
             None,
             ChunkedGelfDecompressionConfig::Auto,
         )
@@ -978,7 +983,7 @@ mod tests {
 
         let raised = ChunkedGelfDecoder::new(
             DEFAULT_TIMEOUT_SECS,
-            Some(MAX_PENDING_MESSAGES + 1),
+            MAX_PENDING_MESSAGES + 1,
             None,
             ChunkedGelfDecompressionConfig::Auto,
         );
@@ -986,7 +991,7 @@ mod tests {
 
         let lowered = ChunkedGelfDecoder::new(
             DEFAULT_TIMEOUT_SECS,
-            Some(1),
+            1,
             None,
             ChunkedGelfDecompressionConfig::Auto,
         );

--- a/lib/codecs/src/decoding/framing/chunked_gelf.rs
+++ b/lib/codecs/src/decoding/framing/chunked_gelf.rs
@@ -25,6 +25,9 @@ const DEFAULT_TIMEOUT_SECS: f64 = 5.0;
 /// Most messages that may await completion at once.
 const MAX_PENDING_MESSAGES: usize = 4096;
 
+/// Most chunk payload held across all incomplete messages. Aggregate, so it also bounds one.
+const MAX_BUFFERED_PAYLOAD: usize = 128 * 1024 * 1024;
+
 const fn default_timeout_secs() -> f64 {
     DEFAULT_TIMEOUT_SECS
 }
@@ -75,14 +78,19 @@ pub struct ChunkedGelfDecoderOptions {
     pub pending_messages_limit: usize,
 
     /// The maximum length of a single GELF message, in bytes. Messages longer than this length are
-    /// dropped. If this option is not set, the decoder does not limit the length of messages and
-    /// the per-message memory is unbounded.
+    /// dropped.
     ///
     /// **Note**: A message can be composed of multiple chunks, and this limit applies to the whole
     /// message, not to individual chunks.
     ///
     /// This limit takes into account only the message payload. GELF header bytes are excluded from the calculation.
     /// The message payload is the concatenation of all chunk payloads.
+    ///
+    /// **Note**: The decoder also caps the payload buffered across *all* incomplete messages
+    /// at 128 MiB, so no chunked message can exceed that whatever this is set to.
+    ///
+    /// An unchunked message is never buffered, so neither limit applies to it; its size is
+    /// bounded by whatever the source accepts as one frame.
     #[serde(default, skip_serializing_if = "vector_core::serde::is_default")]
     pub max_length: Option<usize>,
 
@@ -172,6 +180,33 @@ impl MessageState {
             }
         }
         message.freeze()
+    }
+}
+
+#[derive(Debug)]
+struct PendingMessages {
+    messages: HashMap<u64, Box<MessageState>>,
+    buffered_payload: usize,
+}
+
+impl PendingMessages {
+    fn new() -> Self {
+        Self {
+            messages: HashMap::new(),
+            buffered_payload: 0,
+        }
+    }
+
+    fn discard(&mut self, message_id: u64) {
+        if let Some(state) = self.remove(message_id) {
+            state.timeout_task.abort();
+        }
+    }
+
+    fn remove(&mut self, message_id: u64) -> Option<Box<MessageState>> {
+        self.messages.remove(&message_id).inspect(|state| {
+            self.buffered_payload = self.buffered_payload.saturating_sub(state.current_length);
+        })
     }
 }
 
@@ -278,6 +313,14 @@ pub enum ChunkedGelfDecoderError {
         length: usize,
         max_length: usize,
     },
+    #[snafu(display(
+        "Buffered payload limit of {limit} bytes reached while processing chunk with message id {message_id} and sequence number {sequence_number}. Discarding all buffered chunks of that message."
+    ))]
+    BufferedPayloadLimitReached {
+        message_id: u64,
+        sequence_number: u8,
+        limit: usize,
+    },
     #[snafu(display("Error while decompressing message. {source}"))]
     Decompression {
         source: ChunkedGelfDecompressionError,
@@ -307,10 +350,10 @@ pub struct ChunkedGelfDecoder {
     // message, so we have to read all the bytes from the message (datagram)
     bytes_decoder: BytesDecoder,
     decompression_config: ChunkedGelfDecompressionConfig,
-    state: Arc<Mutex<HashMap<u64, Box<MessageState>>>>,
+    state: Arc<Mutex<PendingMessages>>,
     timeout: Duration,
     pending_messages_limit: usize,
-    max_length: Option<usize>,
+    max_length: usize,
 }
 
 impl ChunkedGelfDecoder {
@@ -324,10 +367,12 @@ impl ChunkedGelfDecoder {
         Self {
             bytes_decoder: BytesDecoder::new(),
             decompression_config,
-            state: Arc::new(Mutex::new(HashMap::new())),
+            state: Arc::new(Mutex::new(PendingMessages::new())),
             timeout: Duration::from_secs_f64(timeout_secs),
             pending_messages_limit,
-            max_length,
+            max_length: max_length
+                .unwrap_or(MAX_BUFFERED_PAYLOAD)
+                .min(MAX_BUFFERED_PAYLOAD),
         }
     }
 
@@ -377,24 +422,24 @@ impl ChunkedGelfDecoder {
             }
         );
 
+        let chunk_len = chunk.len();
+
         // A lone chunk is already complete, but it cannot reuse the ID of a pending message.
         if total_chunks == 1 {
-            if let Some(max_length) = self.max_length
-                && chunk.len() > max_length
-            {
+            if chunk_len > self.max_length {
                 return Err(ChunkedGelfDecoderError::MaxLengthExceed {
                     message_id,
                     sequence_number,
-                    length: chunk.len(),
-                    max_length,
+                    length: chunk_len,
+                    max_length: self.max_length,
                 });
             }
 
             // Copy before taking the shared-state lock, then keep the lock from the ID check
             // through return so another decoder clone cannot insert this ID between them.
             let chunk = Bytes::copy_from_slice(&chunk);
-            let state_lock = self.state.lock().expect("poisoned lock");
-            if let Some(message_state) = state_lock.get(&message_id) {
+            let pending = self.state.lock().expect("poisoned lock");
+            if let Some(message_state) = pending.messages.get(&message_id) {
                 return Err(ChunkedGelfDecoderError::TotalChunksMismatch {
                     message_id,
                     sequence_number,
@@ -405,35 +450,50 @@ impl ChunkedGelfDecoder {
             return Ok(Some(chunk));
         }
 
-        let mut state_lock = self.state.lock().expect("poisoned lock");
+        let mut pending = self.state.lock().expect("poisoned lock");
 
-        // Only a new message grows the table, so the limit applies on insert. Checking it
-        // before the lookup rejected chunks of messages already pending, which could then
-        // never complete and expired instead.
-        if !state_lock.contains_key(&message_id) {
+        let is_new_message = !pending.messages.contains_key(&message_id);
+        // Settle every admission rule before creating state and a timeout task. The count limit
+        // applies only on insert, since rejecting chunks of pending messages would stall them.
+        if is_new_message {
+            if chunk_len > self.max_length {
+                return Err(ChunkedGelfDecoderError::MaxLengthExceed {
+                    message_id,
+                    sequence_number,
+                    length: chunk_len,
+                    max_length: self.max_length,
+                });
+            }
             ensure!(
-                state_lock.len() < self.pending_messages_limit,
+                pending.messages.len() < self.pending_messages_limit,
                 PendingMessagesLimitReachedSnafu {
                     message_id,
                     sequence_number,
                     pending_messages_limit: self.pending_messages_limit
                 }
             );
+            ensure!(
+                pending.buffered_payload.saturating_add(chunk_len) <= MAX_BUFFERED_PAYLOAD,
+                BufferedPayloadLimitReachedSnafu {
+                    message_id,
+                    sequence_number,
+                    limit: MAX_BUFFERED_PAYLOAD,
+                }
+            );
         }
 
-        let message_state = state_lock.entry(message_id).or_insert_with(|| {
-            // We need to spawn a task that will clear the message state after a certain time
-            // otherwise we will have a memory leak due to messages that never complete
+        if is_new_message {
             let state = Arc::clone(&self.state);
             let timeout = self.timeout;
             let timeout_handle = tokio::spawn(async move {
                 tokio::time::sleep(timeout).await;
                 let timeout_task_id = tokio::task::id();
-                let mut state_lock = state.lock().expect("poisoned lock");
-                let owns_message = state_lock
+                let mut pending = state.lock().expect("poisoned lock");
+                let owns_message = pending
+                    .messages
                     .get(&message_id)
                     .is_some_and(|message| message.timeout_task.id() == timeout_task_id);
-                if owns_message && state_lock.remove(&message_id).is_some() {
+                if owns_message && pending.remove(message_id).is_some() {
                     warn!(
                         message_id = message_id,
                         timeout_secs = timeout.as_secs_f64(),
@@ -441,8 +501,13 @@ impl ChunkedGelfDecoder {
                     );
                 }
             });
-            Box::new(MessageState::new(total_chunks, timeout_handle))
-        });
+            pending.messages.insert(
+                message_id,
+                Box::new(MessageState::new(total_chunks, timeout_handle)),
+            );
+        }
+
+        let message_state = pending.messages.get(&message_id).expect("entry must exist");
 
         ensure!(
             message_state.total_chunks == total_chunks,
@@ -463,52 +528,47 @@ impl ChunkedGelfDecoder {
             return Ok(None);
         }
 
-        // Remove a complete message before assembling it. The final chunk goes straight into
-        // the output, so it needs neither an intermediate copy nor shared state during assembly.
-        if message_state.is_final_missing_chunk() {
-            let length = message_state.current_length().saturating_add(chunk.len());
-            if let Some(max_length) = self.max_length
-                && length > max_length
-            {
-                if let Some(dropped) = state_lock.remove(&message_id) {
-                    dropped.timeout_task.abort();
-                }
-                return Err(ChunkedGelfDecoderError::MaxLengthExceed {
-                    message_id,
-                    sequence_number,
-                    length,
-                    max_length,
-                });
-            }
+        // Check both byte limits before `add_chunk` copies the payload.
+        let projected_length = message_state.current_length().saturating_add(chunk_len);
+        if projected_length > self.max_length {
+            pending.discard(message_id);
+            return Err(ChunkedGelfDecoderError::MaxLengthExceed {
+                message_id,
+                sequence_number,
+                length: projected_length,
+                max_length: self.max_length,
+            });
+        }
 
-            let message_state = state_lock.remove(&message_id).expect("entry must exist");
+        // A completing chunk needs no shared budget: removing its state first refunds the
+        // buffered chunks, and the final chunk goes straight into the output.
+        if message_state.is_final_missing_chunk() {
+            let message_state = pending.remove(message_id).expect("entry must exist");
             // Abort while the message ID is still protected. Otherwise another decoder clone
             // can reuse the ID before the old timeout is canceled, and that callback can remove
             // the new message.
             message_state.timeout_task.abort();
-            drop(state_lock);
+            drop(pending);
             return Ok(Some(message_state.finish(sequence_number, chunk)));
         }
 
-        message_state.add_chunk(sequence_number, chunk);
-
-        if let Some(max_length) = self.max_length {
-            let length = message_state.current_length();
-            if length > max_length {
-                // Abort on removal, or the task outlives its entry and the live-task count is
-                // no longer bounded by `pending_messages_limit`.
-                if let Some(dropped) = state_lock.remove(&message_id) {
-                    dropped.timeout_task.abort();
-                }
-                return Err(ChunkedGelfDecoderError::MaxLengthExceed {
-                    message_id,
-                    sequence_number,
-                    length,
-                    max_length,
-                });
-            }
+        // A message that cannot advance would otherwise retain its allocation until timeout.
+        // Discard only that message and refund the payload it already held.
+        if pending.buffered_payload.saturating_add(chunk_len) > MAX_BUFFERED_PAYLOAD {
+            pending.discard(message_id);
+            return Err(ChunkedGelfDecoderError::BufferedPayloadLimitReached {
+                message_id,
+                sequence_number,
+                limit: MAX_BUFFERED_PAYLOAD,
+            });
         }
 
+        pending
+            .messages
+            .get_mut(&message_id)
+            .expect("entry must exist")
+            .add_chunk(sequence_number, chunk);
+        pending.buffered_payload += chunk_len;
         Ok(None)
     }
 
@@ -871,11 +931,11 @@ mod tests {
 
         let frame = decoder.decode_eof(&mut chunks[0]).unwrap();
         assert!(frame.is_none());
-        assert!(!decoder.state.lock().unwrap().is_empty());
+        assert!(!decoder.state.lock().unwrap().messages.is_empty());
 
         // The message state should be cleared after a certain time
         tokio::time::sleep(Duration::from_secs_f64(DEFAULT_TIMEOUT_SECS + 1.0)).await;
-        assert!(decoder.state.lock().unwrap().is_empty());
+        assert!(decoder.state.lock().unwrap().messages.is_empty());
         assert!(logs_contain(
             "Message was not fully received within the timeout window. Discarding it."
         ));
@@ -884,7 +944,7 @@ mod tests {
         assert!(frame.is_none());
 
         tokio::time::sleep(Duration::from_secs_f64(DEFAULT_TIMEOUT_SECS + 1.0)).await;
-        assert!(decoder.state.lock().unwrap().is_empty());
+        assert!(decoder.state.lock().unwrap().messages.is_empty());
         assert!(logs_contain(
             "Message was not fully received within the timeout window. Discarding it"
         ));
@@ -976,6 +1036,250 @@ mod tests {
         ));
     }
 
+    #[rstest]
+    #[tokio::test]
+    async fn buffered_payload_is_settled_on_completion_and_errors(
+        two_chunks_message: ([BytesMut; 2], String),
+    ) {
+        let buffered =
+            |decoder: &ChunkedGelfDecoder| decoder.state.lock().unwrap().buffered_payload;
+        let (chunks, expected) = two_chunks_message;
+
+        let mut decoder = ChunkedGelfDecoder::default();
+        assert!(
+            decoder
+                .decode_eof(&mut chunks[0].clone())
+                .unwrap()
+                .is_none()
+        );
+        assert_eq!(buffered(&decoder), 3);
+        assert_eq!(
+            decoder.decode_eof(&mut chunks[1].clone()).unwrap(),
+            Some(Bytes::from(expected))
+        );
+        assert_eq!(buffered(&decoder), 0, "completion must refund payload");
+
+        let mut decoder = ChunkedGelfDecoder::default();
+        assert!(
+            decoder
+                .decode_eof(&mut chunks[0].clone())
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            decoder
+                .decode_eof(&mut chunks[0].clone())
+                .unwrap()
+                .is_none()
+        );
+        assert_eq!(buffered(&decoder), 3, "duplicates must not be charged");
+
+        let mut decoder = ChunkedGelfDecoder::new(
+            DEFAULT_TIMEOUT_SECS,
+            default_pending_messages_limit(),
+            Some(5),
+            ChunkedGelfDecompressionConfig::Auto,
+        );
+        assert!(
+            decoder
+                .decode_eof(&mut chunks[0].clone())
+                .unwrap()
+                .is_none()
+        );
+        let error = decoder
+            .decode_eof(&mut chunks[1].clone())
+            .expect_err("the message must exceed max_length");
+        assert!(matches!(
+            downcast_framing_error(&error),
+            ChunkedGelfDecoderError::MaxLengthExceed { .. }
+        ));
+        assert_eq!(buffered(&decoder), 0, "discard must refund payload");
+
+        let mut decoder = ChunkedGelfDecoder::default();
+        assert!(
+            decoder
+                .decode_eof(&mut chunks[0].clone())
+                .unwrap()
+                .is_none()
+        );
+        let mut mismatched = create_chunk(1u64, 1u8, 3u8, &"bar");
+        let error = decoder
+            .decode_eof(&mut mismatched)
+            .expect_err("the chunk count must not change");
+        assert!(matches!(
+            downcast_framing_error(&error),
+            ChunkedGelfDecoderError::TotalChunksMismatch { .. }
+        ));
+        assert_eq!(
+            buffered(&decoder),
+            3,
+            "a recoverable mismatch must leave pending state charged"
+        );
+    }
+
+    #[rstest]
+    #[tokio::test(start_paused = true)]
+    async fn timeout_refunds_buffered_payload(two_chunks_message: ([BytesMut; 2], String)) {
+        let (mut chunks, _) = two_chunks_message;
+        let mut decoder = ChunkedGelfDecoder::default();
+
+        assert!(decoder.decode_eof(&mut chunks[0]).unwrap().is_none());
+        assert_eq!(decoder.state.lock().unwrap().buffered_payload, 3);
+
+        tokio::time::sleep(Duration::from_secs_f64(DEFAULT_TIMEOUT_SECS + 1.0)).await;
+
+        let pending = decoder.state.lock().unwrap();
+        assert!(pending.messages.is_empty());
+        assert_eq!(pending.buffered_payload, 0);
+    }
+
+    #[tokio::test]
+    async fn new_message_is_rejected_before_exceeding_the_payload_limit() {
+        let mut chunk = create_chunk(1u64, 0u8, 2u8, &vec![b'x'; 1024]);
+        let mut decoder = ChunkedGelfDecoder::default();
+        let already_buffered = MAX_BUFFERED_PAYLOAD - 1;
+        decoder.state.lock().unwrap().buffered_payload = already_buffered;
+
+        let error = decoder
+            .decode_eof(&mut chunk)
+            .expect_err("the payload budget must reject this message");
+
+        assert!(matches!(
+            downcast_framing_error(&error),
+            ChunkedGelfDecoderError::BufferedPayloadLimitReached {
+                message_id: 1,
+                sequence_number: 0,
+                limit: MAX_BUFFERED_PAYLOAD,
+            }
+        ));
+        let pending = decoder.state.lock().unwrap();
+        assert!(pending.messages.is_empty());
+        assert_eq!(pending.buffered_payload, already_buffered);
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn a_full_budget_discards_only_the_blocked_message(
+        three_chunks_message: ([BytesMut; 3], String),
+    ) {
+        let (mut chunks, _) = three_chunks_message;
+        let mut decoder = ChunkedGelfDecoder::default();
+
+        assert!(decoder.decode_eof(&mut chunks[0]).unwrap().is_none());
+        let mut unrelated = create_chunk(3u64, 0u8, 3u8, &"bar");
+        assert!(decoder.decode_eof(&mut unrelated).unwrap().is_none());
+
+        decoder.state.lock().unwrap().buffered_payload = MAX_BUFFERED_PAYLOAD;
+        let error = decoder
+            .decode_eof(&mut chunks[1].clone())
+            .expect_err("the chunk must be refused");
+
+        assert!(matches!(
+            downcast_framing_error(&error),
+            ChunkedGelfDecoderError::BufferedPayloadLimitReached { .. }
+        ));
+        let pending = decoder.state.lock().unwrap();
+        assert!(!pending.messages.contains_key(&2));
+        assert!(pending.messages.contains_key(&3));
+        assert_eq!(pending.buffered_payload, MAX_BUFFERED_PAYLOAD - 3);
+    }
+
+    #[tokio::test]
+    async fn a_lone_chunk_bypasses_pending_limits() {
+        let mut decoder = ChunkedGelfDecoder::new(
+            DEFAULT_TIMEOUT_SECS,
+            0,
+            None,
+            ChunkedGelfDecompressionConfig::Auto,
+        );
+        decoder.state.lock().unwrap().buffered_payload = MAX_BUFFERED_PAYLOAD;
+
+        let mut chunk = create_chunk(u64::MAX, 0u8, 1u8, &"foo");
+        assert_eq!(
+            decoder.decode_eof(&mut chunk).unwrap(),
+            Some(Bytes::from_static(b"foo"))
+        );
+
+        let pending = decoder.state.lock().unwrap();
+        assert!(pending.messages.is_empty());
+        assert_eq!(pending.buffered_payload, MAX_BUFFERED_PAYLOAD);
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn a_full_budget_still_allows_completion(three_chunks_message: ([BytesMut; 3], String)) {
+        let (mut chunks, expected) = three_chunks_message;
+        let mut decoder = ChunkedGelfDecoder::default();
+
+        assert!(decoder.decode_eof(&mut chunks[0]).unwrap().is_none());
+        assert!(decoder.decode_eof(&mut chunks[1]).unwrap().is_none());
+        decoder.state.lock().unwrap().buffered_payload = MAX_BUFFERED_PAYLOAD;
+
+        assert_eq!(
+            decoder.decode_eof(&mut chunks[2]).unwrap(),
+            Some(Bytes::from(expected))
+        );
+
+        let pending = decoder.state.lock().unwrap();
+        assert!(pending.messages.is_empty());
+        assert_eq!(pending.buffered_payload, MAX_BUFFERED_PAYLOAD - 6);
+    }
+
+    #[rstest]
+    #[tokio::test]
+    async fn max_length_wins_over_temporary_budget_pressure(
+        three_chunks_message: ([BytesMut; 3], String),
+    ) {
+        let (mut chunks, _) = three_chunks_message;
+        let mut decoder = ChunkedGelfDecoder::new(
+            DEFAULT_TIMEOUT_SECS,
+            default_pending_messages_limit(),
+            Some(5),
+            ChunkedGelfDecompressionConfig::Auto,
+        );
+
+        assert!(decoder.decode_eof(&mut chunks[0]).unwrap().is_none());
+        decoder.state.lock().unwrap().buffered_payload = MAX_BUFFERED_PAYLOAD;
+
+        let error = decoder
+            .decode_eof(&mut chunks[1])
+            .expect_err("the permanently oversized message must be discarded");
+        assert!(matches!(
+            downcast_framing_error(&error),
+            ChunkedGelfDecoderError::MaxLengthExceed {
+                length: 6,
+                max_length: 5,
+                ..
+            }
+        ));
+
+        let pending = decoder.state.lock().unwrap();
+        assert!(pending.messages.is_empty());
+        assert_eq!(pending.buffered_payload, MAX_BUFFERED_PAYLOAD - 3);
+    }
+
+    #[test]
+    fn max_length_only_tightens_the_payload_ceiling() {
+        let default = ChunkedGelfDecoder::default();
+        assert_eq!(default.max_length, MAX_BUFFERED_PAYLOAD);
+
+        let raised = ChunkedGelfDecoder::new(
+            DEFAULT_TIMEOUT_SECS,
+            default_pending_messages_limit(),
+            Some(MAX_BUFFERED_PAYLOAD + 1),
+            ChunkedGelfDecompressionConfig::Auto,
+        );
+        assert_eq!(raised.max_length, MAX_BUFFERED_PAYLOAD);
+
+        let lowered = ChunkedGelfDecoder::new(
+            DEFAULT_TIMEOUT_SECS,
+            default_pending_messages_limit(),
+            Some(2),
+            ChunkedGelfDecompressionConfig::Auto,
+        );
+        assert_eq!(lowered.max_length, 2);
+    }
+
     #[test]
     fn pending_messages_limit_defaults_and_allows_overrides() {
         let default = ChunkedGelfDecoder::default();
@@ -1013,7 +1317,7 @@ mod tests {
 
         let frame = decoder.decode_eof(&mut two_chunks[0]).unwrap();
         assert!(frame.is_none());
-        assert!(decoder.state.lock().unwrap().len() == 1);
+        assert!(decoder.state.lock().unwrap().messages.len() == 1);
 
         let frame = decoder.decode_eof(&mut three_chunks[0]);
         let error = frame.unwrap_err();
@@ -1026,7 +1330,7 @@ mod tests {
                 pending_messages_limit: 1,
             }
         ));
-        assert!(decoder.state.lock().unwrap().len() == 1);
+        assert!(decoder.state.lock().unwrap().messages.len() == 1);
     }
 
     #[rstest]
@@ -1045,7 +1349,7 @@ mod tests {
 
         let frame = decoder.decode_eof(&mut two_chunks[0]).unwrap();
         assert!(frame.is_none());
-        assert_eq!(decoder.state.lock().unwrap().len(), 1);
+        assert_eq!(decoder.state.lock().unwrap().messages.len(), 1);
 
         // The table is full, so a new message id is rejected.
         assert!(decoder.decode_eof(&mut three_chunks[0]).is_err());
@@ -1053,7 +1357,7 @@ mod tests {
         // ...but the pending message still completes.
         let frame = decoder.decode_eof(&mut two_chunks[1]).unwrap();
         assert_eq!(frame, Some(Bytes::from(two_chunks_expected)));
-        assert_eq!(decoder.state.lock().unwrap().len(), 0);
+        assert_eq!(decoder.state.lock().unwrap().messages.len(), 0);
     }
 
     #[rstest]
@@ -1064,7 +1368,7 @@ mod tests {
         // An unaborted task outlives its entry, unbounding the live-task count.
         let (mut chunks, _) = two_chunks_message;
         let mut decoder = ChunkedGelfDecoder {
-            max_length: Some(5),
+            max_length: 5,
             ..Default::default()
         };
 
@@ -1072,6 +1376,7 @@ mod tests {
         let timeout_task = {
             let state = decoder.state.lock().unwrap();
             state
+                .messages
                 .values()
                 .next()
                 .map(|message_state| message_state.timeout_task.abort_handle())
@@ -1080,7 +1385,7 @@ mod tests {
         assert!(!timeout_task.is_finished());
 
         assert!(decoder.decode_eof(&mut chunks[1]).is_err());
-        assert_eq!(decoder.state.lock().unwrap().len(), 0);
+        assert_eq!(decoder.state.lock().unwrap().messages.len(), 0);
 
         tokio::task::yield_now().await;
         assert!(
@@ -1100,7 +1405,7 @@ mod tests {
         assert!(decoder.decode_eof(&mut chunk).unwrap().is_none());
 
         let state = decoder.state.lock().unwrap();
-        let message_state = state.values().next().expect("message pending");
+        let message_state = state.messages.values().next().expect("message pending");
         let stored = message_state.chunks[0].as_ptr();
         assert!(
             !source_range.contains(&stored),
@@ -1198,7 +1503,7 @@ mod tests {
     async fn decode_message_greater_than_max_length(two_chunks_message: ([BytesMut; 2], String)) {
         let (mut chunks, _) = two_chunks_message;
         let mut decoder = ChunkedGelfDecoder {
-            max_length: Some(5),
+            max_length: 5,
             ..Default::default()
         };
 
@@ -1216,7 +1521,7 @@ mod tests {
                 max_length: 5,
             }
         ));
-        assert_eq!(decoder.state.lock().unwrap().len(), 0);
+        assert_eq!(decoder.state.lock().unwrap().messages.len(), 0);
     }
 
     #[rstest]

--- a/website/cue/reference/components/generated/schema_definitions.cue
+++ b/website/cue/reference/components/generated/schema_definitions.cue
@@ -409,8 +409,8 @@ _schemaDefinitions: {
 						This limit takes into account only the message payload. GELF header bytes are excluded from the calculation.
 						The message payload is the concatenation of all chunk payloads.
 
-						**Note**: The decoder also caps the payload buffered across *all* incomplete messages
-						at 128 MiB, so no chunked message can exceed that whatever this is set to.
+						The decoder also limits the payload buffered across *all* incomplete messages to 128 MiB by
+						default. Setting this above 128 MiB raises that aggregate limit to the same value.
 
 						An unchunked message is never buffered, so neither limit applies to it; its size is
 						bounded by whatever the source accepts as one frame.
@@ -712,8 +712,8 @@ _schemaDefinitions: {
 				This limit takes into account only the message payload. GELF header bytes are excluded from the calculation.
 				The message payload is the concatenation of all chunk payloads.
 
-				**Note**: The decoder also caps the payload buffered across *all* incomplete messages
-				at 128 MiB, so no chunked message can exceed that whatever this is set to.
+				The decoder also limits the payload buffered across *all* incomplete messages to 128 MiB by
+				default. Setting this above 128 MiB raises that aggregate limit to the same value.
 
 				An unchunked message is never buffered, so neither limit applies to it; its size is
 				bounded by whatever the source accepts as one frame.
@@ -3513,8 +3513,8 @@ _schemaDefinitions: {
 															This limit takes into account only the message payload. GELF header bytes are excluded from the calculation.
 															The message payload is the concatenation of all chunk payloads.
 
-															**Note**: The decoder also caps the payload buffered across *all* incomplete messages
-															at 128 MiB, so no chunked message can exceed that whatever this is set to.
+															The decoder also limits the payload buffered across *all* incomplete messages to 128 MiB by
+															default. Setting this above 128 MiB raises that aggregate limit to the same value.
 
 															An unchunked message is never buffered, so neither limit applies to it; its size is
 															bounded by whatever the source accepts as one frame.

--- a/website/cue/reference/components/generated/schema_definitions.cue
+++ b/website/cue/reference/components/generated/schema_definitions.cue
@@ -416,7 +416,7 @@ _schemaDefinitions: {
 						bounded by whatever the source accepts as one frame.
 						"""
 					required: false
-					type: uint: {}
+					type: uint: default: 134217728
 				}
 				pending_messages_limit: {
 					description: """
@@ -721,7 +721,7 @@ _schemaDefinitions: {
 				bounded by whatever the source accepts as one frame.
 				"""
 			required: false
-			type: uint: {}
+			type: uint: default: 134217728
 		}
 		pending_messages_limit: {
 			description: """
@@ -3524,7 +3524,7 @@ _schemaDefinitions: {
 															bounded by whatever the source accepts as one frame.
 															"""
 							required: false
-							type: uint: {}
+							type: uint: default: 134217728
 						}
 						pending_messages_limit: {
 							description: """

--- a/website/cue/reference/components/generated/schema_definitions.cue
+++ b/website/cue/reference/components/generated/schema_definitions.cue
@@ -401,14 +401,19 @@ _schemaDefinitions: {
 				max_length: {
 					description: """
 						The maximum length of a single GELF message, in bytes. Messages longer than this length are
-						dropped. If this option is not set, the decoder does not limit the length of messages and
-						the per-message memory is unbounded.
+						dropped.
 
 						**Note**: A message can be composed of multiple chunks, and this limit applies to the whole
 						message, not to individual chunks.
 
 						This limit takes into account only the message payload. GELF header bytes are excluded from the calculation.
 						The message payload is the concatenation of all chunk payloads.
+
+						**Note**: The decoder also caps the payload buffered across *all* incomplete messages
+						at 128 MiB, so no chunked message can exceed that whatever this is set to.
+
+						An unchunked message is never buffered, so neither limit applies to it; its size is
+						bounded by whatever the source accepts as one frame.
 						"""
 					required: false
 					type: uint: {}
@@ -699,14 +704,19 @@ _schemaDefinitions: {
 		max_length: {
 			description: """
 				The maximum length of a single GELF message, in bytes. Messages longer than this length are
-				dropped. If this option is not set, the decoder does not limit the length of messages and
-				the per-message memory is unbounded.
+				dropped.
 
 				**Note**: A message can be composed of multiple chunks, and this limit applies to the whole
 				message, not to individual chunks.
 
 				This limit takes into account only the message payload. GELF header bytes are excluded from the calculation.
 				The message payload is the concatenation of all chunk payloads.
+
+				**Note**: The decoder also caps the payload buffered across *all* incomplete messages
+				at 128 MiB, so no chunked message can exceed that whatever this is set to.
+
+				An unchunked message is never buffered, so neither limit applies to it; its size is
+				bounded by whatever the source accepts as one frame.
 				"""
 			required: false
 			type: uint: {}
@@ -3495,14 +3505,19 @@ _schemaDefinitions: {
 						max_length: {
 							description: """
 															The maximum length of a single GELF message, in bytes. Messages longer than this length are
-															dropped. If this option is not set, the decoder does not limit the length of messages and
-															the per-message memory is unbounded.
+															dropped.
 
 															**Note**: A message can be composed of multiple chunks, and this limit applies to the whole
 															message, not to individual chunks.
 
 															This limit takes into account only the message payload. GELF header bytes are excluded from the calculation.
 															The message payload is the concatenation of all chunk payloads.
+
+															**Note**: The decoder also caps the payload buffered across *all* incomplete messages
+															at 128 MiB, so no chunked message can exceed that whatever this is set to.
+
+															An unchunked message is never buffered, so neither limit applies to it; its size is
+															bounded by whatever the source accepts as one frame.
 															"""
 							required: false
 							type: uint: {}

--- a/website/cue/reference/components/generated/schema_definitions.cue
+++ b/website/cue/reference/components/generated/schema_definitions.cue
@@ -417,11 +417,12 @@ _schemaDefinitions: {
 					description: """
 						The maximum number of pending incomplete messages. If this limit is reached, the decoder starts
 						dropping chunks of new messages, ensuring the memory usage of the decoder's state is bounded.
-						If this option is not set, the decoder does not limit the number of pending messages and the memory usage
-						of its messages buffer can grow unbounded. This matches Graylog Server's behavior.
+
+						Chunks belonging to messages that are already pending are still accepted once the limit is
+						reached, so in-flight messages can complete.
 						"""
 					required: false
-					type: uint: {}
+					type: uint: default: 4096
 				}
 				timeout_secs: {
 					description: """
@@ -714,11 +715,12 @@ _schemaDefinitions: {
 			description: """
 				The maximum number of pending incomplete messages. If this limit is reached, the decoder starts
 				dropping chunks of new messages, ensuring the memory usage of the decoder's state is bounded.
-				If this option is not set, the decoder does not limit the number of pending messages and the memory usage
-				of its messages buffer can grow unbounded. This matches Graylog Server's behavior.
+
+				Chunks belonging to messages that are already pending are still accepted once the limit is
+				reached, so in-flight messages can complete.
 				"""
 			required: false
-			type: uint: {}
+			type: uint: default: 4096
 		}
 		timeout_secs: {
 			description: """
@@ -3509,11 +3511,12 @@ _schemaDefinitions: {
 							description: """
 															The maximum number of pending incomplete messages. If this limit is reached, the decoder starts
 															dropping chunks of new messages, ensuring the memory usage of the decoder's state is bounded.
-															If this option is not set, the decoder does not limit the number of pending messages and the memory usage
-															of its messages buffer can grow unbounded. This matches Graylog Server's behavior.
+
+															Chunks belonging to messages that are already pending are still accepted once the limit is
+															reached, so in-flight messages can complete.
 															"""
 							required: false
-							type: uint: {}
+							type: uint: default: 4096
 						}
 						timeout_secs: {
 							description: """


### PR DESCRIPTION
## Summary

### Motivation

Bounding the number of incomplete messages does not bound their combined payload. Many messages can otherwise retain large chunks until completion or timeout.

### Changes

- Add a hard 128 MiB ceiling for payload buffered across incomplete messages.
- Let `max_length` select a lower per-message ceiling without raising the aggregate limit.
- Account for stored bytes exactly across completion, rejection, errors, and timeout.
- Release only the blocked message's state when saturation prevents it from advancing.
- Update generated component documentation and add a security changelog fragment.

### References

Related: #26137

Stack: #26299 -> #26300 -> #26301 -> **#26302**

## Vector configuration

Not applicable; accounting is exercised directly at the decoder boundary.

## How did you test this PR?

Focused tests exercise accounting across completion, timeout, rejection, and saturation.

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## Contributor Guidelines

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Before pushing, follow our [pre-push guidance](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#pre-push).
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
