### PR TITLE
fix(template): validate scheme and authority of strftime-only URI templates

### DIFF
--- a/src/template/confinement.rs
+++ b/src/template/confinement.rs
@@ -259,35 +259,31 @@ impl ConfinementChecker {
                 UriChecker::from_prefix(&prefix).map(|c| Some(Self::Uri(Box::new(c))))
             }
             None => {
-                // Template with no event-field references. Fully static ones
-                // (no strftime either) are validated for URI structure to
-                // enforce the HTTP/HTTPS + authority requirement uniformly.
-                // Strftime-only templates (e.g. `https://logs.example.com/%Y/%m`)
-                // are not: their source is not a literal URI — the strftime
-                // directives render to time-derived text, never event input —
-                // and `http::Uri` would reject the raw `%` directives as
-                // invalid percent escapes.
+                // No event-field references. Static templates are validated
+                // in full; strftime-only ones can't be (raw `%` directives
+                // are invalid percent escapes), so their literal prefix —
+                // scheme and authority before the first `%` — is validated
+                // instead.
                 if !tpl.inner.is_dynamic() {
                     Self::validate_static_uri(tpl).map(|()| None)
                 } else {
-                    Ok(None)
+                    Self::validate_static_uri_prefix(tpl.inner.literal_prefix()).map(|()| None)
                 }
             }
         }
     }
 
-    /// Validate a static URI template for structure and scheme.
-    ///
-    /// Static templates don't need a runtime checker, but we still enforce:
-    /// - Must be HTTP or HTTPS scheme
-    /// - Must have valid URI structure with non-empty authority
-    ///
-    /// This prevents `UriTemplate::confine` from accepting `ftp://`, relative `/path`,
-    /// or schemeless `//host` URIs even when static.
+    /// Validate a fully static URI template: HTTP/HTTPS scheme and a
+    /// non-empty authority, so `ftp://` or relative URIs fail at build time.
     fn validate_static_uri(tpl: &Template) -> Result<(), BuildError> {
-        // Static templates don't need a runtime checker, but we still enforce
-        // HTTP/HTTPS scheme and a non-empty authority (host) uniformly.
         UriChecker::parse_http_uri(tpl.get_ref()).map(|_| ())
+    }
+
+    /// Validate the literal prefix of a strftime-only URI template. The raw
+    /// `%` directives can't be parsed as a URI, so check the operator-authored
+    /// scheme and authority before the first `%` the same way.
+    fn validate_static_uri_prefix(prefix: &str) -> Result<(), BuildError> {
+        UriChecker::parse_http_uri(prefix).map(|_| ())
     }
 
     pub(crate) fn confine(&self, rendered: &str) -> Result<(), ConfineError> {

--- a/src/template/tests.rs
+++ b/src/template/tests.rs
@@ -931,14 +931,18 @@ fn uri_template_confine_enforces_uri_semantics() {
 }
 
 #[rstest]
-// URIs — dynamic or static — must be absolute http(s) URIs with a fully
-// static authority. Reject at build time otherwise.
+// URIs — dynamic, static, or strftime-only — must be absolute http(s) URIs
+// with a fully static authority. Reject at build time otherwise. For
+// strftime-only templates the literal prefix before the first `%` carries
+// the scheme and authority, so they validate the same way.
 #[case::relative_uri("/api/{{ tenant }}", "authority")]
 #[case::schemeless("//api.example.com/{{ tenant }}", "authority")]
 #[case::static_relative_uri("/api/endpoint", "authority")]
 #[case::static_schemeless("//api.example.com/path", "authority")]
+#[case::strftime_only_relative_uri("/relative/%Y", "authority")]
 #[case::unsupported_scheme("ftp://files.example.com/{{ path }}", "ftp")]
 #[case::static_unsupported_scheme("ftp://files.example.com/path", "ftp")]
+#[case::strftime_only_unsupported_scheme("ftp://files.example.com/%Y", "ftp")]
 fn uri_template_confine_rejects_invalid_scheme_or_authority(
     #[case] template: &str,
     #[case] err_fragment: &str,


### PR DESCRIPTION
## Summary

### References
- Related: #26011 (follow-up to review feedback — strftime-only URI templates skipped build-time scheme/authority validation)

## Vector configuration

NA

## How did you test this PR?

`cargo nextest run -p vector --no-default-features template::tests` — 68 passed, including new rstest cases for `ftp://files.example.com/%Y` (UnsupportedUriScheme) and `/relative/%Y` (NoStaticUriAuthority), both now failing at build time instead of the first request.

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## Contributor Guidelines

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Before pushing, follow our [pre-push guidance](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#pre-push).
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.