### PR TITLE
docs: remove unused component support notices

### DIFF
--- a/website/cue/reference/components.cue
+++ b/website/cue/reference/components.cue
@@ -560,13 +560,6 @@ components: {
 		// For example, a transform might be known to have performance issues
 		// or a lack of support for specific features, etc.
 		warnings: [...string] | null // Allow for empty list
-
-		// `notices` communicates useful information to the user that is neither
-		// a requirement or a warning.
-		//
-		// For example, the `lua` transform offers a Lua version notice that
-		// communicate which version of Lua is embedded.
-		notices: [...string] | null // Allow for empty list
 	}
 
 	sources:    #Components

--- a/website/cue/reference/components/amqp.cue
+++ b/website/cue/reference/components/amqp.cue
@@ -36,7 +36,6 @@ components: _amqp: {
 		}
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	configuration: {

--- a/website/cue/reference/components/kafka.cue
+++ b/website/cue/reference/components/kafka.cue
@@ -36,7 +36,6 @@ components: _kafka: {
 
 	support: {
 		requirements: []
-		notices: []
 		warnings: []
 	}
 

--- a/website/cue/reference/components/nats.cue
+++ b/website/cue/reference/components/nats.cue
@@ -36,7 +36,6 @@ components: _nats: {
 
 	support: {
 		requirements: []
-		notices: []
 		warnings: []
 	}
 

--- a/website/cue/reference/components/sinks/appsignal.cue
+++ b/website/cue/reference/components/sinks/appsignal.cue
@@ -56,7 +56,6 @@ components: sinks: appsignal: {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	configuration: generated.components.sinks.appsignal.configuration

--- a/website/cue/reference/components/sinks/aws_cloudwatch_logs.cue
+++ b/website/cue/reference/components/sinks/aws_cloudwatch_logs.cue
@@ -67,7 +67,6 @@ components: sinks: aws_cloudwatch_logs: components._aws & {
 
 	support: {
 		requirements: []
-		notices: []
 		warnings: []
 	}
 

--- a/website/cue/reference/components/sinks/aws_cloudwatch_metrics.cue
+++ b/website/cue/reference/components/sinks/aws_cloudwatch_metrics.cue
@@ -2,6 +2,10 @@ package metadata
 
 components: sinks: aws_cloudwatch_metrics: components._aws & {
 	title: "AWS Cloudwatch Metrics"
+	description: """
+		CloudWatch supports two metric storage representations: statistic sets and data points.
+		Vector uses data points so CloudWatch can calculate statistics without loss.
+		"""
 
 	classes: {
 		delivery:      "at_least_once"
@@ -65,18 +69,6 @@ components: sinks: aws_cloudwatch_metrics: components._aws & {
 				or by delta increments/decrements. Delta gauges are considered an
 				advanced feature useful in a distributed setting, however they
 				should be used with care.
-				""",
-		]
-		notices: [
-			"""
-				CloudWatch Metrics types are organized not by their semantics, but
-				by storage properties:
-
-				* Statistic Sets
-				* Data Points
-
-				In Vector only the latter is used to allow lossless statistics
-				calculations on CloudWatch side.
 				""",
 		]
 	}

--- a/website/cue/reference/components/sinks/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sinks/aws_kinesis_firehose.cue
@@ -67,7 +67,6 @@ components: sinks: aws_kinesis_firehose: components._aws & {
 
 	support: {
 		requirements: []
-		notices: []
 		warnings: []
 	}
 

--- a/website/cue/reference/components/sinks/aws_kinesis_streams.cue
+++ b/website/cue/reference/components/sinks/aws_kinesis_streams.cue
@@ -67,7 +67,6 @@ components: sinks: aws_kinesis_streams: components._aws & {
 
 	support: {
 		requirements: []
-		notices: []
 		warnings: []
 	}
 

--- a/website/cue/reference/components/sinks/aws_s3.cue
+++ b/website/cue/reference/components/sinks/aws_s3.cue
@@ -67,7 +67,6 @@ components: sinks: aws_s3: components._aws & {
 
 	support: {
 		requirements: []
-		notices: []
 		warnings: []
 	}
 

--- a/website/cue/reference/components/sinks/aws_sns.cue
+++ b/website/cue/reference/components/sinks/aws_sns.cue
@@ -62,7 +62,6 @@ components: sinks: aws_sns: components._aws & {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	configuration: generated.components.sinks.aws_sns.configuration & {

--- a/website/cue/reference/components/sinks/aws_sqs.cue
+++ b/website/cue/reference/components/sinks/aws_sqs.cue
@@ -62,7 +62,6 @@ components: sinks: aws_sqs: components._aws & {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	configuration: generated.components.sinks.aws_sqs.configuration & {

--- a/website/cue/reference/components/sinks/axiom.cue
+++ b/website/cue/reference/components/sinks/axiom.cue
@@ -65,7 +65,6 @@ components: sinks: axiom: {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	configuration: generated.components.sinks.axiom.configuration

--- a/website/cue/reference/components/sinks/azure_blob.cue
+++ b/website/cue/reference/components/sinks/azure_blob.cue
@@ -63,7 +63,6 @@ components: sinks: azure_blob: {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	configuration: generated.components.sinks.azure_blob.configuration

--- a/website/cue/reference/components/sinks/azure_logs_ingestion.cue
+++ b/website/cue/reference/components/sinks/azure_logs_ingestion.cue
@@ -66,7 +66,6 @@ components: sinks: azure_logs_ingestion: {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	configuration: generated.components.sinks.azure_logs_ingestion.configuration

--- a/website/cue/reference/components/sinks/blackhole.cue
+++ b/website/cue/reference/components/sinks/blackhole.cue
@@ -26,7 +26,6 @@ components: sinks: blackhole: {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	configuration: generated.components.sinks.blackhole.configuration

--- a/website/cue/reference/components/sinks/clickhouse.cue
+++ b/website/cue/reference/components/sinks/clickhouse.cue
@@ -68,7 +68,6 @@ components: sinks: clickhouse: {
 				""",
 		]
 		warnings: []
-		notices: []
 	}
 
 	configuration: generated.components.sinks.clickhouse.configuration

--- a/website/cue/reference/components/sinks/console.cue
+++ b/website/cue/reference/components/sinks/console.cue
@@ -37,7 +37,6 @@ components: sinks: console: {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	configuration: generated.components.sinks.console.configuration

--- a/website/cue/reference/components/sinks/databend.cue
+++ b/website/cue/reference/components/sinks/databend.cue
@@ -71,7 +71,6 @@ components: sinks: databend: {
 				""",
 		]
 		warnings: []
-		notices: []
 	}
 
 	configuration: generated.components.sinks.databend.configuration

--- a/website/cue/reference/components/sinks/databricks_zerobus.cue
+++ b/website/cue/reference/components/sinks/databricks_zerobus.cue
@@ -57,7 +57,6 @@ components: sinks: databricks_zerobus: {
 				""",
 		]
 		warnings: []
-		notices: []
 	}
 
 	configuration: generated.components.sinks.databricks_zerobus.configuration

--- a/website/cue/reference/components/sinks/datadog.cue
+++ b/website/cue/reference/components/sinks/datadog.cue
@@ -12,7 +12,6 @@ components: sinks: _datadog: {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	configuration: {

--- a/website/cue/reference/components/sinks/datadog_traces.cue
+++ b/website/cue/reference/components/sinks/datadog_traces.cue
@@ -75,7 +75,6 @@ components: sinks: datadog_traces: {
 				function correctly.
 				""",
 		]
-		notices: []
 	}
 
 	configuration: generated.components.sinks.datadog_traces.configuration

--- a/website/cue/reference/components/sinks/doris.cue
+++ b/website/cue/reference/components/sinks/doris.cue
@@ -68,7 +68,6 @@ components: sinks: doris: {
 				"""#,
 		]
 		warnings: []
-		notices: []
 	}
 
 	configuration: generated.components.sinks.doris.configuration

--- a/website/cue/reference/components/sinks/elasticsearch.cue
+++ b/website/cue/reference/components/sinks/elasticsearch.cue
@@ -69,13 +69,6 @@ components: sinks: elasticsearch: {
 				"""#,
 		]
 		warnings: []
-		notices: [
-			#"""
-				This sink is compatible with OpenSearch, including both self-managed OpenSearch instances
-				and Amazon OpenSearch Service. For OpenSearch Serverless, set `opensearch_service_type = "serverless"`
-				and use AWS authentication.
-				"""#,
-		]
 	}
 
 	configuration: generated.components.sinks.elasticsearch.configuration

--- a/website/cue/reference/components/sinks/file.cue
+++ b/website/cue/reference/components/sinks/file.cue
@@ -39,7 +39,6 @@ components: sinks: file: {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	configuration: generated.components.sinks.file.configuration

--- a/website/cue/reference/components/sinks/gcp_chronicle_unstructured.cue
+++ b/website/cue/reference/components/sinks/gcp_chronicle_unstructured.cue
@@ -64,7 +64,6 @@ components: sinks: gcp_chronicle_unstructured: {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	configuration: generated.components.sinks.gcp_chronicle_unstructured.configuration

--- a/website/cue/reference/components/sinks/gcp_cloud_storage.cue
+++ b/website/cue/reference/components/sinks/gcp_cloud_storage.cue
@@ -69,7 +69,6 @@ components: sinks: gcp_cloud_storage: {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	configuration: generated.components.sinks.gcp_cloud_storage.configuration

--- a/website/cue/reference/components/sinks/gcp_pubsub.cue
+++ b/website/cue/reference/components/sinks/gcp_pubsub.cue
@@ -63,7 +63,6 @@ components: sinks: gcp_pubsub: {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	configuration: generated.components.sinks.gcp_pubsub.configuration

--- a/website/cue/reference/components/sinks/gcp_stackdriver_logs.cue
+++ b/website/cue/reference/components/sinks/gcp_stackdriver_logs.cue
@@ -60,7 +60,6 @@ components: sinks: gcp_stackdriver_logs: {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	configuration: generated.components.sinks.gcp_stackdriver_logs.configuration & {

--- a/website/cue/reference/components/sinks/gcp_stackdriver_metrics.cue
+++ b/website/cue/reference/components/sinks/gcp_stackdriver_metrics.cue
@@ -60,7 +60,6 @@ components: sinks: gcp_stackdriver_metrics: {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	configuration: generated.components.sinks.gcp_stackdriver_metrics.configuration & {

--- a/website/cue/reference/components/sinks/greptimedb_logs.cue
+++ b/website/cue/reference/components/sinks/greptimedb_logs.cue
@@ -58,7 +58,6 @@ components: sinks: greptimedb_logs: {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	configuration: generated.components.sinks.greptimedb_logs.configuration

--- a/website/cue/reference/components/sinks/greptimedb_metrics.cue
+++ b/website/cue/reference/components/sinks/greptimedb_metrics.cue
@@ -58,7 +58,6 @@ components: sinks: greptimedb_metrics: {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	configuration: generated.components.sinks.greptimedb_metrics.configuration

--- a/website/cue/reference/components/sinks/honeycomb.cue
+++ b/website/cue/reference/components/sinks/honeycomb.cue
@@ -58,7 +58,6 @@ components: sinks: honeycomb: {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	configuration: generated.components.sinks.honeycomb.configuration

--- a/website/cue/reference/components/sinks/http.cue
+++ b/website/cue/reference/components/sinks/http.cue
@@ -72,7 +72,6 @@ components: sinks: http: {
 	support: {
 		requirements: []
 		warnings: []
-		notices: ["Input type support can depend on configured `encoding.codec`"]
 	}
 
 	configuration: generated.components.sinks.http.configuration

--- a/website/cue/reference/components/sinks/humio.cue
+++ b/website/cue/reference/components/sinks/humio.cue
@@ -14,7 +14,6 @@ components: sinks: _humio: {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	features: {

--- a/website/cue/reference/components/sinks/influxdb_logs.cue
+++ b/website/cue/reference/components/sinks/influxdb_logs.cue
@@ -38,7 +38,6 @@ components: sinks: influxdb_logs: {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	configuration: generated.components.sinks.influxdb_logs.configuration

--- a/website/cue/reference/components/sinks/influxdb_metrics.cue
+++ b/website/cue/reference/components/sinks/influxdb_metrics.cue
@@ -38,7 +38,6 @@ components: sinks: influxdb_metrics: {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	configuration: generated.components.sinks.influxdb_metrics.configuration

--- a/website/cue/reference/components/sinks/keep.cue
+++ b/website/cue/reference/components/sinks/keep.cue
@@ -62,7 +62,6 @@ components: sinks: keep: {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	configuration: generated.components.sinks.keep.configuration

--- a/website/cue/reference/components/sinks/loki.cue
+++ b/website/cue/reference/components/sinks/loki.cue
@@ -64,7 +64,6 @@ components: sinks: loki: {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	configuration: generated.components.sinks.loki.configuration

--- a/website/cue/reference/components/sinks/mezmo.cue
+++ b/website/cue/reference/components/sinks/mezmo.cue
@@ -50,7 +50,6 @@ components: sinks: mezmo: {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	configuration: generated.components.sinks.mezmo.configuration

--- a/website/cue/reference/components/sinks/mqtt.cue
+++ b/website/cue/reference/components/sinks/mqtt.cue
@@ -57,7 +57,6 @@ components: sinks: mqtt: {
 		}
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	configuration: generated.components.sinks.mqtt.configuration & {

--- a/website/cue/reference/components/sinks/nats.cue
+++ b/website/cue/reference/components/sinks/nats.cue
@@ -49,7 +49,6 @@ components: sinks: nats: {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	configuration: generated.components.sinks.nats.configuration

--- a/website/cue/reference/components/sinks/new_relic.cue
+++ b/website/cue/reference/components/sinks/new_relic.cue
@@ -59,7 +59,6 @@ components: sinks: new_relic: {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	configuration: generated.components.sinks.new_relic.configuration

--- a/website/cue/reference/components/sinks/opentelemetry.cue
+++ b/website/cue/reference/components/sinks/opentelemetry.cue
@@ -41,7 +41,6 @@ components: sinks: opentelemetry: {
 				See [#22054](https://github.com/vectordotdev/vector/issues/22054).
 				""",
 		]
-		notices: []
 	}
 
 	configuration: generated.components.sinks.opentelemetry.configuration

--- a/website/cue/reference/components/sinks/papertrail.cue
+++ b/website/cue/reference/components/sinks/papertrail.cue
@@ -55,7 +55,6 @@ components: sinks: papertrail: {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	configuration: generated.components.sinks.papertrail.configuration

--- a/website/cue/reference/components/sinks/postgres.cue
+++ b/website/cue/reference/components/sinks/postgres.cue
@@ -54,7 +54,6 @@ components: sinks: postgres: {
 			to catch the exception and set the desired default value.
 			""",
 		]
-		notices: []
 	}
 
 	configuration: generated.components.sinks.postgres.configuration & {

--- a/website/cue/reference/components/sinks/prometheus_exporter.cue
+++ b/website/cue/reference/components/sinks/prometheus_exporter.cue
@@ -53,7 +53,6 @@ components: sinks: prometheus_exporter: {
 				to protect against this.
 				""",
 		]
-		notices: []
 	}
 
 	configuration: generated.components.sinks.prometheus_exporter.configuration

--- a/website/cue/reference/components/sinks/prometheus_remote_write.cue
+++ b/website/cue/reference/components/sinks/prometheus_remote_write.cue
@@ -74,7 +74,6 @@ components: sinks: prometheus_remote_write: {
 				as a way to protect against this.
 				""",
 		]
-		notices: []
 	}
 
 	configuration: generated.components.sinks.prometheus_remote_write.configuration

--- a/website/cue/reference/components/sinks/pulsar.cue
+++ b/website/cue/reference/components/sinks/pulsar.cue
@@ -52,7 +52,6 @@ components: sinks: pulsar: {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	configuration: generated.components.sinks.pulsar.configuration

--- a/website/cue/reference/components/sinks/redis.cue
+++ b/website/cue/reference/components/sinks/redis.cue
@@ -50,7 +50,6 @@ components: sinks: redis: {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	configuration: generated.components.sinks.redis.configuration

--- a/website/cue/reference/components/sinks/sematext_logs.cue
+++ b/website/cue/reference/components/sinks/sematext_logs.cue
@@ -39,7 +39,6 @@ components: sinks: sematext_logs: {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	configuration: generated.components.sinks.sematext_logs.configuration

--- a/website/cue/reference/components/sinks/sematext_metrics.cue
+++ b/website/cue/reference/components/sinks/sematext_metrics.cue
@@ -43,7 +43,6 @@ components: sinks: sematext_metrics: {
 				with the `sematext_logs` sink.
 				""",
 		]
-		notices: []
 	}
 
 	configuration: generated.components.sinks.sematext_metrics.configuration

--- a/website/cue/reference/components/sinks/socket.cue
+++ b/website/cue/reference/components/sinks/socket.cue
@@ -55,7 +55,6 @@ components: sinks: socket: {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	configuration: generated.components.sinks.socket.configuration

--- a/website/cue/reference/components/sinks/splunk_hec_logs.cue
+++ b/website/cue/reference/components/sinks/splunk_hec_logs.cue
@@ -67,7 +67,6 @@ components: sinks: splunk_hec_logs: {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	configuration: generated.components.sinks.splunk_hec_logs.configuration & {

--- a/website/cue/reference/components/sinks/splunk_hec_metrics.cue
+++ b/website/cue/reference/components/sinks/splunk_hec_metrics.cue
@@ -61,7 +61,6 @@ components: sinks: splunk_hec_metrics: {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	configuration: generated.components.sinks.splunk_hec_metrics.configuration

--- a/website/cue/reference/components/sinks/vector.cue
+++ b/website/cue/reference/components/sinks/vector.cue
@@ -58,7 +58,6 @@ components: sinks: vector: {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	input: {

--- a/website/cue/reference/components/sinks/webhdfs.cue
+++ b/website/cue/reference/components/sinks/webhdfs.cue
@@ -39,7 +39,6 @@ components: sinks: webhdfs: {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	configuration: generated.components.sinks.webhdfs.configuration

--- a/website/cue/reference/components/sinks/websocket.cue
+++ b/website/cue/reference/components/sinks/websocket.cue
@@ -57,7 +57,6 @@ components: sinks: websocket: {
 		}
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	configuration: generated.components.sinks.websocket.configuration & {

--- a/website/cue/reference/components/sinks/websocket_server.cue
+++ b/website/cue/reference/components/sinks/websocket_server.cue
@@ -60,7 +60,6 @@ components: sinks: websocket_server: {
 		}
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	input: {

--- a/website/cue/reference/components/sources/apache_metrics.cue
+++ b/website/cue/reference/components/sources/apache_metrics.cue
@@ -42,7 +42,6 @@ components: sources: apache_metrics: {
 			""",
 		]
 		warnings: []
-		notices: []
 	}
 
 	installation: {

--- a/website/cue/reference/components/sources/aws_ecs_metrics.cue
+++ b/website/cue/reference/components/sources/aws_ecs_metrics.cue
@@ -43,7 +43,6 @@ components: sources: aws_ecs_metrics: {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	installation: {

--- a/website/cue/reference/components/sources/aws_kinesis_firehose.cue
+++ b/website/cue/reference/components/sources/aws_kinesis_firehose.cue
@@ -50,7 +50,6 @@ components: sources: aws_kinesis_firehose: {
 		]
 
 		warnings: []
-		notices: []
 	}
 
 	installation: {

--- a/website/cue/reference/components/sources/aws_s3.cue
+++ b/website/cue/reference/components/sources/aws_s3.cue
@@ -37,7 +37,6 @@ components: sources: aws_s3: components._aws & {
 				""",
 		]
 		warnings: []
-		notices: []
 	}
 
 	installation: {

--- a/website/cue/reference/components/sources/aws_sqs.cue
+++ b/website/cue/reference/components/sources/aws_sqs.cue
@@ -45,7 +45,6 @@ components: sources: aws_sqs: components._aws & {
 		}
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	installation: {

--- a/website/cue/reference/components/sources/datadog_agent.cue
+++ b/website/cue/reference/components/sources/datadog_agent.cue
@@ -48,7 +48,6 @@ components: sources: datadog_agent: {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	installation: {

--- a/website/cue/reference/components/sources/demo_logs.cue
+++ b/website/cue/reference/components/sources/demo_logs.cue
@@ -29,7 +29,6 @@ components: sources: demo_logs: {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	installation: {

--- a/website/cue/reference/components/sources/dnstap.cue
+++ b/website/cue/reference/components/sources/dnstap.cue
@@ -47,7 +47,6 @@ components: sources: dnstap: {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	configuration: generated.components.sources.dnstap.configuration & {

--- a/website/cue/reference/components/sources/docker_logs.cue
+++ b/website/cue/reference/components/sources/docker_logs.cue
@@ -83,7 +83,6 @@ components: sources: docker_logs: {
 				container using [`exclude_containers`](#exclude_containers).
 				""",
 		]
-		notices: []
 	}
 
 	installation: {

--- a/website/cue/reference/components/sources/eventstoredb_metrics.cue
+++ b/website/cue/reference/components/sources/eventstoredb_metrics.cue
@@ -36,7 +36,6 @@ components: sources: eventstoredb_metrics: {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	installation: {

--- a/website/cue/reference/components/sources/exec.cue
+++ b/website/cue/reference/components/sources/exec.cue
@@ -31,7 +31,6 @@ components: sources: exec: {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	installation: {

--- a/website/cue/reference/components/sources/file.cue
+++ b/website/cue/reference/components/sources/file.cue
@@ -40,7 +40,6 @@ components: sources: file: {
 				""",
 		]
 		warnings: []
-		notices: []
 	}
 
 	installation: {

--- a/website/cue/reference/components/sources/file_descriptor.cue
+++ b/website/cue/reference/components/sources/file_descriptor.cue
@@ -32,7 +32,6 @@ components: sources: file_descriptor: {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	installation: {

--- a/website/cue/reference/components/sources/fluent.cue
+++ b/website/cue/reference/components/sources/fluent.cue
@@ -43,7 +43,6 @@ components: sources: fluent: {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	installation: {

--- a/website/cue/reference/components/sources/gcp_pubsub.cue
+++ b/website/cue/reference/components/sources/gcp_pubsub.cue
@@ -49,7 +49,6 @@ components: sources: gcp_pubsub: {
 				""",
 		]
 		warnings: []
-		notices: []
 	}
 
 	installation: {

--- a/website/cue/reference/components/sources/heroku_logs.cue
+++ b/website/cue/reference/components/sources/heroku_logs.cue
@@ -53,7 +53,6 @@ components: sources: heroku_logs: {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	installation: {

--- a/website/cue/reference/components/sources/host_metrics.cue
+++ b/website/cue/reference/components/sources/host_metrics.cue
@@ -27,7 +27,6 @@ components: sources: host_metrics: {
 	}
 
 	support: {
-		notices: []
 		requirements: []
 		warnings: [
 			"""

--- a/website/cue/reference/components/sources/http_client.cue
+++ b/website/cue/reference/components/sources/http_client.cue
@@ -44,7 +44,6 @@ components: sources: http_client: {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	installation: {

--- a/website/cue/reference/components/sources/http_server.cue
+++ b/website/cue/reference/components/sources/http_server.cue
@@ -47,7 +47,6 @@ components: sources: http_server: {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	installation: {

--- a/website/cue/reference/components/sources/internal_logs.cue
+++ b/website/cue/reference/components/sources/internal_logs.cue
@@ -27,7 +27,6 @@ components: sources: internal_logs: {
 	}
 
 	support: {
-		notices: []
 		requirements: []
 		warnings: []
 	}

--- a/website/cue/reference/components/sources/internal_metrics.cue
+++ b/website/cue/reference/components/sources/internal_metrics.cue
@@ -26,7 +26,6 @@ components: sources: internal_metrics: {
 	}
 
 	support: {
-		notices: []
 		requirements: []
 		warnings: []
 	}

--- a/website/cue/reference/components/sources/journald.cue
+++ b/website/cue/reference/components/sources/journald.cue
@@ -40,7 +40,6 @@ components: sources: journald: {
 				""",
 		]
 		warnings: []
-		notices: []
 	}
 
 	installation: {

--- a/website/cue/reference/components/sources/kubernetes_logs.cue
+++ b/website/cue/reference/components/sources/kubernetes_logs.cue
@@ -51,7 +51,6 @@ components: sources: kubernetes_logs: {
 				This source is only tested on Linux. Your mileage may vary for clusters on Windows.
 				""",
 		]
-		notices: []
 	}
 
 	installation: {

--- a/website/cue/reference/components/sources/logstash.cue
+++ b/website/cue/reference/components/sources/logstash.cue
@@ -43,7 +43,6 @@ components: sources: logstash: {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	installation: {

--- a/website/cue/reference/components/sources/mongodb_metrics.cue
+++ b/website/cue/reference/components/sources/mongodb_metrics.cue
@@ -43,7 +43,6 @@ components: sources: mongodb_metrics: {
 		]
 
 		warnings: []
-		notices: []
 	}
 
 	installation: {

--- a/website/cue/reference/components/sources/mqtt.cue
+++ b/website/cue/reference/components/sources/mqtt.cue
@@ -47,7 +47,6 @@ components: sources: mqtt: {
 		}
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	configuration: generated.components.sources.mqtt.configuration

--- a/website/cue/reference/components/sources/nginx_metrics.cue
+++ b/website/cue/reference/components/sources/nginx_metrics.cue
@@ -41,7 +41,6 @@ components: sources: nginx_metrics: {
 		]
 
 		warnings: []
-		notices: []
 	}
 
 	installation: {

--- a/website/cue/reference/components/sources/okta.cue
+++ b/website/cue/reference/components/sources/okta.cue
@@ -21,7 +21,6 @@ components: sources: okta: {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	installation: {

--- a/website/cue/reference/components/sources/opentelemetry.cue
+++ b/website/cue/reference/components/sources/opentelemetry.cue
@@ -39,7 +39,6 @@ components: sources: opentelemetry: {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	installation: {

--- a/website/cue/reference/components/sources/postgresql_metrics.cue
+++ b/website/cue/reference/components/sources/postgresql_metrics.cue
@@ -44,7 +44,6 @@ components: sources: postgresql_metrics: {
 		requirements: []
 
 		warnings: []
-		notices: []
 	}
 
 	installation: {

--- a/website/cue/reference/components/sources/prometheus_pushgateway.cue
+++ b/website/cue/reference/components/sources/prometheus_pushgateway.cue
@@ -42,7 +42,6 @@ components: sources: prometheus_pushgateway: {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	installation: {

--- a/website/cue/reference/components/sources/prometheus_remote_write.cue
+++ b/website/cue/reference/components/sources/prometheus_remote_write.cue
@@ -42,7 +42,6 @@ components: sources: prometheus_remote_write: {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	installation: {

--- a/website/cue/reference/components/sources/prometheus_scrape.cue
+++ b/website/cue/reference/components/sources/prometheus_scrape.cue
@@ -44,7 +44,6 @@ components: sources: prometheus_scrape: {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	installation: {

--- a/website/cue/reference/components/sources/pulsar.cue
+++ b/website/cue/reference/components/sources/pulsar.cue
@@ -25,7 +25,6 @@ components: sources: pulsar: {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	installation: {

--- a/website/cue/reference/components/sources/redis.cue
+++ b/website/cue/reference/components/sources/redis.cue
@@ -49,7 +49,6 @@ components: sources: redis: {
 
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	installation: {

--- a/website/cue/reference/components/sources/socket.cue
+++ b/website/cue/reference/components/sources/socket.cue
@@ -48,7 +48,6 @@ components: sources: socket: {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	installation: {

--- a/website/cue/reference/components/sources/splunk_hec.cue
+++ b/website/cue/reference/components/sources/splunk_hec.cue
@@ -48,7 +48,6 @@ components: sources: splunk_hec: {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	installation: {

--- a/website/cue/reference/components/sources/static_metrics.cue
+++ b/website/cue/reference/components/sources/static_metrics.cue
@@ -26,7 +26,6 @@ components: sources: static_metrics: {
 	}
 
 	support: {
-		notices: []
 		requirements: []
 		warnings: []
 	}

--- a/website/cue/reference/components/sources/statsd.cue
+++ b/website/cue/reference/components/sources/statsd.cue
@@ -47,7 +47,6 @@ components: sources: statsd: {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	installation: {

--- a/website/cue/reference/components/sources/stdin.cue
+++ b/website/cue/reference/components/sources/stdin.cue
@@ -32,7 +32,6 @@ components: sources: stdin: {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	installation: {

--- a/website/cue/reference/components/sources/syslog.cue
+++ b/website/cue/reference/components/sources/syslog.cue
@@ -40,7 +40,6 @@ components: sources: syslog: {
 
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	installation: {

--- a/website/cue/reference/components/sources/vector.cue
+++ b/website/cue/reference/components/sources/vector.cue
@@ -45,7 +45,6 @@ components: sources: vector: {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	installation: {

--- a/website/cue/reference/components/sources/websocket.cue
+++ b/website/cue/reference/components/sources/websocket.cue
@@ -57,7 +57,6 @@ components: sources: websocket: {
 		}
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	configuration: generated.components.sources.websocket.configuration & {

--- a/website/cue/reference/components/sources/windows_event_log.cue
+++ b/website/cue/reference/components/sources/windows_event_log.cue
@@ -39,7 +39,6 @@ components: sources: windows_event_log: {
 				""",
 		]
 		warnings: []
-		notices: []
 	}
 
 	installation: {

--- a/website/cue/reference/components/transforms/aggregate.cue
+++ b/website/cue/reference/components/transforms/aggregate.cue
@@ -21,7 +21,6 @@ components: transforms: aggregate: {
 
 	support: {
 		requirements: []
-		notices: []
 		warnings: []
 	}
 

--- a/website/cue/reference/components/transforms/aws_ec2_metadata.cue
+++ b/website/cue/reference/components/transforms/aws_ec2_metadata.cue
@@ -40,7 +40,6 @@ components: transforms: aws_ec2_metadata: {
 				```
 				""",
 		]
-		notices: []
 		warnings: [
 			"""
 				Do not enable this transform if you are running Vector as an Aggregator, tags will be sourced from the Aggregator node's metadata server and not the client's.

--- a/website/cue/reference/components/transforms/dedupe.cue
+++ b/website/cue/reference/components/transforms/dedupe.cue
@@ -20,7 +20,6 @@ components: transforms: dedupe: {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	configuration: generated.components.transforms.dedupe.configuration

--- a/website/cue/reference/components/transforms/delay.cue
+++ b/website/cue/reference/components/transforms/delay.cue
@@ -26,7 +26,6 @@ components: transforms: delay: {
 				items are emitted in the same millisecond.
 				""",
 		]
-		notices: []
 	}
 
 	configuration: generated.components.transforms.delay.configuration & {

--- a/website/cue/reference/components/transforms/exclusive_route.cue
+++ b/website/cue/reference/components/transforms/exclusive_route.cue
@@ -24,7 +24,6 @@ components: transforms: exclusive_route: {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	configuration: generated.components.transforms.exclusive_route.configuration

--- a/website/cue/reference/components/transforms/filter.cue
+++ b/website/cue/reference/components/transforms/filter.cue
@@ -20,7 +20,6 @@ components: transforms: filter: {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	configuration: generated.components.transforms.filter.configuration

--- a/website/cue/reference/components/transforms/incremental_to_absolute.cue
+++ b/website/cue/reference/components/transforms/incremental_to_absolute.cue
@@ -20,7 +20,6 @@ components: transforms: incremental_to_absolute: {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	configuration: generated.components.transforms.incremental_to_absolute.configuration

--- a/website/cue/reference/components/transforms/log_to_metric.cue
+++ b/website/cue/reference/components/transforms/log_to_metric.cue
@@ -20,7 +20,6 @@ components: transforms: log_to_metric: {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	configuration: generated.components.transforms.log_to_metric.configuration & {

--- a/website/cue/reference/components/transforms/lua.cue
+++ b/website/cue/reference/components/transforms/lua.cue
@@ -34,7 +34,6 @@ components: transforms: lua: {
 			us know.
 			""",
 		]
-		notices: []
 	}
 
 	configuration: generated.components.transforms.lua.configuration & {

--- a/website/cue/reference/components/transforms/metric_to_log.cue
+++ b/website/cue/reference/components/transforms/metric_to_log.cue
@@ -21,7 +21,6 @@ components: transforms: metric_to_log: {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	configuration: generated.components.transforms.metric_to_log.configuration

--- a/website/cue/reference/components/transforms/reduce.cue
+++ b/website/cue/reference/components/transforms/reduce.cue
@@ -21,7 +21,6 @@ components: transforms: reduce: {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	configuration: generated.components.transforms.reduce.configuration

--- a/website/cue/reference/components/transforms/remap.cue
+++ b/website/cue/reference/components/transforms/remap.cue
@@ -30,7 +30,6 @@ components: transforms: "remap": {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	configuration: generated.components.transforms.remap.configuration

--- a/website/cue/reference/components/transforms/route.cue
+++ b/website/cue/reference/components/transforms/route.cue
@@ -24,7 +24,6 @@ components: transforms: route: {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	configuration: generated.components.transforms.route.configuration

--- a/website/cue/reference/components/transforms/sample.cue
+++ b/website/cue/reference/components/transforms/sample.cue
@@ -20,7 +20,6 @@ components: transforms: sample: {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	configuration: generated.components.transforms.sample.configuration

--- a/website/cue/reference/components/transforms/tag_cardinality_limit.cue
+++ b/website/cue/reference/components/transforms/tag_cardinality_limit.cue
@@ -26,7 +26,6 @@ components: transforms: tag_cardinality_limit: {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	// TODO: It'd be nice to have a way to define the description of the enum tag field on the Rust

--- a/website/cue/reference/components/transforms/throttle.cue
+++ b/website/cue/reference/components/transforms/throttle.cue
@@ -20,7 +20,6 @@ components: transforms: throttle: {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	configuration: generated.components.transforms.throttle.configuration & {

--- a/website/cue/reference/components/transforms/trace_to_log.cue
+++ b/website/cue/reference/components/transforms/trace_to_log.cue
@@ -23,7 +23,6 @@ components: transforms: trace_to_log: {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	configuration: generated.components.transforms.trace_to_log.configuration

--- a/website/cue/reference/components/transforms/window.cue
+++ b/website/cue/reference/components/transforms/window.cue
@@ -21,7 +21,6 @@ components: transforms: window: {
 	support: {
 		requirements: []
 		warnings: []
-		notices: []
 	}
 
 	configuration: generated.components.transforms.window.configuration


### PR DESCRIPTION
## Summary

The component metadata includes a `support.notices` field, but component pages do not render it. Only three notices are populated, and two duplicate content already present elsewhere in their pages.

This removes the unused notice field and its empty declarations. The unique CloudWatch metrics guidance moves into that component's introduction, while the redundant Elasticsearch and HTTP notices are removed. Existing component warnings remain unchanged.

### References

Closes: #22592

## Vector configuration

N/A

## How did you test this PR?

- Formatted and validated the CUE sources.
- Generated the documentation JSON and built the production site.
- Verified the rendered CloudWatch metrics, Elasticsearch, and HTTP sink pages retain the relevant content without a separate notices section.

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## Contributor Guidelines

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Before pushing, follow our [pre-push guidance](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#pre-push).
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
