### PR TITLE
feat(postgres sink): Add Upsert support

### DIFF
--- a/changelog.d/postgres_upsert.feature.md
+++ b/changelog.d/postgres_upsert.feature.md
@@ -1,0 +1,3 @@
+Adds support for the upserting in the Postgres sink.
+
+authors: 5Dev24

--- a/src/sinks/postgres/config.rs
+++ b/src/sinks/postgres/config.rs
@@ -14,11 +14,12 @@ use vector_lib::{
 };
 
 use super::{
-    service::{PostgresRetryLogic, PostgresService},
+    service::{PostgresAction, PostgresRetryLogic, PostgresService},
     sink::PostgresSink,
 };
 use crate::{
     config::{Input, SinkConfig, SinkContext, ValidatedSink},
+    serde::OneOrMany,
     sinks::{
         Healthcheck,
         util::{
@@ -27,6 +28,65 @@ use crate::{
         },
     },
 };
+
+/// Action used to put data into a table.
+#[configurable_component]
+#[derive(Clone, Copy, Debug, Derivative)]
+#[derivative(Default)]
+#[serde(rename_all = "lowercase")]
+pub enum ActionKindConfig {
+    /// Inserts an event into a table.
+    ///
+    /// This is the default.
+    #[derivative(Default)]
+    Insert,
+
+    /// Upserts an event into a table.
+    ///
+    /// When an event's insert conflicts with a table's primary key,
+    /// an update will be performed instead of an insert.
+    ///
+    /// **Note**: This only handles **primary key conflicts**. Other
+    /// constraint violations when inserting will cause an error and
+    /// fail the entire batch.
+    ///
+    /// **Note**: If multiple events in a single batch will update the
+    /// same row, only the first event will be used to update the row.
+    /// To avoid this, use a *dedupe* transform long enough for the
+    /// batch size.
+    Upsert,
+}
+
+/// Upsert-specific options
+#[configurable_component]
+#[derive(Clone, Debug, Derivative)]
+#[serde(rename_all = "lowercase")]
+pub struct UpsertOption {
+    /// Column(s) part of the table's primary key.
+    ///
+    /// This parameter is vulnerable to SQL injection attacks as it
+    /// is used directly in an SQL query and cannot be injected as a
+    /// parameter to a prepared statement. Only use trusted inputs/values
+    /// for this field.
+    ///
+    /// **Note**: If a column name needs to be quoted, you must place
+    /// double quotes around the column name here.
+    #[serde(alias = "primary_keys")]
+    pub primary_key: OneOrMany<String>,
+
+    /// Column(s) to update when an insert conflicts with a table's
+    /// primary key.
+    ///
+    /// This parameter is vulnerable to SQL injection attacks as it
+    /// is used directly in an SQL query and cannot be injected as a
+    /// parameter to a prepared statement. Only use trusted inputs/values
+    /// for this field.
+    ///
+    /// **Note**: If a column name needs to be quoted, you must place
+    /// double quotes around the column name here.
+    #[serde(alias = "update_columns")]
+    pub update_column: OneOrMany<String>,
+}
 
 const fn default_pool_size() -> u32 {
     5
@@ -47,6 +107,13 @@ pub struct PostgresConfig {
     /// This parameter will be directly interpolated in the SQL query statement,
     /// as table names as parameters in prepared statements are not allowed in PostgreSQL.
     pub table: String,
+
+    #[serde(default)]
+    pub action: ActionKindConfig,
+
+    #[serde(default)]
+    #[serde(alias = "upsert")]
+    pub upsert_option: Option<UpsertOption>,
 
     /// The postgres connection pool size. See [this](https://docs.rs/sqlx/latest/sqlx/struct.Pool.html#why-use-a-pool) for more
     /// information about why a connection pool should be used.
@@ -105,6 +172,7 @@ pub struct ValidatedPostgres {
     batch_settings: BatcherSettings,
     request_settings: TowerRequestSettings,
     endpoint_uri: UriSerde,
+    action: PostgresAction,
 }
 
 /// PostgreSQL endpoints may carry credentials as userinfo or as a `password`
@@ -168,10 +236,70 @@ impl ValidatedSink for PostgresConfig {
         let endpoint_uri: UriSerde = self.endpoint.parse()?;
         validate_pg_endpoint(&self.endpoint)?;
 
+        let action = match self.action {
+            ActionKindConfig::Insert => PostgresAction::Insert,
+            ActionKindConfig::Upsert => {
+                let Some(ref options) = self.upsert_option else {
+                    return Err("`upsert` must be defined when using the upsert action.".into());
+                };
+
+                match &options.primary_key {
+                    OneOrMany::One(item) => {
+                        if item.is_empty() {
+                            return Err("`primary_key` cannot be empty.".into());
+                        }
+                    }
+                    OneOrMany::Many(items) => {
+                        if items.is_empty() {
+                            return Err("`primary_key` must contain at least one column.".into());
+                        }
+
+                        for item in items {
+                            if item.is_empty() {
+                                return Err("`primary_key` cannot be empty.".into());
+                            }
+                        }
+                    }
+                };
+
+                match &options.update_column {
+                    OneOrMany::One(item) => {
+                        if item.is_empty() {
+                            return Err("`update_column` cannot be empty.".into());
+                        }
+                    }
+                    OneOrMany::Many(items) => {
+                        if items.is_empty() {
+                            return Err("`update_column` must contain at least one column.".into());
+                        }
+
+                        for item in items {
+                            if item.is_empty() {
+                                return Err("`update_column` cannot be empty.".into());
+                            }
+                        }
+                    }
+                };
+
+                PostgresAction::Upsert {
+                    primary_keys: options.primary_key.clone().to_vec().join(","),
+                    update_columns: options
+                        .update_column
+                        .clone()
+                        .to_vec()
+                        .iter()
+                        .map(|column| format!("{column}=EXCLUDED.{column}"))
+                        .collect::<Vec<String>>()
+                        .join(","),
+                }
+            }
+        };
+
         Ok(ValidatedPostgres {
             batch_settings,
             request_settings,
             endpoint_uri,
+            action,
         })
     }
 
@@ -184,6 +312,7 @@ impl ValidatedSink for PostgresConfig {
             batch_settings,
             request_settings,
             endpoint_uri,
+            action,
         } = validated.clone();
 
         // `PgConnectOptions::from_str` may read `$PGPASSFILE` or `~/.pgpass`
@@ -199,7 +328,7 @@ impl ValidatedSink for PostgresConfig {
 
         // The endpoint label must not carry credentials or query parameters.
         let endpoint = protocol_endpoint(endpoint_uri.uri.clone()).1;
-        let service = PostgresService::new(connection_pool, self.table.clone(), endpoint);
+        let service = PostgresService::new(connection_pool, self.table.clone(), endpoint, action);
         let service = ServiceBuilder::new()
             .settings(request_settings, PostgresRetryLogic)
             .service(service);

--- a/src/sinks/postgres/integration_tests.rs
+++ b/src/sinks/postgres/integration_tests.rs
@@ -4,7 +4,7 @@ use chrono::{DateTime, Utc};
 use futures::stream;
 use ordered_float::NotNan;
 use serde::{Deserialize, Serialize};
-use sqlx::{Connection, FromRow, PgConnection};
+use sqlx::{Connection, FromRow, PgConnection, Row};
 use vector_lib::event::{
     BatchNotifier, BatchStatus, BatchStatusReceiver, Event, LogEvent, Metric, MetricKind,
     MetricValue,
@@ -34,14 +34,18 @@ fn timestamp() -> DateTime<Utc> {
     DateTime::from_timestamp_micros(timestamp.timestamp_micros()).unwrap()
 }
 
-fn create_event(id: i64) -> Event {
+fn create_event_with_host(id: i64, host: &str) -> Event {
     let mut event = LogEvent::from("raw log line");
     event.insert(event_path!("id"), id);
-    event.insert(event_path!("host"), "example.com");
+    event.insert(event_path!("host"), host);
     let event_payload = event.clone().into_parts().0;
     event.insert(event_path!("payload"), event_payload);
     event.insert(event_path!("timestamp"), timestamp());
     event.into()
+}
+
+fn create_event(id: i64) -> Event {
+    create_event_with_host(id, "example.com")
 }
 
 fn create_event_with_notifier(id: i64) -> (Event, BatchStatusReceiver) {
@@ -167,6 +171,34 @@ async fn prepare_config() -> (PostgresConfig, String, PgConnection) {
     (config, table, connection)
 }
 
+async fn prepare_upsert_config(
+    primary_keys: Vec<&str>,
+    update_columns: Vec<&str>,
+    max_events: usize,
+) -> (PostgresConfig, String, PgConnection) {
+    let table = random_table_name();
+    let endpoint = pg_url();
+    let config_str = format!(
+        r#"
+            endpoint = "{endpoint}"
+            table = "{table}"
+            batch.max_events = {max_events}
+
+            action = "upsert"
+            upsert.primary_keys = {primary_keys:?}
+            upsert.update_columns = {update_columns:?}
+        "#,
+    );
+
+    let (config, _) = load_sink::<PostgresConfig>(&config_str).unwrap();
+
+    let connection = PgConnection::connect(endpoint.as_str())
+        .await
+        .expect("Failed to connect to Postgres");
+
+    (config, table, connection)
+}
+
 #[tokio::test]
 async fn healthcheck_passes() {
     trace_init();
@@ -255,6 +287,45 @@ async fn insert_single_event() {
 }
 
 #[tokio::test]
+async fn upsert_single_event_without_conflict() {
+    trace_init();
+
+    let (config, table, mut connection) = prepare_upsert_config(
+        vec!["id"],
+        vec!["host", "timestamp", "message", "payload"],
+        1,
+    )
+    .await;
+
+    let (sink, _hc) = config.build(SinkContext::default()).await.unwrap();
+    let create_table_sql = format!(
+        "CREATE TABLE {table} (id BIGINT PRIMARY KEY, host TEXT, timestamp TIMESTAMPTZ, message TEXT, payload JSONB)"
+    );
+    sqlx::query(&create_table_sql)
+        .execute(&mut connection)
+        .await
+        .unwrap();
+
+    let (input_event, mut receiver) = create_event_with_notifier(0);
+    let input_log_event = input_event.clone().into_log();
+    let expected_value = serde_json::to_value(&input_log_event).unwrap();
+
+    run_and_assert_sink_compliance(sink, stream::once(ready(input_event)), &POSTGRES_SINK_TAGS)
+        .await;
+    // We drop the event to notify the receiver that the batch was delivered.
+    std::mem::drop(input_log_event);
+    assert_eq!(receiver.try_recv(), Ok(BatchStatus::Delivered));
+
+    let select_all_sql = format!("SELECT * FROM {table}");
+    let actual_event: TestEvent = sqlx::query_as(&select_all_sql)
+        .fetch_one(&mut connection)
+        .await
+        .unwrap();
+    let actual_value = serde_json::to_value(actual_event).unwrap();
+    assert_eq!(expected_value, actual_value);
+}
+
+#[tokio::test]
 async fn insert_multiple_events() {
     trace_init();
 
@@ -262,6 +333,53 @@ async fn insert_multiple_events() {
     let (sink, _hc) = config.build(SinkContext::default()).await.unwrap();
     let create_table_sql = format!(
         "CREATE TABLE {table} (id BIGINT, host TEXT, timestamp TIMESTAMPTZ, message TEXT, payload JSONB)"
+    );
+    sqlx::query(&create_table_sql)
+        .execute(&mut connection)
+        .await
+        .unwrap();
+
+    let (input_events, mut receiver) = create_events(100);
+    let input_log_events = input_events
+        .clone()
+        .into_iter()
+        .map(Event::into_log)
+        .collect::<Vec<_>>();
+    let expected_values = input_log_events
+        .iter()
+        .map(|event| serde_json::to_value(event).unwrap())
+        .collect::<Vec<_>>();
+    run_and_assert_sink_compliance(sink, stream::iter(input_events), &POSTGRES_SINK_TAGS).await;
+    // We drop the event to notify the receiver that the batch was delivered.
+    std::mem::drop(input_log_events);
+    assert_eq!(receiver.try_recv(), Ok(BatchStatus::Delivered));
+
+    let select_all_sql = format!("SELECT * FROM {table} ORDER BY id");
+    let actual_events: Vec<TestEvent> = sqlx::query_as(&select_all_sql)
+        .fetch_all(&mut connection)
+        .await
+        .unwrap();
+    let actual_values = actual_events
+        .iter()
+        .map(|event| serde_json::to_value(event).unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(expected_values, actual_values);
+}
+
+#[tokio::test]
+async fn upsert_multiple_events_without_conflict() {
+    trace_init();
+
+    let (config, table, mut connection) = prepare_upsert_config(
+        vec!["id"],
+        vec!["host", "timestamp", "message", "payload"],
+        1,
+    )
+    .await;
+
+    let (sink, _hc) = config.build(SinkContext::default()).await.unwrap();
+    let create_table_sql = format!(
+        "CREATE TABLE {table} (id BIGINT PRIMARY KEY, host TEXT, timestamp TIMESTAMPTZ, message TEXT, payload JSONB)"
     );
     sqlx::query(&create_table_sql)
         .execute(&mut connection)
@@ -513,4 +631,177 @@ async fn insertion_fails_primary_key_violation() {
         &COMPONENT_ERROR_TAGS,
     )
     .await;
+}
+
+#[tokio::test]
+async fn upsert_two_events_with_primary_key_violation_succeeds() {
+    trace_init();
+
+    let (config, table, mut connection) = prepare_upsert_config(
+        vec!["id"],
+        vec!["host", "timestamp", "message", "payload"],
+        1,
+    )
+    .await;
+
+    let (sink, _hc) = config.build(SinkContext::default()).await.unwrap();
+    let create_table_sql = format!(
+        "CREATE TABLE {table} (id BIGINT PRIMARY KEY, host TEXT, timestamp TIMESTAMPTZ, message TEXT, payload JSONB)"
+    );
+    sqlx::query(&create_table_sql)
+        .execute(&mut connection)
+        .await
+        .unwrap();
+
+    let (accept_event, mut accept_receiver) = create_event_with_notifier(0);
+    let (replace_event, mut replace_receiver) = create_event_with_notifier(0);
+
+    let input_events = vec![accept_event, replace_event];
+
+    let input_log_events = input_events
+        .clone()
+        .into_iter()
+        .map(Event::into_log)
+        .collect::<Vec<_>>();
+
+    let expected_value = serde_json::to_value(&input_log_events[1]).unwrap();
+
+    run_and_assert_sink_compliance(sink, stream::iter(input_events), &POSTGRES_SINK_TAGS).await;
+
+    // We drop the event to notify the receivers that the batch was delivered.
+    std::mem::drop(input_log_events);
+    assert_eq!(accept_receiver.try_recv(), Ok(BatchStatus::Delivered));
+    assert_eq!(replace_receiver.try_recv(), Ok(BatchStatus::Delivered));
+
+    let select_all_sql = format!("SELECT * FROM {table}");
+    let actual_event: TestEvent = sqlx::query_as(&select_all_sql)
+        .fetch_one(&mut connection)
+        .await
+        .unwrap();
+    let actual_value = serde_json::to_value(actual_event).unwrap();
+    assert_eq!(expected_value, actual_value);
+}
+
+#[tokio::test]
+async fn upsert_two_events_with_primary_key_violation_within_same_batch() {
+    trace_init();
+
+    let (config, table, mut connection) = prepare_upsert_config(
+        vec!["id"],
+        vec!["host", "timestamp", "message", "payload"],
+        2,
+    )
+    .await;
+
+    let (sink, _hc) = config.build(SinkContext::default()).await.unwrap();
+    let create_table_sql = format!(
+        "CREATE TABLE {table} (id BIGINT PRIMARY KEY, host TEXT, timestamp TIMESTAMPTZ, message TEXT, payload JSONB)"
+    );
+    sqlx::query(&create_table_sql)
+        .execute(&mut connection)
+        .await
+        .unwrap();
+
+    let mut input_events = vec![
+        create_event_with_host(0, "host-stored.com"),
+        create_event_with_host(0, "host-ignored.com"),
+    ];
+    let mut receiver = BatchNotifier::apply_to(&mut input_events);
+
+    let input_log_events = input_events
+        .clone()
+        .into_iter()
+        .map(Event::into_log)
+        .collect::<Vec<_>>();
+
+    let expected_value = serde_json::to_value(&input_log_events[0]).unwrap();
+
+    run_and_assert_sink_compliance(sink, stream::iter(input_events), &POSTGRES_SINK_TAGS).await;
+
+    // We drop the event to notify the receiver that the batch was delivered.
+    std::mem::drop(input_log_events);
+    assert_eq!(receiver.try_recv(), Ok(BatchStatus::Delivered));
+
+    let select_all_sql = format!("SELECT * FROM {table}");
+    let actual_event: TestEvent = sqlx::query_as(&select_all_sql)
+        .fetch_one(&mut connection)
+        .await
+        .unwrap();
+    let actual_value = serde_json::to_value(actual_event).unwrap();
+    assert_eq!(expected_value, actual_value);
+}
+
+#[tokio::test]
+async fn upsert_fails_on_unquoted_field() {
+    trace_init();
+
+    let (config, table, mut connection) =
+        prepare_upsert_config(vec!["id"], vec!["column with spaces"], 1).await;
+
+    let (sink, _hc) = config.build(SinkContext::default()).await.unwrap();
+    let create_table_sql = format!(
+        r#"CREATE TABLE {table} (id BIGINT PRIMARY KEY, host TEXT, timestamp TIMESTAMPTZ, message TEXT, payload JSONB, "column with spaces" TEXT NOT NULL)"#
+    );
+    sqlx::query(&create_table_sql)
+        .execute(&mut connection)
+        .await
+        .unwrap();
+
+    let (mut fail_event, mut fail_receiver) = create_event_with_notifier(0);
+    fail_event
+        .as_mut_log()
+        .insert(event_path!("column with spaces"), "bad");
+
+    let fail_log = fail_event.clone().into_log();
+
+    run_and_assert_sink_error(sink, stream::once(ready(fail_event)), &COMPONENT_ERROR_TAGS).await;
+
+    // We drop the event to notify the receivers that the batch was delivered.
+    std::mem::drop(fail_log);
+
+    assert_eq!(fail_receiver.try_recv(), Ok(BatchStatus::Rejected));
+}
+
+#[tokio::test]
+async fn upsert_success_on_quoted_field() {
+    trace_init();
+
+    let (config, table, mut connection) =
+        prepare_upsert_config(vec!["id"], vec![r#""column with spaces""#], 1).await;
+
+    let (sink, _hc) = config.build(SinkContext::default()).await.unwrap();
+    let create_table_sql = format!(
+        r#"CREATE TABLE {table} (id BIGINT PRIMARY KEY, host TEXT, timestamp TIMESTAMPTZ, message TEXT, payload JSONB, "column with spaces" TEXT NOT NULL)"#
+    );
+    sqlx::query(&create_table_sql)
+        .execute(&mut connection)
+        .await
+        .unwrap();
+
+    let (mut accept_event, mut accept_receiver) = create_event_with_notifier(0);
+    accept_event
+        .as_mut_log()
+        .insert(event_path!("column with spaces"), "good");
+
+    let accept_log = accept_event.clone().into_log();
+
+    run_and_assert_sink_compliance(sink, stream::once(ready(accept_event)), &POSTGRES_SINK_TAGS)
+        .await;
+
+    // We drop the event to notify the receivers that the batch was delivered.
+    std::mem::drop(accept_log);
+
+    assert_eq!(accept_receiver.try_recv(), Ok(BatchStatus::Delivered));
+
+    let select_all_sql = format!("SELECT * FROM {table}");
+    let actual_event = sqlx::query(&select_all_sql)
+        .fetch_one(&mut connection)
+        .await
+        .unwrap();
+
+    let column_with_spaces_value: String = actual_event
+        .try_get("column with spaces")
+        .expect("column does exist");
+
+    assert_eq!(column_with_spaces_value, "good");
 }

--- a/src/sinks/postgres/integration_tests.rs
+++ b/src/sinks/postgres/integration_tests.rs
@@ -805,3 +805,71 @@ async fn upsert_success_on_quoted_field() {
 
     assert_eq!(column_with_spaces_value, "good");
 }
+
+#[tokio::test]
+async fn upsert_with_multi_column_primary_key_succeeds() {
+    fn custom_create_event_with_notifier(
+        id1: i64,
+        id2: i64,
+        host: &str,
+    ) -> (Event, BatchStatusReceiver) {
+        let mut event = LogEvent::from("raw log line");
+        event.insert(event_path!("id1"), id1);
+        event.insert(event_path!("id2"), id2);
+        event.insert(event_path!("host"), host);
+        let event_payload = event.clone().into_parts().0;
+        event.insert(event_path!("payload"), event_payload);
+        event.insert(event_path!("timestamp"), timestamp());
+
+        let (batch, receiver) = BatchNotifier::new_with_receiver();
+        let event = Into::<Event>::into(event).with_batch_notifier(&batch);
+        (event, receiver)
+    }
+
+    trace_init();
+
+    let (config, table, mut connection) = prepare_upsert_config(
+        vec!["id1", "id2"],
+        vec!["host", "timestamp", "message", "payload"],
+        1,
+    )
+    .await;
+
+    let (sink, _hc) = config.build(SinkContext::default()).await.unwrap();
+    let create_table_sql = format!(
+        "CREATE TABLE {table} (id1 BIGINT, id2 BIGINT, host TEXT, timestamp TIMESTAMPTZ, message TEXT, payload JSONB, PRIMARY KEY (id1, id2))"
+    );
+    sqlx::query(&create_table_sql)
+        .execute(&mut connection)
+        .await
+        .unwrap();
+
+    let (accept_event, mut accept_receiver) = custom_create_event_with_notifier(0, 1, "original");
+    let (replace_event, mut replace_receiver) =
+        custom_create_event_with_notifier(0, 1, "replacement");
+
+    let input_events = vec![accept_event, replace_event];
+
+    let input_log_events = input_events
+        .clone()
+        .into_iter()
+        .map(Event::into_log)
+        .collect::<Vec<_>>();
+
+    run_and_assert_sink_compliance(sink, stream::iter(input_events), &POSTGRES_SINK_TAGS).await;
+
+    // We drop the event to notify the receivers that the batch was delivered.
+    std::mem::drop(input_log_events);
+    assert_eq!(accept_receiver.try_recv(), Ok(BatchStatus::Delivered));
+    assert_eq!(replace_receiver.try_recv(), Ok(BatchStatus::Delivered));
+
+    let select_all_sql = format!("SELECT * FROM {table}");
+    let actual_event = sqlx::query(&select_all_sql)
+        .fetch_one(&mut connection)
+        .await
+        .unwrap();
+
+    let host: String = actual_event.try_get("host").expect("column does exist");
+
+    assert_eq!(host, "replacement");
+}

--- a/src/sinks/postgres/service.rs
+++ b/src/sinks/postgres/service.rs
@@ -45,19 +45,35 @@ impl RetryLogic for PostgresRetryLogic {
     }
 }
 
+#[derive(Clone, Debug)]
+pub enum PostgresAction {
+    Insert,
+    Upsert {
+        primary_keys: String,
+        update_columns: String,
+    },
+}
+
 #[derive(Clone)]
 pub struct PostgresService {
     connection_pool: Pool<Postgres>,
     table: String,
     endpoint: String,
+    action: PostgresAction,
 }
 
 impl PostgresService {
-    pub const fn new(connection_pool: Pool<Postgres>, table: String, endpoint: String) -> Self {
+    pub const fn new(
+        connection_pool: Pool<Postgres>,
+        table: String,
+        endpoint: String,
+        action: PostgresAction,
+    ) -> Self {
         Self {
             connection_pool,
             table,
             endpoint,
+            action,
         }
     }
 }
@@ -151,13 +167,28 @@ impl Service<PostgresRequest> for PostgresService {
                 .collect::<Result<Vec<_>, _>>()
                 .context(VectorCommonSnafu)?;
 
-            sqlx::query(&format!(
-                "INSERT INTO {table} SELECT * FROM jsonb_populate_recordset(NULL::{table}, $1)"
-            ))
-            .bind(Json(serialized_values))
-            .execute(&service.connection_pool)
-            .await
-            .context(PostgresSnafu)?;
+            match service.action {
+                PostgresAction::Insert => {
+                    sqlx::query(&format!("INSERT INTO {table} SELECT * FROM jsonb_populate_recordset(NULL::{table}, $1)"))
+                        .bind(Json(serialized_values))
+                        .execute(&service.connection_pool)
+                        .await
+                        .context(PostgresSnafu)?;
+                }
+                PostgresAction::Upsert {
+                    primary_keys,
+                    update_columns,
+                } => {
+                    sqlx::query(&format!(
+                        "INSERT INTO {table}
+                            SELECT DISTINCT ON ({primary_keys}) * FROM jsonb_populate_recordset(NULL::{table}, $1)
+                            ON CONFLICT ({primary_keys}) DO UPDATE SET {update_columns}"))
+                        .bind(Json(serialized_values))
+                        .execute(&service.connection_pool)
+                        .await
+                        .context(PostgresSnafu)?;
+                }
+            }
 
             emit!(EndpointBytesSent {
                 byte_size: metadata.request_encoded_size(),

--- a/website/cue/reference/components/sinks/generated/postgres.cue
+++ b/website/cue/reference/components/sinks/generated/postgres.cue
@@ -27,6 +27,35 @@ generated: components: sinks: postgres: configuration: {
 			type: bool: {}
 		}
 	}
+	action: {
+		description: "Action used to put data into a table."
+		required:    false
+		type: string: {
+			default: "insert"
+			enum: {
+				insert: """
+					Inserts an event into a table.
+
+					This is the default.
+					"""
+				upsert: """
+					Upserts an event into a table.
+
+					When an event's insert conflicts with a table's primary key,
+					an update will be performed instead of an insert.
+
+					**Note**: This only handles **primary key conflicts**. Other
+					constraint violations when inserting will cause an error and
+					fail the entire batch.
+
+					**Note**: If multiple events in a single batch will update the
+					same row, only the first event will be used to update the row.
+					To avoid this, use a *dedupe* transform long enough for the
+					batch size.
+					"""
+			}
+		}
+	}
 	batch: {
 		description: """
 			Event batching behavior.
@@ -282,5 +311,42 @@ generated: components: sinks: postgres: configuration: {
 			"""
 		required: true
 		type: string: {}
+	}
+	upsert_option: {
+		description: "Upsert-specific options"
+		required:    false
+		type: object: options: {
+			primary_key: {
+				description: """
+					Column(s) part of the table's primary key.
+
+					This parameter is vulnerable to SQL injection attacks as it
+					is used directly in an SQL query and cannot be injected as a
+					parameter to a prepared statement. Only use trusted inputs/values
+					for this field.
+
+					**Note**: If a column name needs to be quoted, you must place
+					double quotes around the column name here.
+					"""
+				required: true
+				type: string: {}
+			}
+			update_column: {
+				description: """
+					Column(s) to update when an insert conflicts with a table's
+					primary key.
+
+					This parameter is vulnerable to SQL injection attacks as it
+					is used directly in an SQL query and cannot be injected as a
+					parameter to a prepared statement. Only use trusted inputs/values
+					for this field.
+
+					**Note**: If a column name needs to be quoted, you must place
+					double quotes around the column name here.
+					"""
+				required: true
+				type: string: {}
+			}
+		}
 	}
 }

--- a/website/generated/example-configs/sinks/postgres/advanced.yaml
+++ b/website/generated/example-configs/sinks/postgres/advanced.yaml
@@ -3,6 +3,7 @@ sinks:
     type: postgres
     inputs:
       - my-source-or-transform-id
+    action: insert
     endpoint: postgres://localhost:5432
     pool_size: 5
     table: my_table


### PR DESCRIPTION
## Summary
Add support to update a record when it encounters a primary key conflict when inserting, an upsert, on the Postgres sink.

### References
None

## Vector configuration
```yaml
sinks:
  sink_postgres_XXX:
    type: postgres
    inputs:
      - XXX
    endpoint: "postgres://XXX"
    table: XXX
    action: upsert
    upsert:
      primary_key: id
      update_column: last_seen
```

## How did you test this PR?
PR was tested using integrations tests along with this change being deployed in production and has handled 20 million log events so far without issue.

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## Contributor Guidelines

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Before pushing, follow our [pre-push guidance](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#pre-push).
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
