### PR TITLE
fix(disk buffer): record drop_newest discards from disk buffers

### DIFF
--- a/changelog.d/drop_newest_discard_metrics.fix.md
+++ b/changelog.d/drop_newest_discard_metrics.fix.md
@@ -1,4 +1,4 @@
 Fixes buffer `received` / `discarded` metrics not being incremented when
 events are rejected from a full disk buffer configured with `drop_newest`.
 
-authors: jgetz
+authors: jonahgetz

--- a/changelog.d/drop_newest_discard_metrics.fix.md
+++ b/changelog.d/drop_newest_discard_metrics.fix.md
@@ -1,0 +1,4 @@
+Fixes buffer `received` / `discarded` metrics not being incremented when
+events are rejected from a full disk buffer configured with `drop_newest`.
+
+authors: jgetz

--- a/lib/vector-buffers/src/topology/builder.rs
+++ b/lib/vector-buffers/src/topology/builder.rs
@@ -166,7 +166,7 @@ impl<T: Bufferable> TopologyBuilder<T> {
             if !provides_instrumentation {
                 receiver.with_usage_instrumentation(usage_handle.clone());
             }
-            sender.with_usage_instrumentation(usage_handle.clone(), provides_instrumentation);
+            sender.with_usage_instrumentation(usage_handle, provides_instrumentation);
 
             current_stage = Some((sender, receiver));
         }

