### PR TITLE
fix(file source): discard stale checkpoints instead of silently dropping data

### DIFF
--- a/changelog.d/23076_file_source_stale_checkpoints.fix.md
+++ b/changelog.d/23076_file_source_stale_checkpoints.fix.md
@@ -1,0 +1,3 @@
+The `file` source no longer silently drops data when a checkpoint entry is stale. Previously, when a new file happened to match the fingerprint of an old checkpoint — typically a recycled inode with `fingerprint.strategy: device_and_inode` after rotated logs were pruned — Vector resumed reading at the stale offset: nothing was emitted until the new file grew past it, and with an offset beyond the file's size that meant losing the entire file. Vector now starts from the beginning when the stored position lies beyond the end of the file (which also covers truncated files), and discards `device_and_inode` checkpoints recorded before the file's creation time.
+
+authors: Adelagric

--- a/lib/file-source-common/src/checkpointer.rs
+++ b/lib/file-source-common/src/checkpointer.rs
@@ -55,21 +55,24 @@ pub struct CheckpointsView {
     checkpoints: DashMap<FileFingerprint, FilePosition>,
     modified_times: DashMap<FileFingerprint, DateTime<Utc>>,
     removed_times: DashMap<FileFingerprint, DateTime<Utc>>,
+    /// Current watcher generation per fingerprint; `update` ignores positions
+    /// recorded under an older generation. Not persisted: generations only
+    /// disambiguate in-flight updates within a single process lifetime.
+    generations: DashMap<FileFingerprint, u64>,
 }
 
 impl CheckpointsView {
-    pub fn update(&self, fng: FileFingerprint, pos: FilePosition) {
-        // Once a `DevInode` watcher has died, further updates can only be late
-        // acknowledgements of data read before its file disappeared. Record the
-        // position (so a legitimate reappearance of the same file resumes
-        // correctly) but keep the entry marked dead and its modified time
-        // frozen: refreshing them would make a stale checkpoint look current to
-        // the inode-reuse detection in `FileServer::watch_new_file`, and keep
-        // the entry alive past its expiry for as long as acknowledgements
-        // trickle in. A new watcher claiming this fingerprint lifts the dead
-        // mark via `claim`.
-        if matches!(fng, FileFingerprint::DevInode(..)) && self.removed_times.contains_key(&fng) {
-            self.checkpoints.insert(fng, pos);
+    pub fn update(&self, fng: FileFingerprint, pos: FilePosition, generation: u64) {
+        // A fingerprint can be reused by a different file over time (most
+        // notably a recycled inode with `dev_inode` fingerprints), and
+        // acknowledgements from a dead watcher's file can arrive arbitrarily
+        // late. Each watcher records progress under the generation it was
+        // created with; anything older refers to a previous file's data and
+        // must not touch the checkpoint, or a stale offset could masquerade as
+        // current progress for the file now bearing this fingerprint.
+        if let Some(current) = self.generations.get(&fng)
+            && *current.value() != generation
+        {
             return;
         }
 
@@ -78,10 +81,12 @@ impl CheckpointsView {
         self.removed_times.remove(&fng);
     }
 
-    /// Mark a fingerprint as owned by a live watcher again, cancelling any
-    /// pending expiry without refreshing its modified time.
-    pub fn claim(&self, fng: FileFingerprint) {
-        self.removed_times.remove(&fng);
+    /// Start a new watcher generation for this fingerprint, invalidating
+    /// updates from any previous watcher that used it.
+    pub fn begin_generation(&self, fng: FileFingerprint) -> u64 {
+        let mut entry = self.generations.entry(fng).or_insert(0);
+        *entry += 1;
+        *entry
     }
 
     pub fn get(&self, fng: FileFingerprint) -> Option<FilePosition> {
@@ -198,7 +203,8 @@ impl Checkpointer {
 
     #[cfg(test)]
     pub fn update_checkpoint(&mut self, fng: FileFingerprint, pos: FilePosition) {
-        self.checkpoints.update(fng, pos);
+        // No active generation in these tests: updates are always accepted.
+        self.checkpoints.update(fng, pos, 0);
     }
 
     #[cfg(test)]
@@ -484,43 +490,35 @@ mod test {
     }
 
     #[tokio::test]
-    async fn test_update_does_not_resurrect_dead_dev_inode_checkpoints() {
+    async fn test_update_ignores_stale_generations() {
         let data_dir = tempdir().unwrap();
-        let mut chkptr = Checkpointer::new(data_dir.path());
+        let chkptr = Checkpointer::new(data_dir.path());
 
-        let dev_inode = FileFingerprint::DevInode(1, 2);
-        let checksum = FileFingerprint::FirstLinesChecksum(78910);
+        let fingerprint = FileFingerprint::DevInode(1, 2);
 
-        chkptr.update_checkpoint(dev_inode, 100);
-        chkptr.update_checkpoint(checksum, 100);
-        let modified_before = chkptr.checkpoints.modified_time(dev_inode).unwrap();
-        chkptr.checkpoints.set_dead(dev_inode);
-        chkptr.checkpoints.set_dead(checksum);
+        let first = chkptr.checkpoints.begin_generation(fingerprint);
+        chkptr.checkpoints.update(fingerprint, 100, first);
+        assert_eq!(chkptr.get_checkpoint(fingerprint), Some(100));
+        let modified_before = chkptr.checkpoints.modified_time(fingerprint).unwrap();
 
-        // A late acknowledgement advances the position but must neither refresh
-        // the modified time nor lift the dead mark of a dev_inode fingerprint:
-        // its inode may already belong to a new file, and a refreshed modified
-        // time would defeat the inode-reuse detection at watcher creation.
-        chkptr.checkpoints.update(dev_inode, 200);
-        assert_eq!(chkptr.get_checkpoint(dev_inode), Some(200));
+        // A new watcher takes over the fingerprint (e.g. a recycled inode).
+        let second = chkptr.checkpoints.begin_generation(fingerprint);
+        assert!(second > first);
+
+        // A late acknowledgement from the previous watcher's file must not
+        // touch the checkpoint: its offset belongs to a different file, and a
+        // refreshed modified time would defeat the inode-reuse detection at
+        // watcher creation.
+        chkptr.checkpoints.update(fingerprint, 999_999, first);
+        assert_eq!(chkptr.get_checkpoint(fingerprint), Some(100));
         assert_eq!(
-            chkptr.checkpoints.modified_time(dev_inode),
+            chkptr.checkpoints.modified_time(fingerprint),
             Some(modified_before)
         );
-        assert!(chkptr.checkpoints.removed_times.contains_key(&dev_inode));
 
-        // Checksum fingerprints keep the resurrect-on-update semantics.
-        chkptr.checkpoints.update(checksum, 200);
-        assert!(!chkptr.checkpoints.removed_times.contains_key(&checksum));
-
-        // A new watcher claiming the fingerprint lifts the dead mark without
-        // touching the modified time.
-        chkptr.checkpoints.claim(dev_inode);
-        assert!(!chkptr.checkpoints.removed_times.contains_key(&dev_inode));
-        assert_eq!(
-            chkptr.checkpoints.modified_time(dev_inode),
-            Some(modified_before)
-        );
+        // The current watcher's updates apply normally.
+        chkptr.checkpoints.update(fingerprint, 200, second);
+        assert_eq!(chkptr.get_checkpoint(fingerprint), Some(200));
     }
 
     #[tokio::test]

--- a/lib/file-source-common/src/checkpointer.rs
+++ b/lib/file-source-common/src/checkpointer.rs
@@ -68,6 +68,10 @@ impl CheckpointsView {
         self.checkpoints.get(&fng).map(|r| *r.value())
     }
 
+    pub fn modified_time(&self, fng: FileFingerprint) -> Option<DateTime<Utc>> {
+        self.modified_times.get(&fng).map(|r| *r.value())
+    }
+
     pub fn set_dead(&self, fng: FileFingerprint) {
         self.removed_times.insert(fng, Utc::now());
     }

--- a/lib/file-source-common/src/checkpointer.rs
+++ b/lib/file-source-common/src/checkpointer.rs
@@ -90,11 +90,15 @@ impl CheckpointsView {
     }
 
     /// Start a new watcher generation for this fingerprint, invalidating
-    /// updates from any previous watcher that used it.
+    /// updates from any previous watcher that used it. Taking ownership also
+    /// cancels any pending expiry: the fingerprint is live again.
     pub fn begin_generation(&self, fng: FileFingerprint) -> u64 {
         let mut entry = self.generations.entry(fng).or_insert(0);
         *entry += 1;
-        *entry
+        let generation = *entry;
+        drop(entry);
+        self.removed_times.remove(&fng);
+        generation
     }
 
     pub fn get(&self, fng: FileFingerprint) -> Option<FilePosition> {

--- a/lib/file-source-common/src/checkpointer.rs
+++ b/lib/file-source-common/src/checkpointer.rs
@@ -92,12 +92,17 @@ impl CheckpointsView {
     /// Start a new watcher generation for this fingerprint, invalidating
     /// updates from any previous watcher that used it. Taking ownership also
     /// cancels any pending expiry: the fingerprint is live again.
+    ///
+    /// The pending expiry is cleared while the generation entry guard is still
+    /// held: the guard serializes lifecycle transitions against
+    /// `remove_expired`, which re-checks the tombstone under the same guard
+    /// before discarding a generation.
     pub fn begin_generation(&self, fng: FileFingerprint) -> u64 {
         let mut entry = self.generations.entry(fng).or_insert(0);
         *entry += 1;
         let generation = *entry;
-        drop(entry);
         self.removed_times.remove(&fng);
+        drop(entry);
         generation
     }
 
@@ -145,14 +150,29 @@ impl CheckpointsView {
             .collect::<Vec<FileFingerprint>>();
 
         for fng in to_remove {
-            self.checkpoints.remove(&fng);
-            self.modified_times.remove(&fng);
-            self.removed_times.remove(&fng);
-            // Dropping the generation entry keeps this map bounded by the set
-            // of live and recently-dead fingerprints; any update still in
-            // flight for this fingerprint is rejected outright once the entry
-            // is gone (see `update`).
-            self.generations.remove(&fng);
+            // The generation entry guard serializes this against a concurrent
+            // `begin_generation`: either the claim completed first (clearing
+            // the tombstone, which the re-check below observes and keeps the
+            // fingerprint alive), or it waits until the removal is done and
+            // starts from a clean slate. Dropping the generation entry keeps
+            // the map bounded by the set of live and recently-dead
+            // fingerprints; any update still in flight for this fingerprint is
+            // rejected outright once the entry is gone (see `update`).
+            match self.generations.entry(fng) {
+                dashmap::mapref::entry::Entry::Occupied(occupied) => {
+                    if self.removed_times.remove(&fng).is_some() {
+                        self.checkpoints.remove(&fng);
+                        self.modified_times.remove(&fng);
+                        occupied.remove();
+                    }
+                }
+                dashmap::mapref::entry::Entry::Vacant(_) => {
+                    if self.removed_times.remove(&fng).is_some() {
+                        self.checkpoints.remove(&fng);
+                        self.modified_times.remove(&fng);
+                    }
+                }
+            }
         }
     }
 

--- a/lib/file-source-common/src/checkpointer.rs
+++ b/lib/file-source-common/src/checkpointer.rs
@@ -67,18 +67,26 @@ impl CheckpointsView {
         // notably a recycled inode with `dev_inode` fingerprints), and
         // acknowledgements from a dead watcher's file can arrive arbitrarily
         // late. Each watcher records progress under the generation it was
-        // created with; anything older refers to a previous file's data and
+        // created with; anything else refers to a previous file's data and
         // must not touch the checkpoint, or a stale offset could masquerade as
-        // current progress for the file now bearing this fingerprint.
-        if let Some(current) = self.generations.get(&fng)
-            && *current.value() != generation
-        {
+        // current progress for the file now bearing this fingerprint. An
+        // absent entry means every watcher of this fingerprint is gone and its
+        // state has expired, so such updates are stale by definition.
+        //
+        // The entry guard is held for the duration of the writes so that a
+        // concurrent `begin_generation` cannot invalidate the check mid-update
+        // (it only touches this map, so no lock cycle is possible).
+        let Some(current) = self.generations.get(&fng) else {
+            return;
+        };
+        if *current.value() != generation {
             return;
         }
 
         self.checkpoints.insert(fng, pos);
         self.modified_times.insert(fng, Utc::now());
         self.removed_times.remove(&fng);
+        drop(current);
     }
 
     /// Start a new watcher generation for this fingerprint, invalidating
@@ -136,6 +144,11 @@ impl CheckpointsView {
             self.checkpoints.remove(&fng);
             self.modified_times.remove(&fng);
             self.removed_times.remove(&fng);
+            // Dropping the generation entry keeps this map bounded by the set
+            // of live and recently-dead fingerprints; any update still in
+            // flight for this fingerprint is rejected outright once the entry
+            // is gone (see `update`).
+            self.generations.remove(&fng);
         }
     }
 
@@ -203,8 +216,8 @@ impl Checkpointer {
 
     #[cfg(test)]
     pub fn update_checkpoint(&mut self, fng: FileFingerprint, pos: FilePosition) {
-        // No active generation in these tests: updates are always accepted.
-        self.checkpoints.update(fng, pos, 0);
+        let generation = self.checkpoints.begin_generation(fng);
+        self.checkpoints.update(fng, pos, generation);
     }
 
     #[cfg(test)]
@@ -518,6 +531,12 @@ mod test {
 
         // The current watcher's updates apply normally.
         chkptr.checkpoints.update(fingerprint, 200, second);
+        assert_eq!(chkptr.get_checkpoint(fingerprint), Some(200));
+
+        // Once the fingerprint's state has expired (no generation entry left),
+        // any straggling update is rejected rather than resurrecting it.
+        chkptr.checkpoints.generations.remove(&fingerprint);
+        chkptr.checkpoints.update(fingerprint, 999_999, second);
         assert_eq!(chkptr.get_checkpoint(fingerprint), Some(200));
     }
 

--- a/lib/file-source-common/src/checkpointer.rs
+++ b/lib/file-source-common/src/checkpointer.rs
@@ -52,8 +52,10 @@ pub struct Checkpointer {
 /// multiple threads.
 #[derive(Debug, Default)]
 pub struct CheckpointsView {
-    checkpoints: DashMap<FileFingerprint, FilePosition>,
-    modified_times: DashMap<FileFingerprint, DateTime<Utc>>,
+    /// Position and last-progress time are stored together so that a
+    /// concurrent persistence pass can never pair a fresh position with a
+    /// previous generation's timestamp (or vice versa).
+    checkpoints: DashMap<FileFingerprint, (FilePosition, DateTime<Utc>)>,
     removed_times: DashMap<FileFingerprint, DateTime<Utc>>,
     /// Current watcher generation per fingerprint; `update` ignores positions
     /// recorded under any other generation. Not persisted: generations only
@@ -87,9 +89,13 @@ impl CheckpointsView {
             return;
         }
 
-        self.checkpoints.insert(fng, pos);
-        self.modified_times.insert(fng, Utc::now());
-        self.removed_times.remove(&fng);
+        self.checkpoints.insert(fng, (pos, Utc::now()));
+        // A pending expiry is deliberately left armed: once a watcher has
+        // died, its remaining same-generation acknowledgements should record
+        // their final positions without keeping the fingerprint's state alive
+        // forever (the watcher is gone, so nothing would ever mark it dead
+        // again). A file coming back to life clears the tombstone through
+        // `begin_generation` when a new watcher claims the fingerprint.
         drop(current);
     }
 
@@ -114,11 +120,11 @@ impl CheckpointsView {
     }
 
     pub fn get(&self, fng: FileFingerprint) -> Option<FilePosition> {
-        self.checkpoints.get(&fng).map(|r| *r.value())
+        self.checkpoints.get(&fng).map(|r| r.value().0)
     }
 
     pub fn modified_time(&self, fng: FileFingerprint) -> Option<DateTime<Utc>> {
-        self.modified_times.get(&fng).map(|r| *r.value())
+        self.checkpoints.get(&fng).map(|r| r.value().1)
     }
 
     pub fn set_dead(&self, fng: FileFingerprint) {
@@ -128,10 +134,6 @@ impl CheckpointsView {
     pub fn update_key(&self, old: FileFingerprint, new: FileFingerprint) {
         if let Some((_, value)) = self.checkpoints.remove(&old) {
             self.checkpoints.insert(new, value);
-        }
-
-        if let Some((_, value)) = self.modified_times.remove(&old) {
-            self.modified_times.insert(new, value);
         }
 
         if let Some((_, value)) = self.removed_times.remove(&old) {
@@ -173,7 +175,6 @@ impl CheckpointsView {
                         .is_some()
                     {
                         self.checkpoints.remove(&fng);
-                        self.modified_times.remove(&fng);
                         occupied.remove();
                     }
                 }
@@ -184,7 +185,6 @@ impl CheckpointsView {
                         .is_some()
                     {
                         self.checkpoints.remove(&fng);
-                        self.modified_times.remove(&fng);
                     }
                 }
             }
@@ -192,10 +192,10 @@ impl CheckpointsView {
     }
 
     fn load(&self, checkpoint: Checkpoint) {
-        self.checkpoints
-            .insert(checkpoint.fingerprint, checkpoint.position);
-        self.modified_times
-            .insert(checkpoint.fingerprint, checkpoint.modified);
+        self.checkpoints.insert(
+            checkpoint.fingerprint,
+            (checkpoint.position, checkpoint.modified),
+        );
     }
 
     fn set_state(&self, state: State, ignore_before: Option<DateTime<Utc>>) {
@@ -220,15 +220,11 @@ impl CheckpointsView {
                 .iter()
                 .map(|entry| {
                     let fingerprint = entry.key();
-                    let position = entry.value();
+                    let (position, modified) = entry.value();
                     Checkpoint {
                         fingerprint: *fingerprint,
                         position: *position,
-                        modified: self
-                            .modified_times
-                            .get(fingerprint)
-                            .map(|r| *r.value())
-                            .unwrap_or_else(Utc::now),
+                        modified: *modified,
                     }
                 })
                 .collect(),

--- a/lib/file-source-common/src/checkpointer.rs
+++ b/lib/file-source-common/src/checkpointer.rs
@@ -59,8 +59,28 @@ pub struct CheckpointsView {
 
 impl CheckpointsView {
     pub fn update(&self, fng: FileFingerprint, pos: FilePosition) {
+        // Once a `DevInode` watcher has died, further updates can only be late
+        // acknowledgements of data read before its file disappeared. Record the
+        // position (so a legitimate reappearance of the same file resumes
+        // correctly) but keep the entry marked dead and its modified time
+        // frozen: refreshing them would make a stale checkpoint look current to
+        // the inode-reuse detection in `FileServer::watch_new_file`, and keep
+        // the entry alive past its expiry for as long as acknowledgements
+        // trickle in. A new watcher claiming this fingerprint lifts the dead
+        // mark via `claim`.
+        if matches!(fng, FileFingerprint::DevInode(..)) && self.removed_times.contains_key(&fng) {
+            self.checkpoints.insert(fng, pos);
+            return;
+        }
+
         self.checkpoints.insert(fng, pos);
         self.modified_times.insert(fng, Utc::now());
+        self.removed_times.remove(&fng);
+    }
+
+    /// Mark a fingerprint as owned by a live watcher again, cancelling any
+    /// pending expiry without refreshing its modified time.
+    pub fn claim(&self, fng: FileFingerprint) {
         self.removed_times.remove(&fng);
     }
 
@@ -461,6 +481,46 @@ mod test {
         assert_eq!(chkptr.get_checkpoint(cases[1].0), None);
         assert_eq!(chkptr.get_checkpoint(cases[2].0), Some(42));
         assert_eq!(chkptr.get_checkpoint(cases[3].0), None);
+    }
+
+    #[tokio::test]
+    async fn test_update_does_not_resurrect_dead_dev_inode_checkpoints() {
+        let data_dir = tempdir().unwrap();
+        let mut chkptr = Checkpointer::new(data_dir.path());
+
+        let dev_inode = FileFingerprint::DevInode(1, 2);
+        let checksum = FileFingerprint::FirstLinesChecksum(78910);
+
+        chkptr.update_checkpoint(dev_inode, 100);
+        chkptr.update_checkpoint(checksum, 100);
+        let modified_before = chkptr.checkpoints.modified_time(dev_inode).unwrap();
+        chkptr.checkpoints.set_dead(dev_inode);
+        chkptr.checkpoints.set_dead(checksum);
+
+        // A late acknowledgement advances the position but must neither refresh
+        // the modified time nor lift the dead mark of a dev_inode fingerprint:
+        // its inode may already belong to a new file, and a refreshed modified
+        // time would defeat the inode-reuse detection at watcher creation.
+        chkptr.checkpoints.update(dev_inode, 200);
+        assert_eq!(chkptr.get_checkpoint(dev_inode), Some(200));
+        assert_eq!(
+            chkptr.checkpoints.modified_time(dev_inode),
+            Some(modified_before)
+        );
+        assert!(chkptr.checkpoints.removed_times.contains_key(&dev_inode));
+
+        // Checksum fingerprints keep the resurrect-on-update semantics.
+        chkptr.checkpoints.update(checksum, 200);
+        assert!(!chkptr.checkpoints.removed_times.contains_key(&checksum));
+
+        // A new watcher claiming the fingerprint lifts the dead mark without
+        // touching the modified time.
+        chkptr.checkpoints.claim(dev_inode);
+        assert!(!chkptr.checkpoints.removed_times.contains_key(&dev_inode));
+        assert_eq!(
+            chkptr.checkpoints.modified_time(dev_inode),
+            Some(modified_before)
+        );
     }
 
     #[tokio::test]

--- a/lib/file-source-common/src/checkpointer.rs
+++ b/lib/file-source-common/src/checkpointer.rs
@@ -56,9 +56,13 @@ pub struct CheckpointsView {
     modified_times: DashMap<FileFingerprint, DateTime<Utc>>,
     removed_times: DashMap<FileFingerprint, DateTime<Utc>>,
     /// Current watcher generation per fingerprint; `update` ignores positions
-    /// recorded under an older generation. Not persisted: generations only
+    /// recorded under any other generation. Not persisted: generations only
     /// disambiguate in-flight updates within a single process lifetime.
     generations: DashMap<FileFingerprint, u64>,
+    /// Process-wide monotonic source of generation tokens. Tokens are never
+    /// reused, so an old acknowledgement outliving its fingerprint's expiry
+    /// cannot collide with a token handed to a later watcher.
+    next_generation: std::sync::atomic::AtomicU64,
 }
 
 impl CheckpointsView {
@@ -98,9 +102,12 @@ impl CheckpointsView {
     /// `remove_expired`, which re-checks the tombstone under the same guard
     /// before discarding a generation.
     pub fn begin_generation(&self, fng: FileFingerprint) -> u64 {
+        let generation = self
+            .next_generation
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+            + 1;
         let mut entry = self.generations.entry(fng).or_insert(0);
-        *entry += 1;
-        let generation = *entry;
+        *entry = generation;
         self.removed_times.remove(&fng);
         drop(entry);
         generation
@@ -160,14 +167,22 @@ impl CheckpointsView {
             // rejected outright once the entry is gone (see `update`).
             match self.generations.entry(fng) {
                 dashmap::mapref::entry::Entry::Occupied(occupied) => {
-                    if self.removed_times.remove(&fng).is_some() {
+                    if self
+                        .removed_times
+                        .remove_if(&fng, |_, ts| now - *ts >= chrono::Duration::seconds(60))
+                        .is_some()
+                    {
                         self.checkpoints.remove(&fng);
                         self.modified_times.remove(&fng);
                         occupied.remove();
                     }
                 }
                 dashmap::mapref::entry::Entry::Vacant(_) => {
-                    if self.removed_times.remove(&fng).is_some() {
+                    if self
+                        .removed_times
+                        .remove_if(&fng, |_, ts| now - *ts >= chrono::Duration::seconds(60))
+                        .is_some()
+                    {
                         self.checkpoints.remove(&fng);
                         self.modified_times.remove(&fng);
                     }
@@ -560,6 +575,14 @@ mod test {
         // Once the fingerprint's state has expired (no generation entry left),
         // any straggling update is rejected rather than resurrecting it.
         chkptr.checkpoints.generations.remove(&fingerprint);
+        chkptr.checkpoints.update(fingerprint, 999_999, second);
+        assert_eq!(chkptr.get_checkpoint(fingerprint), Some(200));
+
+        // Tokens are process-wide monotonic: a fingerprint claimed again after
+        // its expiry never reuses a token, so acknowledgements from before the
+        // expiry stay rejected.
+        let third = chkptr.checkpoints.begin_generation(fingerprint);
+        assert!(third > second);
         chkptr.checkpoints.update(fingerprint, 999_999, second);
         assert_eq!(chkptr.get_checkpoint(fingerprint), Some(200));
     }

--- a/lib/file-source/src/file_server.rs
+++ b/lib/file-source/src/file_server.rs
@@ -24,7 +24,7 @@ use tokio::{
     time::sleep,
 };
 
-use tracing::{debug, error, info, trace};
+use tracing::{debug, error, info, trace, warn};
 
 use crate::{
     file_watcher::{FileWatcher, RawLineResult},
@@ -457,7 +457,7 @@ where
         // `kubernetes_logs` source returns the files well after start-up, once it has populated
         // them from the k8s metadata, so we now just always use the checkpoints unless opted out.
         // https://github.com/vectordotdev/vector/issues/7139
-        let read_from = if !self.ignore_checkpoints {
+        let mut read_from = if !self.ignore_checkpoints {
             checkpoints
                 .get(file_id)
                 .map(ReadFrom::Checkpoint)
@@ -465,6 +465,26 @@ where
         } else {
             fallback
         };
+
+        // A `DevInode` checkpoint recorded before this file was created cannot hold
+        // this file's progress: the inode has been recycled by a new file (common
+        // after rotated logs are pruned). Trusting it would silently skip the head
+        // of the file, or all of it while it is smaller than the stale position.
+        // Content-based (checksum) fingerprints are exempt: for those, a recreated
+        // file with a matching fingerprint legitimately carries the same identity.
+        if let ReadFrom::Checkpoint(position) = read_from
+            && matches!(file_id, FileFingerprint::DevInode(..))
+            && let Some(checkpoint_modified) = checkpoints.modified_time(file_id)
+            && let Ok(created) = fs::metadata(&path).await.and_then(|m| m.created())
+            && DateTime::<Utc>::from(created) > checkpoint_modified
+        {
+            warn!(
+                message = "Checkpoint predates the file's creation; assuming the inode was reused by a new file and discarding the checkpoint.",
+                ?path,
+                checkpoint = position,
+            );
+            read_from = fallback;
+        }
 
         match FileWatcher::new(
             path.clone(),

--- a/lib/file-source/src/file_server.rs
+++ b/lib/file-source/src/file_server.rs
@@ -453,6 +453,14 @@ where
             ReadFrom::Beginning
         };
 
+        // Invalidate any previous watcher's generation BEFORE reading the stored
+        // checkpoint, so a late acknowledgement from a previous file bearing this
+        // fingerprint cannot refresh the entry between here and the validation
+        // below. Acknowledgements arriving before this point are inherently
+        // indistinguishable from real progress (no new claimant exists yet); the
+        // beyond-EOF guard in `FileWatcher::new` remains the backstop for those.
+        let generation = checkpoints.begin_generation(file_id);
+
         // Always prefer the stored checkpoint unless the user has opted out.  Previously, the
         // checkpoint was only loaded for new files when Vector was started up, but the
         // `kubernetes_logs` source returns the files well after start-up, once it has populated
@@ -517,7 +525,7 @@ where
                     }
                     _ => self.emitter.emit_file_added(&path),
                 }
-                watcher.set_generation(checkpoints.begin_generation(file_id));
+                watcher.set_generation(generation);
                 watcher.set_file_findable(true);
                 fp_map.insert(file_id, watcher);
             }

--- a/lib/file-source/src/file_server.rs
+++ b/lib/file-source/src/file_server.rs
@@ -316,6 +316,7 @@ where
                         text: line.bytes,
                         filename: watcher.path.to_str().expect("not a valid path").to_owned(),
                         file_id,
+                        generation: watcher.generation(),
                         start_offset: line.offset,
                         end_offset: watcher.get_file_position(),
                     });
@@ -481,9 +482,12 @@ where
             // A creation time in the future means the filesystem's clock cannot
             // be trusted (e.g. a skewed network filesystem); don't treat the
             // comparison as proof of inode reuse there, or a legitimate
-            // checkpoint would be discarded on every startup.
-            let plausible = created < Utc::now() + chrono::TimeDelta::seconds(1);
-            if plausible && created > checkpoint_modified {
+            // checkpoint would be discarded on every startup. The comparison
+            // itself also carries an allowance, so sub-second skew between the
+            // two clocks cannot invalidate a legitimate checkpoint.
+            let allowance = chrono::TimeDelta::seconds(1);
+            let plausible = created < Utc::now() + allowance;
+            if plausible && created > checkpoint_modified + allowance {
                 warn!(
                     message = "Checkpoint predates the file's creation; assuming the inode was reused by a new file and discarding the checkpoint.",
                     ?path,
@@ -513,7 +517,7 @@ where
                     }
                     _ => self.emitter.emit_file_added(&path),
                 }
-                checkpoints.claim(file_id);
+                watcher.set_generation(checkpoints.begin_generation(file_id));
                 watcher.set_file_findable(true);
                 fp_map.insert(file_id, watcher);
             }
@@ -629,6 +633,9 @@ pub struct Line {
     pub text: Bytes,
     pub filename: String,
     pub file_id: FileFingerprint,
+    /// Watcher generation this line was read under; see
+    /// [`CheckpointsView::update`](file_source_common::checkpointer::CheckpointsView::update).
+    pub generation: u64,
     pub start_offset: u64,
     pub end_offset: u64,
 }

--- a/lib/file-source/src/file_server.rs
+++ b/lib/file-source/src/file_server.rs
@@ -476,14 +476,21 @@ where
             && matches!(file_id, FileFingerprint::DevInode(..))
             && let Some(checkpoint_modified) = checkpoints.modified_time(file_id)
             && let Ok(created) = fs::metadata(&path).await.and_then(|m| m.created())
-            && DateTime::<Utc>::from(created) > checkpoint_modified
         {
-            warn!(
-                message = "Checkpoint predates the file's creation; assuming the inode was reused by a new file and discarding the checkpoint.",
-                ?path,
-                checkpoint = position,
-            );
-            read_from = fallback;
+            let created = DateTime::<Utc>::from(created);
+            // A creation time in the future means the filesystem's clock cannot
+            // be trusted (e.g. a skewed network filesystem); don't treat the
+            // comparison as proof of inode reuse there, or a legitimate
+            // checkpoint would be discarded on every startup.
+            let plausible = created < Utc::now() + chrono::TimeDelta::seconds(1);
+            if plausible && created > checkpoint_modified {
+                warn!(
+                    message = "Checkpoint predates the file's creation; assuming the inode was reused by a new file and discarding the checkpoint.",
+                    ?path,
+                    checkpoint = position,
+                );
+                read_from = fallback;
+            }
         }
 
         match FileWatcher::new(
@@ -496,11 +503,17 @@ where
         .await
         {
             Ok(mut watcher) => {
-                if let ReadFrom::Checkpoint(file_position) = read_from {
-                    self.emitter.emit_file_resumed(&path, file_position);
-                } else {
-                    self.emitter.emit_file_added(&path);
+                match read_from {
+                    // The watcher itself may have refused a checkpoint pointing
+                    // beyond the end of the file; report what actually happened.
+                    ReadFrom::Checkpoint(file_position)
+                        if watcher.get_file_position() == file_position =>
+                    {
+                        self.emitter.emit_file_resumed(&path, file_position);
+                    }
+                    _ => self.emitter.emit_file_added(&path),
                 }
+                checkpoints.claim(file_id);
                 watcher.set_file_findable(true);
                 fp_map.insert(file_id, watcher);
             }

--- a/lib/file-source/src/file_server.rs
+++ b/lib/file-source/src/file_server.rs
@@ -207,7 +207,22 @@ where
                                     path = ?path,
                                     old_path = ?watcher.path
                                 );
-                                watcher.update_path(path).await.ok(); // ok if this fails: might fix next cycle
+                                // ok if this fails: might fix next cycle
+                                if let Ok(true) = watcher.update_path(path).await {
+                                    // The watcher restarted the replacement from
+                                    // the beginning: give it a new generation so
+                                    // in-flight reads from the previous file
+                                    // cannot be recorded as its progress, and
+                                    // persist the reset so the stale offset
+                                    // cannot be trusted again after a restart.
+                                    let generation = checkpoints.begin_generation(file_id);
+                                    watcher.set_generation(generation);
+                                    checkpoints.update(
+                                        file_id,
+                                        watcher.get_file_position(),
+                                        generation,
+                                    );
+                                }
                             } else {
                                 info!(
                                     message = "More than one file has the same fingerprint.",
@@ -225,7 +240,18 @@ where
                                         new_modified_time = ?new_modified_time,
                                         old_modified_time = ?old_modified_time,
                                     );
-                                    watcher.update_path(path).await.ok(); // ok if this fails: might fix next cycle
+                                    // ok if this fails: might fix next cycle
+                                    if let Ok(true) = watcher.update_path(path).await {
+                                        // Same as the rename branch above: reset
+                                        // means new generation + persisted reset.
+                                        let generation = checkpoints.begin_generation(file_id);
+                                        watcher.set_generation(generation);
+                                        checkpoints.update(
+                                            file_id,
+                                            watcher.get_file_position(),
+                                            generation,
+                                        );
+                                    }
                                 }
                             }
                         } else {
@@ -527,9 +553,27 @@ where
                 }
                 watcher.set_generation(generation);
                 watcher.set_file_findable(true);
+
+                // If the stored checkpoint was rejected (beyond-EOF guard in
+                // `FileWatcher::new`), persist the effective position under the
+                // new generation right away: leaving the stale offset in the
+                // checkpoint file until the first delivered line would let a
+                // restart trust it again once the file has grown past it.
+                if let ReadFrom::Checkpoint(file_position) = read_from
+                    && watcher.get_file_position() != file_position
+                {
+                    checkpoints.update(file_id, watcher.get_file_position(), generation);
+                }
+
                 fp_map.insert(file_id, watcher);
             }
-            Err(error) => self.emitter.emit_file_watch_error(&path, error),
+            Err(error) => {
+                // The generation was already claimed and its pending expiry
+                // cancelled, but no watcher exists to ever mark it dead again;
+                // re-arm the expiry so the fingerprint's state cannot leak.
+                checkpoints.set_dead(file_id);
+                self.emitter.emit_file_watch_error(&path, error)
+            }
         };
     }
 }

--- a/lib/file-source/src/file_watcher/mod.rs
+++ b/lib/file-source/src/file_watcher/mod.rs
@@ -234,6 +234,9 @@ impl FileWatcher {
                         file_size = len,
                     );
                     self.file_position = 0;
+                    // A partial line buffered from the previous file must not
+                    // be glued onto the replacement's first line.
+                    self.buf.clear();
                 }
                 reader.seek(io::SeekFrom::Start(self.file_position)).await?;
                 Box::new(reader)

--- a/lib/file-source/src/file_watcher/mod.rs
+++ b/lib/file-source/src/file_watcher/mod.rs
@@ -65,6 +65,7 @@ pub struct FileWatcher {
     max_line_bytes: usize,
     line_delimiter: Bytes,
     buf: BytesMut,
+    generation: u64,
 }
 
 impl FileWatcher {
@@ -193,7 +194,19 @@ impl FileWatcher {
             max_line_bytes,
             line_delimiter,
             buf: BytesMut::new(),
+            generation: 0,
         })
+    }
+
+    /// The watcher generation under which this watcher records checkpoint
+    /// progress; set by the file server when the watcher takes ownership of a
+    /// fingerprint.
+    pub const fn generation(&self) -> u64 {
+        self.generation
+    }
+
+    pub fn set_generation(&mut self, generation: u64) {
+        self.generation = generation;
     }
 
     pub async fn update_path(&mut self, path: PathBuf) -> io::Result<()> {

--- a/lib/file-source/src/file_watcher/mod.rs
+++ b/lib/file-source/src/file_watcher/mod.rs
@@ -209,7 +209,13 @@ impl FileWatcher {
         self.generation = generation;
     }
 
-    pub async fn update_path(&mut self, path: PathBuf) -> io::Result<()> {
+    /// Returns `true` when the watcher had to abandon its current position and
+    /// start the replacement file from the beginning; the caller should then
+    /// treat the replacement as a new file (new generation, refreshed
+    /// checkpoint) so in-flight reads from the previous file cannot be
+    /// recorded as the replacement's progress.
+    pub async fn update_path(&mut self, path: PathBuf) -> io::Result<bool> {
+        let mut reset = false;
         let file_handle = File::open(&path).await?;
 
         let file_info = file_handle.file_info().await?;
@@ -237,6 +243,7 @@ impl FileWatcher {
                     // A partial line buffered from the previous file must not
                     // be glued onto the replacement's first line.
                     self.buf.clear();
+                    reset = true;
                 }
                 reader.seek(io::SeekFrom::Start(self.file_position)).await?;
                 Box::new(reader)
@@ -250,7 +257,7 @@ impl FileWatcher {
         self.reached_eof = false;
         self.read_retry_delay = EOF_READ_BACKOFF_MIN;
         self.path = path;
-        Ok(())
+        Ok(reset)
     }
 
     pub fn set_file_findable(&mut self, f: bool) {

--- a/lib/file-source/src/file_watcher/mod.rs
+++ b/lib/file-source/src/file_watcher/mod.rs
@@ -210,6 +210,18 @@ impl FileWatcher {
                     Box::new(BufReader::new(gzip_multiple_decoder(reader)))
                 }
             } else {
+                let len = file_handle.metadata().await?.len();
+                if self.file_position > len {
+                    // Same protection as in `new`: rebinding to a file shorter
+                    // than the current position would silently skip its head.
+                    warn!(
+                        message = "Position is beyond the end of the replacement file; reading it from the beginning.",
+                        ?path,
+                        position = self.file_position,
+                        file_size = len,
+                    );
+                    self.file_position = 0;
+                }
                 reader.seek(io::SeekFrom::Start(self.file_position)).await?;
                 Box::new(reader)
             };

--- a/lib/file-source/src/file_watcher/mod.rs
+++ b/lib/file-source/src/file_watcher/mod.rs
@@ -10,7 +10,7 @@ use tokio::{
     io::{AsyncBufRead, AsyncBufReadExt, AsyncSeekExt, BufReader},
     time::Instant,
 };
-use tracing::debug;
+use tracing::{debug, warn};
 use vector_common::constants::GZIP_MAGIC;
 
 use file_source_common::{
@@ -103,54 +103,72 @@ impl FileWatcher {
         let gzipped = is_gzipped(&mut reader).await?;
 
         // Determine the actual position at which we should start reading
-        let (reader, file_position): (Box<dyn AsyncBufRead + Send + Unpin>, FilePosition) =
-            match (gzipped, too_old, read_from) {
-                (true, true, _) => {
-                    debug!(
-                        message = "Not reading gzipped file older than `ignore_older`.",
-                        ?path,
-                    );
-                    (Box::new(null_reader()), 0)
-                }
-                (true, _, ReadFrom::Checkpoint(file_position)) => {
-                    debug!(
-                        message = "Not re-reading gzipped file with existing stored offset.",
-                        ?path,
-                        %file_position
-                    );
-                    (Box::new(null_reader()), file_position)
-                }
-                // TODO: This may become the default, leading us to stop reading gzipped files that
-                // we were reading before. Should we merge this and the next branch to read
-                // compressed file from the beginning even when `read_from = "end"` (implicitly via
-                // default or explicitly via config)?
-                (true, _, ReadFrom::End) => {
-                    debug!(
-                        message = "Can't read from the end of already-compressed file.",
-                        ?path,
-                    );
-                    (Box::new(null_reader()), 0)
-                }
-                (true, false, ReadFrom::Beginning) => {
-                    (Box::new(BufReader::new(gzip_multiple_decoder(reader))), 0)
-                }
-                (false, true, _) => {
-                    let pos = reader.seek(SeekFrom::End(0)).await.unwrap();
-                    (Box::new(reader), pos)
-                }
-                (false, false, ReadFrom::Checkpoint(file_position)) => {
-                    let pos = reader.seek(SeekFrom::Start(file_position)).await.unwrap();
-                    (Box::new(reader), pos)
-                }
-                (false, false, ReadFrom::Beginning) => {
-                    let pos = reader.seek(SeekFrom::Start(0)).await.unwrap();
-                    (Box::new(reader), pos)
-                }
-                (false, false, ReadFrom::End) => {
-                    let pos = reader.seek(SeekFrom::End(0)).await.unwrap();
-                    (Box::new(reader), pos)
-                }
-            };
+        let (reader, file_position): (Box<dyn AsyncBufRead + Send + Unpin>, FilePosition) = match (
+            gzipped, too_old, read_from,
+        ) {
+            (true, true, _) => {
+                debug!(
+                    message = "Not reading gzipped file older than `ignore_older`.",
+                    ?path,
+                );
+                (Box::new(null_reader()), 0)
+            }
+            (true, _, ReadFrom::Checkpoint(file_position)) => {
+                debug!(
+                    message = "Not re-reading gzipped file with existing stored offset.",
+                    ?path,
+                    %file_position
+                );
+                (Box::new(null_reader()), file_position)
+            }
+            // TODO: This may become the default, leading us to stop reading gzipped files that
+            // we were reading before. Should we merge this and the next branch to read
+            // compressed file from the beginning even when `read_from = "end"` (implicitly via
+            // default or explicitly via config)?
+            (true, _, ReadFrom::End) => {
+                debug!(
+                    message = "Can't read from the end of already-compressed file.",
+                    ?path,
+                );
+                (Box::new(null_reader()), 0)
+            }
+            (true, false, ReadFrom::Beginning) => {
+                (Box::new(BufReader::new(gzip_multiple_decoder(reader))), 0)
+            }
+            (false, true, _) => {
+                let pos = reader.seek(SeekFrom::End(0)).await.unwrap();
+                (Box::new(reader), pos)
+            }
+            (false, false, ReadFrom::Checkpoint(file_position))
+                if file_position > metadata.len() =>
+            {
+                // The checkpoint lies beyond the end of the file: either the file
+                // was truncated, or the checkpoint was recorded against a different
+                // file whose fingerprint this one now matches (e.g. a recycled
+                // inode). Seeking to it would silently discard everything written
+                // until the file grows past the stale offset.
+                warn!(
+                    message = "Checkpoint position is beyond the end of the file; starting from the beginning. Was the file truncated, or its fingerprint reused?",
+                    ?path,
+                    checkpoint = file_position,
+                    file_size = metadata.len(),
+                );
+                let pos = reader.seek(SeekFrom::Start(0)).await.unwrap();
+                (Box::new(reader), pos)
+            }
+            (false, false, ReadFrom::Checkpoint(file_position)) => {
+                let pos = reader.seek(SeekFrom::Start(file_position)).await.unwrap();
+                (Box::new(reader), pos)
+            }
+            (false, false, ReadFrom::Beginning) => {
+                let pos = reader.seek(SeekFrom::Start(0)).await.unwrap();
+                (Box::new(reader), pos)
+            }
+            (false, false, ReadFrom::End) => {
+                let pos = reader.seek(SeekFrom::End(0)).await.unwrap();
+                (Box::new(reader), pos)
+            }
+        };
 
         let ts = metadata
             .modified()

--- a/lib/file-source/src/file_watcher/tests/mod.rs
+++ b/lib/file-source/src/file_watcher/tests/mod.rs
@@ -239,6 +239,7 @@ fn watcher_for_timing() -> FileWatcher {
         max_line_bytes: 1024,
         line_delimiter: Bytes::from_static(b"\n"),
         buf: BytesMut::new(),
+        generation: 0,
     }
 }
 

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -346,6 +346,7 @@ impl From<FingerprintConfig> for FingerprintStrategy {
 pub(crate) struct FinalizerEntry {
     pub(crate) file_id: FileFingerprint,
     pub(crate) offset: u64,
+    pub(crate) generation: u64,
 }
 
 impl Default for FileConfig {
@@ -577,7 +578,7 @@ pub fn file_source(
         crate::spawn_in_current_span(async move {
             while let Some((status, entry)) = ack_stream.next().await {
                 if status == BatchStatus::Delivered {
-                    checkpoints.update(entry.file_id, entry.offset);
+                    checkpoints.update(entry.file_id, entry.offset, entry.generation);
                 }
             }
             send_shutdown.send(())
@@ -652,11 +653,12 @@ pub fn file_source(
                 let entry = FinalizerEntry {
                     file_id: line.file_id,
                     offset: line.end_offset,
+                    generation: line.generation,
                 };
                 // checkpoints.update will be called from ack_stream's thread
                 finalizer.add(entry, receiver);
             } else {
-                checkpoints.update(line.file_id, line.end_offset);
+                checkpoints.update(line.file_id, line.end_offset, line.generation);
             }
             event
         });
@@ -729,20 +731,34 @@ fn wrap_with_line_agg(
                 (
                     line.filename,
                     line.text,
-                    (line.file_id, line.start_offset, line.end_offset),
+                    (
+                        line.file_id,
+                        line.generation,
+                        line.start_offset,
+                        line.end_offset,
+                    ),
                 )
             }),
             logic,
         )
         .map(
-            |(filename, text, (file_id, start_offset, initial_end), lastline_context)| Line {
-                text,
+            |(
                 filename,
-                file_id,
-                start_offset,
-                end_offset: lastline_context.map_or(initial_end, |(_, _, lastline_end_offset)| {
-                    lastline_end_offset
-                }),
+                text,
+                (file_id, generation, start_offset, initial_end),
+                lastline_context,
+            )| {
+                Line {
+                    text,
+                    filename,
+                    file_id,
+                    generation,
+                    start_offset,
+                    end_offset: lastline_context
+                        .map_or(initial_end, |(_, _, _, lastline_end_offset)| {
+                            lastline_end_offset
+                        }),
+                }
             },
         ),
     )

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -729,23 +729,23 @@ fn wrap_with_line_agg(
         LineAgg::new(
             rx.map(|line| {
                 (
-                    line.filename,
+                    // Aggregate strictly within one watcher generation of one
+                    // file: a replacement file appearing under the same name
+                    // must not have its first line glued onto the previous
+                    // file's pending aggregate, nor its offsets recorded under
+                    // the previous generation.
+                    (line.filename, line.file_id, line.generation),
                     line.text,
-                    (
-                        line.file_id,
-                        line.generation,
-                        line.start_offset,
-                        line.end_offset,
-                    ),
+                    (line.start_offset, line.end_offset),
                 )
             }),
             logic,
         )
         .map(
             |(
-                filename,
+                (filename, file_id, generation),
                 text,
-                (file_id, generation, start_offset, initial_end),
+                (start_offset, initial_end),
                 lastline_context,
             )| {
                 Line {
@@ -755,9 +755,7 @@ fn wrap_with_line_agg(
                     generation,
                     start_offset,
                     end_offset: lastline_context
-                        .map_or(initial_end, |(_, _, _, lastline_end_offset)| {
-                            lastline_end_offset
-                        }),
+                        .map_or(initial_end, |(_, lastline_end_offset)| lastline_end_offset),
                 }
             },
         ),

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -2116,6 +2116,166 @@ mod tests {
         assert_eq!(lines, vec!["INFO goodbye"]);
     }
 
+    /// Write a `checkpoints.json` containing a single `dev_inode` entry for `file`,
+    /// letting tests forge stale checkpoints deterministically instead of relying
+    /// on the filesystem actually recycling an inode.
+    #[cfg(unix)]
+    fn write_dev_inode_checkpoint(
+        data_dir: &std::path::Path,
+        file: &std::path::Path,
+        position: u64,
+        modified: chrono::DateTime<chrono::Utc>,
+    ) {
+        use std::os::unix::fs::MetadataExt;
+        let metadata = fs::metadata(file).unwrap();
+        let json = format!(
+            r#"{{"version":"1","checkpoints":[{{"fingerprint":{{"dev_inode":[{},{}]}},"position":{},"modified":"{}"}}]}}"#,
+            metadata.dev(),
+            metadata.ino(),
+            position,
+            modified.to_rfc3339_opts(chrono::SecondsFormat::Micros, true),
+        );
+        fs::write(data_dir.join("checkpoints.json"), json).unwrap();
+    }
+
+    // A checkpoint pointing beyond the end of the file (stale entry from a recycled
+    // inode, or a truncated file) must not be trusted: the file should be read from
+    // the beginning instead of silently waiting for it to grow past the stale offset.
+    // Regression test for https://github.com/vectordotdev/vector/issues/23076.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn checkpoint_beyond_file_size_is_discarded() {
+        let dir = tempdir().unwrap();
+        let config = file::FileConfig {
+            fingerprint: FingerprintConfig::DevInode,
+            include: vec![dir.path().join("*")],
+            ..test_default_file_config(&dir)
+        };
+
+        let path = dir.path().join("file");
+        let mut file = File::create(&path).unwrap();
+        for i in 0..10 {
+            writeln!(&mut file, "line {i}").unwrap();
+        }
+        file.sync_all().unwrap();
+
+        write_dev_inode_checkpoint(
+            config.data_dir.as_ref().unwrap(),
+            &path,
+            1_000_000,
+            chrono::Utc::now(),
+        );
+
+        let received = run_file_source(
+            &config,
+            false,
+            Acks,
+            LogNamespace::Legacy,
+            None,
+            sleep_500_millis(),
+        )
+        .await;
+        let lines = extract_messages_string(received);
+        assert_eq!(
+            lines,
+            (0..10).map(|i| format!("line {i}")).collect::<Vec<_>>()
+        );
+    }
+
+    // A `dev_inode` checkpoint recorded before the file was even created belongs to
+    // a previous file whose inode was recycled; it must be discarded even when its
+    // position falls within the new file's size, or the head of the file is lost.
+    // Regression test for https://github.com/vectordotdev/vector/issues/23076.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn dev_inode_checkpoint_predating_file_creation_is_discarded() {
+        let dir = tempdir().unwrap();
+        let config = file::FileConfig {
+            fingerprint: FingerprintConfig::DevInode,
+            include: vec![dir.path().join("*")],
+            ..test_default_file_config(&dir)
+        };
+
+        let path = dir.path().join("file");
+        let mut file = File::create(&path).unwrap();
+        for i in 0..10 {
+            writeln!(&mut file, "line {i}").unwrap();
+        }
+        file.sync_all().unwrap();
+
+        if fs::metadata(&path).unwrap().created().is_err() {
+            // The filesystem does not report creation times; the check under test
+            // cannot run here (it falls back to trusting the checkpoint).
+            return;
+        }
+
+        let offset: usize = (0..5).map(|i| format!("line {i}\n").len()).sum();
+        write_dev_inode_checkpoint(
+            config.data_dir.as_ref().unwrap(),
+            &path,
+            offset as u64,
+            chrono::Utc::now() - chrono::Duration::hours(1),
+        );
+
+        let received = run_file_source(
+            &config,
+            false,
+            Acks,
+            LogNamespace::Legacy,
+            None,
+            sleep_500_millis(),
+        )
+        .await;
+        let lines = extract_messages_string(received);
+        assert_eq!(
+            lines,
+            (0..10).map(|i| format!("line {i}")).collect::<Vec<_>>()
+        );
+    }
+
+    // Control for the two tests above: a plausible checkpoint (recorded after the
+    // file's creation, position within its size) must still be honored.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn dev_inode_checkpoint_newer_than_file_creation_is_honored() {
+        let dir = tempdir().unwrap();
+        let config = file::FileConfig {
+            fingerprint: FingerprintConfig::DevInode,
+            include: vec![dir.path().join("*")],
+            ..test_default_file_config(&dir)
+        };
+
+        let path = dir.path().join("file");
+        let mut file = File::create(&path).unwrap();
+        for i in 0..10 {
+            writeln!(&mut file, "line {i}").unwrap();
+        }
+        file.sync_all().unwrap();
+
+        let offset: usize = (0..5).map(|i| format!("line {i}\n").len()).sum();
+        write_dev_inode_checkpoint(
+            config.data_dir.as_ref().unwrap(),
+            &path,
+            offset as u64,
+            chrono::Utc::now() + chrono::Duration::seconds(5),
+        );
+
+        let received = run_file_source(
+            &config,
+            false,
+            Acks,
+            LogNamespace::Legacy,
+            None,
+            sleep_500_millis(),
+        )
+        .await;
+        let lines = extract_messages_string(received);
+        assert_eq!(
+            lines,
+            (5..10).map(|i| format!("line {i}")).collect::<Vec<_>>()
+        );
+    }
+
     #[tokio::test]
     async fn test_fair_reads() {
         let dir = tempdir().unwrap();

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -946,7 +946,7 @@ impl Source {
                 }
             }
 
-            checkpoints.update(line.file_id, line.end_offset);
+            checkpoints.update(line.file_id, line.end_offset, line.generation);
             event
         });
 


### PR DESCRIPTION
## Summary

The `file` source silently drops data when a new file matches the fingerprint of a stale
checkpoint entry. With `fingerprint.strategy: device_and_inode`, this happens whenever an inode
is recycled — e.g. rotated logs pruned by retention, then a new `access.log` created with the
freed inode. The watcher then "resumes" at the stale offset: with an offset beyond the file's
size, nothing is ever emitted until the file grows past it (104 MB in the original report), and
otherwise the head of the file is silently skipped.

Stale entries are easy to hit because they can outlive their file indefinitely: an entry whose
file disappears while Vector is stopped is never expired (`removed_times` is not persisted, and
`set_dead` only runs for live watchers), so `checkpoints.json` accumulates dead `dev_inode`
entries until one collides.

This PR makes checkpoint use defensive at watcher creation, with two complementary checks:

1. **Position beyond EOF** (`FileWatcher::new`): if the stored position is greater than the
   file's current size, warn and read from the beginning. This also covers truncated files,
   for which production code previously had no guard at all.
2. **Checkpoint predating the file** (`FileServer::watch_new_file`): a `DevInode` checkpoint
   whose `modified` timestamp is older than the file's creation time cannot belong to that file
   (progress cannot predate existence) — warn and fall back as if no checkpoint existed. This
   catches collisions even when the new file is already larger than the stale offset.
   Content-based (checksum) fingerprints are exempt, since a recreated file matching the same
   checksum legitimately carries the same identity (and `kubernetes_logs` uses checksum
   fingerprints, so its late-appearing files are unaffected). Filesystems that don't report
   creation times keep the previous behavior.

Neither check adds config; both log a warning when they trigger. The discarded entry is
overwritten by the new watcher's own progress on the next checkpoint write.

### References

Closes: #23076

## Vector configuration

```yaml
data_dir: /data/vector
sources:
  logs:
    type: file
    include: [/data/logs/*/access.log]
    fingerprint: {strategy: device_and_inode}
sinks:
  out:
    type: file
    inputs: [logs]
    path: /data/out/received.ndjson
    encoding: {codec: json}
```

## How did you test this PR?

- Reproduced the issue deterministically on 0.58.0 (details in #23076): write 50k lines,
  checkpoint, prune the file, recreate it with the recycled inode (ext4/overlayfs reuse the
  lowest free inode), restart → `Resuming to watch file … file_position=2438894` on a
  47 KB file, 0/1000 new lines emitted. A restart-free variant (rotate + prune + recreate
  within the 60 s in-memory expiry window) reproduces the same loss.
- With this patch, both scenarios emit 1000/1000 lines, with the new warning logged
  (`Checkpoint predates the file's creation; assuming the inode was reused by a new file and
  discarding the checkpoint.`).
- Added three regression tests in `src/sources/file.rs` (forging `checkpoints.json` entries so
  the tests don't depend on the filesystem actually recycling inodes): position beyond EOF is
  discarded; a `DevInode` checkpoint predating file creation is discarded; a plausible
  checkpoint is still honored.
- `make test FEATURES="sources-file"` (1532 passed), `cargo clippy` on the touched crates and
  on the `vector` tests with `--no-default-features --features sources-file`, `cargo fmt --check`.

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
