### PR TITLE
chore(vector-core): remove fanout pass-by-value lint allow

### DIFF
--- a/lib/vector-core/src/fanout.rs
+++ b/lib/vector-core/src/fanout.rs
@@ -278,7 +278,7 @@ impl Fanout {
                     // `SendGroup`, since it has exclusive access to the senders.
                     match maybe_msg {
                         Some(ControlMessage::Add(id, sink)) => {
-                            send_group.add(id, sink);
+                            send_group.add(&id, sink);
                         },
                         Some(ControlMessage::Remove(id)) => {
                             send_group.remove(&id);
@@ -376,8 +376,7 @@ impl<'a> SendGroup<'a> {
         }
     }
 
-    #[allow(clippy::needless_pass_by_value)]
-    fn add(&mut self, id: ComponentKey, sink: BufferSender<EventArray>) {
+    fn add(&mut self, id: &ComponentKey, sink: BufferSender<EventArray>) {
         // When we're in the middle of a send, we can only keep track of the new sink, but can't
         // actually send to it, as we don't have the item to send... so only add it to `senders`.
         assert!(


### PR DESCRIPTION
## Summary

Removes the `clippy::needless_pass_by_value` suppression from `SendGroup::add` by borrowing the component key and cloning it only when inserting it into the sender map.

### References

Related: #23659

## Vector configuration

Not applicable; this is an internal refactor with no configuration changes.

## How did you test this PR?

- `cargo test -p vector-core fanout --lib`
- `cargo clippy -p vector-core --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## Contributor Guidelines

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Before pushing, follow our [pre-push guidance](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#pre-push).
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.