### PR TITLE
fix(buffers): report a record ID behind the acked ID as a monotonicity violation

### DIFF
--- a/changelog.d/disk_v2_stale_record_id_monotonicity.fix.md
+++ b/changelog.d/disk_v2_stale_record_id_monotonicity.fix.md
@@ -1,0 +1,3 @@
+The `disk` buffer no longer treats a record whose ID is behind the last acknowledged ID as a gap of nearly 2^64 events. Previously, when no records were pending acknowledgement, such a record was silently "skipped" (logged as `Events dropped. count=1844674407370946xxxx ... reason=unprocessable_events`), the reader's position was wrapped backwards, and the sink's buffer stalled without crashing until Vector was restarted. The condition is now reported as a record ID monotonicity violation, which surfaces the fault immediately instead of leaving the buffer wedged.
+
+authors: giannimassi

--- a/lib/vector-buffers/src/topology/acks.rs
+++ b/lib/vector-buffers/src/topology/acks.rs
@@ -231,8 +231,12 @@ where
     /// returned.
     ///
     /// Otherwise, we return one of the following variants:
-    /// - if we have no pending markers, `MarkerOffset::Gap` is returned, and contains the delta
-    ///   between the given ID and the next expected marker ID
+    /// - if we have no pending markers, and the given ID is behind the acknowledged marker ID,
+    ///   `MarkerOffset::MonotonicityViolation` is returned, as record IDs are monotonic and such an
+    ///   ID can only belong to a stale record
+    /// - if we have no pending markers, and the given ID is ahead of the acknowledged marker ID,
+    ///   `MarkerOffset::Gap` is returned, and contains the delta between the given ID and the
+    ///   acknowledged marker ID
     /// - if we have pending markers, and the given ID is logically behind the next expected marker
     ///   ID, `MarkerOffset::MonotonicityViolation` is returned, indicating that the monotonicity
     ///   invariant has been violated
@@ -325,8 +329,10 @@ where
     ///
     /// ## Errors
     ///
-    /// When other pending markers are present, and the given ID is logically behind the next
-    /// expected marker ID, `Err(MarkerError::MonotonicityViolation)` is returned.
+    /// When the given ID is logically behind the next expected marker ID,
+    /// `Err(MarkerError::MonotonicityViolation)` is returned. With no pending markers, the next
+    /// expected marker ID is the acknowledged marker ID; with a fixed-size pending marker at the
+    /// back, it is that marker's ID plus its length.
     ///
     /// # Panics
     ///

--- a/lib/vector-buffers/src/topology/acks.rs
+++ b/lib/vector-buffers/src/topology/acks.rs
@@ -254,6 +254,14 @@ where
             //
             // Basically, it's up to the caller to figure this out.  We're just trying to give them
             // as much information as we can.