--- a/lib/vector-buffers/src/topology/builder.rs
+++ b/lib/vector-buffers/src/topology/builder.rs
@@ -166,6 +166,8 @@ impl<T: Bufferable> TopologyBuilder<T> {
             if !provides_instrumentation {
                 sender.with_usage_instrumentation(usage_handle.clone());
                 receiver.with_usage_instrumentation(usage_handle);
+            } else if stage.when_full == WhenFull::DropNewest {
+                sender.with_drop_newest_usage_instrumentation(usage_handle);
             }
 
             current_stage = Some((sender, receiver));

--- a/lib/vector-buffers/src/topology/builder.rs
+++ b/lib/vector-buffers/src/topology/builder.rs
@@ -164,11 +164,9 @@ impl<T: Bufferable> TopologyBuilder<T> {
 
             sender.with_send_duration_instrumentation(stage_idx, &span);
             if !provides_instrumentation {
-                sender.with_usage_instrumentation(usage_handle.clone());
-                receiver.with_usage_instrumentation(usage_handle);
-            } else if stage.when_full == WhenFull::DropNewest {
-                sender.with_drop_newest_usage_instrumentation(usage_handle);
+                receiver.with_usage_instrumentation(usage_handle.clone());
             }
+            sender.with_usage_instrumentation(usage_handle.clone(), provides_instrumentation);
 
             current_stage = Some((sender, receiver));
         }
@@ -252,7 +250,7 @@ impl<T: Bufferable> TopologyBuilder<T> {
         let mut sender = BufferSender::new(sender.into(), mode);
         let mut receiver = BufferReceiver::new(receiver.into());
 
-        sender.with_usage_instrumentation(usage_handle.clone());
+        sender.with_usage_instrumentation(usage_handle.clone(), false);
         receiver.with_usage_instrumentation(usage_handle);
 
         (sender, receiver)

--- a/lib/vector-buffers/src/topology/channel/sender.rs
+++ b/lib/vector-buffers/src/topology/channel/sender.rs
@@ -179,27 +179,22 @@ struct UsageInstrumentation {
 }
 
 impl UsageAccounting {
-    fn record(self, instrumentation: &UsageInstrumentation, item_count: usize, item_size: usize) {
+    fn record(self, handle: &BufferUsageHandle, item_count: usize, item_size: usize) {
         match self {
-            Self::Accepted if !instrumentation.provides_instrumentation => instrumentation
-                .handle
+            Self::Accepted => handle
                 .increment_received_event_count_and_byte_size(item_count as u64, item_size as u64),
             Self::DroppedNewest => {
-                instrumentation
-                    .handle
-                    .increment_received_event_count_and_byte_size(
-                        item_count as u64,
-                        item_size as u64,
-                    );
-                instrumentation
-                    .handle
-                    .increment_dropped_event_count_and_byte_size(
-                        item_count as u64,
-                        item_size as u64,
-                        true,
-                    );
+                handle.increment_received_event_count_and_byte_size(
+                    item_count as u64,
+                    item_size as u64,
+                );
+                handle.increment_dropped_event_count_and_byte_size(
+                    item_count as u64,
+                    item_size as u64,
+                    true,
+                );
             }
-            _ => {}
+            Self::NotAccepted => {}
         }
     }
 }
@@ -379,8 +374,10 @@ impl<T: Bufferable> BufferSender<T> {
 
         if let Some(instrumentation) = self.usage_instrumentation.as_ref()
             && let Some((item_count, item_size)) = item_sizing
+            && (!instrumentation.provides_instrumentation
+                || matches!(&accounting, UsageAccounting::DroppedNewest))
         {
-            accounting.record(instrumentation, item_count, item_size);
+            accounting.record(&instrumentation.handle, item_count, item_size);
         }
         if let Some(send_duration) = self.send_duration.as_ref()
             && let Some(send_reference) = send_reference

--- a/lib/vector-buffers/src/topology/channel/sender.rs
+++ b/lib/vector-buffers/src/topology/channel/sender.rs
@@ -222,6 +222,7 @@ pub struct BufferSender<T: Bufferable> {
     overflow: Option<Box<BufferSender<T>>>,
     when_full: WhenFull,
     usage_instrumentation: Option<BufferUsageHandle>,
+    drop_newest_usage_instrumentation: Option<BufferUsageHandle>,
     #[derivative(Debug = "ignore")]
     send_duration: Option<Registered<BufferSendDuration>>,
     #[derivative(Debug = "ignore")]
@@ -236,6 +237,7 @@ impl<T: Bufferable> BufferSender<T> {
             overflow: None,
             when_full,
             usage_instrumentation: None,
+            drop_newest_usage_instrumentation: None,
             send_duration: None,
             custom_instrumentation: None,
         }
@@ -248,6 +250,7 @@ impl<T: Bufferable> BufferSender<T> {
             overflow: Some(Box::new(overflow)),
             when_full: WhenFull::Overflow,
             usage_instrumentation: None,
+            drop_newest_usage_instrumentation: None,
             send_duration: None,
             custom_instrumentation: None,
         }
@@ -266,6 +269,10 @@ impl<T: Bufferable> BufferSender<T> {
     /// Configures this sender to instrument the items passing through it.
     pub fn with_usage_instrumentation(&mut self, handle: BufferUsageHandle) {
         self.usage_instrumentation = Some(handle);
+    }
+
+    pub(crate) fn with_drop_newest_usage_instrumentation(&mut self, handle: BufferUsageHandle) {
+        self.drop_newest_usage_instrumentation = Some(handle);
     }
 
     /// Configures this sender to instrument the send duration.
@@ -303,6 +310,7 @@ impl<T: Bufferable> BufferSender<T> {
         let item_sizing = self
             .usage_instrumentation
             .as_ref()
+            .or(self.drop_newest_usage_instrumentation.as_ref())
             .map(|_| (item.event_count(), item.size_of()));
 
         let accounting = match self.when_full {
@@ -352,15 +360,14 @@ impl<T: Bufferable> BufferSender<T> {
             }
         };
 
-        // Backend filter drops are accounted directly through the backend's own
-        // usage handle (e.g. disk-v2's ledger), so they show up in the buffer
-        // stage's `received` / `dropped` metrics even when the `BufferSender`
-        // does not carry instrumentation. This block only reports fullness-driven
-        // drops captured via `was_dropped`.
-        if let Some(instrumentation) = self.usage_instrumentation.as_ref()
-            && let Some((item_count, item_size)) = item_sizing
-        {
-            accounting.record(instrumentation, item_count, item_size);
+        if let Some((item_count, item_size)) = item_sizing {
+            if let Some(instrumentation) = self.usage_instrumentation.as_ref() {
+                accounting.record(instrumentation, item_count, item_size);
+            } else if matches!(&accounting, UsageAccounting::DroppedNewest)
+                && let Some(instrumentation) = self.drop_newest_usage_instrumentation.as_ref()
+            {
+                accounting.record(instrumentation, item_count, item_size);
+            }
         }
         if let Some(send_duration) = self.send_duration.as_ref()
             && let Some(send_reference) = send_reference

--- a/lib/vector-buffers/src/topology/channel/sender.rs
+++ b/lib/vector-buffers/src/topology/channel/sender.rs
@@ -313,17 +313,11 @@ impl<T: Bufferable> BufferSender<T> {
         if let Some(instrumentation) = self.custom_instrumentation.as_ref() {
             instrumentation.on_send(&mut item);
         }
-        let item_sizing = match (&self.usage_instrumentation, self.when_full) {
-            (None, _)
-            | (
-                Some(UsageInstrumentation {
-                    provides_instrumentation: true,
-                    ..
-                }),
-                WhenFull::Block | WhenFull::Overflow,
-            ) => None,
-            _ => Some((item.event_count(), item.size_of())),
-        };
+        let mut item_sizing = self
+            .usage_instrumentation
+            .as_ref()
+            .filter(|instrumentation| !instrumentation.provides_instrumentation)
+            .map(|_| (item.event_count(), item.size_of()));
 
         let accounting = match self.when_full {
             WhenFull::Block => match self.base.send(item).await? {
@@ -333,7 +327,16 @@ impl<T: Bufferable> BufferSender<T> {
             },
             WhenFull::DropNewest => match self.base.try_send(item).await? {
                 TryWriteOutcome::Written => UsageAccounting::Accepted,
-                TryWriteOutcome::Full(_) => UsageAccounting::DroppedNewest,
+                TryWriteOutcome::Full(item) => {
+                    if self
+                        .usage_instrumentation
+                        .as_ref()
+                        .is_some_and(|instrumentation| instrumentation.provides_instrumentation)
+                    {
+                        item_sizing = Some((item.event_count(), item.size_of()));
+                    }
+                    UsageAccounting::DroppedNewest
+                }
                 TryWriteOutcome::Dropped => UsageAccounting::NotAccepted,
             },
             WhenFull::Overflow => {
@@ -374,8 +377,6 @@ impl<T: Bufferable> BufferSender<T> {
 
         if let Some(instrumentation) = self.usage_instrumentation.as_ref()
             && let Some((item_count, item_size)) = item_sizing
-            && (!instrumentation.provides_instrumentation
-                || matches!(&accounting, UsageAccounting::DroppedNewest))
         {
             accounting.record(&instrumentation.handle, item_count, item_size);
         }

--- a/lib/vector-buffers/src/topology/channel/sender.rs
+++ b/lib/vector-buffers/src/topology/channel/sender.rs
@@ -327,11 +327,7 @@ impl<T: Bufferable> BufferSender<T> {
             WhenFull::DropNewest => match self.base.try_send(item).await? {
                 TryWriteOutcome::Written => UsageAccounting::Accepted,
                 TryWriteOutcome::Full(item) => {
-                    if self
-                        .usage_instrumentation
-                        .as_ref()
-                        .is_some_and(|instrumentation| instrumentation.provides_instrumentation)
-                    {
+                    if self.usage_instrumentation.is_some() && item_sizing.is_none() {
                         item_sizing = Some((item.event_count(), item.size_of()));
                     }
                     UsageAccounting::DroppedNewest

--- a/lib/vector-buffers/src/topology/channel/sender.rs
+++ b/lib/vector-buffers/src/topology/channel/sender.rs
@@ -179,16 +179,16 @@ struct UsageInstrumentation {
 }
 
 impl UsageAccounting {
-    fn record(self, handle: &BufferUsageHandle, item_count: usize, item_size: usize) {
+    fn record(self, instrumentation: &BufferUsageHandle, item_count: usize, item_size: usize) {
         match self {
-            Self::Accepted => handle
+            Self::Accepted => instrumentation
                 .increment_received_event_count_and_byte_size(item_count as u64, item_size as u64),
             Self::DroppedNewest => {
-                handle.increment_received_event_count_and_byte_size(
+                instrumentation.increment_received_event_count_and_byte_size(
                     item_count as u64,
                     item_size as u64,
                 );
-                handle.increment_dropped_event_count_and_byte_size(
+                instrumentation.increment_dropped_event_count_and_byte_size(
                     item_count as u64,
                     item_size as u64,
                     true,

--- a/lib/vector-buffers/src/topology/channel/sender.rs
+++ b/lib/vector-buffers/src/topology/channel/sender.rs
@@ -75,8 +75,7 @@ where
                     // The whole item was filtered out (e.g. every sub-item over the
                     // protobuf nesting budget). Report the drop directly via the
                     // ledger's usage handle so it shows up in the disk-v2 stage's
-                    // `received` / `dropped` metrics — `BufferSender` does not carry
-                    // its own handle for backends that `provides_instrumentation()`.
+                    // `received` / `dropped` metrics.
                     writer.track_dropped(pre_count, pre_size);
                     return Ok(TryWriteOutcome::Dropped);
                 };
@@ -375,6 +374,11 @@ impl<T: Bufferable> BufferSender<T> {
             }
         };
 
+        // Backend filter drops are accounted directly through the backend's own
+        // usage handle (e.g. disk-v2's ledger), so they show up in the buffer
+        // stage's `received` / `dropped` metrics even when the `BufferSender`
+        // does not carry instrumentation. This block only reports fullness-driven
+        // drops captured via `UsageAccounting::DroppedNewest`.
         if let Some(instrumentation) = self.usage_instrumentation.as_ref()
             && let Some((item_count, item_size)) = item_sizing
         {

--- a/lib/vector-buffers/src/topology/channel/sender.rs
+++ b/lib/vector-buffers/src/topology/channel/sender.rs
@@ -172,23 +172,34 @@ enum UsageAccounting {
     NotAccepted,
 }
 
+#[derive(Clone, Debug)]
+struct UsageInstrumentation {
+    handle: BufferUsageHandle,
+    provides_instrumentation: bool,
+}
+
 impl UsageAccounting {
-    fn record(self, instrumentation: &BufferUsageHandle, item_count: usize, item_size: usize) {
+    fn record(self, instrumentation: &UsageInstrumentation, item_count: usize, item_size: usize) {
         match self {
-            Self::Accepted => instrumentation
+            Self::Accepted if !instrumentation.provides_instrumentation => instrumentation
+                .handle
                 .increment_received_event_count_and_byte_size(item_count as u64, item_size as u64),
             Self::DroppedNewest => {
-                instrumentation.increment_received_event_count_and_byte_size(
-                    item_count as u64,
-                    item_size as u64,
-                );
-                instrumentation.increment_dropped_event_count_and_byte_size(
-                    item_count as u64,
-                    item_size as u64,
-                    true,
-                );
+                instrumentation
+                    .handle
+                    .increment_received_event_count_and_byte_size(
+                        item_count as u64,
+                        item_size as u64,
+                    );
+                instrumentation
+                    .handle
+                    .increment_dropped_event_count_and_byte_size(
+                        item_count as u64,
+                        item_size as u64,
+                        true,
+                    );
             }
-            Self::NotAccepted => {}
+            _ => {}
         }
     }
 }
@@ -221,8 +232,7 @@ pub struct BufferSender<T: Bufferable> {
     base: SenderAdapter<T>,
     overflow: Option<Box<BufferSender<T>>>,
     when_full: WhenFull,
-    usage_instrumentation: Option<BufferUsageHandle>,
-    drop_newest_usage_instrumentation: Option<BufferUsageHandle>,
+    usage_instrumentation: Option<UsageInstrumentation>,
     #[derivative(Debug = "ignore")]
     send_duration: Option<Registered<BufferSendDuration>>,
     #[derivative(Debug = "ignore")]
@@ -237,7 +247,6 @@ impl<T: Bufferable> BufferSender<T> {
             overflow: None,
             when_full,
             usage_instrumentation: None,
-            drop_newest_usage_instrumentation: None,
             send_duration: None,
             custom_instrumentation: None,
         }
@@ -250,7 +259,6 @@ impl<T: Bufferable> BufferSender<T> {
             overflow: Some(Box::new(overflow)),
             when_full: WhenFull::Overflow,
             usage_instrumentation: None,
-            drop_newest_usage_instrumentation: None,
             send_duration: None,
             custom_instrumentation: None,
         }
@@ -267,12 +275,15 @@ impl<T: Bufferable> BufferSender<T> {
     }
 
     /// Configures this sender to instrument the items passing through it.
-    pub fn with_usage_instrumentation(&mut self, handle: BufferUsageHandle) {
-        self.usage_instrumentation = Some(handle);
-    }
-
-    pub(crate) fn with_drop_newest_usage_instrumentation(&mut self, handle: BufferUsageHandle) {
-        self.drop_newest_usage_instrumentation = Some(handle);
+    pub fn with_usage_instrumentation(
+        &mut self,
+        handle: BufferUsageHandle,
+        provides_instrumentation: bool,
+    ) {
+        self.usage_instrumentation = Some(UsageInstrumentation {
+            handle,
+            provides_instrumentation,
+        });
     }
 
     /// Configures this sender to instrument the send duration.
@@ -307,11 +318,17 @@ impl<T: Bufferable> BufferSender<T> {
         if let Some(instrumentation) = self.custom_instrumentation.as_ref() {
             instrumentation.on_send(&mut item);
         }
-        let item_sizing = self
-            .usage_instrumentation
-            .as_ref()
-            .or(self.drop_newest_usage_instrumentation.as_ref())
-            .map(|_| (item.event_count(), item.size_of()));
+        let item_sizing = match (&self.usage_instrumentation, self.when_full) {
+            (None, _)
+            | (
+                Some(UsageInstrumentation {
+                    provides_instrumentation: true,
+                    ..
+                }),
+                WhenFull::Block | WhenFull::Overflow,
+            ) => None,
+            _ => Some((item.event_count(), item.size_of())),
+        };
 
         let accounting = match self.when_full {
             WhenFull::Block => match self.base.send(item).await? {
@@ -360,14 +377,10 @@ impl<T: Bufferable> BufferSender<T> {
             }
         };
 
-        if let Some((item_count, item_size)) = item_sizing {
-            if let Some(instrumentation) = self.usage_instrumentation.as_ref() {
-                accounting.record(instrumentation, item_count, item_size);
-            } else if matches!(&accounting, UsageAccounting::DroppedNewest)
-                && let Some(instrumentation) = self.drop_newest_usage_instrumentation.as_ref()
-            {
-                accounting.record(instrumentation, item_count, item_size);
-            }
+        if let Some(instrumentation) = self.usage_instrumentation.as_ref()
+            && let Some((item_count, item_size)) = item_sizing
+        {
+            accounting.record(instrumentation, item_count, item_size);
         }
         if let Some(send_duration) = self.send_duration.as_ref()
             && let Some(send_reference) = send_reference

--- a/lib/vector-buffers/src/variants/disk_v2/tests/mod.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/tests/mod.rs
@@ -277,6 +277,29 @@ where
     P: AsRef<Path>,
     R: Bufferable,
 {
+    let (writer, reader, ledger, _) = create_buffer_v2_with_data_file_count_limit_and_usage(
+        data_dir,
+        max_data_file_size,
+        data_file_count_limit,
+    )
+    .await;
+    (writer, reader, ledger)
+}
+
+pub(crate) async fn create_buffer_v2_with_data_file_count_limit_and_usage<P, R>(
+    data_dir: P,
+    max_data_file_size: u64,
+    data_file_count_limit: u64,
+) -> (
+    BufferWriter<R, FilesystemUnderTest>,
+    BufferReader<R, FilesystemUnderTest>,
+    Arc<Ledger<FilesystemUnderTest>>,
+    BufferUsageHandle,
+)
+where
+    P: AsRef<Path>,
+    R: Bufferable,
+{
     // We do this here, despite the fact that configuration builder also implicitly does it, because our error message
     // can be more pointed given that we're running tests, whereas the user-visible error message is just about getting
     // them to set a valid amount without needing to understand the internals.
@@ -302,10 +325,10 @@ where
         .build()
         .expect("creating buffer should not fail");
     let usage_handle = BufferUsageHandle::noop();
-
-    Buffer::from_config_inner(config, usage_handle)
+    let (writer, reader, ledger) = Buffer::from_config_inner(config, usage_handle.clone())
         .await
-        .expect("should not fail to create buffer")
+        .expect("should not fail to create buffer");
+    (writer, reader, ledger, usage_handle)
 }
 
 /// Creates a disk v2 buffer with the specified maximum record size, but returns a handle to the

--- a/lib/vector-buffers/src/variants/disk_v2/tests/size_limits.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/tests/size_limits.rs
@@ -5,15 +5,18 @@ use tokio_test::{assert_pending, task::spawn};
 use tracing::Instrument;
 
 use super::{
-    create_buffer_v2_with_data_file_count_limit, create_buffer_v2_with_max_data_file_size,
-    create_buffer_v2_with_max_record_size_and_usage, read_next, read_next_some,
+    create_buffer_v2_with_data_file_count_limit,
+    create_buffer_v2_with_data_file_count_limit_and_usage,
+    create_buffer_v2_with_max_data_file_size, create_buffer_v2_with_max_record_size_and_usage,
+    read_next, read_next_some,
 };
 use vector_common::finalization::{AddBatchNotifier, BatchNotifier, BatchStatus};
 
 use crate::{
-    assert_buffer_is_empty, assert_buffer_records, assert_buffer_size, assert_enough_bytes_written,
-    assert_reader_writer_v2_file_positions,
+    WhenFull, assert_buffer_is_empty, assert_buffer_records, assert_buffer_size,
+    assert_enough_bytes_written, assert_reader_writer_v2_file_positions,
     test::{SizedRecord, acknowledge, install_tracing_helpers, with_temp_dir},
+    topology::channel::{BufferSender, SenderAdapter},
     variants::disk_v2::{
         TryWriteOutcome,
         common::align16,
@@ -465,6 +468,42 @@ async fn writer_try_write_returns_when_buffer_is_full() {
                 .await
                 .expect("write should not fail");
             assert!(matches!(second_write_result, TryWriteOutcome::Full(_)));
+        }
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn buffer_sender_drop_newest_tracks_intentional_drop() {
+    let _a = install_tracing_helpers();
+    with_temp_dir(|dir| {
+        let data_dir = dir.to_path_buf();
+
+        async move {
+            let record = SizedRecord::new(96);
+            let max_data_file_size = get_minimum_data_file_size_for_record_payload(&record);
+            let (writer, _, _, usage) = create_buffer_v2_with_data_file_count_limit_and_usage(
+                data_dir,
+                max_data_file_size,
+                2,
+            )
+            .await;
+            let mut sender = BufferSender::new(SenderAdapter::from(writer), WhenFull::DropNewest);
+            sender.with_drop_newest_usage_instrumentation(usage.clone());
+
+            sender
+                .send(record.clone(), None)
+                .await
+                .expect("send should not fail");
+            sender.flush().await.expect("flush should not fail");
+            sender
+                .send(record, None)
+                .await
+                .expect("send should not fail");
+
+            let snapshot = usage.snapshot();
+            assert_eq!(snapshot.received_event_count, 2);
+            assert_eq!(snapshot.dropped_event_count_intentional, 1);
         }
     })
     .await;

--- a/lib/vector-buffers/src/variants/disk_v2/tests/size_limits.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/tests/size_limits.rs
@@ -489,7 +489,7 @@ async fn buffer_sender_drop_newest_tracks_intentional_drop() {
             )
             .await;
             let mut sender = BufferSender::new(SenderAdapter::from(writer), WhenFull::DropNewest);
-            sender.with_drop_newest_usage_instrumentation(usage.clone());
+            sender.with_usage_instrumentation(usage.clone(), true);
 
             sender
                 .send(record.clone(), None)

--- a/lib/vector-buffers/src/variants/disk_v2/writer.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/writer.rs
@@ -1465,8 +1465,7 @@ where
     /// reaching disk (e.g. `Bufferable::filter_unencodable` rejecting events
     /// the protobuf decoder cannot handle). Delegates to the ledger's usage
     /// handle so the rejection shows up under the disk-v2 stage's
-    /// `received` / `dropped` metrics in production, where the
-    /// `BufferSender` does not carry its own usage instrumentation.
+    /// `received` / `dropped` metrics in production.
     pub(crate) fn track_dropped(&self, event_count: u64, byte_size: u64) {
         self.ledger.track_dropped(event_count, byte_size);
     }


### PR DESCRIPTION
## Summary
<!-- Please provide a brief summary about what this PR does.
This should help the reviewers give feedback faster and with higher quality. -->
Fixes a bug where events discarded from a full disk buffer configured with `drop_newest` did not increment `buffer_received_events_total`, `buffer_discarded_events_total`, or the corresponding byte metrics.

Currently the `disk_v2` backend does not increment these metrics in this case. In fact it cannot, as it does not know if a `BufferSender` will drop or overflow when an event is rejected from a full buffer. Conversely, the `BufferSender` does not increment these metrics (and is not given a `BufferUsageHandle`) because the `disk_v2` backend declares `provides_instrumentation = true`.

This PR changes `BufferSender` to receive a `BufferUsageHandle` and increment the `received` / `discarded` metrics on `UsageAccounting::DroppedNewest` regardless of whether the backend provides instrumentation.

### References
<!-- Closes: <#issue/#PR or full link> -->
<!-- Related: <#issue/#PR or full link> -->
Related: #24606 
Closes: https://github.com/vectordotdev/vector/issues/26325

## Vector configuration
<!-- Include Vector configuration(s) you used to test and debug your changes. -->
I used the following test configuration for reproducing the bug and testing my fix.
```
data_dir: /tmp/vector-data

sources:
  load:
    type: demo_logs
    format: json
    interval: 0.0

  metrics:
    type: internal_metrics

sinks:
  slow:
    type: blackhole
    inputs: [load]
    rate: 1
    buffer:
      type: disk
      max_size: 268435488
      when_full: drop_newest

  prometheus:
    type: prometheus_exporter
    inputs: [metrics]
    address: 127.0.0.1:9598
```
To reproduce bug:
1. run vector with above config
2. allow vector to run long enough for disk buffer to fill
3. curl metrics endpoint, verify that
a. `vector_component_sent_events_total{component_id="load"}` > `vector_buffer_received_events_total{component_id="slow"}`, which indicates that events discarded from the `slow` buffer do not increment `vector_buffer_received_events_total`
b. `vector_buffer_discarded_events_total` and `vector_component_discarded_events_total` metrics do not show up, indicating no discard metric is incremented for events dropped by the buffer.

## How did you test this PR?
<!-- Please describe how you tested your changes. Also include any information about your setup. -->
This PR adds a regression test. Additionally, I built locally and followed the bug reproduction steps above to verify that the PR works. This included running through steps 1-3 then verifying:
1. `vector_component_sent_events_total{component_id="load"}` = `vector_buffer_received_events_total{component_id="slow"}` (approximately, they will be slightly different due to in flight events and buffer metrics reporting interval)
2. `vector_buffer_discarded_events_total` shows up, and 
```
vector_buffer_discarded_events_total{component_id="slow"} + 
vector_buffer_size_events{component_id="slow"} + 
vector_buffer_sent_events_total{component_id="slow"} 
= 
vector_buffer_received_events_total{component_id="slow"}
```

## Does this PR include user facing changes?
<!-- If this PR alters Vector behavior in any way, for example, it adds a new config field or changes internal metrics it is considered a user facing change.
Changes to CI, website, playground and similar are generally not considered user facing -->

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## Contributor Guidelines

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Before pushing, follow our [pre-push guidance](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#pre-push).
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
