### PR TITLE
style: enforce and satisfy clippy::uninlined_format_args

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,6 +144,7 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tokio_unstable)', 'cfg(dds
 string_slice = "warn"
 await_holding_lock = "warn"
 let_underscore_must_use = "warn"
+uninlined_format_args = "warn"
 
 [workspace.dependencies]
 antithesis-instrumentation = { version = "0.1", default-features = false, features = [] }

--- a/benches/batch.rs
+++ b/benches/batch.rs
@@ -51,7 +51,7 @@ fn benchmark_batch(c: &mut Criterion) {
                         PartitionedBuffer::new(batch.size, *compression),
                         Duration::from_secs(1),
                     )
-                    .sink_map_err(|error| panic!("{}", error));
+                    .sink_map_err(|error| panic!("{error}"));
 
                     (
                         rt,
@@ -81,7 +81,7 @@ fn benchmark_batch(c: &mut Criterion) {
                         Buffer::new(batch.size, *compression),
                         Duration::from_secs(1),
                     )
-                    .sink_map_err(|error| panic!("{}", error));
+                    .sink_map_err(|error| panic!("{error}"));
 
                     (
                         rt,

--- a/benches/http.rs
+++ b/benches/http.rs
@@ -104,7 +104,7 @@ fn serve(addr: SocketAddr) -> Runtime {
 
         Server::bind(&addr)
             .serve(make_service)
-            .map_err(|e| panic!("{}", e))
+            .map_err(|e| panic!("{e}"))
             .await
     });
     rt

--- a/lib/codecs/src/decoding/format/influxdb.rs
+++ b/lib/codecs/src/decoding/format/influxdb.rs
@@ -126,7 +126,7 @@ impl Deserializer for InfluxdbDeserializer {
                         };
                         Some(Event::Metric(
                             Metric::new(
-                                format!("{0}_{1}", measurement, f.0),
+                                format!("{measurement}_{}", f.0),
                                 MetricKind::Absolute,
                                 MetricValue::Gauge { value: val },
                             )

--- a/lib/codecs/src/decoding/format/otlp.rs
+++ b/lib/codecs/src/decoding/format/otlp.rs
@@ -466,8 +466,7 @@ mod tests {
         if let Some(timestamp_key) = log_schema().timestamp_key_target_path() {
             assert!(
                 trace.get(timestamp_key).is_none(),
-                "Trace event should not have spurious timestamp field '{}' injected when using LogNamespace::Legacy",
-                timestamp_key
+                "Trace event should not have spurious timestamp field '{timestamp_key}' injected when using LogNamespace::Legacy"
             );
         }
 

--- a/lib/codecs/src/encoding/chunking/gelf.rs
+++ b/lib/codecs/src/encoding/chunking/gelf.rs
@@ -43,8 +43,7 @@ impl Chunking for GelfChunker {
 
         if chunk_count > GELF_MAX_TOTAL_CHUNKS {
             return Err(vector_common::Error::from(format!(
-                "Too many chunks to generate for GELF: {}, max: {}",
-                chunk_count, GELF_MAX_TOTAL_CHUNKS
+                "Too many chunks to generate for GELF: {chunk_count}, max: {GELF_MAX_TOTAL_CHUNKS}"
             )));
         }
 

--- a/lib/codecs/src/encoding/format/cef.rs
+++ b/lib/codecs/src/encoding/format/cef.rs
@@ -326,14 +326,12 @@ impl Encoder<Event> for CefSerializer {
         }
 
         buffer.write_fmt(format_args!(
-            "CEF:{}|{}|{}|{}|{}|{}|{}",
+            "CEF:{}|{}|{}|{}|{}|{name}|{severity}",
             &self.version,
             &self.device.vendor,
             &self.device.product,
             &self.device.version,
             &self.device.event_class_id,
-            name,
-            severity,
         ))?;
         if !formatted_extensions.is_empty() {
             formatted_extensions.sort();

--- a/lib/codecs/src/encoding/format/parquet.rs
+++ b/lib/codecs/src/encoding/format/parquet.rs
@@ -570,9 +570,8 @@ mod tests {
     fn write_temp_schema(name: &str, content: &str) -> std::path::PathBuf {
         use std::io::Write;
         let path = std::env::temp_dir().join(format!(
-            "vector_parquet_test_{}_{}.schema",
+            "vector_parquet_test_{}_{name}.schema",
             std::process::id(),
-            name,
         ));
         let mut f = std::fs::File::create(&path).expect("Failed to create schema file");
         write!(f, "{content}").expect("Failed to write schema");
@@ -661,15 +660,14 @@ mod tests {
             let mut buffer = BytesMut::new();
             serializer
                 .encode(events.clone(), &mut buffer)
-                .unwrap_or_else(|e| panic!("Encoding with {:?} failed: {}", compression, e));
+                .unwrap_or_else(|e| panic!("Encoding with {compression:?} failed: {e}"));
 
             let data = buffer.freeze();
             assert_parquet_magic(&data);
             assert_eq!(
                 parquet_row_count(&data),
                 1,
-                "Wrong row count for {:?}",
-                compression
+                "Wrong row count for {compression:?}"
             );
         }
     }

--- a/lib/codecs/src/encoding/format/syslog.rs
+++ b/lib/codecs/src/encoding/format/syslog.rs
@@ -401,7 +401,7 @@ struct Tag {
 impl Tag {
     fn encode_rfc_3164(&self) -> String {
         let mut tag = if let Some(proc_id) = self.proc_id.as_deref() {
-            format!("{}[{}]:", self.app_name, proc_id)
+            format!("{}[{proc_id}]:", self.app_name)
         } else {
             format!("{}:", self.app_name)
         };
@@ -418,7 +418,7 @@ impl Tag {
     fn encode_rfc_5424(&self) -> String {
         let proc_id_str = self.proc_id.as_deref().unwrap_or(NIL_VALUE);
         let msg_id_str = self.msg_id.as_deref().unwrap_or(NIL_VALUE);
-        format!("{} {} {}", self.app_name, proc_id_str, msg_id_str)
+        format!("{} {proc_id_str} {msg_id_str}", self.app_name)
     }
 }
 
@@ -502,7 +502,7 @@ fn flatten_object(obj: ObjectMap, prefix: String, result: &mut BTreeMap<String, 
                 if let Ok(json) = serde_json::to_string(&arr) {
                     result.insert(full_key, json);
                 } else {
-                    result.insert(full_key, format!("{:?}", arr));
+                    result.insert(full_key, format!("{arr:?}"));
                 }
             }
             scalar => {
@@ -1172,7 +1172,7 @@ mod tests {
 
         let output = run_encode(config, Event::Log(log));
         let expected_id = "a".repeat(32);
-        assert!(output.contains(&format!("[{}", expected_id)));
+        assert!(output.contains(&format!("[{expected_id}")));
         assert!(!output.contains(&format!("[{}", "a".repeat(50))));
     }
 
@@ -1214,7 +1214,7 @@ mod tests {
         assert!(output.contains("app_"));
 
         let expected_sd_id: String = "_".repeat(32);
-        assert!(output.contains(&format!("[{}", expected_sd_id)));
+        assert!(output.contains(&format!("[{expected_sd_id}")));
     }
 
     #[test]

--- a/lib/dnsmsg-parser/src/dns_message_parser.rs
+++ b/lib/dnsmsg-parser/src/dns_message_parser.rs
@@ -257,7 +257,7 @@ impl DnsMessageParser {
             port_string
         };
         Ok((
-            Some(format!("{} {} {}", address, protocol, port.trim_end())),
+            Some(format!("{address} {protocol} {}", port.trim_end())),
             None,
         ))
     }
@@ -549,11 +549,10 @@ impl DnsMessageParser {
                 let crl = BASE64.encode(&cert.cert_data);
                 Ok((
                     Some(format!(
-                        "{} {} {} {}",
+                        "{} {} {} {crl}",
                         u16::from(cert.cert_type),
                         cert.key_tag,
-                        cert.algorithm,
-                        crl
+                        cert.algorithm
                     )),
                     None,
                 ))
@@ -873,7 +872,7 @@ fn format_svcb_record(svcb: &SVCB, options: &DnsParserOptions) -> String {
         svcb.target_name.to_string_with_options(options),
         svcb.svc_params
             .iter()
-            .map(|(key, value)| format!(r#"{}="{}""#, key, value.to_string().trim_end_matches(',')))
+            .map(|(key, value)| format!(r#"{key}="{}""#, value.to_string().trim_end_matches(',')))
             .collect::<Vec<_>>()
             .join(" ")
     )
@@ -1086,11 +1085,10 @@ fn parse_loc_rdata_coordinates(coordinates: u32, dir: &str) -> String {
     let second = minute.fract() * 60.0;
 
     format!(
-        "{} {} {:.3} {}",
+        "{} {} {:.3} {dir}",
         degree.trunc().abs(),
         minute.trunc().abs(),
-        second.abs(),
-        dir
+        second.abs()
     )
 }
 
@@ -1111,8 +1109,7 @@ fn parse_character_string(decoder: &mut BinDecoder<'_>) -> DnsParserResult<Strin
         Ok(verified_text) => Ok(String::from_utf8_lossy(verified_text).to_string()),
         Err(raw_data) => Err(DnsMessageParserError::SimpleError {
             cause: format!(
-                "Unexpected data length: expected {}, got {}. Raw data {}",
-                len,
+                "Unexpected data length: expected {len}, got {}. Raw data {}",
                 raw_data.len(),
                 format_bytes_as_hex_string(raw_data)
             ),

--- a/lib/docs-renderer/src/main.rs
+++ b/lib/docs-renderer/src/main.rs
@@ -72,7 +72,7 @@ fn main() -> Result<()> {
                 "Failed to render the '{component_name}' component schema."
             ))?;
             rendered_component_schemas.insert(
-                format!("{}s/base/{}", base_component_type.as_str(), component_name),
+                format!("{}s/base/{component_name}", base_component_type.as_str()),
                 rendered_component_schema,
             );
         }

--- a/lib/file-source-common/src/buffer.rs
+++ b/lib/file-source-common/src/buffer.rs
@@ -397,14 +397,14 @@ mod test {
             // We want (delimiter_len - 1) bytes before boundary, then 1 byte after
             let line_content = if bytes_until_boundary > delimiter_len {
                 let content_len = bytes_until_boundary - (delimiter_len - 1);
-                format!("line{:0width$}", i, width = content_len.saturating_sub(4)).into_bytes()
+                format!("line{i:0width$}", width = content_len.saturating_sub(4)).into_bytes()
             } else {
                 // Not enough room in this buffer, pad to next boundary
                 let padding = bytes_until_boundary;
                 let extra_content = buffer_capacity - (delimiter_len - 1);
                 let mut content = vec![b'X'; padding];
                 content.extend_from_slice(
-                    format!("L{:0width$}", i, width = extra_content.saturating_sub(1)).as_bytes(),
+                    format!("L{i:0width$}", width = extra_content.saturating_sub(1)).as_bytes(),
                 );
                 content
             };
@@ -436,16 +436,14 @@ mod test {
             assert_eq!(
                 buffer.as_ref(),
                 expected_line.as_slice(),
-                "Line {} should match expected content. Got: {:?}, Expected: {:?}",
-                i,
+                "Line {i} should match expected content. Got: {:?}, Expected: {:?}",
                 String::from_utf8_lossy(&buffer),
                 String::from_utf8_lossy(expected_line)
             );
 
             assert!(
                 result.successfully_read.is_some(),
-                "Should find delimiter for line {}",
-                i
+                "Should find delimiter for line {i}"
             );
         }
     }

--- a/lib/file-source/src/file_server.rs
+++ b/lib/file-source/src/file_server.rs
@@ -577,7 +577,7 @@ fn scale(bytes: u64) -> String {
         bytes /= 1000.0;
         i += 1;
     }
-    format!("{:.3}{}/sec", bytes, units[i])
+    format!("{bytes:.3}{}/sec", units[i])
 }
 
 impl Default for TimingStats {

--- a/lib/k8s-e2e-tests/src/lib.rs
+++ b/lib/k8s-e2e-tests/src/lib.rs
@@ -265,7 +265,7 @@ where
 {
     let mut lines_till_we_give_up = 10000;
     while let Some(line) = log_reader.read_line().await {
-        debug!("Got line: {:?}", line);
+        debug!("Got line: {line:?}");
 
         lines_till_we_give_up -= 1;
         if lines_till_we_give_up <= 0 {

--- a/lib/k8s-e2e-tests/tests/vector-agent.rs
+++ b/lib/k8s-e2e-tests/tests/vector-agent.rs
@@ -896,7 +896,7 @@ async fn pod_filtering() -> Result<(), Box<dyn std::error::Error>> {
             Some(line) => line,
             None => break,
         };
-        debug!("Got line: {:?}", line);
+        debug!("Got line: {line:?}");
 
         lines_till_we_give_up -= 1;
         if lines_till_we_give_up == 0 {
@@ -1119,7 +1119,7 @@ async fn custom_selectors() -> Result<(), Box<dyn std::error::Error>> {
             Some(line) => line,
             None => break,
         };
-        debug!("Got line: {:?}", line);
+        debug!("Got line: {line:?}");
 
         lines_till_we_give_up -= 1;
         if lines_till_we_give_up == 0 {
@@ -1300,7 +1300,7 @@ async fn container_filtering() -> Result<(), Box<dyn std::error::Error>> {
             Some(line) => line,
             None => break,
         };
-        debug!("Got line: {:?}", line);
+        debug!("Got line: {line:?}");
 
         lines_till_we_give_up -= 1;
         if lines_till_we_give_up == 0 {
@@ -1486,7 +1486,7 @@ async fn glob_pattern_filtering() -> Result<(), Box<dyn std::error::Error>> {
             Some(line) => line,
             None => break,
         };
-        debug!("Got line: {:?}", line);
+        debug!("Got line: {line:?}");
 
         lines_till_we_give_up -= 1;
         if lines_till_we_give_up == 0 {
@@ -1640,7 +1640,7 @@ async fn multiple_ns() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut test_pods = vec![];
     for ns in &expected_namespaces {
-        debug!("creating {}", ns);
+        debug!("creating {ns}");
         let test_pod = framework
             .test_pod(test_pod::Config::from_pod(&make_test_pod_with_affinity(
                 ns,

--- a/lib/k8s-test-framework/src/reader.rs
+++ b/lib/k8s-test-framework/src/reader.rs
@@ -50,7 +50,7 @@ impl Reader {
         match result {
             Ok(0) => None,
             Ok(_) => Some(s),
-            Err(err) => panic!("{}", err),
+            Err(err) => panic!("{err}"),
         }
     }
 }

--- a/lib/tracing-limit/src/lib.rs
+++ b/lib/tracing-limit/src/lib.rs
@@ -444,10 +444,10 @@ enum TraceValue {
 impl fmt::Display for TraceValue {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            TraceValue::String(s) => write!(f, "{}", s),
-            TraceValue::Int(i) => write!(f, "{}", i),
-            TraceValue::Uint(u) => write!(f, "{}", u),
-            TraceValue::Bool(b) => write!(f, "{}", b),
+            TraceValue::String(s) => write!(f, "{s}"),
+            TraceValue::Int(i) => write!(f, "{i}"),
+            TraceValue::Uint(u) => write!(f, "{u}"),
+            TraceValue::Bool(b) => write!(f, "{b}"),
         }
     }
 }

--- a/lib/vector-buffers/examples/buffer_perf.rs
+++ b/lib/vector-buffers/examples/buffer_perf.rs
@@ -268,8 +268,7 @@ where
     let variant = match buffer_type {
         "in-memory" => {
             info!(
-                "[buffer-perf] creating in-memory v2 buffer with max_events={}, in blocking mode",
-                max_size_events
+                "[buffer-perf] creating in-memory v2 buffer with max_events={max_size_events}, in blocking mode"
             );
             BufferType::Memory {
                 size: MemoryBufferSize::MaxEvents(max_size_events),
@@ -278,8 +277,7 @@ where
         }
         "disk-v2" => {
             info!(
-                "[buffer-perf] creating disk v2 buffer with max_size={}, in blocking mode",
-                max_size_bytes
+                "[buffer-perf] creating disk v2 buffer with max_size={max_size_bytes}, in blocking mode"
             );
             BufferType::DiskV2 {
                 max_size: max_size_bytes,
@@ -313,8 +311,7 @@ async fn main() {
     let write_total_records = config.write_total_records;
     let write_batch_size = config.write_batch_size;
     debug!(
-        "[buffer-perf] going to write {} records, with a write batch size of {} record(s), and read {} records",
-        write_total_records, write_batch_size, read_total_records
+        "[buffer-perf] going to write {write_total_records} records, with a write batch size of {write_batch_size} record(s), and read {read_total_records} records"
     );
 
     let record_cache = generate_record_cache(config.min_record_size, config.max_record_size);
@@ -342,9 +339,8 @@ async fn main() {
     let buffer_delta = buffer_start.elapsed();
 
     info!(
-        "[buffer-perf] {:?}s: created/loaded buffer in {:?}",
-        start.elapsed().as_secs(),
-        buffer_delta
+        "[buffer-perf] {:?}s: created/loaded buffer in {buffer_delta:?}",
+        start.elapsed().as_secs()
     );
 
     let (writer_tx, mut writer_rx) = oneshot::channel();
@@ -461,7 +457,7 @@ async fn main() {
                 let write_pos = write_position.load(Ordering::Relaxed);
                 let read_pos = read_position.load(Ordering::Relaxed);
 
-                info!("[buffer-perf] {:?}s: writer pos = {:11}, reader pos = {:11}", elapsed.as_secs(), write_pos, read_pos);
+                info!("[buffer-perf] {:?}s: writer pos = {write_pos:11}, reader pos = {read_pos:11}", elapsed.as_secs());
             },
             else => break,
         }
@@ -473,8 +469,7 @@ async fn main() {
     let write_pos = write_position.load(Ordering::Relaxed);
 
     info!(
-        "[buffer-perf] writer and reader done: {} records written and {} records read in {:?}",
-        write_pos, read_pos, total_time
+        "[buffer-perf] writer and reader done: {write_pos} records written and {read_pos} records read in {total_time:?}"
     );
 
     info!("[buffer-perf] writer summary:");
@@ -487,7 +482,7 @@ async fn main() {
     info!("       q=min -> {:?}", nanos_to_dur(writer_histo.min()));
     for q in &[0.5, 0.95, 0.99, 0.999, 0.9999] {
         let latency = writer_histo.value_at_quantile(*q);
-        info!("       q={} -> {:?}", q, nanos_to_dur(latency));
+        info!("       q={q} -> {:?}", nanos_to_dur(latency));
     }
     info!("       q=max -> {:?}", nanos_to_dur(writer_histo.max()));
 
@@ -501,7 +496,7 @@ async fn main() {
     info!("       q=min -> {:?}", nanos_to_dur(reader_histo.min()));
     for q in &[0.5, 0.95, 0.99, 0.999, 0.9999] {
         let latency = reader_histo.value_at_quantile(*q);
-        info!("       q={} -> {:?}", q, nanos_to_dur(latency));
+        info!("       q={q} -> {:?}", nanos_to_dur(latency));
     }
     info!("       q=max -> {:?}", nanos_to_dur(reader_histo.max()));
 }

--- a/lib/vector-buffers/src/test/messages.rs
+++ b/lib/vector-buffers/src/test/messages.rs
@@ -174,8 +174,7 @@ impl FixedEncodable for SizedRecord {
         let minimum_len = self.encoded_len();
         if buffer.remaining_mut() < minimum_len {
             return Err(io::Error::other(format!(
-                "not enough capacity to encode record: need {}, only have {}",
-                minimum_len,
+                "not enough capacity to encode record: need {minimum_len}, only have {}",
                 buffer.remaining_mut()
             )));
         }

--- a/lib/vector-buffers/src/variants/disk_v2/tests/mod.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/tests/mod.rs
@@ -142,16 +142,14 @@ macro_rules! assert_reader_writer_v2_file_positions {
         assert_eq!(
             u16::try_from($reader).expect("Reader value is out of range"),
             reader,
-            "expected reader file ID of {}, got {} instead",
-            ($reader),
-            reader
+            "expected reader file ID of {}, got {reader} instead",
+            ($reader)
         );
         assert_eq!(
             u16::try_from($writer).expect("Writer value is out of range"),
             writer,
-            "expected writer file ID of {}, got {} instead",
-            ($writer),
-            writer
+            "expected writer file ID of {}, got {writer} instead",
+            ($writer)
         );
     }};
 }
@@ -163,13 +161,13 @@ macro_rules! assert_reader_last_writer_next_positions {
         let writer_actual = $ledger.state().get_next_writer_record_id();
         assert_eq!(
             $reader_expected, reader_actual,
-            "expected reader last read record ID of {}, got {} instead",
-            $reader_expected, reader_actual,
+            "expected reader last read record ID of {}, got {reader_actual} instead",
+            $reader_expected,
         );
         assert_eq!(
             $writer_expected, writer_actual,
-            "expected writer next record ID of {}, got {} instead",
-            $writer_expected, writer_actual,
+            "expected writer next record ID of {}, got {writer_actual} instead",
+            $writer_expected,
         );
     }};
 }

--- a/lib/vector-buffers/src/variants/disk_v2/tests/model/mod.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/tests/model/mod.rs
@@ -560,10 +560,8 @@ impl WriterModel {
         match self.record_writer.archive_record(1, record) {
             Ok(token) => token.serialized_len() as u64,
             Err(e) => panic!(
-                "unexpected encode error: archived_len={} max_record_size={} error={:?}",
-                record_len,
+                "unexpected encode error: archived_len={record_len} max_record_size={} error={e:?}",
                 self.ledger.config().max_record_size,
-                e,
             ),
         }
     }

--- a/lib/vector-buffers/src/variants/disk_v2/writer.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/writer.rs
@@ -604,8 +604,7 @@ where
         if serialized_len <= 8 || self.ser_buf.len() != serialized_len {
             return Err(WriterError::InconsistentState {
                 reason: format!(
-                    "serializer position invalid after serializing record: pos={} len={}",
-                    serialized_len,
+                    "serializer position invalid after serializing record: pos={serialized_len} len={}",
                     self.ser_buf.len(),
                 ),
             });

--- a/lib/vector-common/src/event_data_eq.rs
+++ b/lib/vector-common/src/event_data_eq.rs
@@ -19,8 +19,8 @@ macro_rules! assert_event_data_eq {
                     "assertion failed: {}\n\n{}\n",
                     $message,
                     similar_asserts::SimpleDiff::from_str(
-                        format!("{:#?}", left).as_str(),
-                        format!("{:#?}", right).as_str(),
+                        format!("{left:#?}").as_str(),
+                        format!("{right:#?}").as_str(),
                         "left",
                         "right"
                     ),

--- a/lib/vector-common/src/shutdown.rs
+++ b/lib/vector-common/src/shutdown.rs
@@ -318,10 +318,7 @@ impl SourceShutdownCoordinator {
                     shutdown_force_trigger.into_inner().disable();
                     true
                 } else {
-                    error!(
-                        "Source '{}' failed to shutdown before deadline. Forcing shutdown.",
-                        id,
-                    );
+                    error!("Source '{id}' failed to shutdown before deadline. Forcing shutdown.");
                     shutdown_force_trigger.into_inner().cancel();
                     false
                 }

--- a/lib/vector-config/src/schema/visitors/unevaluated.rs
+++ b/lib/vector-config/src/schema/visitors/unevaluated.rs
@@ -42,9 +42,8 @@ impl Visitor for DisallowUnevaluatedPropertiesVisitor {
         let eligible_to_flatten = build_closed_schema_flatten_eligibility_mappings(root);
 
         debug!(
-            "Found {} referents eligible for flattening: {:?}",
+            "Found {} referents eligible for flattening: {eligible_to_flatten:?}",
             eligible_to_flatten.len(),
-            eligible_to_flatten,
         );
 
         self.eligible_to_flatten = eligible_to_flatten;
@@ -233,22 +232,16 @@ fn build_closed_schema_flatten_eligibility_mappings(
             Schema::Object(schema) => schema,
         };
 
-        debug!(
-            "Evaluating schema definition '{}' for markability.",
-            definition_name
-        );
+        debug!("Evaluating schema definition '{definition_name}' for markability.");
 
         // If a schema itself would not be considered markable, then we don't need to consider the
         // eligibility between parent/child since there's nothing to drive the "now unmark the child
         // schemas" logic.
         if !is_markable_schema(&root_schema.definitions, parent_schema) {
-            debug!("Schema definition '{}' not markable.", definition_name);
+            debug!("Schema definition '{definition_name}' not markable.");
             continue;
         } else {
-            debug!(
-                "Schema definition '{}' markable. Collecting referents.",
-                definition_name
-            );
+            debug!("Schema definition '{definition_name}' markable. Collecting referents.");
         }
 
         // Collect all referents for this definition, which includes both property-based referents
@@ -258,10 +251,8 @@ fn build_closed_schema_flatten_eligibility_mappings(
         get_referents(parent_schema, &mut referents);
 
         debug!(
-            "Collected {} referents for '{}': {:?}",
-            referents.len(),
-            definition_name,
-            referents
+            "Collected {} referents for '{definition_name}': {referents:?}",
+            referents.len()
         );
 
         // Store the parent/child mapping.
@@ -359,10 +350,7 @@ fn is_markable_schema(definitions: &Map<String, Schema>, schema: &SchemaObject) 
                 })
                 .and_then(|(name, schema)| schema.as_object().map(|schema| (name, schema)))
                 .is_some_and(|(name, schema)| {
-                    debug!(
-                        "Following schema reference '{}' for subschema markability.",
-                        name
-                    );
+                    debug!("Following schema reference '{name}' for subschema markability.");
                     is_markable_schema(definitions, schema)
                 })
         });

--- a/lib/vector-core/src/event/lua/event.rs
+++ b/lib/vector-core/src/event/lua/event.rs
@@ -88,8 +88,7 @@ mod test {
         for assertion in assertions {
             assert!(
                 lua.load(assertion).eval::<bool>().expect(assertion),
-                "{}",
-                assertion
+                "{assertion}"
             );
         }
     }

--- a/lib/vector-core/src/event/lua/log.rs
+++ b/lib/vector-core/src/event/lua/log.rs
@@ -48,7 +48,7 @@ mod test {
                 .load(assertion)
                 .eval()
                 .unwrap_or_else(|_| panic!("Failed to verify assertion {assertion:?}"));
-            assert!(result, "{}", assertion);
+            assert!(result, "{assertion}");
         }
     }
 

--- a/lib/vector-core/src/event/lua/metric.rs
+++ b/lib/vector-core/src/event/lua/metric.rs
@@ -360,8 +360,7 @@ mod test {
         for assertion in assertions {
             assert!(
                 lua.load(assertion).eval::<bool>().expect(assertion),
-                "{}",
-                assertion
+                "{assertion}"
             );
         }
     }

--- a/lib/vector-core/src/fanout.rs
+++ b/lib/vector-core/src/fanout.rs
@@ -131,7 +131,7 @@ impl Fanout {
     ///
     /// This method should not be used if there is an active `SendGroup` being processed.
     fn apply_control_message(&mut self, message: ControlMessage) {
-        trace!("Processing control message outside of send: {:?}", message);
+        trace!("Processing control message outside of send: {message:?}");
 
         match message {
             ControlMessage::Add(id, sink) => self.add(id, sink),
@@ -272,7 +272,7 @@ impl Fanout {
                 biased;
 
                 maybe_msg = self.control_channel.recv(), if control_channel_open => {
-                    trace!("Processing control message inside of send: {:?}", maybe_msg);
+                    trace!("Processing control message inside of send: {maybe_msg:?}");
 
                     // During a send operation, control messages must be applied via the
                     // `SendGroup`, since it has exclusive access to the senders.

--- a/lib/vector-core/src/metrics/ddsketch.rs
+++ b/lib/vector-core/src/metrics/ddsketch.rs
@@ -1363,12 +1363,7 @@ mod tests {
             let _err = (estimated - actual).abs() / actual;
             assert!(
                 err <= relative_accuracy,
-                "relative accuracy out of bounds: q={}, estimate={}, actual={}, target-rel-acc={}, actual-rel-acc={}, bin-count={}",
-                q,
-                estimated,
-                actual,
-                relative_accuracy,
-                err,
+                "relative accuracy out of bounds: q={q}, estimate={estimated}, actual={actual}, target-rel-acc={relative_accuracy}, actual-rel-acc={err}, bin-count={}",
                 sketch.bin_count()
             );
         }
@@ -1630,10 +1625,9 @@ mod tests {
             let actual = round_to_even(*input);
             assert!(
                 alike(actual, *expected),
-                "input -> {}, expected {}, got {}",
+                "input -> {}, expected {}, got {actual}",
                 *input,
-                *expected,
-                actual
+                *expected
             );
         }
     }

--- a/lib/vector-core/src/metrics/storage.rs
+++ b/lib/vector-core/src/metrics/storage.rs
@@ -177,15 +177,13 @@ mod test {
                 let index = Histogram::bucket_index(value);
                 assert!(
                     value <= sut.buckets[index].0,
-                    "Value {} is not less than the upper limit {}.",
-                    value,
+                    "Value {value} is not less than the upper limit {}.",
                     sut.buckets[index].0
                 );
                 if index > 0 {
                     assert!(
                         value > sut.buckets[index - 1].0,
-                        "Value {} is not greater than the previous upper limit {}.",
-                        value,
+                        "Value {value} is not greater than the previous upper limit {}.",
                         sut.buckets[index - 1].0
                     );
                 }

--- a/lib/vector-core/src/schema/definition.rs
+++ b/lib/vector-core/src/schema/definition.rs
@@ -384,7 +384,7 @@ impl Definition {
     /// This method panics if the provided path points to an unknown location in the collection.
     pub fn add_meaning(&mut self, target_path: OwnedTargetPath, meaning: &str) {
         self.try_with_meaning(target_path, meaning)
-            .unwrap_or_else(|err| panic!("{}", err));
+            .unwrap_or_else(|err| panic!("{err}"));
     }
 
     /// Register a semantic meaning for the definition.
@@ -554,8 +554,7 @@ mod test_utils {
                 let actual_kind = Kind::from(log.value());
                 if let Err(path) = self.event_kind.is_superset(&actual_kind) {
                     return Result::Err(format!(
-                        "Event value doesn't match at path: {}\n\nEvent type at path = {:?}\n\nDefinition at path = {:?}",
-                        path,
+                        "Event value doesn't match at path: {path}\n\nEvent type at path = {:?}\n\nDefinition at path = {:?}",
                         actual_kind.at_path(&path).debug_info(),
                         self.event_kind.at_path(&path).debug_info()
                     ));
@@ -566,8 +565,7 @@ mod test_utils {
                     // return Result::Err(format!("Event metadata doesn't match definition.\n\nDefinition type=\n{:?}\n\nActual event metadata type=\n{:?}\n",
                     //                            self.metadata_kind.debug_info(), actual_metadata_kind.debug_info()));
                     return Result::Err(format!(
-                        "Event METADATA value doesn't match at path: {}\n\nMetadata type at path = {:?}\n\nDefinition at path = {:?}",
-                        path,
+                        "Event METADATA value doesn't match at path: {path}\n\nMetadata type at path = {:?}\n\nDefinition at path = {:?}",
                         actual_metadata_kind.at_path(&path).debug_info(),
                         self.metadata_kind.at_path(&path).debug_info()
                     ));

--- a/lib/vector-core/src/schema/requirement.rs
+++ b/lib/vector-core/src/schema/requirement.rs
@@ -226,8 +226,7 @@ impl std::fmt::Display for ValidationError {
             ),
             Self::MeaningDuplicate { identifier, paths } => write!(
                 f,
-                "semantic meaning {} pointing to multiple fields: {}",
-                identifier,
+                "semantic meaning {identifier} pointing to multiple fields: {}",
                 paths
                     .iter()
                     .map(ToString::to_string)

--- a/lib/vector-core/src/source_sender/tests.rs
+++ b/lib/vector-core/src/source_sender/tests.rs
@@ -91,9 +91,8 @@ async fn emit_and_test(make_event: impl FnOnce(DateTime<Utc>) -> Event) {
             assert_eq!(*count, 1);
             assert!(
                 (*sum - expected).abs() <= 0.002,
-                "Histogram sum does not match expected sum: {} vs {}",
+                "Histogram sum does not match expected sum: {} vs {expected}",
                 *sum,
-                expected,
             );
         }
         _ => panic!("source_lag_time_seconds has invalid type"),

--- a/lib/vector-tap/src/runner.rs
+++ b/lib/vector-tap/src/runner.rs
@@ -56,14 +56,13 @@ impl EventFormatter {
         if self.meta {
             match self.format {
                 TapEncodingFormat::Json => format!(
-                    r#"{{"{}":"{}","{}":"{}","{}":"{}","event":{}}}"#,
+                    r#"{{"{}":"{}","{}":"{}","{}":"{}","event":{event}}}"#,
                     self.component_id_label,
                     component_id.green(),
                     self.component_kind_label,
                     component_kind.green(),
                     self.component_type_label,
-                    component_type.green(),
-                    event
+                    component_type.green()
                 )
                 .into(),
                 TapEncodingFormat::Yaml => {
@@ -85,14 +84,13 @@ impl EventFormatter {
                     .into()
                 }
                 TapEncodingFormat::Logfmt => format!(
-                    "{}={} {}={} {}={} {}",
+                    "{}={} {}={} {}={} {event}",
                     self.component_id_label,
                     component_id.green(),
                     self.component_kind_label,
                     component_kind.green(),
                     self.component_type_label,
-                    component_type.green(),
-                    event
+                    component_type.green()
                 )
                 .into(),
             }
@@ -126,9 +124,9 @@ impl TapExecutorError {
 impl From<vector_api_client::Error> for TapExecutorError {
     fn from(err: vector_api_client::Error) -> Self {
         if err.is_fatal() {
-            TapExecutorError::Fatal(format!("{}", err))
+            TapExecutorError::Fatal(format!("{err}"))
         } else {
-            TapExecutorError::GrpcError(format!("{}", err))
+            TapExecutorError::GrpcError(format!("{err}"))
         }
     }
 }
@@ -263,17 +261,19 @@ impl<'a> TapRunner<'a> {
 
         let core_event_wrapper =
             vector_core::event::proto::EventWrapper::decode(Bytes::from(bytes))
-                .map_err(|e| format!("Failed to decode event: {}", e))?;
+                .map_err(|e| format!("Failed to decode event: {e}"))?;
 
         // Convert to vector-core Event (which has Serialize)
         let event: Event = core_event_wrapper.into();
 
         // Serialize based on format
         match format {
-            TapEncodingFormat::Json => serde_json::to_string(&event)
-                .map_err(|e| format!("JSON serialization failed: {}", e)),
-            TapEncodingFormat::Yaml => serde_yaml::to_string(&event)
-                .map_err(|e| format!("YAML serialization failed: {}", e)),
+            TapEncodingFormat::Json => {
+                serde_json::to_string(&event).map_err(|e| format!("JSON serialization failed: {e}"))
+            }
+            TapEncodingFormat::Yaml => {
+                serde_yaml::to_string(&event).map_err(|e| format!("YAML serialization failed: {e}"))
+            }
             TapEncodingFormat::Logfmt => {
                 // For logfmt, we need to extract the log event and serialize it
                 match event {
@@ -284,9 +284,9 @@ impl<'a> TapRunner<'a> {
                         // Wrap the LogEvent back into Event for the serializer
                         serializer
                             .encode(Event::Log(log_event), &mut bytes)
-                            .map_err(|e| format!("Logfmt serialization failed: {}", e))?;
+                            .map_err(|e| format!("Logfmt serialization failed: {e}"))?;
                         String::from_utf8(bytes.to_vec())
-                            .map_err(|e| format!("UTF-8 conversion failed: {}", e))
+                            .map_err(|e| format!("UTF-8 conversion failed: {e}"))
                     }
                     Event::Metric(_) => {
                         Err("logfmt format is only supported for log events".to_string())
@@ -315,7 +315,7 @@ impl<'a> TapRunner<'a> {
                         Ok(s) => s,
                         Err(e) => {
                             error!(message = "Failed to serialize event.", error = %e);
-                            format!("{:?}", event_wrapper)
+                            format!("{event_wrapper:?}")
                         }
                     }
                 } else {

--- a/lib/vector-vrl/tests/src/docs.rs
+++ b/lib/vector-vrl/tests/src/docs.rs
@@ -141,8 +141,8 @@ fn test_from_cue_example(category: &'static str, name: String, example: Example)
 
     if returns.is_some() && output.is_some() {
         panic!(
-            "example must either specify return or output, not both: {}/{}",
-            category, &name
+            "example must either specify return or output, not both: {category}/{}",
+            &name
         );
     }
 

--- a/lib/vector-vrl/web-playground/build.rs
+++ b/lib/vector-vrl/web-playground/build.rs
@@ -82,7 +82,7 @@ fn write_vrl_constants(lockfile: &Lockfile, output_file: &mut File) {
                 )
             }
             SourceKind::Path => (vrl_dep.version.to_string(), None),
-            kind => unimplemented!("unhandled source kind: {:?}", kind),
+            kind => unimplemented!("unhandled source kind: {kind:?}"),
         }
     } else {
         (vrl_dep.version.to_string(), None)

--- a/src/api/grpc_server.rs
+++ b/src/api/grpc_server.rs
@@ -50,14 +50,14 @@ impl GrpcServer {
         // Bind the TCP listener first to ensure the port is available
         // This will fail fast if the address is already in use
         let listener = tokio::net::TcpListener::bind(addr).await.map_err(|e| {
-            crate::Error::from(format!("Failed to bind gRPC API server to {}: {}", addr, e))
+            crate::Error::from(format!("Failed to bind gRPC API server to {addr}: {e}"))
         })?;
 
         let actual_addr = listener
             .local_addr()
-            .map_err(|e| crate::Error::from(format!("Failed to get local address: {}", e)))?;
+            .map_err(|e| crate::Error::from(format!("Failed to get local address: {e}")))?;
 
-        info!("GRPC API server bound to {}.", actual_addr);
+        info!("GRPC API server bound to {actual_addr}.");
 
         let service = ObservabilityService::new(watch_rx);
 
@@ -72,9 +72,9 @@ impl GrpcServer {
         // Convert the tokio TcpListener into a std listener for hyper's Server.
         let std_listener = listener
             .into_std()
-            .map_err(|e| crate::Error::from(format!("Failed to convert TCP listener: {}", e)))?;
+            .map_err(|e| crate::Error::from(format!("Failed to convert TCP listener: {e}")))?;
         std_listener.set_nonblocking(true).map_err(|e| {
-            crate::Error::from(format!("Failed to set TCP listener non-blocking: {}", e))
+            crate::Error::from(format!("Failed to set TCP listener non-blocking: {e}"))
         })?;
 
         let router_serving = Arc::clone(&serving);
@@ -120,7 +120,7 @@ impl GrpcServer {
             }
         });
 
-        info!("GRPC API server started on {}.", actual_addr);
+        info!("GRPC API server started on {actual_addr}.");
 
         Ok(Self {
             _shutdown,

--- a/src/app.rs
+++ b/src/app.rs
@@ -443,7 +443,7 @@ async fn handle_signal(
             None
         }
         Err(RecvError::Lagged(amt)) => {
-            warn!("Overflow, dropped {} signals.", amt);
+            warn!("Overflow, dropped {amt} signals.");
             None
         }
         Err(RecvError::Closed) => Some(SignalTo::Shutdown(None)),

--- a/src/common/expansion.rs
+++ b/src/common/expansion.rs
@@ -29,14 +29,13 @@ pub(crate) fn pair_expansion(
             let key = slugify_text(&format!("{opening_prefix}{k}"));
             let val = Value::from(v).to_string_lossy().into_owned();
             if val == "<null>" {
-                warn!("Encountered \"null\" value for dynamic pair. key: {}", key);
+                warn!("Encountered \"null\" value for dynamic pair. key: {key}");
                 continue;
             }
             if let Some(prev) = dynamic_pairs.insert(key.clone(), val.clone()) {
                 warn!(
                     "Encountered duplicated dynamic pair. \
-                                key: {}, value: {:?}, discarded value: {:?}",
-                    key, val, prev
+                                key: {key}, value: {val:?}, discarded value: {prev:?}"
                 );
             };
             expanded_pairs.insert(key, val);

--- a/src/common/http/server_auth.rs
+++ b/src/common/http/server_auth.rs
@@ -275,7 +275,7 @@ impl HttpServerAuthMatcher {
 
         let result = Runtime::default().resolve(&mut target, program, &timezone);
         match result.map_err(|e| {
-            warn!("Handling auth failed: {}", e);
+            warn!("Handling auth failed: {e}");
             ErrorMessage::new(StatusCode::UNAUTHORIZED, "Auth failed".to_owned())
         })? {
             vrl::core::Value::Boolean(true) => {

--- a/src/components/validation/mod.rs
+++ b/src/components/validation/mod.rs
@@ -284,8 +284,7 @@ pub struct RunnerMetrics {
 fn run_validation(configuration: ValidationConfiguration, test_case_data_path: std::path::PathBuf) {
     let component_name = configuration.component_name();
     info!(
-        "Running validation for component '{}' (type: {:?})...",
-        component_name,
+        "Running validation for component '{component_name}' (type: {:?})...",
         configuration.component_type()
     );
 
@@ -356,14 +355,12 @@ fn run_validation(configuration: ValidationConfiguration, test_case_data_path: s
 
                 if had_failures {
                     panic!(
-                        "Failed to validate component '{}':\n{}",
-                        component_name,
+                        "Failed to validate component '{component_name}':\n{}",
                         details.join("")
                     );
                 } else {
                     info!(
-                        "Successfully validated component '{}':\n{}",
-                        component_name,
+                        "Successfully validated component '{component_name}':\n{}",
                         details.join("")
                     );
                 }
@@ -427,8 +424,7 @@ fn get_validation_configuration_from_test_case_path(
     // Now that we've theoretically got the component type and component name, try to query the
     // validatable component descriptions to find it.
     ValidatableComponentDescription::query(&component_name, component_type).ok_or(format!(
-        "No validation configuration for component '{}' with component type '{}'.",
-        component_name,
+        "No validation configuration for component '{component_name}' with component type '{}'.",
         component_type.as_str()
     ))
 }

--- a/src/components/validation/resources/http.rs
+++ b/src/components/validation/resources/http.rs
@@ -273,7 +273,7 @@ fn spawn_input_http_client(
                 }
                 Err(e) => {
                     // TODO: Emit metric that tracks a failed response from the HTTP server.
-                    error!("Failed to send request: {}", e);
+                    error!("Failed to send request: {e}");
                 }
             }
         }

--- a/src/components/validation/runner/mod.rs
+++ b/src/components/validation/runner/mod.rs
@@ -374,7 +374,7 @@ impl Runner {
             telemetry_task_coordinator.shutdown().await;
             topology_task_coordinator.shutdown().await;
 
-            info!("Collected runner metrics: {:?}", runner_metrics);
+            info!("Collected runner metrics: {runner_metrics:?}");
             let final_runner_metrics = runner_metrics.lock().await;
 
             // Run the relevant data -- inputs, outputs, telemetry, etc -- through each validator to

--- a/src/components/validation/validators/component_spec/mod.rs
+++ b/src/components/validation/validators/component_spec/mod.rs
@@ -36,11 +36,11 @@ impl Validator for ComponentSpecValidator {
             .count() as u64;
 
         for input in inputs {
-            info!("Validator observed input event: {:?}", input);
+            info!("Validator observed input event: {input:?}");
         }
 
         for output in outputs {
-            info!("Validator observed output event: {:?}", output);
+            info!("Validator observed output event: {output:?}");
         }
 
         // Validate that the number of inputs/outputs matched the test case expectation.
@@ -203,9 +203,8 @@ fn filter_events_by_metric_and_component<'a>(
     component_id: &'a str,
 ) -> Vec<&'a Metric> {
     info!(
-        "Filter looking for metric {} {}",
-        metric.to_string(),
-        component_id
+        "Filter looking for metric {} {component_id}",
+        metric.to_string()
     );
 
     let metrics: Vec<&Metric> = telemetry_events
@@ -219,7 +218,7 @@ fn filter_events_by_metric_and_component<'a>(
         })
         .filter(|&m| {
             if m.name() == metric.to_string() {
-                debug!("{}", m);
+                debug!("{m}");
                 if let Some(tags) = m.tags()
                     && tags.get("component_id").unwrap_or("") == component_id
                 {
@@ -297,5 +296,5 @@ fn compare_actual_to_expected(
         return Err(errs);
     }
 
-    Ok(vec![format!("{}: {}", metric_type, actual)])
+    Ok(vec![format!("{metric_type}: {actual}")])
 }

--- a/src/conditions/datadog_search.rs
+++ b/src/conditions/datadog_search.rs
@@ -1646,15 +1646,13 @@ mod test {
 
             assert!(
                 cond.check_with_context(pass.clone()).0.is_ok(),
-                "should pass: {}\nevent: {}",
-                source,
+                "should pass: {source}\nevent: {}",
                 serde_json::to_string(&pass.as_log()).unwrap(),
             );
 
             assert!(
                 cond.check_with_context(fail.clone()).0.is_err(),
-                "should fail: {}\nevent: {}",
-                source,
+                "should fail: {source}\nevent: {}",
                 serde_json::to_string(&fail.as_log()).unwrap(),
             );
         }

--- a/src/config/builder.rs
+++ b/src/config/builder.rs
@@ -137,7 +137,7 @@ impl ConfigBuilder {
         let (config, warnings) = self.build_with_warnings()?;
 
         for warning in warnings {
-            warn!("{}", warning);
+            warn!("{warning}");
         }
 
         Ok(config)

--- a/src/config/compiler.rs
+++ b/src/config/compiler.rs
@@ -205,7 +205,7 @@ fn validate_sinks(config: &mut Config) -> Vec<String> {
         let dyn_sink: &dyn DynValidatedSink = sink.inner.as_ref();
         match dyn_sink.validate_dyn() {
             Ok(state) => sink.validated = Some(Arc::from(state)),
-            Err(e) => errors.push(format!("Failed to validate sink \"{}\": {}", key, e)),
+            Err(e) => errors.push(format!("Failed to validate sink \"{key}\": {e}")),
         }
     }
 

--- a/src/config/graph.rs
+++ b/src/config/graph.rs
@@ -251,8 +251,8 @@ impl Graph {
 
             if !from_ty.intersects(to_ty) {
                 errors.push(format!(
-                    "Data type mismatch between {} ({}) and {} ({})",
-                    edge.from, from_ty, edge.to, to_ty
+                    "Data type mismatch between {} ({from_ty}) and {} ({to_ty})",
+                    edge.from, edge.to
                 ));
             }
         }

--- a/src/config/loading/mod.rs
+++ b/src/config/loading/mod.rs
@@ -47,7 +47,7 @@ pub fn env_var_interpolation_enabled() -> bool {
 pub(super) fn read_dir<P: AsRef<Path> + Debug>(path: P) -> Result<ReadDir, Vec<String>> {
     path.as_ref()
         .read_dir()
-        .map_err(|err| vec![format!("Could not read config dir: {:?}, {}.", path, err)])
+        .map_err(|err| vec![format!("Could not read config dir: {path:?}, {err}.")])
 }
 
 pub(super) fn component_name<P: AsRef<Path> + Debug>(path: P) -> Result<String, Vec<String>> {
@@ -55,7 +55,7 @@ pub(super) fn component_name<P: AsRef<Path> + Debug>(path: P) -> Result<String, 
         .file_stem()
         .and_then(|name| name.to_str())
         .map(|name| name.to_string())
-        .ok_or_else(|| vec![format!("Couldn't get component name for file: {:?}", path)])
+        .ok_or_else(|| vec![format!("Couldn't get component name for file: {path:?}")])
 }
 
 pub(super) fn open_file<P: AsRef<Path> + Debug>(path: P) -> Option<File> {
@@ -146,7 +146,7 @@ pub fn load_from_paths(config_paths: &[ConfigPath]) -> Result<Config, Vec<String
     let (config, build_warnings) = builder.build_with_warnings()?;
 
     for warning in build_warnings {
-        warn!("{}", warning);
+        warn!("{warning}");
     }
 
     Ok(config)
@@ -222,7 +222,7 @@ async fn finalize_config(builder: ConfigBuilder) -> Result<Config, Vec<String>> 
     validation::check_buffer_preconditions(&new_config).await?;
 
     for warning in build_warnings {
-        warn!("{}", warning);
+        warn!("{warning}");
     }
 
     Ok(new_config)
@@ -293,7 +293,7 @@ pub fn load_from_str(input: &str, format: Format) -> Result<Config, Vec<String>>
     let (config, build_warnings) = builder.build_with_warnings()?;
 
     for warning in build_warnings {
-        warn!("{}", warning);
+        warn!("{warning}");
     }
 
     Ok(config)
@@ -366,7 +366,7 @@ fn default_path() -> PathBuf {
 fn default_path() -> PathBuf {
     let program_files =
         std::env::var("ProgramFiles").expect("%ProgramFiles% environment variable must be defined");
-    format!("{}\\Vector\\config\\vector.yaml", program_files).into()
+    format!("{program_files}\\Vector\\config\\vector.yaml").into()
 }
 
 fn default_config_paths() -> Vec<ConfigPath> {

--- a/src/config/unit_test/mod.rs
+++ b/src/config/unit_test/mod.rs
@@ -180,7 +180,7 @@ impl UnitTestBuildMetadata {
 
         let source_ids = available_insert_targets
             .iter()
-            .map(|key| (key.clone(), format!("{}-{}-{}", key, "source", random_id)))
+            .map(|key| (key.clone(), format!("{key}-{}-{random_id}", "source")))
             .collect::<HashMap<_, _>>();
 
         // Map a test source to every transform
@@ -214,10 +214,9 @@ impl UnitTestBuildMetadata {
                 (
                     key.clone(),
                     format!(
-                        "{}-{}-{}",
+                        "{}-{}-{random_id}",
                         key.to_string().replace('.', "-"),
-                        "sink",
-                        random_id
+                        "sink"
                     ),
                 )
             })
@@ -552,8 +551,8 @@ fn build_and_validate_inputs(
             }
         } else {
             errors.push(format!(
-                "inputs[{}]: unable to locate target transform '{}'",
-                index, input.insert_at
+                "inputs[{index}]: unable to locate target transform '{}'",
+                input.insert_at
             ))
         }
     }
@@ -610,9 +609,8 @@ fn build_outputs(
                 {
                     if prev != new {
                         errors.push(format!(
-                            "conflicting expected_event_count for extract_from {:?}: {} vs {}",
-                            output.extract_from, prev, new
-                        ));
+                            "conflicting expected_event_count for extract_from {:?}: {prev} vs {new}",
+                            output.extract_from));
                     }
                 } else if existing.expected_event_count.is_none() {
                     existing.expected_event_count = expected_event_count;

--- a/src/config/unit_test/unit_test_components.rs
+++ b/src/config/unit_test/unit_test_components.rs
@@ -227,9 +227,7 @@ impl StreamSink<Event> for UnitTestSink {
                     let actual = output_events.len();
                     if actual != expected {
                         result.test_errors.push(format!(
-                            "expected {} events from transforms {:?}, but received {}",
-                            expected, self.transform_ids, actual
-                        ));
+                            "expected {expected} events from transforms {:?}, but received {actual}", self.transform_ids));
                     }
                 }
 
@@ -260,8 +258,8 @@ impl StreamSink<Event> for UnitTestSink {
                             check_errors.insert(
                                 0,
                                 format!(
-                                    "check[{}] for transforms {:?} failed conditions:",
-                                    i, self.transform_ids
+                                    "check[{i}] for transforms {:?} failed conditions:",
+                                    self.transform_ids
                                 ),
                             );
                         }

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -121,8 +121,7 @@ pub fn check_shape(config: &ConfigBuilder) -> Result<(), Vec<String>> {
 
     for (id, uses) in used_keys.into_iter().filter(|(_id, uses)| uses.len() > 1) {
         errors.push(format!(
-            "More than one component with name \"{}\" ({}).",
-            id,
+            "More than one component with name \"{id}\" ({}).",
             uses.join(", ")
         ));
     }
@@ -139,9 +138,8 @@ pub fn check_shape(config: &ConfigBuilder) -> Result<(), Vec<String>> {
     for (output_type, key, inputs) in sink_inputs.chain(transform_inputs) {
         if inputs.is_empty() {
             errors.push(format!(
-                "{} \"{}\" has no inputs",
-                capitalize(output_type),
-                key
+                "{} \"{key}\" has no inputs",
+                capitalize(output_type)
             ));
         }
 
@@ -153,11 +151,8 @@ pub fn check_shape(config: &ConfigBuilder) -> Result<(), Vec<String>> {
 
         for (dup, count) in frequencies.into_iter().filter(|(_name, count)| *count > 1) {
             errors.push(format!(
-                "{} \"{}\" has input \"{}\" duplicated {} times",
+                "{} \"{key}\" has input \"{dup}\" duplicated {count} times",
                 capitalize(output_type),
-                key,
-                dup,
-                count,
             ));
         }
     }
@@ -362,9 +357,9 @@ pub async fn check_buffer_preconditions(config: &Config) -> Result<(), Vec<Strin
                 .map(|usage| usage.id().id())
                 .collect::<Vec<_>>();
             errors.push(format!(
-                "Mountpoint '{}' has total capacity of {} bytes, but configured buffers using mountpoint have total maximum size of {} bytes. \
+                "Mountpoint '{}' has total capacity of {mountpoint_total_capacity} bytes, but configured buffers using mountpoint have total maximum size of {buffer_max_size_total} bytes. \
 Reduce the `max_size` of the buffers to fit within the total capacity of the mountpoint. (components associated with mountpoint: {})",
-                mountpoint.to_string_lossy(), mountpoint_total_capacity, buffer_max_size_total, component_ids.join(", "),
+                mountpoint.to_string_lossy(), component_ids.join(", "),
             ));
         }
     }
@@ -443,9 +438,8 @@ pub fn warnings(config: &Config) -> Vec<String> {
                 .any(|(_, sink)| sink.inputs.contains(&id))
         {
             warnings.push(format!(
-                "{} \"{}\" has no consumers",
-                capitalize(input_type),
-                id
+                "{} \"{id}\" has no consumers",
+                capitalize(input_type)
             ));
         }
     }

--- a/src/docker.rs
+++ b/src/docker.rs
@@ -108,10 +108,7 @@ fn get_authority(url: &str) -> Result<String, Error> {
 
 async fn pull_image(docker: &Docker, image: &str, tag: &str) {
     let mut filters = HashMap::new();
-    filters.insert(
-        String::from("reference"),
-        vec![format!("{}:{}", image, tag)],
-    );
+    filters.insert(String::from("reference"), vec![format!("{image}:{tag}")]);
 
     let options = Some(ListImagesOptionsBuilder::new().filters(&filters).build());
 

--- a/src/enrichment_tables/file.rs
+++ b/src/enrichment_tables/file.rs
@@ -218,9 +218,8 @@ impl FileConfig {
             .collect::<crate::Result<Vec<_>>>()?;
 
         trace!(
-            "Loaded enrichment file {} with headers {:?}.",
-            self.file.path.to_str().unwrap_or("path with invalid utf"),
-            headers
+            "Loaded enrichment file {} with headers {headers:?}.",
+            self.file.path.to_str().unwrap_or("path with invalid utf")
         );
 
         let file = reader.into_inner();

--- a/src/enrichment_tables/memory/bloom_table.rs
+++ b/src/enrichment_tables/memory/bloom_table.rs
@@ -69,7 +69,7 @@ impl BloomMemoryTable {
         if let Some(max_byte_size) = config.max_byte_size
             && filter_size > max_byte_size
         {
-            return Err(format!("Configured bloom filter is larger ({}) than defined `max_byte_size` ({}). Reduce the size of bloom filter or increase or remove `max_byte_size`.", filter_size, max_byte_size).into());
+            return Err(format!("Configured bloom filter is larger ({filter_size}) than defined `max_byte_size` ({max_byte_size}). Reduce the size of bloom filter or increase or remove `max_byte_size`.").into());
         }
         let filter = Arc::new(RwLock::new(BloomFilter::new(
             bloom_config.max_entries.get(),
@@ -94,7 +94,7 @@ impl BloomMemoryTable {
                 if let Some(max_byte_size) = config.max_byte_size
                     && filter_size > max_byte_size
                 {
-                    return Err(format!("Configured bloom filter is larger ({}) than defined `max_byte_size` ({}). Reduce the size of bloom filter or increase or remove `max_byte_size`.", filter_size, max_byte_size).into());
+                    return Err(format!("Configured bloom filter is larger ({filter_size}) than defined `max_byte_size` ({max_byte_size}). Reduce the size of bloom filter or increase or remove `max_byte_size`.").into());
                 }
                 Ok(Self {
                     filter: prev_memory.filter,

--- a/src/enrichment_tables/memory/config.rs
+++ b/src/enrichment_tables/memory/config.rs
@@ -273,7 +273,7 @@ impl MemoryConfig {
                 if let Some(max_byte_size) = self.max_byte_size
                     && filter_size > max_byte_size
                 {
-                    return Err(format!("Configured bloom filter is larger ({}) than defined `max_byte_size` ({}). Reduce the size of bloom filter or increase or remove `max_byte_size`.", filter_size, max_byte_size).into());
+                    return Err(format!("Configured bloom filter is larger ({filter_size}) than defined `max_byte_size` ({max_byte_size}). Reduce the size of bloom filter or increase or remove `max_byte_size`.").into());
                 }
             }
             _ => {}

--- a/src/enrichment_tables/memory/cuckoo_table.rs
+++ b/src/enrichment_tables/memory/cuckoo_table.rs
@@ -238,9 +238,8 @@ impl CuckooMemoryTable {
                         }
                         _ => {
                             return Err(format!(
-                                "Couldn't open \"{}\" for cuckoo filter state import. {}",
-                                path.to_str().unwrap_or(""),
-                                err
+                                "Couldn't open \"{}\" for cuckoo filter state import. {err}",
+                                path.to_str().unwrap_or("")
                             )
                             .into());
                         }
@@ -252,14 +251,14 @@ impl CuckooMemoryTable {
                         Ok(imported) => imported,
                         Err(error) => {
                             return Err(
-                            format!("Cuckoo filter state import failed: {}. Delete the persisted state file ({}) to proceed.", error, path.to_str().unwrap_or("")).into(),
+                            format!("Cuckoo filter state import failed: {error}. Delete the persisted state file ({}) to proceed.", path.to_str().unwrap_or("")).into(),
                         );
                         }
                     };
 
                 if !built_config.compatible_layout(&persisted_config) {
                     return Err(
-                        format!("Stored cuckoo filter configuration is not compatible with new configuration. Only changes to values that don't affect layout or size are allowed. If this is intended, remove the persisted state file ({}). Built: {:?}. Persisted: {:?}", path.to_str().unwrap_or(""), built_config, persisted_config).into(),
+                        format!("Stored cuckoo filter configuration is not compatible with new configuration. Only changes to values that don't affect layout or size are allowed. If this is intended, remove the persisted state file ({}). Built: {built_config:?}. Persisted: {persisted_config:?}", path.to_str().unwrap_or("")).into(),
                     );
                 }
 
@@ -280,7 +279,7 @@ impl CuckooMemoryTable {
                     Ok(filter) => filter,
                     Err(error) => {
                         return Err(
-                            format!("Cuckoo filter state import failed: {}. Delete the persisted state file ({}) to proceed.", error, path.to_str().unwrap_or("")).into(),
+                            format!("Cuckoo filter state import failed: {error}. Delete the persisted state file ({}) to proceed.", path.to_str().unwrap_or("")).into(),
                         );
                     }
                 }
@@ -366,9 +365,8 @@ impl CuckooMemoryTable {
                 + 1;
             if starting_value_needed_bits as usize > cuckoo_config.lru_bits.get() {
                 return Err(format!(
-                    "`lru_bits` ({}) must be set to at least {} to support the `lru_starting_value` value ({}).",
+                    "`lru_bits` ({}) must be set to at least {starting_value_needed_bits} to support the `lru_starting_value` value ({}).",
                     cuckoo_config.lru_bits.get(),
-                    starting_value_needed_bits,
                     cuckoo_config.lru_starting_value,
                 ).into());
             }
@@ -376,9 +374,8 @@ impl CuckooMemoryTable {
                 cuckoo_config.lru_increment.checked_ilog2().unwrap_or(0) + 1;
             if increment_needed_bits as usize > cuckoo_config.lru_bits.get() {
                 return Err(format!(
-                    "`lru_bits` ({}) must be set to at least {} to support the `lru_increment` value ({}).",
+                    "`lru_bits` ({}) must be set to at least {increment_needed_bits} to support the `lru_increment` value ({}).",
                     cuckoo_config.lru_bits.get(),
-                    increment_needed_bits,
                     cuckoo_config.lru_increment,
                 ).into());
             }
@@ -397,9 +394,8 @@ impl CuckooMemoryTable {
             if needed_bits as usize > cuckoo_config.ttl_bits.get() {
                 return Err(
                     format!(
-                    "`ttl_bits` ({}) must be set to at least {} to support the default `ttl` value ({}) at the configured scan interval ({}).",
+                    "`ttl_bits` ({}) must be set to at least {needed_bits} to support the default `ttl` value ({}) at the configured scan interval ({}).",
                     cuckoo_config.ttl_bits.get(),
-                        needed_bits,
                     config.ttl,
                     config.scan_interval.get()).into(),
                 );
@@ -424,7 +420,7 @@ impl CuckooMemoryTable {
         if let Some(max_byte_size) = config.max_byte_size
             && filter_size as u64 > max_byte_size
         {
-            return Err(format!("Configured cuckoo filter is larger ({}) than defined `max_byte_size` ({}). Reduce the size of cuckoo filter or increase or remove `max_byte_size`.", filter_size, max_byte_size).into());
+            return Err(format!("Configured cuckoo filter is larger ({filter_size}) than defined `max_byte_size` ({max_byte_size}). Reduce the size of cuckoo filter or increase or remove `max_byte_size`.").into());
         }
 
         Ok(built_config)
@@ -446,12 +442,11 @@ impl CuckooMemoryTable {
                             }
                         }
                         if let Err(error) = temp.persist(path) {
-                            warn!("Cuckoo filter export failed: {}", error);
+                            warn!("Cuckoo filter export failed: {error}");
                         }
                     }
                     Err(err) => warn!(
-                        "Couldn't open temporary file for export. Aborting export. Error: {}",
-                        err
+                        "Couldn't open temporary file for export. Aborting export. Error: {err}"
                     ),
                 }
             }
@@ -508,13 +503,13 @@ impl CuckooMemoryTable {
         match self.filter.exporter().write_to(&mut writer) {
             Ok(()) => {
                 if let Err(error) = writer.flush() {
-                    warn!("Cuckoo filter export failed: {}", error);
+                    warn!("Cuckoo filter export failed: {error}");
                     return Err(());
                 };
                 Ok(())
             }
             Err(error) => {
-                warn!("Cuckoo filter export failed: {}", error);
+                warn!("Cuckoo filter export failed: {error}");
                 Err(())
             }
         }
@@ -549,10 +544,8 @@ impl CuckooMemoryTable {
                     let needed_bits = ttl.checked_ilog2().unwrap_or(0) + 1;
                     if needed_bits as usize > self.cuckoo_config.ttl_bits.get() {
                         warn!(
-                            "`ttl_bits` ({}) must be set to at least {} to support the provided `ttl` value ({}) at the configured scan interval ({}).",
+                            "`ttl_bits` ({}) must be set to at least {needed_bits} to support the provided `ttl` value ({ttl}) at the configured scan interval ({}).",
                             self.cuckoo_config.ttl_bits.get(),
-                            needed_bits,
-                            ttl,
                             self.config.scan_interval.get()
                         );
                         // Unchecked conversion to u32, because ttl_bits can't be higher than 32 anyways
@@ -783,7 +776,7 @@ impl StreamSink<Event> for CuckooMemoryTable {
                         continue;
                     } else if let Some(handle) = export_handle
                         && let Err(join_error) = handle.join() {
-                        warn!("Cuckoo enrichment table export failed: {:?}", join_error);
+                        warn!("Cuckoo enrichment table export failed: {join_error:?}");
                     }
                     let exporting_instance = self.clone();
                     export_handle = Some(std::thread::spawn(move || {
@@ -804,7 +797,7 @@ impl StreamSink<Event> for CuckooMemoryTable {
         if let Some(handle) = export_handle
             && let Err(join_error) = handle.join()
         {
-            warn!("Cuckoo enrichment table export failed: {:?}", join_error);
+            warn!("Cuckoo enrichment table export failed: {join_error:?}");
         }
 
         // Final export before exiting

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -150,8 +150,7 @@ fn render_dot(config: config::Config) -> exitcode::ExitCode {
     {
         writeln!(
             dot,
-            "  \"{}\" [{}]",
-            id,
+            "  \"{id}\" [{}]",
             node_attributes_to_string(&table.graph.node_attributes, "cylinder")
         )
         .expect("write to String never fails");
@@ -166,8 +165,7 @@ fn render_dot(config: config::Config) -> exitcode::ExitCode {
         if !written_tables.contains(&id) {
             writeln!(
                 dot,
-                "  \"{}\" [{}]",
-                id,
+                "  \"{id}\" [{}]",
                 node_attributes_to_string(&table.graph.node_attributes, "cylinder")
             )
             .expect("write to String never fails");
@@ -181,8 +179,7 @@ fn render_dot(config: config::Config) -> exitcode::ExitCode {
     for (id, source) in config.sources() {
         writeln!(
             dot,
-            "  \"{}\" [{}]",
-            id,
+            "  \"{id}\" [{}]",
             node_attributes_to_string(&source.graph.node_attributes, "trapezium")
         )
         .expect("write to String never fails");
@@ -191,8 +188,7 @@ fn render_dot(config: config::Config) -> exitcode::ExitCode {
     for (id, transform) in config.transforms() {
         writeln!(
             dot,
-            "  \"{}\" [{}]",
-            id,
+            "  \"{id}\" [{}]",
             node_attributes_to_string(&transform.graph.node_attributes, "diamond")
         )
         .expect("write to String never fails");
@@ -205,8 +201,7 @@ fn render_dot(config: config::Config) -> exitcode::ExitCode {
     for (id, sink) in config.sinks() {
         writeln!(
             dot,
-            "  \"{}\" [{}]",
-            id,
+            "  \"{id}\" [{}]",
             node_attributes_to_string(&sink.graph.node_attributes, "invtrapezium")
         )
         .expect("write to String never fails");
@@ -280,9 +275,9 @@ fn render_mermaid(config: config::Config) -> exitcode::ExitCode {
 
         for input in table.inputs.iter() {
             if let Some(port) = &input.port {
-                writeln!(mermaid, "  {0} -->|{port}| {id}", input.component).unwrap();
+                writeln!(mermaid, "  {} -->|{port}| {id}", input.component).unwrap();
             } else {
-                writeln!(mermaid, "  {0} --> {id}", input.component).unwrap();
+                writeln!(mermaid, "  {} --> {id}", input.component).unwrap();
             }
         }
     }
@@ -298,9 +293,9 @@ fn render_mermaid(config: config::Config) -> exitcode::ExitCode {
 
         for input in transform.inputs.iter() {
             if let Some(port) = &input.port {
-                writeln!(mermaid, "  {0} -->|{port}| {id}", input.component).unwrap();
+                writeln!(mermaid, "  {} -->|{port}| {id}", input.component).unwrap();
             } else {
-                writeln!(mermaid, "  {0} --> {id}", input.component).unwrap();
+                writeln!(mermaid, "  {} --> {id}", input.component).unwrap();
             }
         }
     }
@@ -311,9 +306,9 @@ fn render_mermaid(config: config::Config) -> exitcode::ExitCode {
 
         for input in &sink.inputs {
             if let Some(port) = &input.port {
-                writeln!(mermaid, "  {0} -->|{port}| {id}", input.component).unwrap();
+                writeln!(mermaid, "  {} -->|{port}| {id}", input.component).unwrap();
             } else {
-                writeln!(mermaid, "  {0} --> {id}", input.component).unwrap();
+                writeln!(mermaid, "  {} --> {id}", input.component).unwrap();
             }
         }
     }

--- a/src/internal_events/exec.rs
+++ b/src/internal_events/exec.rs
@@ -175,7 +175,7 @@ impl std::fmt::Display for ExecFailedToSignalChild {
             #[cfg(unix)]
             NoPid => write!(f, "child had no pid"),
             #[cfg(windows)]
-            IoError(err) => write!(f, "io error: {}", err),
+            IoError(err) => write!(f, "io error: {err}"),
         }
     }
 }

--- a/src/internal_events/parser.rs
+++ b/src/internal_events/parser.rs
@@ -20,7 +20,7 @@ fn truncate_string_at(s: &str, maxlen: usize) -> Cow<'_, str> {
             clippy::string_slice,
             reason = "len is adjusted to a char boundary in the loop above"
         )]
-        format!("{}{}", &s[..len], ellipsis).into()
+        format!("{}{ellipsis}", &s[..len]).into()
     } else {
         s.into()
     }

--- a/src/internal_telemetry/allocations/mod.rs
+++ b/src/internal_telemetry/allocations/mod.rs
@@ -206,8 +206,7 @@ pub fn acquire_allocation_group_id(
     }
 
     warn!(
-        "Maximum number of registrable allocation group IDs reached ({}). Allocations for component '{}' will be attributed to the root allocation group.",
-        NUM_GROUPS, component_id
+        "Maximum number of registrable allocation group IDs reached ({NUM_GROUPS}). Allocations for component '{component_id}' will be attributed to the root allocation group."
     );
     AllocationGroupId::ROOT
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,7 +205,7 @@ pub fn get_version() -> String {
     let pkg_version = vector_version();
     let build_desc = built_info::VECTOR_BUILD_DESC;
     let build_string = match build_desc {
-        Some(desc) => format!("{} {}", built_info::TARGET, desc),
+        Some(desc) => format!("{} {desc}", built_info::TARGET),
         None => built_info::TARGET.into(),
     };
 

--- a/src/secrets/aws_secrets_manager.rs
+++ b/src/secrets/aws_secrets_manager.rs
@@ -86,16 +86,16 @@ impl SecretBackend for AwsSecretsManagerBackend {
             if let Some(secret) = output.get(&k) {
                 if secret.is_empty() {
                     return Err(format!(
-                        "value for key '{}' in secret with id '{}' was empty",
-                        k, &self.secret_id
+                        "value for key '{k}' in secret with id '{}' was empty",
+                        &self.secret_id
                     )
                     .into());
                 }
                 secrets.insert(k.to_string(), secret.to_string());
             } else {
                 return Err(format!(
-                    "key '{}' in secret with id '{}' does not exist",
-                    k, &self.secret_id
+                    "key '{k}' in secret with id '{}' does not exist",
+                    &self.secret_id
                 )
                 .into());
             }

--- a/src/secrets/exec.rs
+++ b/src/secrets/exec.rs
@@ -194,8 +194,8 @@ async fn query_backend(
             }
             Some(stderr) = stderr_stream.next() => {
                 match stderr {
-                    Ok(l) => warn!("An exec backend generated message on stderr: {}.", l),
-                    Err(e) => warn!("Error while reading from an exec backend stderr: {}.", e),
+                    Ok(l) => warn!("An exec backend generated message on stderr: {l}."),
+                    Err(e) => warn!("Error while reading from an exec backend stderr: {e}."),
                 }
             }
             stdout = stdout_stream.next() => {

--- a/src/sinks/amqp/channel.rs
+++ b/src/sinks/amqp/channel.rs
@@ -22,7 +22,7 @@ pub(super) fn new_channel_pool(config: &AmqpSinkConfig) -> crate::Result<AmqpSin
         .max_size(max_channels)
         .runtime(deadpool::Runtime::Tokio1)
         .build()?;
-    debug!("AMQP channel pool created with max size: {}", max_channels);
+    debug!("AMQP channel pool created with max size: {max_channels}");
     Ok(channels)
 }
 

--- a/src/sinks/amqp/sink.rs
+++ b/src/sinks/amqp/sink.rs
@@ -117,7 +117,7 @@ impl AmqpSink {
             .filter_map(|request| async move {
                 match request {
                     Err(e) => {
-                        error!("Failed to build AMQP request: {:?}.", e);
+                        error!("Failed to build AMQP request: {e:?}.");
                         None
                     }
                     Ok(req) => Some(req),

--- a/src/sinks/aws_kinesis/firehose/integration_tests.rs
+++ b/src/sinks/aws_kinesis/firehose/integration_tests.rs
@@ -100,7 +100,7 @@ async fn firehose_put_records_without_partition_key() {
         .expect("Could not build HTTP client");
 
     let response = client
-        .get(format!("{}/{}/_search", common.base_url, stream))
+        .get(format!("{}/{stream}/_search", common.base_url))
         .json(&json!({
             "query": { "query_string": { "query": "*" } }
         }))
@@ -213,7 +213,7 @@ async fn firehose_put_records_with_partition_key() {
         .expect("Could not build HTTP client");
 
     let response = client
-        .get(format!("{}/{}/_search", common.base_url, stream))
+        .get(format!("{}/{stream}/_search", common.base_url))
         .json(&json!({
             "query": { "query_string": { "query": "*" } }
         }))

--- a/src/sinks/aws_s3/integration_tests.rs
+++ b/src/sinks/aws_s3/integration_tests.rs
@@ -523,7 +523,7 @@ async fn s3_parquet_insert_message() {
     let (batch_notifier, receiver) = BatchNotifier::new_with_receiver();
     let events: Vec<Event> = (0..10)
         .map(|i| {
-            let mut log = LogEvent::from(format!("message_{}", i));
+            let mut log = LogEvent::from(format!("message_{i}"));
             log.insert(event_path!("host"), format!("host_{}", i % 3));
             Event::from(log).with_batch_notifier(&batch_notifier)
         })
@@ -539,8 +539,7 @@ async fn s3_parquet_insert_message() {
     let key = keys[0].clone();
     assert!(
         key.ends_with(".parquet"),
-        "Expected .parquet extension, got: {}",
-        key
+        "Expected .parquet extension, got: {key}"
     );
 
     // Download and validate Parquet file

--- a/src/sinks/azure_blob/config.rs
+++ b/src/sinks/azure_blob/config.rs
@@ -406,7 +406,7 @@ impl ValidatedSink for AzureBlobSinkConfig {
                         "`auth` configuration must be provided when using `account_name`".into(),
                     );
                 }
-                format!("AccountName={}", account_name)
+                format!("AccountName={account_name}")
             }
             (None, None, Some(blob_endpoint)) => {
                 if self.auth.is_none() {
@@ -418,9 +418,9 @@ impl ValidatedSink for AzureBlobSinkConfig {
                 let blob_endpoint = if blob_endpoint.ends_with('/') {
                     blob_endpoint.clone()
                 } else {
-                    format!("{}/", blob_endpoint)
+                    format!("{blob_endpoint}/")
                 };
-                format!("BlobEndpoint={}", blob_endpoint)
+                format!("BlobEndpoint={blob_endpoint}")
             }
             (None, None, None) => {
                 return Err("One of `connection_string`, `account_name`, or `blob_endpoint` must be provided".into());
@@ -1148,7 +1148,7 @@ pub async fn build_client(
         let port = url.port();
         proxy.no_proxy.matches(host)
             || port
-                .map(|p| proxy.no_proxy.matches(&format!("{}:{}", host, p)))
+                .map(|p| proxy.no_proxy.matches(&format!("{host}:{p}")))
                 .unwrap_or(false)
     };
     if bypass_proxy || !proxy.enabled {

--- a/src/sinks/azure_blob/integration_tests.rs
+++ b/src/sinks/azure_blob/integration_tests.rs
@@ -487,9 +487,8 @@ async fn assert_append_blob_default_hourly_rotation(config: AzureBlobSinkConfig)
         );
         assert!(
             blobs[0].contains(&before),
-            "blob name '{}' must contain the current hour '{}'",
-            blobs[0],
-            before
+            "blob name '{}' must contain the current hour '{before}'",
+            blobs[0]
         );
     } else {
         assert!(

--- a/src/sinks/azure_blob/request_builder.rs
+++ b/src/sinks/azure_blob/request_builder.rs
@@ -77,10 +77,8 @@ impl RequestBuilder<(String, Vec<Event>)> for AzureBlobRequestOptions {
         };
 
         let extension = self.compression.extension();
-        azure_metadata.partition_key = format!(
-            "{}{}.{}",
-            azure_metadata.partition_key, blob_name, extension
-        );
+        azure_metadata.partition_key =
+            format!("{}{blob_name}.{extension}", azure_metadata.partition_key);
 
         let blob_data = payload.into_payload();
 

--- a/src/sinks/azure_blob/test.rs
+++ b/src/sinks/azure_blob/test.rs
@@ -282,8 +282,7 @@ async fn azure_blob_build_config_with_null_auth() {
             let err_str = e.to_string();
             assert!(
                 err_str.contains("data did not match any variant of untagged enum"),
-                "Config parsing did not complain about invalid auth config: {}",
-                err_str
+                "Config parsing did not complain about invalid auth config: {err_str}"
             );
         }
     }
@@ -405,8 +404,7 @@ async fn azure_blob_build_config_with_account_name_with_no_auth() {
             let err_str = e.to_string();
             assert!(
                 err_str.contains("`auth` configuration must be provided"),
-                "Config build did not complain about missing `auth`: {}",
-                err_str
+                "Config build did not complain about missing `auth`: {err_str}"
             );
         }
     }
@@ -454,8 +452,7 @@ async fn azure_blob_build_config_with_blob_endpoint_with_no_auth() {
             let err_str = e.to_string();
             assert!(
                 err_str.contains("`auth` configuration must be provided"),
-                "Config build did not complain about missing `auth`: {}",
-                err_str
+                "Config build did not complain about missing `auth`: {err_str}"
             );
         }
     }
@@ -483,8 +480,7 @@ async fn azure_blob_build_config_with_conflicting_connection_string_and_account_
             let err_str = e.to_string();
             assert!(
                 err_str.contains("`connection_string` and `account_name`"),
-                "Config build did not complain about conflicting connection_string and account_name: {}",
-                err_str
+                "Config build did not complain about conflicting connection_string and account_name: {err_str}"
             );
         }
     }
@@ -519,8 +515,7 @@ async fn azure_blob_build_config_with_conflicting_connection_string_and_client_i
             assert!(
                 err_str
                     .contains("Cannot use both Shared Key and another Azure Authentication method"),
-                "Config build did not complain about conflicting Shared Key and Client ID: {}",
-                err_str
+                "Config build did not complain about conflicting Shared Key and Client ID: {err_str}"
             );
         }
     }

--- a/src/sinks/azure_common/config.rs
+++ b/src/sinks/azure_common/config.rs
@@ -421,9 +421,8 @@ impl TokenCredential for MockTokenCredential {
         .to_string();
 
         warn!(
-            "Using mock token credential, JWT: {}, base64: {}",
-            serde_json::to_string(&jwt).unwrap(),
-            jwt_base64
+            "Using mock token credential, JWT: {}, base64: {jwt_base64}",
+            serde_json::to_string(&jwt).unwrap()
         );
 
         Ok(azure_core::credentials::AccessToken::new(

--- a/src/sinks/azure_common/connection_string.rs
+++ b/src/sinks/azure_common/connection_string.rs
@@ -213,23 +213,23 @@ impl ParsedConnectionString {
                 .unwrap_or_else(|| "127.0.0.1:10000".to_string());
 
             let base = if host.starts_with("http://") || host.starts_with("https://") {
-                format!("{}/{}", trim_trailing_slash(&host), account_name)
+                format!("{}/{account_name}", trim_trailing_slash(&host))
             } else {
-                format!("{proto}://{host}/{}", account_name)
+                format!("{proto}://{host}/{account_name}")
             };
             return Ok(base);
         }
 
         // Public cloud-style base
         let suffix = self.endpoint_suffix();
-        Ok(format!("{proto}://{}.blob.{}", account_name, suffix))
+        Ok(format!("{proto}://{account_name}.blob.{suffix}"))
     }
 
     /// Build a container URL, optionally appending SAS if present.
     pub fn container_url(&self, container: &str) -> Result<String, ConnectionStringError> {
         let base = self.blob_account_endpoint()?;
         Ok(append_query_segment(
-            &format!("{}/{}", trim_trailing_slash(&base), container),
+            &format!("{}/{container}", trim_trailing_slash(&base)),
             self.shared_access_signature.as_deref(),
         ))
     }
@@ -239,7 +239,7 @@ impl ParsedConnectionString {
         // Build the base container URL without SAS, then append the blob path,
         // and finally append the SAS so it appears after the full path.
         let base = self.blob_account_endpoint()?;
-        let container_no_sas = format!("{}/{}", trim_trailing_slash(&base), container);
+        let container_no_sas = format!("{}/{container}", trim_trailing_slash(&base));
         let blob_full = format!(
             "{}/{}",
             trim_trailing_slash(&container_no_sas),

--- a/src/sinks/azure_common/shared_key_policy.rs
+++ b/src/sinks/azure_common/shared_key_policy.rs
@@ -205,7 +205,7 @@ impl SharedKeyAuthorizationPolicy {
             vals.sort();
             vals.dedup();
             let joined = vals.join(",");
-            writeln!(s, "{}:{}", k, joined).ok();
+            writeln!(s, "{k}:{joined}").ok();
         }
 
         // CanonicalizedResource
@@ -261,7 +261,7 @@ impl Policy for SharedKeyAuthorizationPolicy {
         // Authorization: SharedKey {account}:{signature}
         request.insert_header(
             "authorization",
-            format!("SharedKey {}:{}", self.account_name, signature),
+            format!("SharedKey {}:{signature}", self.account_name),
         );
 
         // Continue pipeline
@@ -293,7 +293,7 @@ fn append_canonicalized_resource(s: &mut String, account: &str, url: &Url) -> Az
         for (k, mut vals) in qp_map {
             vals.sort();
             let mut line = String::new();
-            write!(&mut line, "\n{}:", k).ok();
+            write!(&mut line, "\n{k}:").ok();
             let joined = vals.join(",");
             line.push_str(&joined);
             s.push_str(&line);

--- a/src/sinks/azure_logs_ingestion/tests.rs
+++ b/src/sinks/azure_logs_ingestion/tests.rs
@@ -116,8 +116,7 @@ async fn basic_config_error_with_no_auth() {
             let err_str = e.to_string();
             assert!(
                 err_str.contains("missing field `auth`"),
-                "Config parsing did not complain about missing auth field: {}",
-                err_str
+                "Config parsing did not complain about missing auth field: {err_str}"
             );
         }
     }
@@ -378,13 +377,11 @@ async fn mock_healthcheck_with_400_response() {
     // Both generic 400 "Bad Request", and our mock error message should be present
     assert!(
         err_str.contains("Bad Request"),
-        "Healthcheck error does not contain 'Bad Request': {}",
-        err_str
+        "Healthcheck error does not contain 'Bad Request': {err_str}"
     );
     assert!(
         err_str.contains("Mock400ErrorResponse"),
-        "Healthcheck error does not contain 'Mock400ErrorResponse': {}",
-        err_str
+        "Healthcheck error does not contain 'Mock400ErrorResponse': {err_str}"
     );
 }
 
@@ -444,7 +441,6 @@ async fn mock_healthcheck_with_403_response() {
     let err_str = hc_err.to_string();
     assert!(
         err_str.contains("Forbidden"),
-        "Healthcheck error does not contain 'Forbidden': {}",
-        err_str
+        "Healthcheck error does not contain 'Forbidden': {err_str}"
     );
 }

--- a/src/sinks/clickhouse/arrow/parser.rs
+++ b/src/sinks/clickhouse/arrow/parser.rs
@@ -115,8 +115,7 @@ impl ClickHouseType {
                     7..=9 => TimeUnit::Nanosecond,
                     _ => {
                         return Err(format!(
-                            "Unsupported DateTime64 precision {}. Must be 0-9",
-                            precision
+                            "Unsupported DateTime64 precision {precision}. Must be 0-9"
                         ));
                     }
                 };

--- a/src/sinks/clickhouse/config.rs
+++ b/src/sinks/clickhouse/config.rs
@@ -412,10 +412,7 @@ impl ClickhouseConfig {
         let table_str = self.table.get_ref();
         let database_str = database.get_ref();
 
-        debug!(
-            "Fetching schema for table {}.{} at startup.",
-            database_str, table_str
-        );
+        debug!("Fetching schema for table {database_str}.{table_str} at startup.");
 
         let provider = arrow::ClickHouseSchemaProvider::new(
             client.clone(),
@@ -599,8 +596,7 @@ mod tests {
 
             assert!(
                 config.batch_encoding.is_none(),
-                "batch_encoding should be None for format {:?}",
-                format
+                "batch_encoding should be None for format {format:?}"
             );
             assert_eq!(
                 config.format, format,
@@ -633,8 +629,7 @@ mod tests {
         let error = result.unwrap_err().to_string();
         assert!(
             error.contains("'batch_encoding' is only compatible"),
-            "Error message should mention incompatibility: {}",
-            error
+            "Error message should mention incompatibility: {error}"
         );
     }
 
@@ -707,8 +702,7 @@ mod tests {
         let err = result.unwrap_err().to_string();
         assert!(
             err.contains("static table and database"),
-            "Error should mention static requirement: {}",
-            err
+            "Error should mention static requirement: {err}"
         );
 
         // Dynamic database
@@ -735,8 +729,7 @@ mod tests {
         let err = result.unwrap_err().to_string();
         assert!(
             err.contains("static table and database"),
-            "Error should mention static requirement: {}",
-            err
+            "Error should mention static requirement: {err}"
         );
     }
 
@@ -781,8 +774,7 @@ mod tests {
         let err = result.unwrap_err().to_string();
         assert!(
             err.contains("confinement") || err.contains("prefix"),
-            "Error should mention confinement/prefix: {}",
-            err
+            "Error should mention confinement/prefix: {err}"
         );
     }
 }

--- a/src/sinks/clickhouse/integration_tests.rs
+++ b/src/sinks/clickhouse/integration_tests.rs
@@ -533,8 +533,8 @@ async fn insert_events_arrow_format() {
 
     let mut events: Vec<Event> = Vec::new();
     for i in 0..5 {
-        let mut event = LogEvent::from(format!("log message {}", i));
-        event.insert(event_path!("host"), format!("host{}.example.com", i));
+        let mut event = LogEvent::from(format!("log message {i}"));
+        event.insert(event_path!("host"), format!("host{i}.example.com"));
         event.insert(event_path!("count"), i as i64);
         events.push(event.into());
     }
@@ -598,15 +598,15 @@ async fn insert_events_arrow_with_schema_fetching() {
     // Create events with various types that should match the schema
     let mut events: Vec<Event> = Vec::new();
     for i in 0..3 {
-        let mut event = LogEvent::from(format!("Test message {}", i));
-        event.insert(event_path!("host"), format!("host{}.example.com", i));
+        let mut event = LogEvent::from(format!("Test message {i}"));
+        event.insert(event_path!("host"), format!("host{i}.example.com"));
         event.insert(event_path!("id"), i as i64);
-        event.insert(event_path!("name"), format!("user_{}", i));
+        event.insert(event_path!("name"), format!("user_{i}"));
         event.insert(event_path!("score"), 95.5 + i as f64);
         event.insert(event_path!("active"), i % 2 == 0);
         event.insert(
             event_path!("request_id"),
-            format!("550e8400-e29b-41d4-a716-44665544000{}", i),
+            format!("550e8400-e29b-41d4-a716-44665544000{i}"),
         );
         events.push(event.into());
     }
@@ -641,7 +641,7 @@ async fn insert_events_arrow_with_schema_fetching() {
             .expect("request_id should be present");
         assert_eq!(
             request_id,
-            format!("550e8400-e29b-41d4-a716-44665544000{}", i)
+            format!("550e8400-e29b-41d4-a716-44665544000{i}")
         );
     }
 }

--- a/src/sinks/clickhouse/service.rs
+++ b/src/sinks/clickhouse/service.rs
@@ -129,12 +129,12 @@ impl HttpServiceRequestBuilder<PartitionKey> for ClickhouseServiceRequestBuilder
 
 fn append_param<T: ToString>(uri: &mut String, key: &str, value: Option<T>) {
     if let Some(val) = value {
-        uri.push_str(&format!("{}={}&", key, val.to_string()));
+        uri.push_str(&format!("{key}={}&", val.to_string()));
     }
 }
 fn append_param_bool(uri: &mut String, key: &str, value: Option<bool>) {
     if let Some(val) = value {
-        uri.push_str(&format!("{}={}&", key, if val { 1 } else { 0 }));
+        uri.push_str(&format!("{key}={}&", if val { 1 } else { 0 }));
     }
 }
 
@@ -154,10 +154,7 @@ fn set_uri_query(
     let query = url::form_urlencoded::Serializer::new(String::new())
         .append_pair(
             "query",
-            &format!(
-                "INSERT INTO {{database:Identifier}}.{{table:Identifier}} FORMAT {}",
-                format
-            ),
+            &format!("INSERT INTO {{database:Identifier}}.{{table:Identifier}} FORMAT {format}"),
         )
         .append_pair("param_database", database)
         .append_pair("param_table", table)

--- a/src/sinks/databend/service.rs
+++ b/src/sinks/databend/service.rs
@@ -129,7 +129,7 @@ impl DatabendService {
             .take(8)
             .map(char::from)
             .collect::<String>();
-        format!("@~/vector/{}/{}/{}-{}", database, self.table, now, suffix,)
+        format!("@~/vector/{database}/{}/{now}-{suffix}", self.table,)
     }
 
     pub(crate) async fn insert_with_stage(&self, data: Bytes) -> Result<(), DatabendError> {

--- a/src/sinks/databricks_zerobus/service.rs
+++ b/src/sinks/databricks_zerobus/service.rs
@@ -47,7 +47,7 @@ fn build_connector_factory(proxy: &ProxyConfig) -> Result<ConnectorFactory, Zero
     // Validate the proxy URL once up-front so a malformed value surfaces at
     // sink startup rather than per-connection.
     ProxyConnector::new(&proxy_url).map_err(|e| ZerobusSinkError::ConfigError {
-        message: format!("Invalid proxy URL '{}': {}", proxy_url, e),
+        message: format!("Invalid proxy URL '{proxy_url}': {e}"),
     })?;
     let no_proxy = proxy.no_proxy.clone();
     Ok(Arc::new(move |host: &str| {
@@ -327,12 +327,12 @@ impl ZerobusService {
             .application_name(config.user_agent_suffix());
         builder = builder.connector_factory(build_connector_factory(proxy)?);
         let sdk = builder.build().map_err(|e| ZerobusSinkError::ConfigError {
-            message: format!("Failed to create Zerobus SDK: {}", e),
+            message: format!("Failed to create Zerobus SDK: {e}"),
         })?;
 
         let http_client = HttpClient::new(TlsSettings::default(), proxy).map_err(|e| {
             ZerobusSinkError::ConfigError {
-                message: format!("Failed to create HTTP client: {}", e),
+                message: format!("Failed to create HTTP client: {e}"),
             }
         })?;
 
@@ -380,7 +380,7 @@ impl ZerobusService {
                 )
                 .build_batch_serializer()
                 .map_err(|e| ZerobusSinkError::ConfigError {
-                    message: format!("Failed to build batch serializer: {}", e),
+                    message: format!("Failed to build batch serializer: {e}"),
                 })?;
 
                 Ok(ResolvedSchema {
@@ -409,7 +409,7 @@ impl ZerobusService {
                 .encoder
                 .encode_batch(events)
                 .map_err(|e| ZerobusSinkError::EncodingError {
-                    message: format!("Failed to encode batch: {}", e),
+                    message: format!("Failed to encode batch: {e}"),
                 })?;
         Ok(batch)
     }
@@ -600,12 +600,12 @@ impl ZerobusService {
             )
             .build()
             .map_err(|e| ZerobusSinkError::ConfigError {
-                message: format!("Failed to create Zerobus SDK: {}", e),
+                message: format!("Failed to create Zerobus SDK: {e}"),
             })?;
 
         let http_client = HttpClient::new(TlsSettings::default(), &ProxyConfig::default())
             .map_err(|e| ZerobusSinkError::ConfigError {
-                message: format!("Failed to create HTTP client: {}", e),
+                message: format!("Failed to create HTTP client: {e}"),
             })?;
 
         Ok(Self {

--- a/src/sinks/databricks_zerobus/unity_catalog_schema.rs
+++ b/src/sinks/databricks_zerobus/unity_catalog_schema.rs
@@ -67,28 +67,27 @@ pub async fn fetch_table_schema(
         .collect::<Vec<_>>()
         .join(".");
     let url = format!(
-        "{}/api/2.1/unity-catalog/tables/{}",
-        unity_catalog_endpoint.trim_end_matches('/'),
-        encoded_table_name
+        "{}/api/2.1/unity-catalog/tables/{encoded_table_name}",
+        unity_catalog_endpoint.trim_end_matches('/')
     );
 
     let uri: Uri = url.parse().map_err(|e| ZerobusSinkError::ConfigError {
-        message: format!("Invalid Unity Catalog endpoint URL: {}", e),
+        message: format!("Invalid Unity Catalog endpoint URL: {e}"),
     })?;
 
     let request = Request::get(uri)
-        .header("Authorization", format!("Bearer {}", token))
+        .header("Authorization", format!("Bearer {token}"))
         .header("Content-Type", "application/json")
         .body(Body::empty())
         .map_err(|e| ZerobusSinkError::ConfigError {
-            message: format!("Failed to build request: {}", e),
+            message: format!("Failed to build request: {e}"),
         })?;
 
     let response = http_client
         .send(request)
         .await
         .map_err(|e| ZerobusSinkError::SchemaError {
-            message: format!("Failed to fetch table schema: {}", e),
+            message: format!("Failed to fetch table schema: {e}"),
             retryable: true,
         })?;
 
@@ -102,10 +101,7 @@ pub async fn fetch_table_schema(
             .unwrap_or_default();
         let error_text = String::from_utf8_lossy(&body_bytes);
         return Err(ZerobusSinkError::SchemaError {
-            message: format!(
-                "Unity Catalog API returned error {}: {}",
-                status, error_text
-            ),
+            message: format!("Unity Catalog API returned error {status}: {error_text}"),
             retryable: status_is_retryable(status),
         });
     }
@@ -116,14 +112,14 @@ pub async fn fetch_table_schema(
         .await
         .map(|c| c.to_bytes())
         .map_err(|e| ZerobusSinkError::SchemaError {
-            message: format!("Failed to read response body: {}", e),
+            message: format!("Failed to read response body: {e}"),
             retryable: true,
         })?;
 
     let schema: UnityCatalogTableSchema =
         serde_json::from_reader(body_bytes.reader()).map_err(|e| {
             ZerobusSinkError::ConfigError {
-                message: format!("Failed to parse table schema response: {}", e),
+                message: format!("Failed to parse table schema response: {e}"),
             }
         })?;
 
@@ -145,7 +141,7 @@ async fn get_oauth_token(
     let uri: Uri = token_url
         .parse()
         .map_err(|e| ZerobusSinkError::ConfigError {
-            message: format!("Invalid token endpoint URL: {}", e),
+            message: format!("Invalid token endpoint URL: {e}"),
         })?;
 
     // Build form-encoded body
@@ -159,14 +155,14 @@ async fn get_oauth_token(
         .header("Content-Type", "application/x-www-form-urlencoded")
         .body(Body::from(form_body))
         .map_err(|e| ZerobusSinkError::ConfigError {
-            message: format!("Failed to build OAuth request: {}", e),
+            message: format!("Failed to build OAuth request: {e}"),
         })?;
 
     let response = http_client
         .send(request)
         .await
         .map_err(|e| ZerobusSinkError::SchemaError {
-            message: format!("Failed to get OAuth token: {}", e),
+            message: format!("Failed to get OAuth token: {e}"),
             retryable: true,
         })?;
 
@@ -180,7 +176,7 @@ async fn get_oauth_token(
             .unwrap_or_default();
         let error_text = String::from_utf8_lossy(&body_bytes);
         return Err(ZerobusSinkError::SchemaError {
-            message: format!("OAuth token request failed {}: {}", status, error_text),
+            message: format!("OAuth token request failed {status}: {error_text}"),
             retryable: status_is_retryable(status),
         });
     }
@@ -191,14 +187,14 @@ async fn get_oauth_token(
         .await
         .map(|c| c.to_bytes())
         .map_err(|e| ZerobusSinkError::SchemaError {
-            message: format!("Failed to read OAuth response body: {}", e),
+            message: format!("Failed to read OAuth response body: {e}"),
             retryable: true,
         })?;
 
     let token_response: OAuthTokenResponse =
         serde_json::from_reader(body_bytes.reader()).map_err(|e| {
             ZerobusSinkError::ConfigError {
-                message: format!("Failed to parse OAuth token response: {}", e),
+                message: format!("Failed to parse OAuth token response: {e}"),
             }
         })?;
 
@@ -220,13 +216,13 @@ pub fn generate_arrow_schema_from_schema(
 ) -> Result<arrow::datatypes::Schema, ZerobusSinkError> {
     let arrow_schema =
         arrow_schema_from_uc_schema(schema).map_err(|e| ZerobusSinkError::ConfigError {
-            message: format!("Failed to convert Unity Catalog schema to Arrow: {}", e),
+            message: format!("Failed to convert Unity Catalog schema to Arrow: {e}"),
         })?;
 
     if tracing::enabled!(tracing::Level::INFO) {
         info!(
-            "Inferred Arrow schema from Unity Catalog table {}.{}.{}:\n{:#?}",
-            schema.catalog_name, schema.schema_name, schema.name, arrow_schema
+            "Inferred Arrow schema from Unity Catalog table {}.{}.{}:\n{arrow_schema:#?}",
+            schema.catalog_name, schema.schema_name, schema.name
         );
     }
 

--- a/src/sinks/datadog/metrics/sink.rs
+++ b/src/sinks/datadog/metrics/sink.rs
@@ -279,7 +279,7 @@ mod tests {
             values
                 .into_iter()
                 .map(|(id, value)| {
-                    let name = format!("{}-{}", value.as_name(), id);
+                    let name = format!("{}-{id}", value.as_name());
                     Metric::new(name, MetricKind::Incremental, value).with_timestamp(Some(ts))
                 })
                 // Filter out duplicates other than counters. We do this to prevent false positives. False positives would occur

--- a/src/sinks/datadog/traces/apm_stats/aggregation.rs
+++ b/src/sinks/datadog/traces/apm_stats/aggregation.rs
@@ -268,7 +268,7 @@ impl Aggregator {
                 };
                 b.add(span, weight, is_top, aggkey);
 
-                debug!("Created {} start_time bucket.", btime);
+                debug!("Created {btime} start_time bucket.");
                 self.buckets.insert(btime, b);
             }
         }
@@ -305,7 +305,7 @@ impl Aggregator {
             align_timestamp(now) - ((BUCKET_WINDOW_LEN - 1) * BUCKET_DURATION_NANOSECONDS);
 
         if new_oldest_ts > self.oldest_timestamp {
-            debug!("Updated oldest_timestamp to {}.", new_oldest_ts);
+            debug!("Updated oldest_timestamp to {new_oldest_ts}.");
             self.oldest_timestamp = new_oldest_ts;
         }
 
@@ -358,7 +358,7 @@ impl Aggregator {
             let retain = bucket_start > flush_cutoff_time;
 
             if !retain {
-                debug!("Flushing {} start_time bucket.", bucket_start);
+                debug!("Flushing {bucket_start} start_time bucket.");
 
                 bucket.export().into_iter().for_each(|(payload_key, csb)| {
                     match m.get_mut(&payload_key) {

--- a/src/sinks/datadog/traces/apm_stats/integration_tests.rs
+++ b/src/sinks/datadog/traces/apm_stats/integration_tests.rs
@@ -81,7 +81,7 @@ async fn run_server(name: String, port: u16, tx: Sender<StatsPayload>) {
 
     let addr = SocketAddr::from(([0, 0, 0, 0], port));
 
-    info!("HTTP server for `{}` listening on {}", name, addr);
+    info!("HTTP server for `{name}` listening on {addr}");
 
     axum::Server::bind(&addr)
         .serve(app.into_make_service())
@@ -110,10 +110,7 @@ async fn process_traces(Extension(_state): Extension<Arc<AppState>>, request: Re
 /// Process a POST request from the stats endpoint.
 /// De-compresses and De-serializes the payload, then forwards it on the Sender channel.
 async fn process_stats(Extension(state): Extension<Arc<AppState>>, mut request: Request<Body>) {
-    debug!(
-        "`{}` server process_stats request: {:?}",
-        state.name, request
-    );
+    debug!("`{}` server process_stats request: {request:?}", state.name);
 
     let content_type_header = request.headers().get(CONTENT_TYPE);
     let content_type = content_type_header.and_then(|value| value.to_str().ok());
@@ -140,7 +137,7 @@ async fn process_stats(Extension(state): Extension<Arc<AppState>>, mut request: 
             "`{}` server received and deserialized stats payload.",
             state.name
         );
-        debug!("{:?}", payload);
+        debug!("{payload:?}");
 
         state.tx.send(payload).await.unwrap();
     }
@@ -204,10 +201,10 @@ async fn send_agent_traces(urls: &Vec<String>, start: i64, duration: i64, span_i
                 .unwrap();
 
             if res.status() != hyper::StatusCode::OK {
-                error!("Error sending traces to {}, res: {:?}.", url, res);
+                error!("Error sending traces to {url}, res: {res:?}.");
                 return false;
             }
-            info!("Sent a trace to the Agent at {}.", url);
+            info!("Sent a trace to the Agent at {url}.");
         }
         true
     }
@@ -294,8 +291,8 @@ fn validate_stats(agent_stats: &StatsPayload, vector_stats: &StatsPayload) {
     let agent_s = agent_bucket.stats.first().unwrap();
     let vector_s = vector_bucket.stats.first().unwrap();
 
-    info!("\nagent_stats : {:?}", agent_s);
-    info!("\nvector_stats : {:?}", vector_s);
+    info!("\nagent_stats : {agent_s:?}");
+    info!("\nvector_stats : {vector_s:?}");
 
     assert!(agent_s.service == vector_s.service);
     assert!(agent_s.name == vector_s.name);

--- a/src/sinks/datadog/traces/apm_stats/weight.rs
+++ b/src/sinks/datadog/traces/apm_stats/weight.rs
@@ -75,8 +75,7 @@ pub(crate) fn extract_weight_from_root_span(spans: &[&ObjectMap]) -> f64 {
         // TODO remove the debug print and emit the Error event as outlined in
         // https://github.com/vectordotdev/vector/issues/14859
         debug!(
-            "Didn't reliably find the root span for weight calculation of trace_id {:?}.",
-            trace_id
+            "Didn't reliably find the root span for weight calculation of trace_id {trace_id:?}."
         );
     }
 
@@ -87,8 +86,7 @@ pub(crate) fn extract_weight_from_root_span(spans: &[&ObjectMap]) -> f64 {
             // TODO remove the debug print and emit the Error event as outlined in
             // https://github.com/vectordotdev/vector/issues/14859
             debug!(
-                "Root span was not found. Defaulting to weight of 1.0 for trace_id {:?}.",
-                trace_id
+                "Root span was not found. Defaulting to weight of 1.0 for trace_id {trace_id:?}."
             );
             &1.0
         })

--- a/src/sinks/datadog/traces/request_builder.rs
+++ b/src/sinks/datadog/traces/request_builder.rs
@@ -521,9 +521,8 @@ mod test {
                     assert_eq!(1, processed.len());
                     assert!(
                         encoded.len() <= max_size,
-                        "encoded len {} longer than max size {}",
-                        encoded.len(),
-                        max_size
+                        "encoded len {} longer than max size {max_size}",
+                        encoded.len()
                     );
                 }
             }

--- a/src/sinks/datadog/traces/service.rs
+++ b/src/sinks/datadog/traces/service.rs
@@ -47,7 +47,7 @@ impl RetryLogic for TraceApiRetry {
             StatusCode::FORBIDDEN => RetryAction::Retry("forbidden".into()),
             StatusCode::REQUEST_TIMEOUT => RetryAction::Retry("request timeout".into()),
             _ if status.is_server_error() => RetryAction::Retry(
-                format!("{}: {}", status, String::from_utf8_lossy(&response.body)).into(),
+                format!("{status}: {}", String::from_utf8_lossy(&response.body)).into(),
             ),
             _ if status.is_success() => RetryAction::Successful,
             _ => RetryAction::DontRetry(format!("response status: {status}").into()),

--- a/src/sinks/doris/client.rs
+++ b/src/sinks/doris/client.rs
@@ -94,10 +94,8 @@ impl DorisSinkClient {
     /// Generate a unique label for the stream load
     fn generate_label(&self, database: &str, table: &str) -> String {
         format!(
-            "{}_{}_{}_{}_{}",
+            "{}_{database}_{table}_{}_{}",
             self.label_prefix,
-            database,
-            table,
             SystemTime::now()
                 .duration_since(SystemTime::UNIX_EPOCH)
                 .unwrap_or_default()
@@ -144,8 +142,7 @@ impl DorisSinkClient {
             let encoded_database = utf8_percent_encode(database, PATH_SEGMENT);
             let encoded_table = utf8_percent_encode(table, PATH_SEGMENT);
             let stream_load_url = format!(
-                "{}://{}/api/{}/{}/_stream_load",
-                scheme, authority, encoded_database, encoded_table
+                "{scheme}://{authority}/api/{encoded_database}/{encoded_table}/_stream_load"
             );
 
             stream_load_url.parse::<Uri>().map_err(|source| {
@@ -341,7 +338,7 @@ impl DorisSinkClient {
         // Use Doris bootstrap API endpoint for health check, GET method
         let scheme = endpoint.scheme_str().unwrap_or("http");
         let authority = endpoint.authority().map(|a| a.as_str()).unwrap_or("");
-        let uri_str = format!("{}://{}/api/bootstrap", scheme, authority);
+        let uri_str = format!("{scheme}://{authority}/api/bootstrap");
 
         let uri = uri_str.parse::<Uri>().map_err(|source| {
             debug!(
@@ -415,7 +412,7 @@ impl DorisSinkClient {
         );
 
         Err(HealthCheckError::HealthCheckFailed {
-            message: format!("HTTP status: {}", status),
+            message: format!("HTTP status: {status}"),
         }
         .into())
     }

--- a/src/sinks/doris/integration_test.rs
+++ b/src/sinks/doris/integration_test.rs
@@ -69,13 +69,13 @@ fn assert_fields_match(
 
         // Build error message
         let error_msg = if let Some(table) = table_name {
-            format!("Field '{}' mismatch in table {}", field, table)
+            format!("Field '{field}' mismatch in table {table}")
         } else {
-            format!("Field '{}' mismatch", field)
+            format!("Field '{field}' mismatch")
         };
 
         // Compare string representations
-        assert_eq!(event_str, db_str, "{}", error_msg);
+        assert_eq!(event_str, db_str, "{error_msg}");
     }
 }
 
@@ -178,9 +178,9 @@ enum DbValue {
 impl std::fmt::Display for DbValue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            DbValue::String(s) => write!(f, "{}", s),
-            DbValue::Integer(i) => write!(f, "{}", i),
-            DbValue::Float(fl) => write!(f, "{}", fl),
+            DbValue::String(s) => write!(f, "{s}"),
+            DbValue::Integer(i) => write!(f, "{i}"),
+            DbValue::Float(fl) => write!(f, "{fl}"),
             DbValue::Null => write!(f, "null"),
         }
     }
@@ -231,7 +231,7 @@ impl DorisTestClient {
     async fn create_connection(&self) -> MySqlConnection {
         MySqlConnection::connect_with(&self.connect_options)
             .await
-            .unwrap_or_else(|e| panic!("Failed to connect to database: {}", e))
+            .unwrap_or_else(|e| panic!("Failed to connect to database: {e}"))
     }
 
     /// Execute a query that doesn't return data (DDL/DML operations)
@@ -264,7 +264,7 @@ impl DorisTestClient {
                     );
                     return;
                 }
-                panic!("SQL query execution failed: {} - {}", query, e);
+                panic!("SQL query execution failed: {query} - {e}");
             }
         }
         // Connection is automatically closed when it goes out of scope
@@ -291,7 +291,7 @@ impl DorisTestClient {
         // Connection is automatically closed when it goes out of scope
         conn.fetch_one(query)
             .await
-            .unwrap_or_else(|e| panic!("{} failed: {} - {}", operation_name, query, e))
+            .unwrap_or_else(|e| panic!("{operation_name} failed: {query} - {e}"))
     }
 
     /// Execute a query that returns multiple rows
@@ -317,36 +317,35 @@ impl DorisTestClient {
 
     /// Create database using the common execute pattern
     async fn create_database(&self, database: &str) {
-        let query = format!("CREATE DATABASE IF NOT EXISTS {}", database);
+        let query = format!("CREATE DATABASE IF NOT EXISTS {database}");
         self.execute_query(&query).await;
     }
 
     /// Create table using the common execute pattern
     async fn create_table(&self, database: &str, table: &str, schema: &str) {
         let query = format!(
-            "CREATE TABLE IF NOT EXISTS {}.{} ({}) ENGINE=OLAP
+            "CREATE TABLE IF NOT EXISTS {database}.{table} ({schema}) ENGINE=OLAP
              DISTRIBUTED BY HASH(`host`) BUCKETS 1
-             PROPERTIES(\"replication_num\" = \"1\")",
-            database, table, schema
+             PROPERTIES(\"replication_num\" = \"1\")"
         );
         self.execute_query(&query).await;
     }
 
     /// Drop table using the common execute pattern
     async fn drop_table(&self, database: &str, table: &str) {
-        let query = format!("DROP TABLE IF EXISTS {}.{}", database, table);
+        let query = format!("DROP TABLE IF EXISTS {database}.{table}");
         self.execute_query(&query).await;
     }
 
     /// Drop database using the common execute pattern
     async fn drop_database(&self, database: &str) {
-        let query = format!("DROP DATABASE IF EXISTS {}", database);
+        let query = format!("DROP DATABASE IF EXISTS {database}");
         self.execute_query(&query).await;
     }
 
     /// Count rows using the common fetch_one pattern
     async fn count_rows(&self, database: &str, table: &str) -> i64 {
-        let query = format!("SELECT COUNT(*) FROM {}.{}", database, table);
+        let query = format!("SELECT COUNT(*) FROM {database}.{table}");
         let row = self.fetch_one_query(&query, "Counting rows").await;
 
         let count: i64 = row.get(0);
@@ -361,8 +360,7 @@ impl DorisTestClient {
     /// Get column names using the common fetch_all pattern
     async fn get_column_names(&self, database: &str, table: &str) -> Vec<String> {
         let query = format!(
-            "SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = '{}' AND TABLE_NAME = '{}' ORDER BY ORDINAL_POSITION",
-            database, table
+            "SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = '{database}' AND TABLE_NAME = '{table}' ORDER BY ORDINAL_POSITION"
         );
 
         let rows = self.fetch_all_query(&query, "Getting column names").await;
@@ -394,7 +392,7 @@ impl DorisTestClient {
 
     /// Get first row data using the refactored helper methods
     async fn get_first_row(&self, database: &str, table: &str) -> HashMap<String, DbValue> {
-        let query = format!("SELECT * FROM {}.{} LIMIT 1", database, table);
+        let query = format!("SELECT * FROM {database}.{table} LIMIT 1");
 
         // Get column names and row data using helper methods
         let columns = self.get_column_names(database, table).await;

--- a/src/sinks/doris/retry.rs
+++ b/src/sinks/doris/retry.rs
@@ -54,7 +54,7 @@ impl RetryLogic for DorisRetryLogic {
                     error_message = %message
                 );
                 return RetryAction::Retry(
-                    format!("Doris error: {} - {}", doris_resp.status, message).into(),
+                    format!("Doris error: {} - {message}", doris_resp.status).into(),
                 );
             } else {
                 // HTTP success but failed to parse response
@@ -74,7 +74,7 @@ impl RetryLogic for DorisRetryLogic {
                 message = "Server error encountered, will retry.",
                 status_code = %status
             );
-            return RetryAction::Retry(format!("Server error from Doris: {}", status).into());
+            return RetryAction::Retry(format!("Server error from Doris: {status}").into());
         }
 
         // Don't retry for client errors (4xx) and other cases
@@ -82,6 +82,6 @@ impl RetryLogic for DorisRetryLogic {
             message = "Client error encountered, not retrying.",
             status_code = %status
         );
-        RetryAction::DontRetry(format!("Client error from Doris: {}", status).into())
+        RetryAction::DontRetry(format!("Client error from Doris: {status}").into())
     }
 }

--- a/src/sinks/elasticsearch/common.rs
+++ b/src/sinks/elasticsearch/common.rs
@@ -115,7 +115,7 @@ impl ElasticsearchCommon {
                     }
                 }
             }
-            format!("{}/_bulk?{}", base_url, query.finish())
+            format!("{base_url}/_bulk?{}", query.finish())
         };
         let bulk_uri = bulk_url.parse::<Uri>().unwrap();
 

--- a/src/sinks/elasticsearch/integration_tests.rs
+++ b/src/sinks/elasticsearch/integration_tests.rs
@@ -140,7 +140,7 @@ async fn flush(common: ElasticsearchCommon) -> crate::Result<()> {
 
 async fn create_template_index(common: &ElasticsearchCommon, name: &str) -> crate::Result<()> {
     let client = create_http_client();
-    let uri = format!("{}/_index_template/{}", common.base_url, name);
+    let uri = format!("{}/_index_template/{name}", common.base_url);
     let response = client
         .put(uri)
         .json(&json!({
@@ -553,8 +553,8 @@ async fn insert_events_with_failure_and_gzip_compression() {
 async fn insert_events_in_data_stream() {
     trace_init();
     let index = gen_index();
-    let template_index = format!("my-template-{}", index);
-    let stream_index = format!("my-stream-{}", index);
+    let template_index = format!("my-template-{index}");
+    let stream_index = format!("my-stream-{index}");
 
     let cfg = ElasticsearchConfig {
         endpoints: vec![http_server()],
@@ -893,7 +893,7 @@ fn gen_index() -> Template {
 
 async fn create_data_stream(common: &ElasticsearchCommon, name: &str) -> crate::Result<()> {
     let client = create_http_client();
-    let uri = format!("{}/_data_stream/{}", common.base_url, name);
+    let uri = format!("{}/_data_stream/{name}", common.base_url);
     let response = client
         .put(uri)
         .header("Content-Type", "application/json")

--- a/src/sinks/elasticsearch/retry.rs
+++ b/src/sinks/elasticsearch/retry.rs
@@ -117,8 +117,7 @@ impl RetryLogic for ElasticsearchRetryLogic {
             }
             _ if status.is_server_error() => RetryAction::Retry(
                 format!(
-                    "{}: {}",
-                    status,
+                    "{status}: {}",
                     String::from_utf8_lossy(response.http_response.body())
                 )
                 .into(),

--- a/src/sinks/file/mod.rs
+++ b/src/sinks/file/mod.rs
@@ -678,8 +678,7 @@ async fn create_dirs_nofollow(path: &Path, base: &Path) -> std::io::Result<()> {
         match fs::symlink_metadata(&current).await {
             Ok(meta) if meta.file_type().is_symlink() => {
                 return Err(std::io::Error::other(format!(
-                    "intermediate path component {:?} is a symlink",
-                    current
+                    "intermediate path component {current:?} is a symlink"
                 )));
             }
             Ok(_) => {}

--- a/src/sinks/gcp/cloud_storage.rs
+++ b/src/sinks/gcp/cloud_storage.rs
@@ -427,13 +427,13 @@ impl RequestBuilder<(String, Vec<Event>)> for RequestSettings {
 
             if self.append_uuid {
                 let uuid = Uuid::new_v4();
-                format!("{}-{}", seconds, uuid.hyphenated())
+                format!("{seconds}-{}", uuid.hyphenated())
             } else {
                 seconds.to_string()
             }
         };
 
-        let key = format!("{}{}.{}", key, filename, self.extension);
+        let key = format!("{key}{filename}.{}", self.extension);
         let body = payload.into_payload();
 
         GcsRequest {

--- a/src/sinks/gcp/pubsub.rs
+++ b/src/sinks/gcp/pubsub.rs
@@ -457,7 +457,7 @@ mod integration_tests {
         request(
             Method::PUT,
             &format!("subscriptions/{subscription}"),
-            json!({ "topic": format!("projects/{}/topics/{}", PROJECT, topic) }),
+            json!({ "topic": format!("projects/{PROJECT}/topics/{topic}") }),
         )
         .await
         .json::<Value>()
@@ -467,7 +467,7 @@ mod integration_tests {
     }
 
     async fn request(method: Method, path: &str, json: Value) -> Response {
-        let url = format!("{}/v1/projects/{}/{}", *gcp::PUBSUB_ADDRESS, PROJECT, path);
+        let url = format!("{}/v1/projects/{PROJECT}/{path}", *gcp::PUBSUB_ADDRESS);
         Client::new()
             .request(method.clone(), &url)
             .json(&json)

--- a/src/sinks/gcp/stackdriver/metrics/request_builder.rs
+++ b/src/sinks/gcp/stackdriver/metrics/request_builder.rs
@@ -74,8 +74,7 @@ impl encoding::Encoder<Vec<Metric>> for StackdriverMetricsEncoder {
                     .namespace
                     .unwrap_or_else(|| self.default_namespace.clone());
                 let metric_type = format!(
-                    "custom.googleapis.com/{}/metrics/{}",
-                    namespace, series.name.name
+                    "custom.googleapis.com/{namespace}/metrics/{}", series.name.name
                 );
 
                 let end_time = data.time.timestamp.unwrap_or_else(chrono::Utc::now);

--- a/src/sinks/gcp/stackdriver/metrics/sink.rs
+++ b/src/sinks/gcp/stackdriver/metrics/sink.rs
@@ -59,7 +59,7 @@ where
                     &MetricValue::Counter { .. } => Some(metric),
                     &MetricValue::Gauge { .. } => Some(metric),
                     not_supported => {
-                        warn!("Unsupported metric type: {:?}.", not_supported);
+                        warn!("Unsupported metric type: {not_supported:?}.");
                         None
                     }
                 })

--- a/src/sinks/gcp_chronicle/chronicle_unstructured.rs
+++ b/src/sinks/gcp_chronicle/chronicle_unstructured.rs
@@ -404,14 +404,13 @@ impl ChronicleUnstructuredConfig {
 
     fn create_endpoint(&self, path: &str) -> Result<String, ChronicleError> {
         Ok(format!(
-            "{}/{}",
+            "{}/{path}",
             match (&self.endpoint, self.region) {
                 (Some(endpoint), None) => endpoint.to_string().trim_end_matches('/').to_string(),
                 (None, Some(region)) => region.endpoint().to_string(),
                 (Some(_), Some(_)) => return Err(ChronicleError::BothRegionAndEndpoint),
                 (None, None) => return Err(ChronicleError::RegionOrEndpoint),
-            },
-            path
+            }
         ))
     }
 }

--- a/src/sinks/greptimedb/logs/integration_tests.rs
+++ b/src/sinks/greptimedb/logs/integration_tests.rs
@@ -113,8 +113,8 @@ impl GreptimeClient {
     async fn create_pipeline(&self, pipeline_name: &str, pipeline_content: &str) {
         self.client
             .post(format!(
-                "{}/v1/events/pipelines/{}",
-                self.endpoint, pipeline_name
+                "{}/v1/events/pipelines/{pipeline_name}",
+                self.endpoint
             ))
             .header("Content-Type", "application/x-yaml")
             .body(String::from(pipeline_content))

--- a/src/sinks/humio/logs.rs
+++ b/src/sinks/humio/logs.rs
@@ -563,9 +563,8 @@ mod integration_tests {
 
         // https://docs.humio.com/api/using-the-search-api-with-humio
         let search_url = format!(
-            "{}/api/v1/repositories/{}/query",
-            humio_address(),
-            repository_name
+            "{}/api/v1/repositories/{repository_name}/query",
+            humio_address()
         );
         let search_query = format!(r#"message="{message}""#);
 

--- a/src/sinks/influxdb/metrics.rs
+++ b/src/sinks/influxdb/metrics.rs
@@ -1434,7 +1434,7 @@ mod integration_tests {
                 .position(|&r| r.trim() == "_measurement")
                 .unwrap()]
             .trim(),
-            format!("ns.{}", metric)
+            format!("ns.{metric}")
         );
         assert_eq!(
             record[header.iter().position(|&r| r.trim() == "_field").unwrap()].trim(),

--- a/src/sinks/influxdb/mod.rs
+++ b/src/sinks/influxdb/mod.rs
@@ -488,7 +488,7 @@ pub mod test_util {
         // this with empty writes and loop if it reports the database
         // does not exist yet.
         crate::test_util::wait_for(|| {
-            let write_url = format!("{}/write?db={}", endpoint, &database);
+            let write_url = format!("{endpoint}/write?db={}", &database);
             async move {
                 match client()
                     .post(&write_url)

--- a/src/sinks/kafka/tests.rs
+++ b/src/sinks/kafka/tests.rs
@@ -41,7 +41,7 @@ mod integration_test {
     }
 
     fn kafka_address(port: u16) -> String {
-        format!("{}:{}", kafka_host(), port)
+        format!("{}:{port}", kafka_host())
     }
 
     // Tests exercise the sink itself, not confinement; build a checkerless confined topic.
@@ -337,7 +337,7 @@ mod integration_test {
 
         assert_sink_compliance(&SINK_TAGS, async move {
             let topic_prefix = format!("test-trace-{}", random_string(10));
-            let topic_now = format!("{}-{}", topic_prefix, chrono::Utc::now().format("%Y%m%d"));
+            let topic_now = format!("{topic_prefix}-{}", chrono::Utc::now().format("%Y%m%d"));
             let topic = Template::try_from(format!("{topic_prefix}-%Y%m%d")).unwrap();
             let key_field = ConfigTargetPath::try_from("trace_key".to_string()).unwrap();
             let headers_key = ConfigTargetPath::try_from("trace_headers".to_string()).unwrap();
@@ -497,7 +497,7 @@ mod integration_test {
             acknowledgements: Default::default(),
             confinement: Default::default(),
         };
-        let topic = format!("{}-{}", topic, chrono::Utc::now().format("%Y%m%d"));
+        let topic = format!("{topic}-{}", chrono::Utc::now().format("%Y%m%d"));
         println!("Topic name generated in test: {topic:?}");
 
         let num_events = 1000;

--- a/src/sinks/loki/integration_tests.rs
+++ b/src/sinks/loki/integration_tests.rs
@@ -69,14 +69,12 @@ async fn build_sink_with_compression(codec: &str, compression: &str) -> (uuid::U
         r#"
             endpoint = "{}"
             labels = {{test_name = "placeholder"}}
-            encoding.codec = "{}"
-            compression = "{}"
+            encoding.codec = "{codec}"
+            compression = "{compression}"
             remove_timestamp = false
             tenant_id = "default"
         "#,
-        loki_address(),
-        codec,
-        compression
+        loki_address()
     );
 
     let (mut config, cx) = load_sink::<LokiConfig>(&config).unwrap();
@@ -687,9 +685,8 @@ async fn fetch_stream(stream: String, tenant: &str) -> (Vec<i64>, Vec<String>) {
 async fn fetch_stream_with_key(key: &str, stream: String, tenant: &str) -> (Vec<i64>, Vec<String>) {
     let query = format!("%7B{key}%3D\"{stream}\"%7D");
     let query = format!(
-        "{}/loki/api/v1/query_range?query={}&direction=forward",
-        loki_address(),
-        query
+        "{}/loki/api/v1/query_range?query={query}&direction=forward",
+        loki_address()
     );
 
     let res = reqwest::Client::new()

--- a/src/sinks/mqtt/sink.rs
+++ b/src/sinks/mqtt/sink.rs
@@ -100,7 +100,7 @@ impl MqttSink {
             .filter_map(|request| async move {
                 match request {
                     Err(e) => {
-                        error!("Failed to build MQTT request: {:?}.", e);
+                        error!("Failed to build MQTT request: {e:?}.");
                         None
                     }
                     Ok(req) => Some(req),

--- a/src/sinks/nats/sink.rs
+++ b/src/sinks/nats/sink.rs
@@ -86,7 +86,7 @@ impl NatsSink {
             .filter_map(|request| async move {
                 match request {
                     Err(e) => {
-                        error!("Failed to build NATS request: {:?}.", e);
+                        error!("Failed to build NATS request: {e:?}.");
                         None
                     }
                     Ok(req) => Some(req),

--- a/src/sinks/new_relic/config.rs
+++ b/src/sinks/new_relic/config.rs
@@ -324,7 +324,7 @@ mod tests {
         config.account_id = SensitiveString::from("super-secret-account-id".to_string());
 
         let validated = config.validate().expect("validation should succeed");
-        let debug = format!("{:?}", validated);
+        let debug = format!("{validated:?}");
 
         assert!(!debug.contains("super-secret-license-key"));
         assert!(!debug.contains("super-secret-account-id"));

--- a/src/sinks/opendal_common.rs
+++ b/src/sinks/opendal_common.rs
@@ -205,7 +205,7 @@ impl RequestBuilder<(String, Vec<Event>)> for OpenDalRequestBuilder {
         let name = uuid::Uuid::new_v4().to_string();
         let extension = self.compression.extension();
 
-        metadata.partition_key = format!("{}{}.{}", metadata.partition_key, name, extension);
+        metadata.partition_key = format!("{}{name}.{extension}", metadata.partition_key);
 
         OpenDalRequest {
             metadata,

--- a/src/sinks/prometheus/exporter.rs
+++ b/src/sinks/prometheus/exporter.rs
@@ -322,7 +322,7 @@ fn authorized<T: HttpBody>(req: &Request<T>, auth: &Option<Auth>) -> bool {
                 Auth::Basic { user, password } => Some(HeaderValue::from_str(
                     format!(
                         "Basic {}",
-                        BASE64_STANDARD.encode(format!("{}:{}", user, password.inner()))
+                        BASE64_STANDARD.encode(format!("{user}:{}", password.inner()))
                     )
                     .as_str(),
                 )),
@@ -480,7 +480,7 @@ impl PrometheusExporter {
                 .with_graceful_shutdown(tripwire.then(crate::shutdown::tripwire_handler))
                 .instrument(span)
                 .await
-                .map_err(|error| error!("Server error: {}.", error))?;
+                .map_err(|error| error!("Server error: {error}."))?;
 
             Ok::<(), ()>(())
         });
@@ -544,7 +544,7 @@ impl StreamSink<Event> for PrometheusExporter {
     async fn run(mut self: Box<Self>, mut input: BoxStream<'_, Event>) -> Result<(), ()> {
         self.start_server_if_needed()
             .await
-            .map_err(|error| error!("Failed to start Prometheus exporter: {}.", error))?;
+            .map_err(|error| error!("Failed to start Prometheus exporter: {error}."))?;
 
         let mut last_flush = Instant::now();
         let flush_period = self.config.flush_period_secs;
@@ -1566,11 +1566,7 @@ mod integration_tests {
     }
 
     async fn prometheus_query(query: &str) -> Value {
-        let url = format!(
-            "http://{}/api/v1/query?query={}",
-            prometheus_address(),
-            query
-        );
+        let url = format!("http://{}/api/v1/query?query={query}", prometheus_address());
         let request = Request::post(url)
             .body(Body::empty())
             .expect("Error creating request.");

--- a/src/sinks/prometheus/remote_write/integration_tests.rs
+++ b/src/sinks/prometheus/remote_write/integration_tests.rs
@@ -57,7 +57,7 @@ async fn insert_metrics(url: &str) {
             let metric = event.into_metric();
             let result = query(
                 url,
-                &format!(r#"SELECT * FROM "{}".."{}""#, database, metric.name()),
+                &format!(r#"SELECT * FROM "{database}".."{}""#, metric.name()),
             )
             .await;
 

--- a/src/sinks/prometheus/remote_write/sink.rs
+++ b/src/sinks/prometheus/remote_write/sink.rs
@@ -194,7 +194,7 @@ where
             .filter_map(|request| async move {
                 match request {
                     Err(e) => {
-                        error!("Failed to build Remote Write request: {:?}.", e);
+                        error!("Failed to build Remote Write request: {e:?}.");
                         None
                     }
                     Ok(req) => Some(req),

--- a/src/sinks/pulsar/config.rs
+++ b/src/sinks/pulsar/config.rs
@@ -435,7 +435,7 @@ impl ValidatedSink for PulsarSinkConfig {
             validate_auth_shape(auth)?;
         }
         let url = url::Url::parse(&self.endpoint)
-            .map_err(|e| format!("Invalid Pulsar endpoint `{}`: {}", self.endpoint, e))?;
+            .map_err(|e| format!("Invalid Pulsar endpoint `{}`: {e}", self.endpoint))?;
         if !matches!(url.scheme(), "pulsar" | "pulsar+ssl") {
             return Err(format!(
                 "Invalid Pulsar endpoint `{}`: scheme must be pulsar or pulsar+ssl",

--- a/src/sinks/pulsar/integration_tests.rs
+++ b/src/sinks/pulsar/integration_tests.rs
@@ -24,7 +24,7 @@ fn pulsar_host() -> String {
 }
 
 fn pulsar_address(scheme: &str, port: u16) -> String {
-    format!("{}://{}:{}", scheme, pulsar_host(), port)
+    format!("{scheme}://{}:{port}", pulsar_host())
 }
 
 async fn pulsar_happy_reuse(mut cnf: PulsarSinkConfig) {

--- a/src/sinks/pulsar/sink.rs
+++ b/src/sinks/pulsar/sink.rs
@@ -121,7 +121,7 @@ impl PulsarSink {
             .request_builder(default_request_builder_concurrency_limit(), request_builder)
             .filter_map(|request| async move {
                 request
-                    .map_err(|e| error!("Failed to build Pulsar request: {:?}.", e))
+                    .map_err(|e| error!("Failed to build Pulsar request: {e:?}."))
                     .ok()
             })
             .into_driver(service)

--- a/src/sinks/splunk_hec/common/util.rs
+++ b/src/sinks/splunk_hec/common/util.rs
@@ -112,7 +112,7 @@ pub fn build_uri(
     path: &str,
     query: impl IntoIterator<Item = (&'static str, String)>,
 ) -> Result<Uri, http::uri::InvalidUri> {
-    let mut uri = format!("{}{}", host.trim_end_matches('/'), path);
+    let mut uri = format!("{}{path}", host.trim_end_matches('/'));
 
     let mut first = true;
 

--- a/src/sinks/splunk_hec/logs/sink.rs
+++ b/src/sinks/splunk_hec/logs/sink.rs
@@ -135,7 +135,7 @@ where
             .filter_map(|request| async move {
                 match request {
                     Err(e) => {
-                        error!("Failed to build HEC Logs request: {:?}.", e);
+                        error!("Failed to build HEC Logs request: {e:?}.");
                         None
                     }
                     Ok(req) => Some(req),

--- a/src/sinks/splunk_hec/metrics/integration_tests.rs
+++ b/src/sinks/splunk_hec/metrics/integration_tests.rs
@@ -252,9 +252,8 @@ async fn metric_dimensions(metric_name: &str) -> Vec<JsonValue> {
 
     let res = client
         .get(format!(
-            "{}/services/catalog/metricstore/dimensions?output_mode=json&metric_name={}",
-            splunk_api_address(),
-            metric_name
+            "{}/services/catalog/metricstore/dimensions?output_mode=json&metric_name={metric_name}",
+            splunk_api_address()
         ))
         .form(&vec![("filter", "index=*")])
         .basic_auth(USERNAME, Some(PASSWORD))

--- a/src/sinks/splunk_hec/metrics/sink.rs
+++ b/src/sinks/splunk_hec/metrics/sink.rs
@@ -63,7 +63,7 @@ where
             .filter_map(|request| async move {
                 match request {
                     Err(e) => {
-                        error!("Failed to build HEC Metrics request: {:?}.", e);
+                        error!("Failed to build HEC Metrics request: {e:?}.");
                         None
                     }
                     Ok(req) => Some(req),

--- a/src/sinks/util/adaptive_concurrency/tests.rs
+++ b/src/sinks/util/adaptive_concurrency/tests.rs
@@ -670,8 +670,8 @@ async fn run_compare(input: TestInput) {
             FailureMode::ExceededMaximum => "maximum",
         };
         eprintln!(
-            "Comparison failed: {} = {}; {} = {}",
-            failure.stat_name, failure.value, mode, failure.reference
+            "Comparison failed: {} = {}; {mode} = {}",
+            failure.stat_name, failure.value, failure.reference
         );
     }
     assert!(failures.is_empty(), "{results:#?}");

--- a/src/sinks/util/retries.rs
+++ b/src/sinks/util/retries.rs
@@ -426,10 +426,8 @@ mod tests {
             // Check if the backoff is within the expected range, considering the jitter
             assert!(
                 !backoff.is_zero() && backoff <= upper_bound,
-                "Attempt {}: Expected backoff to be within 0 and {:?}, got {:?}",
-                i + 1,
-                upper_bound,
-                backoff
+                "Attempt {}: Expected backoff to be within 0 and {upper_bound:?}, got {backoff:?}",
+                i + 1
             );
 
             policy.advance();

--- a/src/sinks/websocket_server/sink.rs
+++ b/src/sinks/websocket_server/sink.rs
@@ -173,7 +173,7 @@ impl WebSocketListenerSink {
         // Base url for parsing request URLs that may be relative
         let base_url = Url::parse("ws://localhost").ok();
         let addr = stream.peer_addr();
-        debug!("Incoming TCP connection from: {}", addr);
+        debug!("Incoming TCP connection from: {addr}");
 
         let mut extra_tags: Vec<(String, String)> = extra_tags_config
             .iter()
@@ -255,7 +255,7 @@ impl WebSocketListenerSink {
                     let mut response = ErrorResponse::default();
                     *response.status_mut() = StatusCode::UNAUTHORIZED;
                     *response.body_mut() = Some(message.message().to_string());
-                    debug!("Websocket handshake auth validation failed: {}", message);
+                    debug!("Websocket handshake auth validation failed: {message}");
                     Err(response)
                 }
             }
@@ -264,7 +264,7 @@ impl WebSocketListenerSink {
         let ws_stream = tokio_tungstenite::accept_hdr_async(stream, header_callback)
             .await
             .map_err(|err| {
-                debug!("Error during websocket handshake: {}", err);
+                debug!("Error during websocket handshake: {err}");
                 emit!(WebSocketListenerConnectionFailedError {
                     error: Box::new(err),
                     extra_tags: extra_tags.clone()
@@ -289,7 +289,7 @@ impl WebSocketListenerSink {
                 },
             );
 
-            debug!("WebSocket connection established: {}", addr);
+            debug!("WebSocket connection established: {addr}");
 
             peers.insert(addr, tx);
             emit!(WebSocketListenerConnectionEstablished {

--- a/src/sources/amqp.rs
+++ b/src/sources/amqp.rs
@@ -685,7 +685,7 @@ mod integration_test {
     ) {
         let payload = text.as_bytes();
         let payload_len = payload.len();
-        trace!("Sending message of length {} to {}.", payload_len, exchange,);
+        trace!("Sending message of length {payload_len} to {exchange}.");
 
         channel
             .basic_publish(
@@ -705,7 +705,7 @@ mod integration_test {
         let exchange = format!("test-{}-exchange", random_string(10));
         let queue = format!("test-{}-queue", random_string(10));
         let routing_key = "my_key";
-        trace!("Test exchange name: {}.", exchange);
+        trace!("Test exchange name: {exchange}.");
         let exchange: ShortString = exchange.into();
         let consumer = format!("test-consumer-{}", random_string(10));
 
@@ -770,7 +770,7 @@ mod integration_test {
         assert!(!events.is_empty());
 
         let log = events[0].as_log();
-        trace!("{:?}", log);
+        trace!("{log:?}");
         assert_eq!(*log.get_message().unwrap(), "my message".into());
         assert_eq!(log["routing"], routing_key.into());
         assert_eq!(*log.get_source_type().unwrap(), "amqp".into());

--- a/src/sources/apache_metrics/mod.rs
+++ b/src/sources/apache_metrics/mod.rs
@@ -360,7 +360,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
         wait_for_tcp(in_addr).await;
 
         let config = ApacheMetricsConfig {
-            endpoints: vec![format!("http://foo:bar@{}/metrics", in_addr)],
+            endpoints: vec![format!("http://foo:bar@{in_addr}/metrics")],
             scrape_interval_secs: Duration::from_secs(1),
             namespace: "custom".to_string(),
         };
@@ -419,7 +419,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
         let (tx, rx) = SourceSender::new_test();
 
         let source = ApacheMetricsConfig {
-            endpoints: vec![format!("http://{}", in_addr)],
+            endpoints: vec![format!("http://{in_addr}")],
             scrape_interval_secs: Duration::from_secs(1),
             namespace: "apache".to_string(),
         }
@@ -453,7 +453,7 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
         let (tx, rx) = SourceSender::new_test();
 
         let source = ApacheMetricsConfig {
-            endpoints: vec![format!("http://{}", in_addr)],
+            endpoints: vec![format!("http://{in_addr}")],
             scrape_interval_secs: Duration::from_secs(1),
             namespace: "custom".to_string(),
         }

--- a/src/sources/aws_ecs_metrics/mod.rs
+++ b/src/sources/aws_ecs_metrics/mod.rs
@@ -626,7 +626,7 @@ mod integration_tests {
     }
 
     fn ecs_url(version: &str) -> String {
-        format!("{}/{}", ecs_address(), version)
+        format!("{}/{version}", ecs_address())
     }
 
     async fn scrape_metrics(endpoint: String, version: Version) {

--- a/src/sources/aws_kinesis_firehose/mod.rs
+++ b/src/sources/aws_kinesis_firehose/mod.rs
@@ -220,7 +220,7 @@ impl SourceConfig for AwsKinesisFirehoseConfig {
                 .with_graceful_shutdown(shutdown.map(|_| ()))
                 .await
                 .map_err(|err| {
-                    error!("An error occurred: {:?}.", err);
+                    error!("An error occurred: {err:?}.");
                 })?;
 
             Ok(())

--- a/src/sources/datadog_agent/mod.rs
+++ b/src/sources/datadog_agent/mod.rs
@@ -263,7 +263,7 @@ impl SourceConfig for DatadogAgentConfig {
                 .with_graceful_shutdown(shutdown.map(|_| ()))
                 .await
                 .map_err(|err| {
-                    error!("An error occurred: {:?}.", err);
+                    error!("An error occurred: {err:?}.");
                 })?;
 
             Ok(())

--- a/src/sources/datadog_agent/tests.rs
+++ b/src/sources/datadog_agent/tests.rs
@@ -2111,7 +2111,7 @@ fn test_config_outputs() {
                 .remove(&name.map(ToOwned::to_owned))
                 .expect("output exists");
 
-            assert_eq!(got, want, "{}", title);
+            assert_eq!(got, want, "{title}");
         }
     }
 }

--- a/src/sources/docker_logs/tests.rs
+++ b/src/sources/docker_logs/tests.rs
@@ -554,9 +554,9 @@ mod integration_tests {
             let included1_message = "included 1";
 
             let prefix = format!("vector_test_exclude_containers_{}", uuid::Uuid::new_v4());
-            let included0 = format!("{}_{}", prefix, "include0");
-            let included1 = format!("{}_{}", prefix, "include1");
-            let excluded0 = format!("{}_{}", prefix, "excluded0");
+            let included0 = format!("{prefix}_{}", "include0");
+            let included1 = format!("{prefix}_{}", "include1");
+            let excluded0 = format!("{prefix}_{}", "excluded0");
 
             let docker = docker(None, None).unwrap();
 

--- a/src/sources/exec/mod.rs
+++ b/src/sources/exec/mod.rs
@@ -720,7 +720,7 @@ fn spawn_reader_thread<R: 'static + AsyncRead + Unpin + std::marker::Send>(
 ) {
     // Start the green background thread for collecting
     drop(crate::spawn_in_current_span(async move {
-        debug!("Start capturing {} command output.", origin);
+        debug!("Start capturing {origin} command output.");
 
         let mut stream = DecoderFramedRead::new(reader, decoder);
         while let Some(result) = stream.next().await {
@@ -743,6 +743,6 @@ fn spawn_reader_thread<R: 'static + AsyncRead + Unpin + std::marker::Send>(
             }
         }
 
-        debug!("Finished capturing {} command output.", origin);
+        debug!("Finished capturing {origin} command output.");
     }));
 }

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -1189,14 +1189,14 @@ mod tests {
             let line =
                 event.as_log()[log_schema().message_key().unwrap().to_string()].to_string_lossy();
             if line.starts_with("hello") {
-                assert_eq!(line, format!("hello {}", hello_i));
+                assert_eq!(line, format!("hello {hello_i}"));
                 assert_eq!(
                     event.as_log()["file"].to_string_lossy(),
                     path1.to_str().unwrap()
                 );
                 hello_i += 1;
             } else {
-                assert_eq!(line, format!("goodbye {}", goodbye_i));
+                assert_eq!(line, format!("goodbye {goodbye_i}"));
                 assert_eq!(
                     event.as_log()["file"].to_string_lossy(),
                     path2.to_str().unwrap()
@@ -1285,9 +1285,9 @@ mod tests {
                 event.as_log()[log_schema().message_key().unwrap().to_string()].to_string_lossy();
 
             if pre_trunc {
-                assert_eq!(line, format!("pretrunc {}", i));
+                assert_eq!(line, format!("pretrunc {i}"));
             } else {
-                assert_eq!(line, format!("posttrunc {}", i));
+                assert_eq!(line, format!("posttrunc {i}"));
             }
 
             i += 1;
@@ -1350,9 +1350,9 @@ mod tests {
                 event.as_log()[log_schema().message_key().unwrap().to_string()].to_string_lossy();
 
             if pre_rot {
-                assert_eq!(line, format!("prerot {}", i));
+                assert_eq!(line, format!("prerot {i}"));
             } else {
-                assert_eq!(line, format!("postrot {}", i));
+                assert_eq!(line, format!("postrot {i}"));
             }
 
             i += 1;
@@ -2409,14 +2409,14 @@ mod tests {
             // Event 1: Position \r\n to split at first boundary
             let event1_prefix = "Event 1: ";
             let padding1_len = buffer_size - event1_prefix.len() - 1; // -1 for the \r
-            write!(&mut file, "{}", event1_prefix).unwrap();
+            write!(&mut file, "{event1_prefix}").unwrap();
             file.write_all(&vec![b'X'; padding1_len]).unwrap();
             write!(&mut file, "\r\n").unwrap(); // \r at byte 8191, \n at byte 8192
 
             // Event 2: Position \r\n to split at second boundary
             let event2_prefix = "Event 2: ";
             let padding2_len = buffer_size - event2_prefix.len() - 1;
-            write!(&mut file, "{}", event2_prefix).unwrap();
+            write!(&mut file, "{event2_prefix}").unwrap();
             file.write_all(&vec![b'Y'; padding2_len]).unwrap();
             write!(&mut file, "\r\n").unwrap(); // \r at byte 16383, \n at byte 16384
 
@@ -2443,13 +2443,11 @@ mod tests {
 
         assert!(
             msg0.starts_with("Event 1: "),
-            "First event should start with 'Event 1: ', got: {}",
-            msg0
+            "First event should start with 'Event 1: ', got: {msg0}"
         );
         assert!(
             msg1.starts_with("Event 2: "),
-            "Second event should start with 'Event 2: ', got: {}",
-            msg1
+            "Second event should start with 'Event 2: ', got: {msg1}"
         );
         assert_eq!(msg2, "Event 3: Final");
 
@@ -2458,13 +2456,11 @@ mod tests {
             let msg_str = msg.to_string_lossy();
             assert!(
                 !msg_str.contains('\r'),
-                "Event {} should not contain embedded \\r",
-                i
+                "Event {i} should not contain embedded \\r"
             );
             assert!(
                 !msg_str.contains('\n'),
-                "Event {} should not contain embedded \\n",
-                i
+                "Event {i} should not contain embedded \\n"
             );
         }
     }

--- a/src/sources/file_descriptors/mod.rs
+++ b/src/sources/file_descriptors/mod.rs
@@ -70,7 +70,7 @@ pub trait FileDescriptorConfig: NamedComponent {
         // until another newline is entered. See
         // https://github.com/tokio-rs/tokio/blob/a73428252b08bf1436f12e76287acbc4600ca0e5/tokio/src/io/stdin.rs#L33-L42
         std::thread::spawn(move || {
-            info!("Capturing {}.", description);
+            info!("Capturing {description}.");
             read_from_fd(reader, sender);
         });
 

--- a/src/sources/gcp_pubsub.rs
+++ b/src/sources/gcp_pubsub.rs
@@ -870,7 +870,7 @@ mod integration_tests {
 
     const PROJECT: &str = "sourceproject";
     static PROJECT_URI: LazyLock<String> =
-        LazyLock::new(|| format!("{}/v1/projects/{}", *gcp::PUBSUB_ADDRESS, PROJECT));
+        LazyLock::new(|| format!("{}/v1/projects/{PROJECT}", *gcp::PUBSUB_ADDRESS));
     static ACK_DEADLINE: LazyLock<Duration> = LazyLock::new(|| Duration::from_secs(10)); // Minimum custom deadline allowed by Pub/Sub
 
     #[ignore = "https://github.com/vectordotdev/vector/issues/24133"]
@@ -1051,7 +1051,7 @@ mod integration_tests {
             this.request(Method::PUT, "topics/{topic}", json!({})).await;
 
             let body = json!({
-                "topic": format!("projects/{}/topics/{}", PROJECT, this.topic),
+                "topic": format!("projects/{PROJECT}/topics/{}", this.topic),
                 "ackDeadlineSeconds": *ACK_DEADLINE,
             });
             this.request(Method::PUT, "subscriptions/{sub}", body).await;

--- a/src/sources/heroku_logs.rs
+++ b/src/sources/heroku_logs.rs
@@ -257,13 +257,12 @@ impl LogplexSource {
 
         if events.len() != msg_count {
             let error_msg = format!(
-                "Parsed event count does not match message count header: {} vs {}",
-                events.len(),
-                msg_count
+                "Parsed event count does not match message count header: {} vs {msg_count}",
+                events.len()
             );
 
             if cfg!(test) {
-                panic!("{}", error_msg);
+                panic!("{error_msg}");
             }
             return Err(header_error_message("Logplex-Msg-Count", &error_msg));
         }

--- a/src/sources/host_metrics/filesystem.rs
+++ b/src/sources/host_metrics/filesystem.rs
@@ -246,12 +246,7 @@ mod tests {
             "filesystem_total_bytes",
             "filesystem_used_bytes",
         ] {
-            assert_eq!(
-                count_name(&metrics, name),
-                metrics.len() / 3,
-                "name={}",
-                name
-            );
+            assert_eq!(count_name(&metrics, name), metrics.len() / 3, "name={name}");
         }
 
         // They should all have "filesystem" and "mountpoint" tags

--- a/src/sources/host_metrics/tcp.rs
+++ b/src/sources/host_metrics/tcp.rs
@@ -19,8 +19,7 @@ impl HostMetrics {
             .await
             .unwrap_or_else(|join_error| {
                 Err(procfs::ProcError::Other(format!(
-                    "Failed to join blocking task: {}",
-                    join_error
+                    "Failed to join blocking task: {join_error}"
                 )))
             });
 

--- a/src/sources/http_client/client.rs
+++ b/src/sources/http_client/client.rs
@@ -202,7 +202,7 @@ fn compile_parameter_vrl(
         Err(diagnostics) => {
             let error = format_vrl_diagnostics(param.value(), diagnostics);
             Err(sources::BuildError::VrlCompilationError {
-                message: format!("VRL compilation failed: {}", error),
+                message: format!("VRL compilation failed: {error}"),
             })
         }
     }

--- a/src/sources/http_client/tests.rs
+++ b/src/sources/http_client/tests.rs
@@ -714,8 +714,7 @@ async fn query_vrl_compilation_error() {
             let err_msg = err.to_string();
             assert!(
                 err_msg.contains("VRL compilation failed"),
-                "Expected VRL compilation error, got: {}",
-                err_msg
+                "Expected VRL compilation error, got: {err_msg}"
             );
         }
         Ok(_) => panic!("Expected build to fail with VRL compilation error, but it succeeded"),
@@ -757,8 +756,7 @@ async fn body_vrl_compilation_error() {
             let err_msg = err.to_string();
             assert!(
                 err_msg.contains("VRL compilation failed"),
-                "Expected VRL compilation error, got: {}",
-                err_msg
+                "Expected VRL compilation error, got: {err_msg}"
             );
         }
         Ok(_) => panic!("Expected build to fail with VRL compilation error, but it succeeded"),

--- a/src/sources/http_server.rs
+++ b/src/sources/http_server.rs
@@ -256,8 +256,7 @@ pub fn remove_duplicates(mut list: Vec<String>, list_name: &str) -> Vec<String> 
     for (idx, name) in list.iter().enumerate() {
         if idx < list.len() - 1 && list[idx] == list[idx + 1] {
             warn!(
-                "`{}` configuration contains duplicate entry for `{}`. Removing duplicate.",
-                list_name, name
+                "`{list_name}` configuration contains duplicate entry for `{name}`. Removing duplicate."
             );
             dedup = true;
         }

--- a/src/sources/kafka.rs
+++ b/src/sources/kafka.rs
@@ -451,7 +451,7 @@ async fn kafka_source(
 
     let topics: Vec<&str> = config.topics.iter().map(|s| s.as_str()).collect();
     if let Err(e) = consumer.subscribe(&topics).context(SubscribeSnafu) {
-        error!("{}", e);
+        error!("{e}");
         return Err(());
     }
 
@@ -656,7 +656,7 @@ impl ConsumerStateInner<Consuming> {
                         None => unreachable!("MessageStream never calls Ready(None)"),
                         Some(Err(error)) => match error {
                             rdkafka::error::KafkaError::PartitionEOF(partition) if exit_eof => {
-                                debug!("EOF for partition {}.", partition);
+                                debug!("EOF for partition {partition}.");
                                 status = PartitionConsumerStatus::PartitionEOF;
                                 finalizer.take();
                             },
@@ -1422,7 +1422,7 @@ impl ConsumerContext for KafkaSourceContext {
             }
 
             Rebalance::Error(message) => {
-                error!("Error during Kafka consumer group rebalance: {}.", message);
+                error!("Error during Kafka consumer group rebalance: {message}.");
             }
         }
     }
@@ -1983,13 +1983,10 @@ mod integration_test {
                         .is_timestamp()
                 );
 
-                assert_eq!(
-                    event.as_log().value(),
-                    &value!(format!("{} {:03}", TEXT, i))
-                );
+                assert_eq!(event.as_log().value(), &value!(format!("{TEXT} {i:03}")));
                 assert_eq!(
                     meta.get(path!("kafka", "message_key")).unwrap(),
-                    &value!(format!("{} {}", KEY, i))
+                    &value!(format!("{KEY} {i}"))
                 );
 
                 assert_eq!(
@@ -2246,9 +2243,8 @@ mod integration_test {
 
         debug!("Consumer group.id: {}", &group_id);
         debug!(
-            "First consumer read {} of {} messages.",
-            events1.len(),
-            expect_count
+            "First consumer read {} of {expect_count} messages.",
+            events1.len()
         );
 
         // 4. Run the kafka source again to finish reading the events
@@ -2264,9 +2260,8 @@ mod integration_test {
         };
 
         debug!(
-            "Second consumer read {} of {} messages.",
-            events2.len(),
-            expect_count
+            "Second consumer read {} of {expect_count} messages.",
+            events2.len()
         );
 
         // 5. Total number of events processed should equal the number sent
@@ -2357,20 +2352,17 @@ mod integration_test {
         .await;
 
         debug!(
-            "First consumer read {} of {} messages.",
-            events1.len(),
-            expect_count
+            "First consumer read {} of {expect_count} messages.",
+            events1.len()
         );
 
         debug!(
-            "Second consumer read {} of {} messages.",
-            events2.len(),
-            expect_count
+            "Second consumer read {} of {expect_count} messages.",
+            events2.len()
         );
         debug!(
-            "Third consumer read {} of {} messages.",
-            events3.len(),
-            expect_count
+            "Third consumer read {} of {expect_count} messages.",
+            events3.len()
         );
 
         // 5. Total number of events processed should equal the number sent

--- a/src/sources/kubernetes_logs/mod.rs
+++ b/src/sources/kubernetes_logs/mod.rs
@@ -1178,10 +1178,7 @@ fn prepare_field_selector(config: &Config, self_node_name: &str) -> crate::Resul
         return Ok(field_selector);
     }
 
-    Ok(format!(
-        "{},{}",
-        field_selector, config.extra_field_selector
-    ))
+    Ok(format!("{field_selector},{}", config.extra_field_selector))
 }
 
 // This function constructs the selector for a node to annotate entries with a node metadata.

--- a/src/sources/nats/integration_tests.rs
+++ b/src/sources/nats/integration_tests.rs
@@ -1108,9 +1108,8 @@ async fn nats_jetstream_messages_during_downtime() {
     assert_eq!(
         found.len(),
         5,
-        "Expected all 5 queued messages after recovery, got {}: {:?}",
-        found.len(),
-        found
+        "Expected all 5 queued messages after recovery, got {}: {found:?}",
+        found.len()
     );
 }
 
@@ -1175,7 +1174,6 @@ async fn nats_jetstream_backoff_resets_after_recovery() {
     let round2_elapsed = round2_start.elapsed();
     assert!(
         round2_elapsed < std::time::Duration::from_secs(15),
-        "Second recovery took {:?}, suggesting backoff did not reset",
-        round2_elapsed
+        "Second recovery took {round2_elapsed:?}, suggesting backoff did not reset"
     );
 }

--- a/src/sources/opentelemetry/reply.rs
+++ b/src/sources/opentelemetry/reply.rs
@@ -15,7 +15,7 @@ where
     let mut buf = BytesMut::with_capacity(1024);
     Protobuf {
         inner: val.encode(&mut buf).map(|_| buf.to_vec()).map_err(|err| {
-            error!("Failed to encode value: {}", err);
+            error!("Failed to encode value: {err}");
         }),
     }
 }

--- a/src/sources/opentelemetry/tests.rs
+++ b/src/sources/opentelemetry/tests.rs
@@ -1688,8 +1688,7 @@ async fn http_logs_use_otlp_decoding_emits_metric() {
         MetricValue::Counter { value } => {
             assert!(
                 *value > 0.0,
-                "component_received_events_total should be > 0, got {}",
-                value
+                "component_received_events_total should be > 0, got {value}"
             );
         }
         _ => panic!("component_received_events_total should be a counter"),

--- a/src/sources/prometheus/pushgateway.rs
+++ b/src/sources/prometheus/pushgateway.rs
@@ -391,13 +391,7 @@ mod test {
                 .unwrap()
                 .http_protocol_name();
             let push_path = "metrics/job/async_worker";
-            let push_url = format!(
-                "{}://{}:{}/{}",
-                proto,
-                address.ip(),
-                address.port(),
-                push_path
-            );
+            let push_url = format!("{proto}://{}:{}/{push_path}", address.ip(), address.port());
             let push_body = r#"
                 # TYPE jobs_total counter
                 # HELP jobs_total Total number of jobs

--- a/src/sources/prometheus/remote_write.rs
+++ b/src/sources/prometheus/remote_write.rs
@@ -261,7 +261,7 @@ mod test {
         wait_for_tcp(address).await;
 
         let sink = RemoteWriteConfig {
-            endpoint: HttpEndpoint::parse(&format!("{}://localhost:{}/", proto, address.port()))
+            endpoint: HttpEndpoint::parse(&format!("{proto}://localhost:{}/", address.port()))
                 .unwrap(),
             tls: tls.map(|tls| tls.options),
             ..Default::default()
@@ -335,7 +335,7 @@ mod test {
         // Send the request via HTTP POST
         let client = reqwest::Client::new();
         let response = client
-            .post(format!("http://localhost:{}{}", port, default_path()))
+            .post(format!("http://localhost:{port}{}", default_path()))
             .header("Content-Type", "application/x-protobuf")
             .header("Content-Encoding", "snappy")
             .body(request_body)
@@ -422,7 +422,7 @@ mod test {
     async fn send_request(port: u16, request_body: Vec<u8>) -> reqwest::Response {
         let client = reqwest::Client::new();
         client
-            .post(format!("http://localhost:{}{}", port, default_path()))
+            .post(format!("http://localhost:{port}{}", default_path()))
             .header("Content-Type", "application/x-protobuf")
             .header("Content-Encoding", "snappy")
             .body(request_body)

--- a/src/sources/prometheus/scrape.rs
+++ b/src/sources/prometheus/scrape.rs
@@ -352,7 +352,7 @@ mod test {
         wait_for_tcp(in_addr).await;
 
         let config = PrometheusScrapeConfig {
-            endpoints: vec![format!("http://{}/metrics", in_addr)],
+            endpoints: vec![format!("http://{in_addr}/metrics")],
             interval: Duration::from_secs(1),
             timeout: default_timeout(),
             instance_tag: Some("instance".to_string()),
@@ -386,7 +386,7 @@ mod test {
         wait_for_tcp(in_addr).await;
 
         let config = PrometheusScrapeConfig {
-            endpoints: vec![format!("http://{}/metrics", in_addr)],
+            endpoints: vec![format!("http://{in_addr}/metrics")],
             interval: Duration::from_secs(1),
             timeout: default_timeout(),
             instance_tag: Some("instance".to_string()),
@@ -438,7 +438,7 @@ mod test {
         wait_for_tcp(in_addr).await;
 
         let config = PrometheusScrapeConfig {
-            endpoints: vec![format!("http://{}/metrics", in_addr)],
+            endpoints: vec![format!("http://{in_addr}/metrics")],
             interval: Duration::from_secs(1),
             timeout: default_timeout(),
             instance_tag: Some("instance".to_string()),
@@ -504,7 +504,7 @@ mod test {
         wait_for_tcp(in_addr).await;
 
         let config = PrometheusScrapeConfig {
-            endpoints: vec![format!("http://{}/metrics", in_addr)],
+            endpoints: vec![format!("http://{in_addr}/metrics")],
             interval: Duration::from_secs(1),
             timeout: default_timeout(),
             instance_tag: Some("instance".to_string()),
@@ -559,7 +559,7 @@ mod test {
         wait_for_tcp(in_addr).await;
 
         let config = PrometheusScrapeConfig {
-            endpoints: vec![format!("http://{}/metrics?key1=val1", in_addr)],
+            endpoints: vec![format!("http://{in_addr}/metrics?key1=val1")],
             interval: Duration::from_secs(1),
             timeout: default_timeout(),
             instance_tag: Some("instance".to_string()),
@@ -675,7 +675,7 @@ mod test {
         config.add_source(
             "in",
             PrometheusScrapeConfig {
-                endpoints: vec![format!("http://{}", in_addr)],
+                endpoints: vec![format!("http://{in_addr}")],
                 instance_tag: None,
                 endpoint_tag: None,
                 honor_labels: false,

--- a/src/sources/pulsar.rs
+++ b/src/sources/pulsar.rs
@@ -555,7 +555,7 @@ mod integration_tests {
     }
 
     fn pulsar_address(scheme: &str, port: u16) -> String {
-        format!("{}://{}:{}", scheme, pulsar_host(), port)
+        format!("{scheme}://{}:{port}", pulsar_host())
     }
     #[tokio::test]
     async fn consumes_event_with_acknowledgements() {

--- a/src/sources/redis/mod.rs
+++ b/src/sources/redis/mod.rs
@@ -324,7 +324,7 @@ mod integration_test {
         let mut conn = client.get_connection_manager().await.unwrap();
 
         let key = format!("test-key-{}", random_string(10));
-        debug!("Test key name: {}.", key);
+        debug!("Test key name: {key}.");
 
         let _: i32 = conn.rpush(&key, "1").await.unwrap();
         let _: i32 = conn.rpush(&key, "2").await.unwrap();
@@ -367,7 +367,7 @@ mod integration_test {
         let mut conn = client.get_connection_manager().await.unwrap();
 
         let key = format!("test-key-{}", random_string(10));
-        debug!("Test key name: {}.", key);
+        debug!("Test key name: {key}.");
 
         let _: i32 = conn.rpush(&key, "1").await.unwrap();
 
@@ -406,7 +406,7 @@ mod integration_test {
         let mut conn = client.get_connection_manager().await.unwrap();
 
         let key = format!("test-key-{}", random_string(10));
-        debug!("Test key name: {}.", key);
+        debug!("Test key name: {key}.");
 
         let _: i32 = conn.rpush(&key, "1").await.unwrap();
         let _: i32 = conn.rpush(&key, "2").await.unwrap();

--- a/src/sources/splunk_hec/mod.rs
+++ b/src/sources/splunk_hec/mod.rs
@@ -294,7 +294,7 @@ impl SplunkConfig {
                 .with_graceful_shutdown(shutdown.map(|_| ()))
                 .await
                 .map_err(|err| {
-                    error!("An error occurred: {:?}.", err);
+                    error!("An error occurred: {err:?}.");
                 })?;
 
             Ok(())
@@ -2928,8 +2928,7 @@ mod tests {
 
         let b = reqwest::Client::new()
             .post(format!(
-                "http://{}/{}",
-                address, "services/collector/event"
+                "http://{address}/{}", "services/collector/event"
             ))
             .header("Authorization", format!("Splunk {TOKEN}"))
             .body::<&[u8]>(message);

--- a/src/sources/syslog.rs
+++ b/src/sources/syslog.rs
@@ -826,10 +826,9 @@ mod test {
         // this should also match rsyslog omfwd with template=RSYSLOG_SyslogProtocol23Format
         let msg = "i am foobar";
         let raw = format!(
-            r#"<13>1 2019-02-13T19:48:34+00:00 74794bfb6795 root 8449 - {}{} {}"#,
+            r#"<13>1 2019-02-13T19:48:34+00:00 74794bfb6795 root 8449 - {}{} {msg}"#,
             r#"[meta sequenceId="1" sysUpTime="37" language="EN"]"#,
-            r#"[origin ip="192.168.0.1" software="test"]"#,
-            msg
+            r#"[origin ip="192.168.0.1" software="test"]"#
         );
 
         let mut expected = Event::Log(LogEvent::from(msg));
@@ -879,8 +878,8 @@ mod test {
     fn handles_incorrect_sd_element() {
         let msg = "qwerty";
         let raw = format!(
-            r#"<13>1 2019-02-13T19:48:34+00:00 74794bfb6795 root 8449 - {} {}"#,
-            r"[incorrect x]", msg
+            r#"<13>1 2019-02-13T19:48:34+00:00 74794bfb6795 root 8449 - {} {msg}"#,
+            r"[incorrect x]"
         );
 
         let mut expected = Event::Log(LogEvent::from(msg));
@@ -919,8 +918,8 @@ mod test {
         assert_event_data_eq!(event, expected);
 
         let raw = format!(
-            r#"<13>1 2019-02-13T19:48:34+00:00 74794bfb6795 root 8449 - {} {}"#,
-            r"[incorrect x=]", msg
+            r#"<13>1 2019-02-13T19:48:34+00:00 74794bfb6795 root 8449 - {} {msg}"#,
+            r"[incorrect x=]"
         );
 
         let event = event_from_bytes(
@@ -1401,7 +1400,7 @@ mod test {
                 .iter()
                 .map(|msg| {
                     let s = msg.to_string();
-                    format!("{} {}", s.len(), s).into()
+                    format!("{} {s}", s.len()).into()
                 })
                 .collect();
 

--- a/src/sources/util/framestream.rs
+++ b/src/sources/util/framestream.rs
@@ -117,7 +117,7 @@ impl ControlHeader {
             0x04 => Ok(ControlHeader::Ready),
             0x05 => Ok(ControlHeader::Finish),
             _ => {
-                error!("Don't know header value {} (expected 0x01 - 0x05).", val);
+                error!("Don't know header value {val} (expected 0x01 - 0x05).");
                 Err(())
             }
         }
@@ -143,7 +143,7 @@ impl ControlField {
         match val {
             0x01 => Ok(ControlField::ContentType),
             _ => {
-                error!("Don't know field type {} (expected 0x01).", val);
+                error!("Don't know field type {val} (expected 0x01).");
                 Err(())
             }
         }
@@ -341,8 +341,8 @@ impl FrameStreamReader {
         }
 
         error!(
-            "Content types did not match up. Expected {} got {:?}.",
-            self.expected_content_type, content_types
+            "Content types did not match up. Expected {} got {content_types:?}.",
+            self.expected_content_type
         );
         Err(())
     }
@@ -363,7 +363,7 @@ impl FrameStreamReader {
         let mut stream = stream::iter(vec![Ok(empty_frame), Ok(frame)]);
 
         if let Err(e) = block_on(self.response_sink.lock().unwrap().send_all(&mut stream)) {
-            error!("Encountered error '{:#?}' while sending control frame.", e);
+            error!("Encountered error '{e:#?}' while sending control frame.");
         }
     }
 }
@@ -704,7 +704,7 @@ pub fn build_framestream_unix_source(
         }
         Err(ref e) if e.kind() == std::io::ErrorKind::NotFound => {} //doesn't exist, do nothing
         Err(e) => {
-            error!("Unable to get socket information; error = {:?}.", e);
+            error!("Unable to get socket information; error = {e:?}.");
             return Err(Box::new(e));
         }
     };
@@ -751,13 +751,10 @@ pub fn build_framestream_unix_source(
         }
         match fs::set_permissions(&path, fs::Permissions::from_mode(socket_permission)) {
             Ok(_) => {
-                info!("Socket permissions updated to {:#o}.", socket_permission);
+                info!("Socket permissions updated to {socket_permission:#o}.");
             }
             Err(e) => {
-                error!(
-                    "Failed to update listener socket permissions; error = {:?}.",
-                    e
-                );
+                error!("Failed to update listener socket permissions; error = {e:?}.");
                 return Err(Box::new(e));
             }
         };
@@ -772,7 +769,7 @@ pub fn build_framestream_unix_source(
         while let Some(socket) = stream.next().await {
             let socket = match socket {
                 Err(e) => {
-                    error!("Failed to accept socket; error = {:?}.", e);
+                    error!("Failed to accept socket; error = {e:?}.");
                     continue;
                 }
                 Ok(s) => s,
@@ -864,7 +861,7 @@ fn build_framestream_source<T: Send + 'static>(
 
         let handler = async move {
             if let Err(e) = event_sink.send_event_stream(&mut events).await {
-                error!("Error sending event: {:?}.", e);
+                error!("Error sending event: {e:?}.");
             }
 
             info!("Finished sending.");

--- a/src/sources/util/http/prelude.rs
+++ b/src/sources/util/http/prelude.rs
@@ -275,7 +275,7 @@ pub trait HttpSource: Clone + Send + Sync + 'static {
                 .bind(&address)
                 .await
                 .map_err(|err| {
-                    error!("An error occurred: {:?}.", err);
+                    error!("An error occurred: {err:?}.");
                 })?
                 .with_keepalive(keepalive_settings.tcp_keepalive);
 
@@ -284,7 +284,7 @@ pub trait HttpSource: Clone + Send + Sync + 'static {
                 .with_graceful_shutdown(cx.shutdown.map(|_| ()))
                 .await
                 .map_err(|err| {
-                    error!("An error occurred: {:?}.", err);
+                    error!("An error occurred: {err:?}.");
                 })?;
 
             Ok(())

--- a/src/sources/util/http_client.rs
+++ b/src/sources/util/http_client.rs
@@ -124,7 +124,7 @@ pub(crate) fn build_url(uri: &Uri, query: &QueryParameters) -> Uri {
         builder = builder.authority(authority.clone());
     };
     builder = builder.path_and_query(match serializer.finish() {
-        query if !query.is_empty() => format!("{}?{}", uri.path(), query),
+        query if !query.is_empty() => format!("{}?{query}", uri.path()),
         _ => uri.path().to_string(),
     });
     builder

--- a/src/sources/util/unix_stream.rs
+++ b/src/sources/util/unix_stream.rs
@@ -52,9 +52,8 @@ where
     Ok(Box::pin(async move {
         let listener = UnixListener::bind(&listen_path).unwrap_or_else(|e| {
             panic!(
-                "Failed to bind to listener socket at path: {}. Err: {}",
-                listen_path.to_string_lossy(),
-                e
+                "Failed to bind to listener socket at path: {}. Err: {e}",
+                listen_path.to_string_lossy()
             )
         });
         info!(message = "Listening.", path = ?listen_path, r#type = "unix");

--- a/src/sources/websocket/source.rs
+++ b/src/sources/websocket/source.rs
@@ -150,8 +150,7 @@ impl WebSocketSource {
                     | WebSocketSourceError::InitialMessageTimeout
                     | WebSocketSourceError::ConnectionClosedPrematurely => {
                         unreachable!(
-                            "Encountered a connection-time error during runtime: {:?}",
-                            error
+                            "Encountered a connection-time error during runtime: {error:?}"
                         );
                     }
                 }

--- a/src/sources/windows_event_log/bookmark.rs
+++ b/src/sources/windows_event_log/bookmark.rs
@@ -140,7 +140,7 @@ impl BookmarkManager {
 
             if required_size > MAX_BOOKMARK_XML_SIZE as u32 {
                 return Err(WindowsEventLogError::RenderError {
-                    message: format!("Bookmark buffer size too large: {}", required_size),
+                    message: format!("Bookmark buffer size too large: {required_size}"),
                 });
             }
 
@@ -158,7 +158,7 @@ impl BookmarkManager {
                 &mut property_count,
             )
             .map_err(|e| WindowsEventLogError::RenderError {
-                message: format!("Failed to render bookmark XML: {}", e),
+                message: format!("Failed to render bookmark XML: {e}"),
             })?;
 
             // Convert UTF-16 buffer to String
@@ -220,7 +220,7 @@ impl BookmarkManager {
 
             if buffer_used > MAX_BOOKMARK_XML_SIZE as u32 {
                 return Err(WindowsEventLogError::RenderError {
-                    message: format!("Bookmark buffer size too large: {}", buffer_used),
+                    message: format!("Bookmark buffer size too large: {buffer_used}"),
                 });
             }
 
@@ -238,7 +238,7 @@ impl BookmarkManager {
                 &mut property_count,
             )
             .map_err(|e| WindowsEventLogError::RenderError {
-                message: format!("Failed to render bookmark XML: {}", e),
+                message: format!("Failed to render bookmark XML: {e}"),
             })?;
 
             let xml = String::from_utf16_lossy(&buffer[0..((actual_used / 2) as usize)]);

--- a/src/sources/windows_event_log/checkpoint.rs
+++ b/src/sources/windows_event_log/checkpoint.rs
@@ -309,8 +309,7 @@ mod tests {
     /// Helper to create test bookmark XML
     fn test_bookmark_xml(channel: &str, record_id: u64) -> String {
         format!(
-            r#"<BookmarkList><Bookmark Channel="{}" RecordId="{}" IsCurrent="True"/></BookmarkList>"#,
-            channel, record_id
+            r#"<BookmarkList><Bookmark Channel="{channel}" RecordId="{record_id}" IsCurrent="True"/></BookmarkList>"#
         )
     }
 

--- a/src/sources/windows_event_log/config.rs
+++ b/src/sources/windows_event_log/config.rs
@@ -307,10 +307,9 @@ impl WindowsEventLogConfig {
         // One handle is reserved for the shutdown event, leaving 63 for channels.
         if self.channels.len() > MAX_CHANNELS {
             return Err(format!(
-                "Too many channels: {} specified, maximum is {} \
+                "Too many channels: {} specified, maximum is {MAX_CHANNELS} \
                  (limited by WaitForMultipleObjects)",
-                self.channels.len(),
-                MAX_CHANNELS
+                self.channels.len()
             )
             .into());
         }
@@ -320,8 +319,7 @@ impl WindowsEventLogConfig {
             || self.connection_timeout_secs > MAX_CONNECTION_TIMEOUT_SECS
         {
             return Err(format!(
-                "Connection timeout must be between 1 and {} seconds",
-                MAX_CONNECTION_TIMEOUT_SECS
+                "Connection timeout must be between 1 and {MAX_CONNECTION_TIMEOUT_SECS} seconds"
             )
             .into());
         }
@@ -329,8 +327,7 @@ impl WindowsEventLogConfig {
         // Validate event timeout
         if self.event_timeout_ms == 0 || self.event_timeout_ms > MAX_EVENT_TIMEOUT_MS {
             return Err(format!(
-                "Event timeout must be between 1 and {} milliseconds",
-                MAX_EVENT_TIMEOUT_MS
+                "Event timeout must be between 1 and {MAX_EVENT_TIMEOUT_MS} milliseconds"
             )
             .into());
         }
@@ -342,7 +339,7 @@ impl WindowsEventLogConfig {
 
         // Prevent resource exhaustion via excessive batch sizes
         if self.batch_size == 0 || self.batch_size > MAX_BATCH_SIZE {
-            return Err(format!("Batch size must be between 1 and {}", MAX_BATCH_SIZE).into());
+            return Err(format!("Batch size must be between 1 and {MAX_BATCH_SIZE}").into());
         }
 
         // Enhanced channel name validation with security checks
@@ -354,18 +351,15 @@ impl WindowsEventLogConfig {
             // Prevent excessively long channel names
             if channel.len() > MAX_CHANNEL_NAME_LENGTH {
                 return Err(format!(
-                    "Channel name '{}' exceeds maximum length of {} characters",
-                    channel, MAX_CHANNEL_NAME_LENGTH
-                )
+                    "Channel name '{channel}' exceeds maximum length of {MAX_CHANNEL_NAME_LENGTH} characters")
                 .into());
             }
 
             // Reject wildcard patterns - they cause heap corruption issues with many channels
             if is_channel_pattern(channel) {
                 return Err(format!(
-                    "Channel name '{}' contains wildcard characters (*, ?, [). \
-                     Wildcard patterns are not supported. Please specify exact channel names.",
-                    channel
+                    "Channel name '{channel}' contains wildcard characters (*, ?, [). \
+                     Wildcard patterns are not supported. Please specify exact channel names."
                 )
                 .into());
             }
@@ -374,9 +368,7 @@ impl WindowsEventLogConfig {
             // validation is handled by EvtOpenChannelConfig at subscription time,
             // so we only block characters that could cause issues before that check.
             if channel.chars().any(|c| c.is_control()) {
-                return Err(
-                    format!("Channel name '{}' contains control characters", channel).into(),
-                );
+                return Err(format!("Channel name '{channel}' contains control characters").into());
             }
         }
 
@@ -389,8 +381,7 @@ impl WindowsEventLogConfig {
             // Prevent excessively long XPath queries
             if query.len() > MAX_XPATH_QUERY_LENGTH {
                 return Err(format!(
-                    "Event query exceeds maximum length of {} characters",
-                    MAX_XPATH_QUERY_LENGTH
+                    "Event query exceeds maximum length of {MAX_XPATH_QUERY_LENGTH} characters"
                 )
                 .into());
             }
@@ -434,8 +425,7 @@ impl WindowsEventLogConfig {
             for pattern in &dangerous_patterns {
                 if query_lower.contains(pattern) {
                     return Err(format!(
-                        "Event query contains potentially unsafe pattern: '{}'",
-                        pattern
+                        "Event query contains potentially unsafe pattern: '{pattern}'"
                     )
                     .into());
                 }
@@ -450,8 +440,7 @@ impl WindowsEventLogConfig {
 
             if event_ids.len() > MAX_EVENT_ID_LIST_SIZE {
                 return Err(format!(
-                    "Only event IDs list cannot contain more than {} entries",
-                    MAX_EVENT_ID_LIST_SIZE
+                    "Only event IDs list cannot contain more than {MAX_EVENT_ID_LIST_SIZE} entries"
                 )
                 .into());
             }
@@ -459,8 +448,7 @@ impl WindowsEventLogConfig {
 
         if self.ignore_event_ids.len() > MAX_EVENT_ID_LIST_SIZE {
             return Err(format!(
-                "Ignore event IDs list cannot contain more than {} entries",
-                MAX_EVENT_ID_LIST_SIZE
+                "Ignore event IDs list cannot contain more than {MAX_EVENT_ID_LIST_SIZE} entries"
             )
             .into());
         }
@@ -473,15 +461,14 @@ impl WindowsEventLogConfig {
 
             if include_fields.len() > MAX_FIELD_COUNT {
                 return Err(format!(
-                    "Include fields list cannot contain more than {} entries",
-                    MAX_FIELD_COUNT
+                    "Include fields list cannot contain more than {MAX_FIELD_COUNT} entries"
                 )
                 .into());
             }
 
             for field in include_fields {
                 if field.trim().is_empty() || field.len() > MAX_FIELD_NAME_LENGTH {
-                    return Err(format!("Invalid field name: '{}'", field).into());
+                    return Err(format!("Invalid field name: '{field}'").into());
                 }
 
                 // Enhanced security validation for field names
@@ -492,8 +479,7 @@ impl WindowsEventLogConfig {
                     || field.contains('>')
                 {
                     return Err(format!(
-                        "Invalid field name contains dangerous characters: '{}'",
-                        field
+                        "Invalid field name contains dangerous characters: '{field}'"
                     )
                     .into());
                 }
@@ -507,15 +493,14 @@ impl WindowsEventLogConfig {
 
             if exclude_fields.len() > MAX_FIELD_COUNT {
                 return Err(format!(
-                    "Exclude fields list cannot contain more than {} entries",
-                    MAX_FIELD_COUNT
+                    "Exclude fields list cannot contain more than {MAX_FIELD_COUNT} entries"
                 )
                 .into());
             }
 
             for field in exclude_fields {
                 if field.trim().is_empty() || field.len() > MAX_FIELD_NAME_LENGTH {
-                    return Err(format!("Invalid field name: '{}'", field).into());
+                    return Err(format!("Invalid field name: '{field}'").into());
                 }
 
                 // Enhanced security validation for field names
@@ -526,8 +511,7 @@ impl WindowsEventLogConfig {
                     || field.contains('>')
                 {
                     return Err(format!(
-                        "Invalid field name contains dangerous characters: '{}'",
-                        field
+                        "Invalid field name contains dangerous characters: '{field}'"
                     )
                     .into());
                 }

--- a/src/sources/windows_event_log/error.rs
+++ b/src/sources/windows_event_log/error.rs
@@ -120,18 +120,16 @@ impl WindowsEventLogError {
         match self {
             Self::AccessDeniedError { channel } => {
                 format!(
-                    "Access denied to event log channel '{}'. Try running Vector as Administrator.",
-                    channel
+                    "Access denied to event log channel '{channel}'. Try running Vector as Administrator."
                 )
             }
             Self::ChannelNotFoundError { channel } => {
                 format!(
-                    "Event log channel '{}' not found. Check the channel name and ensure the service is installed.",
-                    channel
+                    "Event log channel '{channel}' not found. Check the channel name and ensure the service is installed."
                 )
             }
             Self::InvalidXPathQuery { query, .. } => {
-                format!("Invalid XPath query '{}'. Check the query syntax.", query)
+                format!("Invalid XPath query '{query}'. Check the query syntax.")
             }
             Self::ResourceExhaustedError { .. } => {
                 "System resources exhausted. Consider reducing batch_size or poll_interval_secs."
@@ -139,8 +137,7 @@ impl WindowsEventLogError {
             }
             Self::TimeoutError { timeout_secs } => {
                 format!(
-                    "Operation timed out after {} seconds. Consider increasing timeout values.",
-                    timeout_secs
+                    "Operation timed out after {timeout_secs} seconds. Consider increasing timeout values."
                 )
             }
             _ => self.to_string(),
@@ -181,8 +178,7 @@ mod tests {
         for error in recoverable_errors {
             assert!(
                 error.is_recoverable(),
-                "Error should be recoverable: {}",
-                error
+                "Error should be recoverable: {error}"
             );
         }
 
@@ -205,8 +201,7 @@ mod tests {
         for error in non_recoverable_errors {
             assert!(
                 !error.is_recoverable(),
-                "Error should not be recoverable: {}",
-                error
+                "Error should not be recoverable: {error}"
             );
         }
     }

--- a/src/sources/windows_event_log/integration_tests.rs
+++ b/src/sources/windows_event_log/integration_tests.rs
@@ -845,9 +845,8 @@ async fn test_event_data_format_coercion() {
     if let Some(eid) = log.get(event_path!("event_id")) {
         assert!(
             matches!(eid, vrl::value::Value::Bytes(_)),
-            "event_data_format set event_id to String but got {:?}. \
-             Check apply_custom_formatting in parser.",
-            eid
+            "event_data_format set event_id to String but got {eid:?}. \
+             Check apply_custom_formatting in parser."
         );
     }
 }
@@ -1134,8 +1133,7 @@ async fn test_acknowledgements_checkpoint_after_delivery() {
     assert!(
         checkpoint_path.exists(),
         "Checkpoint file should exist after acknowledged delivery. \
-         Path: {:?}",
-        checkpoint_path
+         Path: {checkpoint_path:?}"
     );
 
     // Phase 2: emit a NEW event, run with same data_dir
@@ -1380,9 +1378,7 @@ fn write_custom_log_event(log_name: &str, source: &str, event_id: u32, message: 
             "-NoProfile",
             "-Command",
             &format!(
-                "Write-EventLog -LogName '{}' -Source '{}' -EventId {} -EntryType Information -Message '{}'",
-                log_name, source, event_id, message
-            ),
+                "Write-EventLog -LogName '{log_name}' -Source '{source}' -EventId {event_id} -EntryType Information -Message '{message}'"),
         ])
         .status()
         .expect("failed to run powershell Write-EventLog");
@@ -1665,12 +1661,10 @@ async fn test_checkpoint_resume_no_duplicate_record_ids() {
     let overlap: HashSet<_> = first_ids.intersection(&second_ids).collect();
     assert!(
         overlap.len() <= batch_size,
-        "Found {} duplicate record_ids between run 1 and run 2 (max allowed: {}): {:?}. \
+        "Found {} duplicate record_ids between run 1 and run 2 (max allowed: {batch_size}): {overlap:?}. \
          Bookmark checkpoint is not preventing re-delivery. \
          Run 1 had {} IDs, run 2 had {} IDs.",
         overlap.len(),
-        batch_size,
-        overlap,
         first_ids.len(),
         second_ids.len()
     );

--- a/src/sources/windows_event_log/parser.rs
+++ b/src/sources/windows_event_log/parser.rs
@@ -427,7 +427,7 @@ impl EventLogParser {
                     })?,
                     _ => {
                         return Err(WindowsEventLogError::FilterError {
-                            message: format!("Cannot convert {:?} to integer", value),
+                            message: format!("Cannot convert {value:?} to integer"),
                         });
                     }
                 };
@@ -447,7 +447,7 @@ impl EventLogParser {
                     })?,
                     _ => {
                         return Err(WindowsEventLogError::FilterError {
-                            message: format!("Cannot convert {:?} to float", value),
+                            message: format!("Cannot convert {value:?} to float"),
                         });
                     }
                 };
@@ -466,7 +466,7 @@ impl EventLogParser {
                     }
                     _ => {
                         return Err(WindowsEventLogError::FilterError {
-                            message: format!("Cannot convert {:?} to boolean", value),
+                            message: format!("Cannot convert {value:?} to boolean"),
                         });
                     }
                 };

--- a/src/sources/windows_event_log/subscription.rs
+++ b/src/sources/windows_event_log/subscription.rs
@@ -261,7 +261,7 @@ impl EventLogSubscription {
                 query = %query,
                 has_valid_checkpoint = has_valid_checkpoint,
                 read_existing = config.read_existing_events,
-                flags = format!("{:#x}", subscription_flags)
+                flags = format!("{subscription_flags:#x}")
             );
 
             // EvtSubscribe with signal event and NULL callback = pull mode
@@ -285,7 +285,7 @@ impl EventLogSubscription {
                                 message = "Strict bookmark subscribe failed, retrying without bookmark. Potential re-delivery of events.",
                                 channel = %channel,
                                 error = %e,
-                                fallback_flags = format!("{:#x}", fallback_flags)
+                                fallback_flags = format!("{fallback_flags:#x}")
                             );
                             EvtSubscribe(
                                 None,
@@ -853,7 +853,7 @@ impl EventLogSubscription {
                             message = "Strict bookmark resubscribe failed, retrying without bookmark. Potential re-delivery of events.",
                             channel = %channel_sub.channel,
                             error = %e,
-                            fallback_flags = format!("{:#x}", fallback_flags)
+                            fallback_flags = format!("{fallback_flags:#x}")
                         );
                         EvtSubscribe(
                             None,
@@ -1352,10 +1352,9 @@ mod tests {
         for event in &events {
             assert!(
                 event.time_created >= earliest_allowed,
-                "Event timestamp {} is before subscription start time {} (minus tolerance). \
+                "Event timestamp {} is before subscription start time {subscription_start_time} (minus tolerance). \
                  read_existing_events=false may not be respected. Event ID: {}, Record ID: {}",
                 event.time_created,
-                subscription_start_time,
                 event.event_id,
                 event.record_id
             );

--- a/src/sources/windows_event_log/tests.rs
+++ b/src/sources/windows_event_log/tests.rs
@@ -456,8 +456,7 @@ mod error_tests {
         for error in recoverable_errors {
             assert!(
                 error.is_recoverable(),
-                "Error should be recoverable: {}",
-                error
+                "Error should be recoverable: {error}"
             );
         }
 
@@ -481,8 +480,7 @@ mod error_tests {
         for error in non_recoverable_errors {
             assert!(
                 !error.is_recoverable(),
-                "Error should not be recoverable: {}",
-                error
+                "Error should not be recoverable: {error}"
             );
         }
     }
@@ -897,16 +895,14 @@ mod security_tests {
             let result = config.validate();
             assert!(
                 result.is_err(),
-                "JavaScript injection '{}' should be blocked",
-                attack
+                "JavaScript injection '{attack}' should be blocked"
             );
             assert!(
                 result
                     .unwrap_err()
                     .to_string()
                     .contains("potentially unsafe pattern"),
-                "Error should mention unsafe pattern for: {}",
-                attack
+                "Error should mention unsafe pattern for: {attack}"
             );
         }
 
@@ -923,8 +919,7 @@ mod security_tests {
             let result = config.validate();
             assert!(
                 result.is_ok(),
-                "Valid XPath query '{}' should be allowed",
-                valid_query
+                "Valid XPath query '{valid_query}' should be allowed"
             );
         }
     }
@@ -1027,8 +1022,7 @@ mod security_tests {
             let result = config.validate();
             assert!(
                 result.is_ok(),
-                "Valid channel name '{}' should be allowed",
-                valid_channel
+                "Valid channel name '{valid_channel}' should be allowed"
             );
         }
     }
@@ -1096,11 +1090,11 @@ mod buffer_safety_tests {
         let mut nested_xml = "<Event>".to_string();
         for i in 0..100 {
             // Reduced from 1000
-            nested_xml.push_str(&format!("<Level{}>", i));
+            nested_xml.push_str(&format!("<Level{i}>"));
         }
         nested_xml.push_str("<EventData><Data Name='test'>value</Data></EventData>");
         for i in (0..100).rev() {
-            nested_xml.push_str(&format!("</Level{}>", i));
+            nested_xml.push_str(&format!("</Level{i}>"));
         }
         nested_xml.push_str("</Event>");
 
@@ -1124,8 +1118,7 @@ mod buffer_safety_tests {
         for i in 0..200 {
             // Reduced from 5000
             xml_with_attrs.push_str(&format!(
-                "<Data Name='attr{}' Value='value{}'>data{}</Data>",
-                i, i, i
+                "<Data Name='attr{i}' Value='value{i}'>data{i}</Data>"
             ));
         }
         xml_with_attrs.push_str("</EventData></Event>");
@@ -1459,8 +1452,7 @@ mod message_rendering_tests {
             let msg_str = message.to_string_lossy();
             assert!(
                 msg_str.contains("Event ID") || msg_str.contains(&event.event_id.to_string()),
-                "Fallback message should contain Event ID: got '{}'",
-                msg_str
+                "Fallback message should contain Event ID: got '{msg_str}'"
             );
         }
     }

--- a/src/tap/cmd.rs
+++ b/src/tap/cmd.rs
@@ -89,8 +89,7 @@ async fn tap_internal(
                             break;
                         } else if !opts.no_reconnect {
                             eprintln!(
-                                "[tap] Connection failed with error {:?}. Reconnecting in {:?} seconds.",
-                                tap_executor_error,
+                                "[tap] Connection failed with error {tap_executor_error:?}. Reconnecting in {:?} seconds.",
                                 RECONNECT_DELAY_MS / 1000);
                             tokio::time::sleep(Duration::from_millis(RECONNECT_DELAY_MS)).await;
                         } else {

--- a/src/test_util/components.rs
+++ b/src/test_util/components.rs
@@ -275,7 +275,7 @@ impl ComponentTester {
                             .tags()
                             .map(|t| format!("{{{}}}", itertools::join(t.keys(), ",")))
                             .unwrap_or_default();
-                        format!("\n    -> Found similar metric `{}{}`", m.name(), tags)
+                        format!("\n    -> Found similar metric `{}{tags}`", m.name())
                     })
                     .collect::<Vec<_>>();
                 let partial = partial_matches.join("");
@@ -298,7 +298,7 @@ impl ComponentTester {
         let expected: HashSet<String> = requirement
             .suffixes
             .iter()
-            .map(|suffix| format!("{}{}", requirement.prefix, suffix))
+            .map(|suffix| format!("{}{suffix}", requirement.prefix))
             .collect();
 
         let mut missing = expected.clone();

--- a/src/test_util/metrics.rs
+++ b/src/test_util/metrics.rs
@@ -226,8 +226,8 @@ pub fn assert_distribution(
     for (i, (bound, count)) in expected_bounds.iter().enumerate() {
         assert_eq!(
             actual_bounds[i], *count,
-            "expected {} samples less than or equal to {} for '{}', found {} instead",
-            count, bound, series, actual_bounds[i]
+            "expected {count} samples less than or equal to {bound} for '{series}', found {} instead",
+            actual_bounds[i]
         );
     }
 }

--- a/src/test_util/mod.rs
+++ b/src/test_util/mod.rs
@@ -73,7 +73,7 @@ macro_rules! assert_downcast_matches {
     ($e:expr_2021, $t:ty, $v:pat) => {{
         match $e.downcast_ref::<$t>() {
             Some($v) => (),
-            got => panic!("Assertion failed: got wrong error variant {:?}", got),
+            got => panic!("Assertion failed: got wrong error variant {got:?}"),
         }
     }};
 }

--- a/src/topology/mod.rs
+++ b/src/topology/mod.rs
@@ -68,7 +68,7 @@ async fn handle_errors(
         .map_err(|_| TaskError::Panicked)
         .and_then(|res| res)
         .map_err(|e| {
-            error!("An error occurred that Vector couldn't handle: {}.", e);
+            error!("An error occurred that Vector couldn't handle: {e}.");
             _ = abort_tx.send(error(e.to_string()));
             e
         })

--- a/src/topology/schema.rs
+++ b/src/topology/schema.rs
@@ -827,7 +827,7 @@ mod tests {
                 &mut HashMap::default(),
             )
             .unwrap();
-            assert_eq!(got, case.want, "{}", title);
+            assert_eq!(got, case.want, "{title}");
         }
     }
 }

--- a/src/transforms/aggregate/transform.rs
+++ b/src/transforms/aggregate/transform.rs
@@ -110,24 +110,22 @@ impl Aggregate {
         }
         if config.interval_ms > MAX_DURATION_MS {
             return Err(format!(
-                "`interval_ms` ({}) exceeds the maximum supported value of {} ms",
-                config.interval_ms, MAX_DURATION_MS
+                "`interval_ms` ({}) exceeds the maximum supported value of {MAX_DURATION_MS} ms",
+                config.interval_ms
             )
             .into());
         }
         if let Some(event_time) = &config.event_time {
             if event_time.max_future_ms > MAX_DURATION_MS {
                 return Err(format!(
-                    "`event_time.max_future_ms` ({}) exceeds the maximum supported value of {} ms",
-                    event_time.max_future_ms, MAX_DURATION_MS
-                )
+                    "`event_time.max_future_ms` ({}) exceeds the maximum supported value of {MAX_DURATION_MS} ms",
+                    event_time.max_future_ms)
                 .into());
             }
             if event_time.allowed_lateness_ms > MAX_DURATION_MS {
                 return Err(format!(
-                    "`event_time.allowed_lateness_ms` ({}) exceeds the maximum supported value of {} ms",
-                    event_time.allowed_lateness_ms, MAX_DURATION_MS
-                )
+                    "`event_time.allowed_lateness_ms` ({}) exceeds the maximum supported value of {MAX_DURATION_MS} ms",
+                    event_time.allowed_lateness_ms)
                 .into());
             }
         }

--- a/src/transforms/aws_ec2_metadata.rs
+++ b/src/transforms/aws_ec2_metadata.rs
@@ -561,7 +561,7 @@ impl MetadataClient {
                                 .role_name_key
                                 .log_path
                                 .with_index_appended(i as isize),
-                            metric_tag: format!("{}[{}]", self.keys.role_name_key.metric_tag, i),
+                            metric_tag: format!("{}[{i}]", self.keys.role_name_key.metric_tag),
                         },
                         role_name.to_string().into(),
                     ));
@@ -656,7 +656,7 @@ fn create_key(namespace: &Option<OwnedTargetPath>, key: &str) -> MetadataKey {
     if let Some(namespace) = namespace {
         MetadataKey {
             log_path: namespace.with_field_appended(key),
-            metric_tag: format!("{}.{}", create_metric_namespace(namespace), key),
+            metric_tag: format!("{}.{key}", create_metric_namespace(namespace)),
         }
     } else {
         MetadataKey {
@@ -1083,11 +1083,10 @@ mod integration_tests {
             expected_metric.replace_tag(PUBLIC_IPV4_KEY.to_string(), "192.0.2.54".to_string());
             expected_metric.replace_tag(REGION_KEY.to_string(), "us-east-1".to_string());
             expected_metric.replace_tag(
-                format!("{}[{}]", TAGS_KEY, "Name"),
+                format!("{TAGS_KEY}[{}]", "Name"),
                 "test-instance".to_string(),
             );
-            expected_metric
-                .replace_tag(format!("{}[{}]", TAGS_KEY, "Test"), "test-tag".to_string());
+            expected_metric.replace_tag(format!("{TAGS_KEY}[{}]", "Test"), "test-tag".to_string());
 
             tx.send(metric.into()).await.unwrap();
 

--- a/src/transforms/log_to_metric.rs
+++ b/src/transforms/log_to_metric.rs
@@ -314,8 +314,7 @@ fn render_tags(
                 if let Some(discarded_v) = dynamic_tags.insert(k.clone(), v.clone()) {
                     warn!(
                         "Static tags overrides dynamic tags. \
-                key: {}, value: {:?}, discarded value: {:?}",
-                        k, v, discarded_v
+                key: {k}, value: {v:?}, discarded value: {discarded_v:?}"
                     );
                 };
             }

--- a/src/transforms/lua/v1/mod.rs
+++ b/src/transforms/lua/v1/mod.rs
@@ -466,8 +466,7 @@ mod tests {
         let err = format_error(&err);
         assert!(
             err.contains("error converting Lua boolean to String"),
-            "{}",
-            err
+            "{err}"
         );
     }
 
@@ -487,8 +486,7 @@ mod tests {
         let err = format_error(&err);
         assert!(
             err.contains("error converting Lua boolean to String"),
-            "{}",
-            err
+            "{err}"
         );
     }
 
@@ -506,7 +504,7 @@ mod tests {
 
         let err = transform.process(LogEvent::default().into()).unwrap_err();
         let err = format_error(&err);
-        assert!(err.contains("this is an error"), "{}", err);
+        assert!(err.contains("this is an error"), "{err}");
     }
 
     #[test]
@@ -523,7 +521,7 @@ mod tests {
         .unwrap_err()
         .to_string();
 
-        assert!(err.contains("syntax error:"), "{}", err);
+        assert!(err.contains("syntax error:"), "{err}");
     }
 
     #[test]

--- a/src/transforms/lua/v2/mod.rs
+++ b/src/transforms/lua/v2/mod.rs
@@ -862,8 +862,7 @@ mod tests {
         let err = format_error(&err);
         assert!(
             err.contains("error converting Lua boolean to String"),
-            "{}",
-            err
+            "{err}"
         );
         Ok(())
     }
@@ -911,7 +910,7 @@ mod tests {
             .process_single(LogEvent::default().into())
             .unwrap_err();
         let err = format_error(&err);
-        assert!(err.contains("this is an error"), "{}", err);
+        assert!(err.contains("this is an error"), "{err}");
         Ok(())
     }
 
@@ -928,7 +927,7 @@ mod tests {
         .unwrap_err()
         .to_string();
 
-        assert!(err.contains("syntax error:"), "{}", err);
+        assert!(err.contains("syntax error:"), "{err}");
         Ok(())
     }
 

--- a/src/transforms/mod.rs
+++ b/src/transforms/mod.rs
@@ -96,7 +96,7 @@ mod test {
             "out",
             &["transform"],
             UnitTestStreamSinkConfig::new(
-                PollSender::new(tx).sink_map_err(|error| panic!("{}", error)),
+                PollSender::new(tx).sink_map_err(|error| panic!("{error}")),
             ),
         );
 

--- a/src/transforms/sample/tests.rs
+++ b/src/transforms/sample/tests.rs
@@ -491,13 +491,11 @@ fn dynamic_ratio_honors_group_by_key() {
 
     assert!(
         (60..140).contains(&sampled_service_a),
-        "service-a sampled {} out of {events_per_service}",
-        sampled_service_a
+        "service-a sampled {sampled_service_a} out of {events_per_service}"
     );
     assert!(
         (60..140).contains(&sampled_service_b),
-        "service-b sampled {} out of {events_per_service}",
-        sampled_service_b
+        "service-b sampled {sampled_service_b} out of {events_per_service}"
     );
 }
 
@@ -538,13 +536,11 @@ fn dynamic_rate_honors_group_by_key() {
 
     assert!(
         (60..140).contains(&sampled_service_a),
-        "service-a sampled {} out of {events_per_service}",
-        sampled_service_a
+        "service-a sampled {sampled_service_a} out of {events_per_service}"
     );
     assert!(
         (60..140).contains(&sampled_service_b),
-        "service-b sampled {} out of {events_per_service}",
-        sampled_service_b
+        "service-b sampled {sampled_service_b} out of {events_per_service}"
     );
 }
 
@@ -584,13 +580,11 @@ fn dynamic_ratio_group_by_samples_mixed_ratios_at_expected_rates() {
 
     assert!(
         (80..220).contains(&sampled_low_ratio),
-        "ratio=0.25 sampled {} out of {events_per_ratio}",
-        sampled_low_ratio
+        "ratio=0.25 sampled {sampled_low_ratio} out of {events_per_ratio}"
     );
     assert!(
         (300..450).contains(&sampled_high_ratio),
-        "ratio=0.75 sampled {} out of {events_per_ratio}",
-        sampled_high_ratio
+        "ratio=0.75 sampled {sampled_high_ratio} out of {events_per_ratio}"
     );
     assert!(
         sampled_high_ratio > sampled_low_ratio,
@@ -634,13 +628,11 @@ fn dynamic_rate_group_by_samples_mixed_rates_at_expected_rates() {
 
     assert!(
         (220..380).contains(&sampled_rate_2),
-        "rate=2 sampled {} out of {events_per_rate}",
-        sampled_rate_2
+        "rate=2 sampled {sampled_rate_2} out of {events_per_rate}"
     );
     assert!(
         (120..280).contains(&sampled_rate_3),
-        "rate=3 sampled {} out of {events_per_rate}",
-        sampled_rate_3
+        "rate=3 sampled {sampled_rate_3} out of {events_per_rate}"
     );
     assert!(
         sampled_rate_2 > sampled_rate_3,

--- a/src/unit_test.rs
+++ b/src/unit_test.rs
@@ -182,13 +182,13 @@ pub async fn cmd(opts: &Opts, signal_handler: &mut signal::SignalHandler) -> exi
                     if !errors.is_empty() {
                         #[allow(clippy::print_stdout)]
                         {
-                            println!("test {} ... {}", name, "failed".red());
+                            println!("test {name} ... {}", "failed".red());
                         }
                         aggregated_test_errors.push((name, errors));
                     } else {
                         #[allow(clippy::print_stdout)]
                         {
-                            println!("test {} ... {}", name, "passed".green());
+                            println!("test {name} ... {}", "passed".green());
                         }
                     }
                 }
@@ -197,7 +197,7 @@ pub async fn cmd(opts: &Opts, signal_handler: &mut signal::SignalHandler) -> exi
                 match junit_reporter.write_reports(test_suite_elapsed) {
                     Ok(()) => {}
                     Err(error) => {
-                        error!("Failed to write test output:\n{}.", error);
+                        error!("Failed to write test output:\n{error}.");
                         return exitcode::CONFIG;
                     }
                 }

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -574,7 +574,7 @@ impl Formatter {
         I::Item: fmt::Display,
     {
         for msg in msgs {
-            self.print(format!("{} {}\n", intro.as_ref(), msg));
+            self.print(format!("{} {msg}\n", intro.as_ref()));
         }
         self.space();
     }

--- a/src/vector_windows.rs
+++ b/src/vector_windows.rs
@@ -121,7 +121,7 @@ pub mod service_control {
                 "stop" => Ok(ControlAction::Stop {
                     stop_timeout: Duration::from_secs(10),
                 }),
-                _ => Err(format!("invalid option {} for ControlAction", s)),
+                _ => Err(format!("invalid option {s} for ControlAction")),
             }
         }
     }

--- a/tests/e2e/datadog/metrics/mod.rs
+++ b/tests/e2e/datadog/metrics/mod.rs
@@ -47,7 +47,7 @@ where
         // decode base64
         let payload = BASE64_STANDARD
             .decode(&payload.data)
-            .map_err(|e| format!("Invalid base64 data: {}", e))?;
+            .map_err(|e| format!("Invalid base64 data: {e}"))?;
 
         // Skip empty or near-empty payloads (e.g., health checks like '{}' sent with
         // X-Requested-With: datadog-agent-diagnose header)
@@ -56,15 +56,13 @@ where
 
             // Try to parse as JSON to show structured content
             let json_repr = serde_json::from_slice::<Value>(&payload)
-                .map(|v| format!("JSON: {}", v))
-                .unwrap_or_else(|_| format!("raw: '{}'", content_str));
+                .map(|v| format!("JSON: {v}"))
+                .unwrap_or_else(|_| format!("raw: '{content_str}'"));
 
             warn!(
-                "Skipping small payload (likely diagnostic/health check): expected protobuf type {}, got {} bytes, content: {}, hex: {:02x?}",
+                "Skipping small payload (likely diagnostic/health check): expected protobuf type {}, got {} bytes, content: {json_repr}, hex: {payload:02x?}",
                 std::any::type_name::<T>(),
-                payload.len(),
-                json_repr,
-                payload
+                payload.len()
             );
             continue;
         }
@@ -90,16 +88,14 @@ where
                 let decompressed = decompress_payload(payload.as_slice())
                     .await
                     .map_err(|e| format!(
-                        "Failed to decompress payload: {}. Type {}, length {}, first 4 bytes: {:02x?}",
-                        e,
+                        "Failed to decompress payload: {e}. Type {}, length {}, first 4 bytes: {:02x?}",
                         std::any::type_name::<T>(),
                         payload.len(),
                         &payload[..payload.len().min(4)]
                     ))?;
                 T::decode(Bytes::from(decompressed)).map_err(|e| {
                     format!(
-                        "Failed to decode protobuf after decompression: {} (type {})",
-                        e,
+                        "Failed to decode protobuf after decompression: {e} (type {})",
                         std::any::type_name::<T>()
                     )
                 })?

--- a/tests/e2e/datadog/metrics/series.rs
+++ b/tests/e2e/datadog/metrics/series.rs
@@ -244,7 +244,7 @@ async fn get_v1_series_from_pipeline(address: String) -> SeriesIntake {
 
     common_series_assertions(&intake);
 
-    info!("{:?}", intake);
+    info!("{intake:?}");
 
     intake
 }
@@ -265,7 +265,7 @@ async fn get_v2_series_from_pipeline(address: String) -> SeriesIntake {
 
     common_series_assertions(&intake);
 
-    info!("{:?}", intake);
+    info!("{intake:?}");
 
     intake
 }

--- a/tests/e2e/datadog/metrics/sketches.rs
+++ b/tests/e2e/datadog/metrics/sketches.rs
@@ -106,7 +106,7 @@ async fn get_sketches_from_pipeline(address: String) -> SketchIntake {
 
     common_sketch_assertions(&sketches);
 
-    info!("{:?}", sketches);
+    info!("{sketches:?}");
 
     sketches
 }

--- a/tests/e2e/opentelemetry/logs/mod.rs
+++ b/tests/e2e/opentelemetry/logs/mod.rs
@@ -27,7 +27,7 @@ fn parse_export_logs_request(content: &str) -> Result<ExportLogsServiceRequest, 
                 LOGS_REQUEST_MESSAGE_TYPE,
                 line,
             )
-            .map_err(|e| format!("Line {}: {}", line_num + 1, e))?
+            .map_err(|e| format!("Line {}: {e}", line_num + 1))?
             .resource_logs,
         );
     }

--- a/tests/e2e/opentelemetry/metrics/mod.rs
+++ b/tests/e2e/opentelemetry/metrics/mod.rs
@@ -30,7 +30,7 @@ fn parse_export_metrics_request(content: &str) -> Result<ExportMetricsServiceReq
                 METRICS_REQUEST_MESSAGE_TYPE,
                 line,
             )
-            .map_err(|e| format!("Line {}: {}", line_num + 1, e))?
+            .map_err(|e| format!("Line {}: {e}", line_num + 1))?
             .resource_metrics,
         );
     }
@@ -220,8 +220,7 @@ fn assert_metric_names_and_types(request: &ExportMetricsServiceRequest) {
     let total_count: usize = metric_type_counts.values().sum();
     assert_eq!(
         total_count, EXPECTED_METRIC_COUNT,
-        "Total metric count mismatch. Breakdown: {:?}",
-        metric_type_counts
+        "Total metric count mismatch. Breakdown: {metric_type_counts:?}"
     );
 }
 

--- a/tests/e2e/opentelemetry/metrics_native/mod.rs
+++ b/tests/e2e/opentelemetry/metrics_native/mod.rs
@@ -33,7 +33,7 @@ fn parse_export_metrics_request(content: &str) -> Result<ExportMetricsServiceReq
                 METRICS_REQUEST_MESSAGE_TYPE,
                 line,
             )
-            .map_err(|e| format!("Line {}: {}", line_num + 1, e))?
+            .map_err(|e| format!("Line {}: {e}", line_num + 1))?
             .resource_metrics,
         );
     }

--- a/tests/vector_api/common.rs
+++ b/tests/vector_api/common.rs
@@ -5,7 +5,7 @@ use indoc::formatdoc;
 /// Creates a single demo_logs source with blackhole sink
 pub fn single_source_config(source_name: &str, interval_secs: f64, count: Option<u32>) -> String {
     let count_line = count
-        .map(|c| format!("    count: {}\n", c))
+        .map(|c| format!("    count: {c}\n"))
         .unwrap_or_default();
 
     formatdoc! {"
@@ -30,7 +30,7 @@ pub fn dual_source_config(
     count: Option<u32>,
 ) -> String {
     let count_line = count
-        .map(|c| format!("    count: {}\n", c))
+        .map(|c| format!("    count: {c}\n"))
         .unwrap_or_default();
 
     formatdoc! {"

--- a/tests/vector_api/harness.rs
+++ b/tests/vector_api/harness.rs
@@ -339,8 +339,7 @@ pub async fn wait_for_topology_match(
         // Check timeout
         if start.elapsed() >= STARTUP_TIMEOUT {
             return Err(format!(
-                "Topology did not match expected components within {STARTUP_TIMEOUT:?}. Last seen: {:?}, expected: {:?}",
-                last_components, expected_component_ids
+                "Topology did not match expected components within {STARTUP_TIMEOUT:?}. Last seen: {last_components:?}, expected: {expected_component_ids:?}"
             ));
         }
 

--- a/tests/vector_api/tap.rs
+++ b/tests/vector_api/tap.rs
@@ -41,10 +41,8 @@ impl TestHarness {
         while events.len() < count {
             if start.elapsed() >= TAP_TIMEOUT {
                 return Err(format!(
-                    "Timeout: collected {}/{} events in {:?}",
-                    events.len(),
-                    count,
-                    TAP_TIMEOUT
+                    "Timeout: collected {}/{count} events in {TAP_TIMEOUT:?}",
+                    events.len()
                 ));
             }
 
@@ -53,7 +51,7 @@ impl TestHarness {
                     events.push(event);
                 }
                 Ok(Some(Err(e))) => {
-                    return Err(format!("Stream error: {}", e));
+                    return Err(format!("Stream error: {e}"));
                 }
                 Ok(None) => {
                     return Err(format!(
@@ -107,9 +105,8 @@ async fn tap_receives_events() {
 
     assert!(
         !tapped_events.is_empty(),
-        "Should receive at least one tapped event, got {} events total ({} notifications)",
-        events.len(),
-        notification_count
+        "Should receive at least one tapped event, got {} events total ({notification_count} notifications)",
+        events.len()
     );
 }
 

--- a/tests/vector_api/top.rs
+++ b/tests/vector_api/top.rs
@@ -105,7 +105,7 @@ async fn displays_pipeline_topology_and_metrics() {
         match component_id.as_str() {
             "demo" => assert_eq!(component_type, ComponentType::Source),
             "blackhole1" | "blackhole2" => assert_eq!(component_type, ComponentType::Sink),
-            _ => panic!("Unexpected component: {}", component_id),
+            _ => panic!("Unexpected component: {component_id}"),
         }
     }
 
@@ -346,13 +346,11 @@ async fn multi_output_transform_reports_per_output_sent_events() {
         .collect();
     assert!(
         output_ids.contains(&"all"),
-        "Missing 'all' output, got: {:?}",
-        output_ids
+        "Missing 'all' output, got: {output_ids:?}"
     );
     assert!(
         output_ids.contains(&"has_host"),
-        "Missing 'has_host' output, got: {:?}",
-        output_ids
+        "Missing 'has_host' output, got: {output_ids:?}"
     );
 
     // --- Assert 2: StreamComponentMetrics(SentEventsTotal) populates output_totals ---
@@ -379,20 +377,16 @@ async fn multi_output_transform_reports_per_output_sent_events() {
 
                     assert!(
                         all_total > 0,
-                        "Expected positive total for 'all' output, got {}",
-                        all_total
+                        "Expected positive total for 'all' output, got {all_total}"
                     );
                     assert!(
                         has_host_total > 0,
-                        "Expected positive total for 'has_host' output, got {}",
-                        has_host_total
+                        "Expected positive total for 'has_host' output, got {has_host_total}"
                     );
                     // "all" must be >= "has_host" since it matches every event
                     assert!(
                         all_total >= has_host_total,
-                        "'all' ({}) should be >= 'has_host' ({})",
-                        all_total,
-                        has_host_total
+                        "'all' ({all_total}) should be >= 'has_host' ({has_host_total})"
                     );
 
                     splitter_totals_found = true;

--- a/vdev/src/commands/build/component_docs/runner.rs
+++ b/vdev/src/commands/build/component_docs/runner.rs
@@ -301,12 +301,11 @@ fn import_json_as_cue(
     let json_output_file = write_to_temp_file(prefix, ".json", &final_json)?;
 
     debug!(
-        "[✓]   Wrote {} schema to '{}'. ({} bytes)",
-        friendly_name,
+        "[✓]   Wrote {friendly_name} schema to '{}'. ({} bytes)",
         json_output_file.display(),
         final_json.len()
     );
-    debug!("[*] Importing {} schema as Cue file...", friendly_name);
+    debug!("[*] Importing {friendly_name} schema as Cue file...");
 
     if let Some(parent) = cue_output_file.parent() {
         fs::create_dir_all(parent)?;
@@ -336,8 +335,7 @@ fn import_json_as_cue(
     }
 
     debug!(
-        "[✓]   Imported {} schema to '{}'.",
-        friendly_name,
+        "[✓]   Imported {friendly_name} schema to '{}'.",
         cue_output_file.display()
     );
     Ok(())

--- a/vdev/src/commands/build/component_docs/schema_core.rs
+++ b/vdev/src/commands/build/component_docs/schema_core.rs
@@ -68,7 +68,7 @@ impl SchemaContext {
             let expanded_ref = if let Some(cached) = self.expanded_schema_cache.get(&r) {
                 cached.clone()
             } else {
-                debug!("Expanding top-level schema ref of '{}'...", r);
+                debug!("Expanding top-level schema ref of '{r}'...");
                 let unexpanded = self.get_schema_by_name(&r)?;
                 let expanded = self.expand_schema_references(&unexpanded)?;
                 self.expanded_schema_cache

--- a/vdev/src/commands/build/component_docs/schema_enum.rs
+++ b/vdev/src/commands/build/component_docs/schema_enum.rs
@@ -388,7 +388,7 @@ impl SchemaContext {
 
         // Fallback schema pattern: mixed-mode enums.
         debug!("Resolved as 'fallback mixed-mode' enum schema.");
-        debug!("Tagging mode: {}", enum_tagging);
+        debug!("Tagging mode: {enum_tagging}");
 
         let mut resolved_subschemas: Vec<Value> = Vec::new();
         for subschema in &subschemas {

--- a/vdev/src/commands/build/component_docs/schema_resolve.rs
+++ b/vdev/src/commands/build/component_docs/schema_resolve.rs
@@ -174,7 +174,7 @@ impl SchemaContext {
 
                 if let Some(props) = properties {
                     for (prop_name, prop_schema) in props {
-                        debug!("Resolving object property '{}'...", prop_name);
+                        debug!("Resolving object property '{prop_name}'...");
                         let mut resolved_property = self.resolve_schema(prop_schema)?;
                         if !resolved_property.is_null() {
                             self.apply_object_property_fields(

--- a/vdev/src/commands/build/component_docs/schema_utils.rs
+++ b/vdev/src/commands/build/component_docs/schema_utils.rs
@@ -68,7 +68,7 @@ impl SchemaContext {
         schema_name: &str,
         friendly_name: &str,
     ) -> Result<Map<String, Value>> {
-        debug!("[*] Resolving schema definition for {}...", friendly_name);
+        debug!("[*] Resolving schema definition for {friendly_name}...");
 
         let resolved_schema = self.resolve_schema_by_name(schema_name)?;
 

--- a/vdev/src/commands/deprecation/check.rs
+++ b/vdev/src/commands/deprecation/check.rs
@@ -88,9 +88,8 @@ impl Cli {
 
         let enacted_count = deprecation::validate_enacted(&repo_root)?;
         println!(
-            "{} is up to date ({} enacted entries valid).",
-            json_path.display(),
-            enacted_count
+            "{} is up to date ({enacted_count} enacted entries valid).",
+            json_path.display()
         );
 
         Ok(())

--- a/vdev/src/testing/integration.rs
+++ b/vdev/src/testing/integration.rs
@@ -148,8 +148,8 @@ impl ComposeTest {
         // hyphens, and underscores. Replace any dots with hyphens.
         let sanitized_env = self.environment.replace('.', "-");
         format!(
-            "vector-{}-{}-{}",
-            self.local_config.directory, self.test_name, sanitized_env
+            "vector-{}-{}-{sanitized_env}",
+            self.local_config.directory, self.test_name
         )
     }
 

--- a/vdev/src/testing/runner.rs
+++ b/vdev/src/testing/runner.rs
@@ -384,8 +384,7 @@ impl ContainerTestRunner for IntegrationTestRunner {
     fn container_name(&self) -> String {
         if let Some(integration) = self.integration.as_ref() {
             format!(
-                "vector-test-runner-{}-{}",
-                integration,
+                "vector-test-runner-{integration}-{}",
                 RustToolchainConfig::rust_version()
             )
         } else {


### PR DESCRIPTION
## Summary

- Enable `clippy::uninlined_format_args` (warn) at the workspace level so `check-clippy` enforces the Rust 1.58+ inline capture syntax (`format!("{err}")` instead of `format!("{}", err)`).
- Mechanically convert all 618 existing violations across `src/`, `lib/`, `tests/`, `benches/`, and `vdev/` to inline format arguments.

### References

<!-- none -->

## Vector configuration

N/A — no behavior changes.

## How did you test this PR?

- `cargo fmt --all` — clean.
- `cargo clippy --workspace --all-targets` — zero warnings with the new lint enabled.
- Full-tree static re-scan for remaining positional-argument-with-identifier cases: 0.
- The only remaining positional args are non-inlinable expressions (field/method accesses, e.g. `src/graph.rs` `writeln!(mermaid, "  {} --> {id}", input.component)`), which the lint correctly ignores.

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.