### PR TITLE
chore(vector-common): remove match arm lint allows

### DIFF
--- a/lib/vector-common/src/finalization.rs
+++ b/lib/vector-common/src/finalization.rs
@@ -364,7 +364,6 @@ impl BatchStatus {
     ///
     /// As not every status has the same priority, some updates may end up being a no-op either due to not being any
     /// different or due to being lower priority than the current status.
-    #[allow(clippy::match_same_arms)] // False positive: https://github.com/rust-lang/rust-clippy/issues/860
     fn update(self, status: EventStatus) -> Self {
         match (self, status) {
             // `Dropped` and `Delivered` do not change the status.
@@ -408,7 +407,6 @@ impl EventStatus {
     /// # Panics
     ///
     /// Passing a new status of `Dropped` is a programming error and will panic in debug/test builds.
-    #[allow(clippy::match_same_arms)] // False positive: https://github.com/rust-lang/rust-clippy/issues/860
     #[must_use]
     pub fn update(self, status: Self) -> Self {
         match (self, status) {


### PR DESCRIPTION
## Summary

Remove two obsolete `clippy::match_same_arms` suppressions from finalization status updates. Current Clippy accepts both match expressions without the historical false-positive workaround.

### References

Related: #23659

## Vector configuration

Not applicable; this is a lint-suppression cleanup with no runtime behavior change.

## How did you test this PR?

- `cargo clippy --package vector-common --all-targets`
- `cargo test --package vector-common finalization`
- `cargo fmt --all -- --check`
- `git diff --check`

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## Contributor Guidelines

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Before pushing, follow our [pre-push guidance](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#pre-push).
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.