### PR TITLE
chore(ci): remove unused macOS bootstrap script

### DIFF
--- a/scripts/environment/bootstrap-macos.sh
+++ b/scripts/environment/bootstrap-macos.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-set -e -o verbose
-
-brew update
-brew install coreutils cue-lang/tap/cue protobuf


### PR DESCRIPTION
## Summary

### Motivation

The macOS bootstrap script is no longer called by CI or other repository tooling. The remaining CI caller was replaced by the shared setup action.

### Changes

- Remove the unused `scripts/environment/bootstrap-macos.sh` script.

## Vector configuration

N/A.

## How did you test this PR?

No runtime tests were needed for this CI-only cleanup. Confirmed that no live in-repository callers remain.

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## Contributor Guidelines

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Before pushing, follow our [pre-push guidance](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#pre-push).
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
