### PR TITLE
fix(lua transform): return conversion error for invalid metric tag values

### DIFF
--- a/changelog.d/lua_metric_tag_conversion.fix.md
+++ b/changelog.d/lua_metric_tag_conversion.fix.md
@@ -1,0 +1,3 @@
+Prevent the Lua transform from panicking when a metric tag contains a non-string value. Such values now produce a Lua conversion error and the event is discarded.
+
+authors: quwin

--- a/changelog.d/lua_metric_tag_conversion.fix.md
+++ b/changelog.d/lua_metric_tag_conversion.fix.md
@@ -1,3 +1,3 @@
-Prevent the Lua transform from panicking when a metric tag contains a non-string value. Such values now produce a Lua conversion error and the event is discarded.
+The `lua` transform no longer panics when a metric tag contains a value that cannot be converted to a string (e.g. a boolean or a nested table). Such values now produce a Lua conversion error and the event is discarded.
 
 authors: quwin

--- a/lib/vector-core/src/event/lua/metric.rs
+++ b/lib/vector-core/src/event/lua/metric.rs
@@ -84,7 +84,13 @@ impl FromLua for TagValueSet {
                 for value in table.sequence_values() {
                     match value {
                         Ok(value) => string_values.push(value),
-                        Err(_) => unimplemented!(),
+                        Err(err) => {
+                            return Err(LuaError::FromLuaConversionError {
+                                from: String::from("metric tag value"),
+                                to: String::from("string"),
+                                message: Some(err.to_string()),
+                            });
+                        }
                     }
                 }
                 Ok(Self::from(string_values))
@@ -450,6 +456,22 @@ mod test {
                 "metric.tags['example tag'][2] == 'b'",
             ],
         );
+    }
+
+    #[test]
+    fn from_lua_tag_value_set_rejects_non_string_element() {
+        let lua = Lua::new();
+
+        let table = lua.create_table().unwrap();
+        table.push("example value").unwrap();
+        table.push(42).unwrap();
+
+        let result = TagValueSet::from_lua(LuaValue::Table(table), &lua);
+
+        assert!(matches!(
+            result,
+            Err(LuaError::FromLuaConversionError { .. })
+        ));
     }
 
     #[test]

--- a/lib/vector-core/src/event/lua/metric.rs
+++ b/lib/vector-core/src/event/lua/metric.rs
@@ -86,7 +86,7 @@ impl FromLua for TagValueSet {
                         Ok(value) => string_values.push(value),
                         Err(err) => {
                             return Err(LuaError::FromLuaConversionError {
-                                from: String::from("metric tag value"),
+                                from: "metric tag value",
                                 to: String::from("string"),
                                 message: Some(err.to_string()),
                             });
@@ -464,7 +464,7 @@ mod test {
 
         let table = lua.create_table().unwrap();
         table.push("example value").unwrap();
-        table.push(42).unwrap();
+        table.push(true).unwrap();
 
         let result = TagValueSet::from_lua(LuaValue::Table(table), &lua);
 


### PR DESCRIPTION
fix(lua transform): return conversion error for invalid metric tag values

## Summary

Return a `LuaError::FromLuaConversionError` when a metric tag table contains a non-string value, instead of reaching `unimplemented!()` and terminating Vector.

Add a regression test for a table containing a numeric tag value and a changelog fragment for the user-visible behavior change.

### References

Related: #12052

## Vector configuration

No configuration changes.

## How did you test this PR?

Added a unit regression test covering conversion of a metric tag table with a non-string element.

## Does this PR include user facing changes?

- [x] Yes. Added a changelog fragment.
