### PR TITLE
chore(elasticsearch): remove copy receiver lint allows

### DIFF
--- a/src/sinks/elasticsearch/mod.rs
+++ b/src/sinks/elasticsearch/mod.rs
@@ -93,9 +93,8 @@ pub enum BulkAction {
     Update,
 }
 
-#[allow(clippy::trivially_copy_pass_by_ref)]
 impl BulkAction {
-    pub const fn as_str(&self) -> &'static str {
+    pub const fn as_str(self) -> &'static str {
         match self {
             BulkAction::Index => "index",
             BulkAction::Create => "create",
@@ -103,7 +102,7 @@ impl BulkAction {
         }
     }
 
-    pub const fn as_json_pointer(&self) -> &'static str {
+    pub const fn as_json_pointer(self) -> &'static str {
         match self {
             BulkAction::Index => "/index",
             BulkAction::Create => "/create",
@@ -140,9 +139,8 @@ pub enum VersionType {
     ExternalGte,
 }
 
-#[allow(clippy::trivially_copy_pass_by_ref)]
 impl VersionType {
-    pub const fn as_str(&self) -> &'static str {
+    pub const fn as_str(self) -> &'static str {
         match self {
             Self::Internal => "internal",
             Self::External => "external",


### PR DESCRIPTION
## Summary

Removes the `clippy::trivially_copy_pass_by_ref` suppressions from the Elasticsearch sink by passing its `Copy` enum values by value.

### References

Related: #23659

## Vector configuration

Not applicable; this is an internal refactor with no configuration changes.

## How did you test this PR?

- `cargo test -p vector --lib sinks::elasticsearch`
- `cargo clippy -p vector --lib --features sinks-elasticsearch --no-default-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## Contributor Guidelines

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Before pushing, follow our [pre-push guidance](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#pre-push).
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.