### PR TITLE
chore(vector-stream): remove semicolon lint allow

### DIFF
--- a/lib/vector-stream/src/partitioned_batcher.rs
+++ b/lib/vector-stream/src/partitioned_batcher.rs
@@ -640,7 +640,6 @@ mod test {
     }
 
     #[tokio::test(start_paused = true)]
-    #[allow(clippy::semicolon_if_nothing_returned)] // https://github.com/rust-lang/rust-clippy/issues/7438
     async fn expiration_queue_impl_keyed_timer() {
         // Asserts that ExpirationQueue properly implements KeyedTimer. We are
         // primarily concerned with whether expiration is properly observed.


### PR DESCRIPTION
## Summary

Remove the obsolete `clippy::semicolon_if_nothing_returned` suppression from the Vector Stream expiration queue test. Current Clippy accepts the test without the historical workaround.

### References

Related: #23659

## Vector configuration

Not applicable; this is a test-only lint cleanup.

## How did you test this PR?

- `cargo clippy --package vector-stream --all-targets`
- `cargo test --package vector-stream expiration_queue_impl_keyed_timer`
- `cargo fmt --all -- --check`
- `git diff --check`

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## Contributor Guidelines

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Before pushing, follow our [pre-push guidance](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#pre-push).
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.