### PR TITLE
chore(lints): enable five low-noise clippy lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,6 +145,11 @@ string_slice = "warn"
 await_holding_lock = "warn"
 let_underscore_must_use = "warn"
 uninlined_format_args = "warn"
+borrow_as_ptr = "warn"
+checked_conversions = "warn"
+ptr_as_ptr = "warn"
+rc_buffer = "warn"
+todo = "warn"
 
 [workspace.dependencies]
 antithesis-instrumentation = { version = "0.1", default-features = false, features = [] }

--- a/lib/docs-renderer/src/renderer.rs
+++ b/lib/docs-renderer/src/renderer.rs
@@ -199,7 +199,7 @@ impl RenderData {
     /// is an array, the value on the `other` side is appended to that array, regardless of the
     /// contents of the array.
     pub fn merge(&mut self, _other: Self) {
-        todo!()
+        unimplemented!()
     }
 }
 
@@ -355,7 +355,7 @@ fn render_bare_schema<T: QueryableSchema>(
             // instance type groupings, knowing that _we_ never generate schemas like that, but it's
             // still technically possible in a real-world JSON Schema document... so we should at
             // least make the error message half-way decent so that it explains as much.
-            todo!()
+            unimplemented!()
         }
     }
 
@@ -403,7 +403,7 @@ fn get_rendered_value_type<T: QueryableSchema>(
     _schema: T,
     _value: &Value,
 ) -> Result<String, RenderError> {
-    todo!()
+    unimplemented!()
 }
 
 fn render_schema_description<T: QueryableSchema>(schema: T) -> Result<Option<String>, RenderError> {

--- a/lib/vector-top/src/metrics.rs
+++ b/lib/vector-top/src/metrics.rs
@@ -33,7 +33,7 @@ async fn poll_components(
     mut client: Client,
     tx: state::EventTx,
     interval_ms: i64,
-    components_patterns: Arc<Vec<Pattern>>,
+    components_patterns: Arc<[Pattern]>,
     initial_components: HashSet<String>,
 ) {
     let mut known_components = initial_components;
@@ -130,7 +130,7 @@ async fn allocated_bytes(
     mut client: Client,
     tx: state::EventTx,
     interval: i64,
-    components_patterns: Arc<Vec<Pattern>>,
+    components_patterns: Arc<[Pattern]>,
 ) {
     let Ok(mut stream) = client
         .stream_component_allocated_bytes(interval as i32)
@@ -159,7 +159,7 @@ async fn received_bytes_totals(
     mut client: Client,
     tx: state::EventTx,
     interval: i64,
-    components_patterns: Arc<Vec<Pattern>>,
+    components_patterns: Arc<[Pattern]>,
 ) {
     let Ok(mut stream) = client
         .stream_component_metrics(MetricName::ReceivedBytesTotal, interval as i32)
@@ -188,7 +188,7 @@ async fn received_bytes_throughputs(
     mut client: Client,
     tx: state::EventTx,
     interval: i64,
-    components_patterns: Arc<Vec<Pattern>>,
+    components_patterns: Arc<[Pattern]>,
 ) {
     let Ok(mut stream) = client
         .stream_component_metrics(MetricName::ReceivedBytesThroughput, interval as i32)
@@ -217,7 +217,7 @@ async fn received_events_totals(
     mut client: Client,
     tx: state::EventTx,
     interval: i64,
-    components_patterns: Arc<Vec<Pattern>>,
+    components_patterns: Arc<[Pattern]>,
 ) {
     let Ok(mut stream) = client
         .stream_component_metrics(MetricName::ReceivedEventsTotal, interval as i32)
@@ -246,7 +246,7 @@ async fn received_events_throughputs(
     mut client: Client,
     tx: state::EventTx,
     interval: i64,
-    components_patterns: Arc<Vec<Pattern>>,
+    components_patterns: Arc<[Pattern]>,
 ) {
     let Ok(mut stream) = client
         .stream_component_metrics(MetricName::ReceivedEventsThroughput, interval as i32)
@@ -275,7 +275,7 @@ async fn sent_bytes_totals(
     mut client: Client,
     tx: state::EventTx,
     interval: i64,
-    components_patterns: Arc<Vec<Pattern>>,
+    components_patterns: Arc<[Pattern]>,
 ) {
     let Ok(mut stream) = client
         .stream_component_metrics(MetricName::SentBytesTotal, interval as i32)
@@ -304,7 +304,7 @@ async fn sent_bytes_throughputs(
     mut client: Client,
     tx: state::EventTx,
     interval: i64,
-    components_patterns: Arc<Vec<Pattern>>,
+    components_patterns: Arc<[Pattern]>,
 ) {
     let Ok(mut stream) = client
         .stream_component_metrics(MetricName::SentBytesThroughput, interval as i32)
@@ -333,7 +333,7 @@ async fn sent_events_totals(
     mut client: Client,
     tx: state::EventTx,
     interval: i64,
-    components_patterns: Arc<Vec<Pattern>>,
+    components_patterns: Arc<[Pattern]>,
 ) {
     let Ok(mut stream) = client
         .stream_component_metrics(MetricName::SentEventsTotal, interval as i32)
@@ -363,7 +363,7 @@ async fn sent_events_throughputs(
     mut client: Client,
     tx: state::EventTx,
     interval: i64,
-    components_patterns: Arc<Vec<Pattern>>,
+    components_patterns: Arc<[Pattern]>,
 ) {
     let Ok(mut stream) = client
         .stream_component_metrics(MetricName::SentEventsThroughput, interval as i32)
@@ -399,7 +399,7 @@ async fn errors_totals(
     mut client: Client,
     tx: state::EventTx,
     interval: i64,
-    components_patterns: Arc<Vec<Pattern>>,
+    components_patterns: Arc<[Pattern]>,
 ) {
     let Ok(mut stream) = client
         .stream_component_metrics(MetricName::ErrorsTotal, interval as i32)
@@ -459,7 +459,7 @@ pub async fn subscribe(
     components_patterns: Vec<Pattern>,
     initial_components: HashSet<String>,
 ) -> Result<SubscribeHandles, vector_api_client::Error> {
-    let components_patterns = Arc::new(components_patterns);
+    let components_patterns = Arc::from(components_patterns);
 
     let mut client = Client::new(uri);
     client.connect().await?;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -405,8 +405,8 @@ fn macos_maxfilesperproc() -> Option<libc::rlim_t> {
     let ret = unsafe {
         libc::sysctlbyname(
             c"kern.maxfilesperproc".as_ptr(),
-            &mut maxfiles as *mut libc::c_int as *mut libc::c_void,
-            &mut len,
+            (&raw mut maxfiles).cast::<libc::c_void>(),
+            &raw mut len,
             std::ptr::null_mut(),
             0,
         )

--- a/src/components/validation/resources/http.rs
+++ b/src/components/validation/resources/http.rs
@@ -441,7 +441,7 @@ impl HttpResourceOutputContext<'_> {
         // TODO: The `prometheus_exporter` sink is the only sink that exposes an HTTP server which must be
         // scraped... but since we need special logic to aggregate/deduplicate scraped metrics, we can't
         // use this generically for that purpose.
-        todo!()
+        unimplemented!()
     }
 }
 

--- a/src/components/validation/resources/mod.rs
+++ b/src/components/validation/resources/mod.rs
@@ -170,7 +170,7 @@ fn deserializer_config_to_serializer(config: &DeserializerConfig) -> encoding::S
         DeserializerConfig::Gelf { .. } => SerializerConfig::Gelf(Default::default()),
         DeserializerConfig::Avro { avro } => SerializerConfig::Avro { avro: avro.into() },
         // TODO: Influxdb has no serializer yet
-        DeserializerConfig::Influxdb { .. } => todo!(),
+        DeserializerConfig::Influxdb { .. } => unimplemented!(),
         DeserializerConfig::Vrl { .. } => unimplemented!(),
         #[cfg(feature = "codecs-opentelemetry")]
         DeserializerConfig::Otlp { .. } => SerializerConfig::Otlp,
@@ -199,9 +199,9 @@ fn decoder_framing_to_encoding_framer(framing: &decoding::FramingConfig) -> enco
         decoding::FramingConfig::NewlineDelimited(_) => encoding::FramingConfig::NewlineDelimited,
         // TODO: There's no equivalent octet counting framer for encoding... although
         // there's no particular reason that would make it hard to write.
-        decoding::FramingConfig::OctetCounting(_) => todo!(),
+        decoding::FramingConfig::OctetCounting(_) => unimplemented!(),
         // TODO: chunked gelf is not supported yet in encoding
-        decoding::FramingConfig::ChunkedGelf(_) => todo!(),
+        decoding::FramingConfig::ChunkedGelf(_) => unimplemented!(),
         decoding::FramingConfig::VarintLengthDelimited(config) => {
             encoding::FramingConfig::VarintLengthDelimited(
                 encoding::VarintLengthDelimitedEncoderConfig {
@@ -218,12 +218,12 @@ fn serializer_config_to_deserializer(
     config: &SerializerConfig,
 ) -> vector_lib::Result<decoding::Deserializer> {
     let deserializer_config = match config {
-        SerializerConfig::Avro { .. } => todo!(),
-        SerializerConfig::Cef { .. } => todo!(),
-        SerializerConfig::Csv { .. } => todo!(),
+        SerializerConfig::Avro { .. } => unimplemented!(),
+        SerializerConfig::Cef { .. } => unimplemented!(),
+        SerializerConfig::Csv { .. } => unimplemented!(),
         SerializerConfig::Gelf { .. } => DeserializerConfig::Gelf(Default::default()),
         SerializerConfig::Json(_) => DeserializerConfig::Json(Default::default()),
-        SerializerConfig::Logfmt => todo!(),
+        SerializerConfig::Logfmt => unimplemented!(),
         SerializerConfig::Native => DeserializerConfig::Native,
         SerializerConfig::NativeJson => DeserializerConfig::NativeJson(Default::default()),
         SerializerConfig::Protobuf(config) => {
@@ -237,9 +237,9 @@ fn serializer_config_to_deserializer(
         }
         SerializerConfig::RawMessage | SerializerConfig::Text(_) => DeserializerConfig::Bytes,
         #[cfg(feature = "codecs-opentelemetry")]
-        SerializerConfig::Otlp => todo!(),
+        SerializerConfig::Otlp => unimplemented!(),
         #[cfg(feature = "codecs-syslog")]
-        SerializerConfig::Syslog(_) => todo!(),
+        SerializerConfig::Syslog(_) => unimplemented!(),
     };
 
     deserializer_config.build()

--- a/src/cpu_time.rs
+++ b/src/cpu_time.rs
@@ -91,7 +91,7 @@ impl Inner {
         //   are an invalid clock ID (not the case here) or an invalid pointer
         //   (not the case here), neither of which can occur.
         unsafe {
-            libc::clock_gettime(libc::CLOCK_THREAD_CPUTIME_ID, &mut ts);
+            libc::clock_gettime(libc::CLOCK_THREAD_CPUTIME_ID, &raw mut ts);
         }
         Inner(Duration::new(ts.tv_sec as u64, ts.tv_nsec as u32))
     }

--- a/src/sinks/databricks_zerobus/service.rs
+++ b/src/sinks/databricks_zerobus/service.rs
@@ -67,7 +67,7 @@ fn build_connector_factory(proxy: &ProxyConfig) -> Result<ConnectorFactory, Zero
 /// would be wasteful.
 #[derive(Clone)]
 pub struct ZerobusRequest {
-    pub events: Arc<Vec<Event>>,
+    pub events: Arc<[Event]>,
     pub metadata: RequestMetadata,
     pub finalizers: EventFinalizers,
 }
@@ -932,7 +932,7 @@ mod tests {
 
     fn dummy_request() -> ZerobusRequest {
         ZerobusRequest {
-            events: Arc::new(vec![]),
+            events: Arc::from(vec![]),
             metadata: RequestMetadata::default(),
             finalizers: EventFinalizers::default(),
         }

--- a/src/sinks/databricks_zerobus/service.rs
+++ b/src/sinks/databricks_zerobus/service.rs
@@ -67,7 +67,8 @@ fn build_connector_factory(proxy: &ProxyConfig) -> Result<ConnectorFactory, Zero
 /// would be wasteful.
 #[derive(Clone)]
 pub struct ZerobusRequest {
-    pub events: Arc<[Event]>,
+    #[allow(clippy::rc_buffer)]
+    pub events: Arc<Vec<Event>>,
     pub metadata: RequestMetadata,
     pub finalizers: EventFinalizers,
 }
@@ -932,7 +933,7 @@ mod tests {
 
     fn dummy_request() -> ZerobusRequest {
         ZerobusRequest {
-            events: Arc::from(vec![]),
+            events: Arc::new(vec![]),
             metadata: RequestMetadata::default(),
             finalizers: EventFinalizers::default(),
         }

--- a/src/sinks/databricks_zerobus/sink.rs
+++ b/src/sinks/databricks_zerobus/sink.rs
@@ -54,7 +54,7 @@ impl ZerobusSink {
                     let metadata = RequestMetadataBuilder::from_events(&events)
                         .with_request_size(NonZeroUsize::MIN);
                     ZerobusRequest {
-                        events: Arc::new(events),
+                        events: Arc::from(events),
                         metadata,
                         finalizers,
                     }

--- a/src/sinks/databricks_zerobus/sink.rs
+++ b/src/sinks/databricks_zerobus/sink.rs
@@ -54,7 +54,7 @@ impl ZerobusSink {
                     let metadata = RequestMetadataBuilder::from_events(&events)
                         .with_request_size(NonZeroUsize::MIN);
                     ZerobusRequest {
-                        events: Arc::from(events),
+                        events: Arc::new(events),
                         metadata,
                         finalizers,
                     }

--- a/src/sources/journald.rs
+++ b/src/sources/journald.rs
@@ -980,12 +980,7 @@ fn decode_array_as_bytes(array: &[JsonValue]) -> Option<JsonValue> {
     // array was not a valid byte.
     array
         .iter()
-        .map(|item| {
-            item.as_u64().and_then(|num| match num {
-                num if num <= u8::MAX as u64 => Some(num as u8),
-                _ => None,
-            })
-        })
+        .map(|item| item.as_u64().and_then(|num| u8::try_from(num).ok()))
         .collect::<Option<Vec<u8>>>()
         .map(|array| String::from_utf8_lossy(&array).into())
 }


### PR DESCRIPTION
## Summary

Enables five additional clippy lints at the workspace level:

- `clippy::todo`
- `clippy::rc_buffer`
- `clippy::ptr_as_ptr`
- `clippy::borrow_as_ptr`
- `clippy::checked_conversions`

These are lints that cargo, rustup, rust-analyzer, zed, and bevy already enforce, and which had only a handful of violations in Vector. All existing violations are fixed:

- All `todo!` call sites become bare `unimplemented!()` calls — same termination behavior, without the "yet to be done" intent, and `clippy::todo` keeps them from creeping back in. `unimplemented!` itself stays allowed.
- `Arc<Vec<T>>` buffer fields become `Arc<[T]>` (vector-top component patterns, databricks_zerobus request events).
- Raw-pointer casts in the macOS `sysctl` and thread-cpu-time code use `&raw mut` / `pointer::cast`.
- The journald byte conversion uses `u8::try_from` instead of a guarded `as` cast.

### References
- Related: #26346 (workspace-level enforcement of `clippy::uninlined_format_args`)

## Vector configuration

N/A — internal lint enforcement, no user-facing behavior.

## How did you test this PR?

- `cargo clippy --workspace --all-targets` (default features) — clean.
- `cargo vdev check rust` (i.e. `cargo clippy --workspace --all-targets --all-features`, the same invocation CI's "Check clippy" job runs) — clean.
- `cargo fmt` — no changes.
- Repo-wide search confirms no remaining `todo!` sites, including in feature-gated code paths.

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.
