### PR TITLE
Log Elasticsearch bulk rejections at debug with per-item error details.

### DIFF
--- a/changelog.d/elasticsearch_log_rejected_events.enhancement.md
+++ b/changelog.d/elasticsearch_log_rejected_events.enhancement.md
@@ -1,0 +1,3 @@
+The `elasticsearch` sink now logs each individually rejected bulk-API event at debug level, including Elasticsearch error type, reason, per-item status, and the original event.
+
+authors: benmali

--- a/src/sinks/elasticsearch/service.rs
+++ b/src/sinks/elasticsearch/service.rs
@@ -194,17 +194,72 @@ impl Service<ElasticsearchRequest> for ElasticsearchService {
         let mut http_service = self.batch_service.clone();
         Box::pin(async move {
             http_service.ready().await?;
+            let original_events = std::mem::take(&mut req.original_events);
             let events_byte_size =
                 std::mem::take(req.metadata_mut()).into_events_estimated_json_encoded_byte_size();
             let http_response = http_service.call(req).await?;
 
             let event_status = get_event_status(&http_response);
+            if event_status == EventStatus::Rejected {
+                log_failed_events(&http_response, &original_events);
+            }
             Ok(ElasticsearchResponse {
                 event_status,
                 http_response,
                 events_byte_size,
             })
         })
+    }
+}
+
+/// When log level is set to debug, logs each event that was individually rejected by Elasticsearch,
+/// along with the ES error type, reason, and per-item status code. Parses the bulk API response
+/// items array and correlates each failed item back to the corresponding original event by index.
+fn log_failed_events(response: &Response<Bytes>, original_events: &[ProcessedEvent]) {
+    if !tracing::enabled!(tracing::Level::DEBUG) {
+        return;
+    }
+    let body = String::from_utf8_lossy(response.body());
+    let parsed = match serde_json::from_str::<serde_json::Value>(&body) {
+        Ok(v) => v,
+        Err(_) => return,
+    };
+    let items = match parsed.get("items").and_then(|v| v.as_array()) {
+        Some(arr) => arr,
+        None => return,
+    };
+    for (i, item) in items.iter().enumerate() {
+        let result = item
+            .get("index")
+            .or_else(|| item.get("create"))
+            .or_else(|| item.get("update"));
+        let result = match result {
+            Some(r) => r,
+            None => continue,
+        };
+        let error = match result.get("error") {
+            Some(e) => e,
+            None => continue,
+        };
+        let error_type = error
+            .get("type")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown");
+        let error_reason = error
+            .get("reason")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown");
+        let es_status = result.get("status").and_then(|v| v.as_u64()).unwrap_or(0);
+
+        if let Some(event) = original_events.get(i) {
+            debug!(
+                message = "Elasticsearch rejected event.",
+                error_type = error_type,
+                error_reason = error_reason,
+                es_status = es_status,
+                event = ?event.log,
+            );
+        }
     }
 }
 


### PR DESCRIPTION
  ## Summary
  This PR improves debug logs for the `elasticsearch` sink.
  When Elasticsearch rejects some events in a bulk request, Vector already marks the batch
  as rejected. Before this change, you did not see *which* event failed or *why*.
  Now, if log level is `debug`, Vector reads the bulk API `items` list and logs each failed
  event. Each log line includes:
  - Elasticsearch error type
  - error reason
  - per-item HTTP status
  - the original event
  Successful items are not logged. If the response body is not JSON, Vector skips this extra
  logging.
  There is no new config field. You only need debug logs to see the extra detail.
  Changelog file: `changelog.d/elasticsearch_log_rejected_events.enhancement.md`
  ### References
  <!-- Closes: <#issue/#PR or full link> -->
  <!-- Related: <#issue/#PR or full link> -->
  ## Vector configuration
  ```yaml
  sources:
    demo:
      type: demo_logs
      format: json

  sinks:
    es:
      type: elasticsearch
      inputs:
        • demo

      endpoints:
        • http://localhost:9200

      bulk:
        index: vector-logs

  Run Vector with debug logs, for example:
  ```bash
  VECTOR_LOG=debug vector --config vector.yaml
  ```
  ## How did you test this PR?
  - Reviewed the bulk response handling in `src/sinks/elasticsearch/service.rs`. The new
  `log_failed_events` helper matches failed `index` / `create` / `update` items to the
  original events by index.
  - Added a changelog fragment for the extra debug logs.
  - Local setup: Rust Vector build with the `elasticsearch` sink. Debug logging is gated
  with `tracing::enabled!(DEBUG)`, so this path does no extra work at info/warn.
  This PR does not add new unit tests. Existing Elasticsearch sink retry/partial-failure
  tests still cover the request path; this change only adds debug logging.
  ## Does this PR include user facing changes?
  - [x] Yes. Please add a changelog fragment based on our
  [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
  - [ ] No. A maintainer will apply the `no-changelog` label to this PR.
  This is user facing because operators get more detail in debug logs when Elasticsearch
  rejects events. Config fields and metrics are unchanged.
  ## Contributor Guidelines
  - Please read our [Vector contributor
  resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
  - Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
  - Before pushing, follow our [pre-push
  guidance](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#pre-push).
  - After a review is requested, please avoid force pushes to help us review incrementally.
    - Feel free to push as many commits as you want. They will be squashed into one before
  merging.
    - For example, you can run `git merge origin master` and `git push`.