### PR TITLE
ci(releasing): drop debian:11 from deb-verify matrix

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -291,7 +291,6 @@ jobs:
           - ubuntu:20.04
           - ubuntu:22.04
           - ubuntu:24.04
-          - debian:11
           - debian:12
           - debian:13
     container:


### PR DESCRIPTION
## Summary

Debian 11 (bullseye) went EOL on 2026-08-31; its security apt repository
Release file is permanently expired, so `apt-get update` fails in the
`debian:11` container and the nightly deb-verify job can never pass
(e.g. https://github.com/vectordotdev/vector/actions/runs/34189972589/job/102168557071).
This removes `debian:11` from the deb-verify matrix. The published deb
package itself is unchanged.

### References

- Failed nightly job: https://github.com/vectordotdev/vector/actions/runs/34189972589/job/102168557071

## Vector configuration

NA

## How did you test this PR?

Confirmed the expired Release file on the live Debian mirror and that all
other matrix cells in the failing run passed.

Additionally triggered a full packaging run (`/ci-run-packaging`) against
this PR's commit, which exercises the modified `deb-verify` job on the
remaining matrix cells:
https://github.com/vectordotdev/vector/actions/runs/34259158617

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## Contributor Guidelines

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Before pushing, follow our [pre-push guidance](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#pre-push).
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.