+            // Record IDs are monotonic (wraparound is unsupported since #25824), so a marker ID
+            // behind the acknowledged ID can only be a stale/re-read record. Report it as a
+            // monotonicity violation instead of synthesising a gap of `2^64 - delta` events,
+            // which the disk_v2 reader would otherwise "skip" (logged as
+            // `Events dropped. count=1844674407370946xxxx reason=unprocessable_events`).
+            if id < self.acked_marker_id {
+                return MarkerOffset::MonotonicityViolation;
+            }
             if self.acked_marker_id != id {
                 return MarkerOffset::Gap(
                     self.acked_marker_id,
@@ -647,6 +655,25 @@ mod tests {
             ],
         );
 
+        // Observed in production on 0.58.0: no pending markers (everything acked), and the next
+        // record ID is BEHIND the acked marker ID by 85_956. Record IDs are monotonic (wraparound
+        // removed in #25824), so this must be a monotonicity violation. Previously it was accepted
+        // as a "gap" of 2^64 - 85_956 events, which the disk_v2 reader then reported as
+        // `Events dropped. count=18446744073709465660` and wedged the buffer.
+        run_test_case(
+            "detect_monotonicity_violation_no_pending",
+            vec![
+                step!(AddMarker, input => (0, Some(1_000_010)), result => Ok(())),
+                step!(Acknowledge, input => 1_000_010, result => 1_000_010),
+                step!(GetNextEligibleMarker, result => Some(
+                    EligibleMarker { id: 0, len: EligibleMarkerLength::Known(1_000_010), data: None }
+                )),
+                // pending is now empty, acked_marker_id == 1_000_010; a stale record ID arrives:
+                step!(AddMarker, input => (1_000_010 - 85_956, Some(1)), result => Err(MarkerError::MonotonicityViolation)),
+                step!(GetNextEligibleMarker, result => None),
+            ],
+        );
+
         // When another marker exists, and is fixed size, we correctly detect when trying to add
         // another marker whose ID comes after the last pending marker we have, including the
         // length of the last pending marker, by updating the marker's unknown length to an
@@ -767,14 +794,20 @@ mod tests {
                         let expected_result = if marker_stack.is_empty() {
                             // Our only comparison is the acked marker ID, which, if it doesn't
                             // match, we generate a gap marker for.
-                            if id != acked_marker_id {
-                                assert!(marker_state.insert(acked_marker_id), "should not be able to add marker that is already in-flight");
+                            if id < acked_marker_id {
+                                // Record IDs are monotonic: an ID behind the acknowledged ID is a
+                                // monotonicity violation, not a wrapped-around gap.
+                                Err(MarkerError::MonotonicityViolation)
+                            } else {
+                                if id != acked_marker_id {
+                                    assert!(marker_state.insert(acked_marker_id), "should not be able to add marker that is already in-flight");
 
-                                let len = PendingMarkerLength::Assumed(id.wrapping_sub(acked_marker_id));
-                                marker_stack.push_back((acked_marker_id, len));
+                                    let len = PendingMarkerLength::Assumed(id.wrapping_sub(acked_marker_id));
+                                    marker_stack.push_back((acked_marker_id, len));
+                                }
+
+                                Ok(())
                             }
-
-                            Ok(())
                         } else {
                             let (back_id, back_len) = marker_stack.back().copied().expect("must exist");
                             match back_len {


### PR DESCRIPTION
## Summary

`OrderedAcknowledgements::get_marker_id_offset` has a branch for "no pending markers": if the incoming marker ID differs from `acked_marker_id` it returns `MarkerOffset::Gap(acked, id.wrapping_sub(acked))`, with no check on direction. When the incoming ID is *behind* the acked ID, that is a synthetic, immediately eligible gap marker of `2^64 - delta` events.

In the `disk_v2` reader this becomes:

- `handle_pending_acknowledgements` sums the `Assumed` gap into `events_skipped` and calls `ledger.track_dropped_events(2^64 - delta)`, which logs `Events dropped. count=1844674407370946xxxx byte_size=0 intentional=false reason=unprocessable_events`.
- `increment_last_reader_record_id(events_skipped)` is a `fetch_add`, so the ledger's reader position wraps backwards by `delta`.
- Nothing crashes. The reader keeps running on inconsistent state and the buffer stalls; with `when_full = "block"` every source feeding the sink stalls with it, until Vector is restarted.

Since #25824 record IDs are monotonic and the ledger no longer uses wrapping arithmetic, but `acks.rs` still does. This PR aligns them: with no pending markers, an ID behind `acked_marker_id` is now `MarkerOffset::MonotonicityViolation`, the same answer the pending-markers branch already gives. The reader's existing `MonotonicityViolation` handling (and its antithesis assertion "reader never sees a record id that breaks monotonicity") then applies, so the fault is reported with `record_id` / `last_reader_record_id` instead of wedging the sink silently.

The proptest reference model is updated with the same rule, a `detect_monotonicity_violation_no_pending` case is added with the numbers below, and the doc comments on `get_marker_id_offset` / `add_marker` now describe the no-pending-markers case.

### References

- Related: #22946, #19379 (same symptom: a disk-buffered sink stops consuming, no crash, a restart fixes it)
- Related: #26198, #25598 (other disk_v2 accounting paths that end in a wedged sink)
- Related: #25824 (removed record ID wraparound; this PR brings `acks.rs` in line with it)

### What we observed (Vector 0.58.0)

An `aws_s3` sink with a disk buffer and `when_full = "block"`, fed by several `file` sources. Two hosts stopped shipping on the same day; the first one logged:

```
2026-09-04T18:11:26.516894Z ERROR sink{component_kind="sink" component_id=s3 component_type=aws_s3}:sink{buffer_type="disk"}: vector_buffers::internal_events: Events dropped. count=18446744073709465660 byte_size=0 intentional=false reason=unprocessable_events buffer_id=s3 stage=0
2026-09-04T18:11:34.564908Z ERROR ...: Internal log [Events dropped.] is being suppressed to avoid flooding.
2026-09-04T18:11:40.563796Z ERROR ...: Internal log [Events dropped.] has been suppressed 1 times.
2026-09-04T18:11:40.563812Z ERROR ...: Events dropped. count=85938 byte_size=0 intentional=false reason=unprocessable_events buffer_id=s3 stage=0
```

`18446744073709465660 = 2^64 - 85956`, and `85938 = 85956 - 18`: the reader consumed one 18-event record whose ID was 85 956 behind the stream, then the next record was back at the expected ID. After these lines the process stayed `active (running)` and shipped nothing until `systemctl restart vector`. The restart drained and deleted the buffer files, so we cannot say what produced the out-of-order record. `byte_size=0` pins the emitter to `Ledger::track_dropped_events`, and the new test reproduces the exact wrapped count against the unpatched code.

## Vector configuration

```toml
[sources.app_log]
type = "file"
include = ["/var/log/app/*.log"]

[sinks.s3]
type = "aws_s3"
inputs = ["app_log"]
bucket = "<bucket>"
region = "<region>"
encoding.codec = "json"
compression = "zstd"
buffer.type = "disk"
buffer.max_size = 5368709120
buffer.when_full = "block"
```

## How did you test this PR?

- `cargo test -p vector-buffers --lib` on the pinned toolchain (1.95): 112 passed, including `topology::acks::tests::property_test` with the updated reference model.
- The new `detect_monotonicity_violation_no_pending` case fails against the unpatched `acks.rs` with `expecting result AddMarker(Err(MonotonicityViolation)), but got result AddMarker(Ok(()))`. A direct check on the unpatched code (`from_acked(1_000_010)` then `add_marker(1_000_010 - 85_956, Some(1), None)`) yields an eligible marker `Assumed(18446744073709465660)`, the count from the log above.
- `cargo fmt -p vector-buffers`, `cargo clippy -p vector-buffers --all-targets`.

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.

## Notes

The pending-markers branch keeps its wraparound-tolerant check (`expected_next < back.id && id < expected_next`), and the existing `fixed_size_u64_boundary_overlap` test that exercises it is untouched. Tightening that branch is a possible follow-up now that wraparound is unsupported; it is out of scope for fixing the silent stall.
