### PR TITLE
chore(http source): remove unnecessary owned lint allow

### DIFF
--- a/src/sources/util/http/prelude.rs
+++ b/src/sources/util/http/prelude.rs
@@ -145,8 +145,6 @@ pub trait HttpSource: Clone + Send + Sync + 'static {
                 HttpMethod::Options => warp::options().boxed(),
             };
 
-            // https://github.com/rust-lang/rust-clippy/issues/8148
-            #[allow(clippy::unnecessary_to_owned)]
             for s in path.split('/').filter(|&x| !x.is_empty()) {
                 filter = filter.and(warp::path(s.to_string())).boxed()
             }


### PR DESCRIPTION
## Summary

Remove the obsolete `clippy::unnecessary_to_owned` allow and its linked workaround comment from the HTTP source path filter. Current Clippy accepts the required owned path segment without emitting the lint.

### References

Related: #23659

## Vector configuration

Not applicable; this is a lint-suppression cleanup with no runtime behavior change.

## How did you test this PR?

- `cargo clippy --package vector --lib --no-default-features --features sources-http_server`
- `cargo fmt --all -- --check`
- `git diff --check`

The broader `FEATURES="sources-http_server" make check-clippy` was also attempted, but currently fails in the unrelated `codecs` OTLP benchmark because its OpenTelemetry items are disabled by that exact feature set.

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## Contributor Guidelines

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Before pushing, follow our [pre-push guidance](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#pre-push).
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.