### PR TITLE
chore(lints): remove obsolete clippy allow attributes

### DIFF
--- a/lib/vector-common/src/finalization.rs
+++ b/lib/vector-common/src/finalization.rs
@@ -364,7 +364,6 @@ impl BatchStatus {
     ///
     /// As not every status has the same priority, some updates may end up being a no-op either due to not being any
     /// different or due to being lower priority than the current status.
-    #[allow(clippy::match_same_arms)] // False positive: https://github.com/rust-lang/rust-clippy/issues/860
     fn update(self, status: EventStatus) -> Self {
         match (self, status) {
             // `Dropped` and `Delivered` do not change the status.
@@ -408,7 +407,6 @@ impl EventStatus {
     /// # Panics
     ///
     /// Passing a new status of `Dropped` is a programming error and will panic in debug/test builds.
-    #[allow(clippy::match_same_arms)] // False positive: https://github.com/rust-lang/rust-clippy/issues/860
     #[must_use]
     pub fn update(self, status: Self) -> Self {
         match (self, status) {

--- a/lib/vector-core/src/event/lua/event.rs
+++ b/lib/vector-core/src/event/lua/event.rs
@@ -12,7 +12,6 @@ pub struct LuaEvent {
 }
 
 impl IntoLua for LuaEvent {
-    #![allow(clippy::wrong_self_convention)] // this trait is defined by mlua
     fn into_lua(self, lua: &Lua) -> LuaResult<LuaValue> {
         let table = lua.create_table()?;
         match self.event {

--- a/lib/vector-core/src/event/lua/log.rs
+++ b/lib/vector-core/src/event/lua/log.rs
@@ -3,7 +3,6 @@ use mlua::prelude::*;
 use super::super::{EventMetadata, LogEvent, Value};
 
 impl IntoLua for LogEvent {
-    #![allow(clippy::wrong_self_convention)] // this trait is defined by mlua
     fn into_lua(self, lua: &Lua) -> LuaResult<LuaValue> {
         let (value, _metadata) = self.into_parts();
         value.into_lua(lua)

--- a/lib/vector-core/src/event/lua/metric.rs
+++ b/lib/vector-core/src/event/lua/metric.rs
@@ -23,7 +23,6 @@ pub struct LuaMetricTags {
 }
 
 impl IntoLua for MetricKind {
-    #![allow(clippy::wrong_self_convention)] // this trait is defined by mlua
     fn into_lua(self, lua: &Lua) -> LuaResult<LuaValue> {
         let kind = match self {
             MetricKind::Absolute => "absolute",
@@ -126,7 +125,6 @@ impl IntoLua for LuaMetricTags {
 }
 
 impl IntoLua for LuaMetric {
-    #![allow(clippy::wrong_self_convention)] // this trait is defined by mlua
     fn into_lua(self, lua: &Lua) -> LuaResult<LuaValue> {
         let tbl = lua.create_table()?;
 

--- a/lib/vector-core/src/event/vrl_target.rs
+++ b/lib/vector-core/src/event/vrl_target.rs
@@ -414,7 +414,6 @@ impl Target for VrlTarget {
         }
     }
 
-    #[allow(clippy::redundant_closure_for_method_calls)] // false positive
     fn target_get(&self, target_path: &OwnedTargetPath) -> Result<Option<&Value>, String> {
         match target_path.prefix {
             PathPrefix::Event => match self {

--- a/lib/vector-core/src/lib.rs
+++ b/lib/vector-core/src/lib.rs
@@ -21,7 +21,6 @@
 #![allow(clippy::match_wildcard_for_single_variants)]
 #![allow(clippy::module_name_repetitions)]
 #![allow(clippy::must_use_candidate)] // many false positives in this package
-#![allow(clippy::non_ascii_literal)] // using unicode literals is a-okay in vector
 #![allow(clippy::unnested_or_patterns)] // nightly-only feature as of 1.51.0
 #![allow(clippy::type_complexity)] // long-types happen, especially in async code
 

--- a/src/components/validation/resources/event.rs
+++ b/src/components/validation/resources/event.rs
@@ -92,7 +92,6 @@ pub enum TestEvent {
 }
 
 impl TestEvent {
-    #[allow(clippy::missing_const_for_fn)] // const cannot run destructor
     pub fn into_event(self) -> Event {
         match self {
             Self::Passthrough(event) => event,

--- a/src/components/validation/resources/http.rs
+++ b/src/components/validation/resources/http.rs
@@ -89,7 +89,6 @@ impl HttpResourceConfig {
 }
 
 /// Spawns an HTTP server that a source will make requests to in order to get events.
-#[allow(clippy::missing_const_for_fn)]
 fn spawn_input_http_server(
     config: HttpResourceConfig,
     codec: ResourceCodec,
@@ -298,7 +297,6 @@ pub struct HttpResourceOutputContext<'a> {
 
 impl HttpResourceOutputContext<'_> {
     /// Spawns an HTTP server that accepts events sent by a sink.
-    #[allow(clippy::missing_const_for_fn)]
     fn spawn_output_http_server(&self, config: HttpResourceConfig) -> vector_lib::Result<()> {
         // This HTTP server will wait for events to be sent by a sink, and collect them and send them on
         // via an output sender. We accept/collect events until we're told to shutdown.
@@ -439,7 +437,6 @@ impl HttpResourceOutputContext<'_> {
     }
 
     /// Spawns an HTTP client that pulls events by making requests to an HTTP server driven by a sink.
-    #[allow(clippy::missing_const_for_fn)]
     fn spawn_output_http_client(&self, _config: HttpResourceConfig) {
         // TODO: The `prometheus_exporter` sink is the only sink that exposes an HTTP server which must be
         // scraped... but since we need special logic to aggregate/deduplicate scraped metrics, we can't

--- a/src/config/format.rs
+++ b/src/config/format.rs
@@ -312,10 +312,9 @@ mod tests {
             let output = deserialize(input, format);
             match expected {
                 Ok(expected) => {
-                    #[allow(clippy::expect_fun_call)] // false positive
-                    let output: ConfigBuilder = output.expect(&format!(
-                        "expected Ok, got Err with format {format:?} and input {input:?}"
-                    ));
+                    let output: ConfigBuilder = output.unwrap_or_else(|_| {
+                        panic!("expected Ok, got Err with format {format:?} and input {input:?}")
+                    });
                     let output_json = serde_json::to_value(output).unwrap();
                     let expected_output: ConfigBuilder = deserialize(expected, Format::Toml)
                         .expect("Invalid TOML passed as an expectation");

--- a/src/config/transform.rs
+++ b/src/config/transform.rs
@@ -179,9 +179,6 @@ impl Default for TransformContext {
 }
 
 impl TransformContext {
-    // clippy allow avoids an issue where vrl is flagged off and `globals` is
-    // the sole field in the struct
-    #[allow(clippy::needless_update)]
     pub fn new_with_globals(globals: GlobalOptions) -> Self {
         Self {
             globals,

--- a/src/sinks/aws_kinesis/firehose/integration_tests.rs
+++ b/src/sinks/aws_kinesis/firehose/integration_tests.rs
@@ -119,7 +119,6 @@ async fn firehose_put_records_without_partition_key() {
     let hits = response["hits"]["hits"]
         .as_array()
         .expect("Elasticsearch response does not include hits->hits");
-    #[allow(clippy::needless_collect)] // https://github.com/rust-lang/rust-clippy/issues/6909
     let input = input
         .into_iter()
         .map(|rec| serde_json::to_value(rec.into_log()).unwrap())
@@ -232,7 +231,6 @@ async fn firehose_put_records_with_partition_key() {
     let hits = response["hits"]["hits"]
         .as_array()
         .expect("Elasticsearch response does not include hits->hits");
-    #[allow(clippy::needless_collect)] // https://github.com/rust-lang/rust-clippy/issues/6909
     let input = input
         .into_iter()
         .map(|rec| serde_json::to_value(rec.into_log()).unwrap())

--- a/src/sinks/datadog/traces/request_builder.rs
+++ b/src/sinks/datadog/traces/request_builder.rs
@@ -47,7 +47,6 @@ pub enum RequestBuilderError {
 }
 
 impl RequestBuilderError {
-    #[allow(clippy::missing_const_for_fn)] // const cannot run destructor
     pub fn into_parts(self) -> (&'static str, String, u64) {
         match self {
             Self::FailedToBuild {

--- a/src/sinks/elasticsearch/retry.rs
+++ b/src/sinks/elasticsearch/retry.rs
@@ -67,8 +67,7 @@ enum EsResultItem {
 }
 
 impl EsResultItem {
-    #[allow(clippy::missing_const_for_fn)] // const cannot run destructor
-    fn result(&self) -> &EsIndexResult {
+    const fn result(&self) -> &EsIndexResult {
         match self {
             EsResultItem::Index(r) => r,
             EsResultItem::Create(r) => r,

--- a/src/sinks/loki/sink.rs
+++ b/src/sinks/loki/sink.rs
@@ -490,7 +490,6 @@ pub struct LokiSink {
 
 impl LokiSink {
     #[cfg(test)]
-    #[allow(clippy::missing_const_for_fn)] // const cannot run destructor
     pub fn new(config: LokiConfig, client: HttpClient) -> crate::Result<Self> {
         let validated = config.validate()?;
         Self::from_validated(&config, validated, client)
@@ -499,7 +498,6 @@ impl LokiSink {
     /// Builds the sink from already-validated state. No pure validation is
     /// repeated here: auth, request limits, encoder, confined templates and
     /// batch settings all come from `validated`.
-    #[allow(clippy::missing_const_for_fn)] // const cannot run destructor
     pub fn from_validated(
         config: &LokiConfig,
         validated: ValidatedLokiSink,

--- a/src/sinks/util/batch.rs
+++ b/src/sinks/util/batch.rs
@@ -474,7 +474,6 @@ impl<B> StatefulBatch<B> {
         self.was_full
     }
 
-    #[allow(clippy::missing_const_for_fn)] // const cannot run destructor
     pub fn into_inner(self) -> B {
         self.inner
     }

--- a/src/sinks/util/buffer/partition.rs
+++ b/src/sinks/util/buffer/partition.rs
@@ -76,7 +76,6 @@ impl<T, K> PartitionInnerBuffer<T, K> {
         Self { inner, key }
     }
 
-    #[allow(clippy::missing_const_for_fn)] // const cannot run destructor
     pub fn into_parts(self) -> (T, K) {
         (self.inner, self.key)
     }

--- a/src/sinks/util/request_builder.rs
+++ b/src/sinks/util/request_builder.rs
@@ -54,9 +54,6 @@ where
 }
 
 impl<P> EncodeResult<P> {
-    // Can't be `const` because you can't (yet?) run deconstructors in a const context, which is what this function does
-    // by dropping the (un)compressed sizes.
-    #[allow(clippy::missing_const_for_fn)]
     pub fn into_payload(self) -> P {
         self.payload
     }

--- a/src/sinks/util/uri.rs
+++ b/src/sinks/util/uri.rs
@@ -64,7 +64,6 @@ impl UriSerde {
         })
     }
 
-    #[allow(clippy::missing_const_for_fn)] // constant functions cannot evaluate destructors
     pub fn with_auth(mut self, auth: Option<Auth>) -> Self {
         self.auth = auth;
         self

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -396,17 +396,13 @@ impl SourceConfig for FileConfig {
             // source are only global, name can be used for subdir
             .resolve_and_make_data_subdir(self.data_dir.as_ref(), cx.key.id())?;
 
-        // Clippy rule, because async_trait?
-        #[allow(clippy::suspicious_else_formatting)]
-        {
-            if let Some(ref config) = self.multiline {
-                let _: line_agg::Config = config.try_into()?;
-            }
+        if let Some(ref config) = self.multiline {
+            let _: line_agg::Config = config.try_into()?;
+        }
 
-            if let Some(ref indicator) = self.message_start_indicator {
-                Regex::new(indicator)
-                    .with_context(|_| InvalidMessageStartIndicatorSnafu { indicator })?;
-            }
+        if let Some(ref indicator) = self.message_start_indicator {
+            Regex::new(indicator)
+                .with_context(|_| InvalidMessageStartIndicatorSnafu { indicator })?;
         }
 
         let acknowledgements = cx.do_acknowledgements(self.acknowledgements);

--- a/src/sources/gcp_pubsub.rs
+++ b/src/sources/gcp_pubsub.rs
@@ -68,10 +68,6 @@ const ACK_QUEUE_SIZE: usize = 8;
 
 type Finalizer = UnorderedFinalizer<Vec<String>>;
 
-// prost emits some generated code that includes clones on `Arc`
-// objects, which causes a clippy ding on this block. We don't
-// directly control the generated code, so allow this lint here.
-#[allow(clippy::clone_on_ref_ptr)]
 // https://github.com/hyperium/tonic/issues/1350
 #[allow(clippy::missing_const_for_fn)]
 #[allow(warnings)]

--- a/src/sources/host_metrics/mod.rs
+++ b/src/sources/host_metrics/mod.rs
@@ -555,7 +555,10 @@ where
     filter_result_sync(result, message)
 }
 
-#[allow(clippy::missing_const_for_fn)]
+#[expect(
+    clippy::missing_const_for_fn,
+    reason = "#[cfg(linux)] calls non-const methods"
+)]
 fn init_roots() {
     #[cfg(target_os = "linux")]
     {

--- a/src/sources/host_metrics/mod.rs
+++ b/src/sources/host_metrics/mod.rs
@@ -555,9 +555,12 @@ where
     filter_result_sync(result, message)
 }
 
-#[expect(
-    clippy::missing_const_for_fn,
-    reason = "#[cfg(linux)] calls non-const methods"
+#[cfg_attr(
+    not(target_os = "linux"),
+    expect(
+        clippy::missing_const_for_fn,
+        reason = "#[cfg(linux)] calls non-const methods"
+    )
 )]
 fn init_roots() {
     #[cfg(target_os = "linux")]

--- a/src/sources/util/http/prelude.rs
+++ b/src/sources/util/http/prelude.rs
@@ -145,8 +145,6 @@ pub trait HttpSource: Clone + Send + Sync + 'static {
                 HttpMethod::Options => warp::options().boxed(),
             };
 
-            // https://github.com/rust-lang/rust-clippy/issues/8148
-            #[allow(clippy::unnecessary_to_owned)]
             for s in path.split('/').filter(|&x| !x.is_empty()) {
                 filter = filter.and(warp::path(s.to_string())).boxed()
             }

--- a/src/transforms/reduce/merge_strategy.rs
+++ b/src/transforms/reduce/merge_strategy.rs
@@ -87,8 +87,7 @@ struct RetainMerger {
 }
 
 impl RetainMerger {
-    #[allow(clippy::missing_const_for_fn)] // const cannot run destructor
-    fn new(v: Value) -> Self {
+    const fn new(v: Value) -> Self {
         Self { v }
     }
 }

--- a/src/utilization.rs
+++ b/src/utilization.rs
@@ -59,7 +59,6 @@ impl<S> Utilization<S> {
     ///
     /// This can't be constant because destructors can't be run in a const context, and we're
     /// discarding `IntervalStream`/`Timer` when we call this.
-    #[allow(clippy::missing_const_for_fn)]
     pub(crate) fn into_inner(self) -> S {
         self.inner
     }


### PR DESCRIPTION
## Summary

Removes clippy `#[allow]`/`#![allow]` attributes that are no longer needed (fixed or no-longer-triggering lints) across 24 files. No behavior changes.

### References

NA

## Vector configuration

NA

## How did you test this PR?

NA — lint-attribute removal only; no functional changes.

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## Contributor Guidelines

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Before pushing, follow our [pre-push guidance](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#pre-push).
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
