### PR TITLE
test(http): add component-level proxy coverage for http_client source and http sink

### DIFF
--- a/src/sinks/http/tests.rs
+++ b/src/sinks/http/tests.rs
@@ -29,6 +29,7 @@ use super::{
 use crate::{
     assert_downcast_matches,
     codecs::EncodingConfigWithFraming,
+    config::ProxyConfig,
     log_event,
     sinks::{
         prelude::*,
@@ -47,7 +48,9 @@ use crate::{
             self, COMPONENT_ERROR_TAGS, HTTP_SINK_TAGS, init_test, run_and_assert_sink_compliance,
             run_and_assert_sink_error_with_events,
         },
-        create_events_batch_with_fn, random_lines_with_stream,
+        create_events_batch_with_fn,
+        http::spawn_authenticated_http_proxy,
+        random_lines_with_stream,
     },
 };
 
@@ -1071,4 +1074,71 @@ async fn build_sink(extra_config: &str) -> (std::net::SocketAddr, crate::sinks::
 
     let (sink, _) = config.build(cx).await.unwrap();
     (in_addr, sink)
+}
+
+/// Events should be delivered through the configured authenticated HTTP proxy,
+/// which forwards the request to the origin without leaking the proxy credentials.
+#[tokio::test]
+async fn sends_through_authenticated_proxy() {
+    init_test();
+
+    let (_guard, in_addr) = next_addr();
+    let (origin_rx, trigger, origin) = build_test_server(in_addr);
+    tokio::spawn(origin);
+
+    let mut proxy = spawn_authenticated_http_proxy();
+    let proxy_config = ProxyConfig {
+        enabled: true,
+        http: Some(proxy.url().to_owned()),
+        https: None,
+        no_proxy: Default::default(),
+    };
+
+    let config = format!(
+        r#"
+        uri: "http://{in_addr}/frames"
+        framing:
+          method: newline_delimited
+        encoding:
+          codec: json
+        "#
+    );
+    let config: HttpSinkConfig = serde_yaml::from_str(&config).unwrap();
+
+    let cx = SinkContext {
+        proxy: proxy_config,
+        ..SinkContext::default()
+    };
+
+    let (sink, _) = config.build(cx).await.unwrap();
+    let event = Event::Log(LogEvent::from("simple message"));
+
+    run_and_assert_sink_compliance(sink, stream::once(ready(event)), &HTTP_SINK_TAGS).await;
+
+    let observation = proxy.next_request().await;
+    assert_eq!(observation.method, Method::POST);
+    assert_eq!(
+        observation.uri.to_string(),
+        format!("http://{in_addr}/frames")
+    );
+    assert!(
+        observation
+            .headers
+            .contains_key(hyper::header::PROXY_AUTHORIZATION)
+    );
+
+    // The proxy forwards the request to the origin without the proxy credentials,
+    // and the origin receives the encoded event.
+    let (parts, body) = origin_rx.into_future().await.0.unwrap();
+    assert_eq!(Method::POST, parts.method);
+    assert_eq!("/frames", parts.uri.path());
+    assert!(
+        !parts
+            .headers
+            .contains_key(hyper::header::PROXY_AUTHORIZATION)
+    );
+    let event: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(event["message"], "simple message");
+
+    drop(trigger);
 }

--- a/src/sinks/http/tests.rs
+++ b/src/sinks/http/tests.rs
@@ -1094,15 +1094,13 @@ async fn sends_through_authenticated_proxy() {
         no_proxy: Default::default(),
     };
 
-    let config = format!(
-        r#"
+    let config = indoc::formatdoc! {r#"
         uri: "http://{in_addr}/frames"
         framing:
           method: newline_delimited
         encoding:
           codec: json
-        "#
-    );
+    "#};
     let config: HttpSinkConfig = serde_yaml::from_str(&config).unwrap();
 
     let cx = SinkContext {

--- a/src/sources/http_client/tests.rs
+++ b/src/sources/http_client/tests.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use http::Uri;
+use http::{Method, Uri, header};
 use tokio::time::Duration;
 use vector_lib::{
     codecs::{
@@ -16,12 +16,17 @@ use warp::{Filter, http::HeaderMap};
 use super::HttpClientConfig;
 use crate::{
     components::validation::prelude::*,
+    config::{ProxyConfig, SourceContext},
     http::{ParamType, ParameterValue, QueryParameterValue},
     serde::{default_decoding, default_framing_message_based},
     sources::util::http::{HttpMethod, capped_body},
     test_util::{
         addr::next_addr,
-        components::{HTTP_PULL_SOURCE_TAGS, run_and_assert_source_compliance},
+        components::{
+            HTTP_PULL_SOURCE_TAGS, run_and_assert_source_compliance,
+            run_and_assert_source_compliance_advanced,
+        },
+        http::spawn_authenticated_http_proxy,
         test_generate_config, wait_for_tcp,
     },
 };
@@ -761,4 +766,78 @@ async fn body_vrl_compilation_error() {
         }
         Ok(_) => panic!("Expected build to fail with VRL compilation error, but it succeeded"),
     }
+}
+
+/// Requests should be routed through the configured authenticated HTTP proxy,
+/// which forwards them to the origin without leaking the proxy credentials.
+#[tokio::test]
+async fn requests_through_authenticated_proxy() {
+    let (_guard, in_addr) = next_addr();
+
+    let dummy_endpoint = warp::path!("endpoint")
+        .and(warp::header::headers_cloned().map(|headers: HeaderMap| {
+            // The proxy credentials must not reach the origin.
+            assert!(!headers.contains_key("Proxy-Authorization"));
+        }))
+        .map(move |()| r#"{"data" : "foo"}"#);
+
+    tokio::spawn(warp::serve(dummy_endpoint).run(in_addr));
+    wait_for_tcp(in_addr).await;
+
+    let mut proxy = spawn_authenticated_http_proxy();
+    let proxy_config = ProxyConfig {
+        enabled: true,
+        http: Some(proxy.url().to_owned()),
+        https: None,
+        no_proxy: Default::default(),
+    };
+
+    let events = run_and_assert_source_compliance_advanced(
+        HttpClientConfig {
+            endpoint: format!("http://{in_addr}/endpoint"),
+            interval: INTERVAL,
+            timeout: TIMEOUT,
+            query: HashMap::new(),
+            decoding: DeserializerConfig::Json(Default::default()),
+            framing: default_framing_message_based(),
+            headers: HashMap::new(),
+            method: HttpMethod::Get,
+            body: None,
+            tls: None,
+            auth: None,
+            log_namespace: None,
+        },
+        move |context: &mut SourceContext| {
+            context.proxy = proxy_config;
+        },
+        Some(Duration::from_secs(3)),
+        None,
+        &HTTP_PULL_SOURCE_TAGS,
+    )
+    .await;
+
+    assert!(!events.is_empty());
+    for event in events {
+        assert_eq!(
+            event
+                .into_log()
+                .get(event_path!("data"))
+                .unwrap()
+                .as_str()
+                .unwrap(),
+            "foo"
+        );
+    }
+
+    let observation = proxy.next_request().await;
+    assert_eq!(observation.method, Method::GET);
+    assert_eq!(
+        observation.uri.to_string(),
+        format!("http://{in_addr}/endpoint")
+    );
+    assert!(
+        observation
+            .headers
+            .contains_key(header::PROXY_AUTHORIZATION)
+    );
 }

--- a/src/test_util/http.rs
+++ b/src/test_util/http.rs
@@ -1,10 +1,11 @@
-use std::{convert::Infallible, future::Future};
+use std::{convert::Infallible, future::Future, net::SocketAddr};
 
-use http::{Request, Response, Uri, uri::Scheme};
+use http::{HeaderMap, Method, Request, Response, StatusCode, Uri, header, uri::Scheme};
 use hyper::{
-    Body, Server,
+    Body, Client, Server,
     service::{make_service_fn, service_fn},
 };
+use tokio::{sync::mpsc, task::JoinHandle, time::timeout};
 
 use super::{addr::next_addr, wait_for_tcp};
 
@@ -49,4 +50,101 @@ where
 /// Responds to every request with a 200 OK response.
 pub async fn always_200_response(_: Request<Body>) -> Result<Response<Body>, Infallible> {
     Ok(Response::new(Body::empty()))
+}
+
+const PROXY_AUTHORIZATION: &str = "Basic cHJveHktdXNlcjpwcm94eS1wYXNz";
+
+/// A request observed by [`AuthenticatedHttpProxy`] before it was forwarded.
+#[derive(Debug)]
+pub struct ProxyRequestObservation {
+    pub method: Method,
+    pub uri: Uri,
+    pub headers: HeaderMap,
+}
+
+/// A deterministic authenticated plaintext HTTP proxy for component tests.
+pub struct AuthenticatedHttpProxy {
+    url: String,
+    observations: mpsc::UnboundedReceiver<ProxyRequestObservation>,
+    task: JoinHandle<()>,
+}
+
+impl AuthenticatedHttpProxy {
+    /// Returns the proxy URL, including its test credentials.
+    pub fn url(&self) -> &str {
+        &self.url
+    }
+
+    /// Waits for the next request received by the proxy.
+    pub async fn next_request(&mut self) -> ProxyRequestObservation {
+        timeout(std::time::Duration::from_secs(5), self.observations.recv())
+            .await
+            .expect("proxy did not receive a request")
+            .expect("proxy observation channel closed")
+    }
+}
+
+impl Drop for AuthenticatedHttpProxy {
+    fn drop(&mut self) {
+        self.task.abort();
+    }
+}
+
+/// Spawns an HTTP proxy requiring the `proxy-user`/`proxy-pass` credentials.
+pub fn spawn_authenticated_http_proxy() -> AuthenticatedHttpProxy {
+    let address = SocketAddr::from(([127, 0, 0, 1], 0));
+    let server = Server::bind(&address);
+    let address = server.local_addr();
+    let (observations_tx, observations) = mpsc::unbounded_channel();
+
+    let make_service = make_service_fn(move |_| {
+        let observations_tx = observations_tx.clone();
+        async move {
+            Ok::<_, Infallible>(service_fn(move |mut request: Request<Body>| {
+                let observations_tx = observations_tx.clone();
+                async move {
+                    let observation = ProxyRequestObservation {
+                        method: request.method().clone(),
+                        uri: request.uri().clone(),
+                        headers: request.headers().clone(),
+                    };
+                    let authorized = observation
+                        .headers
+                        .get(header::PROXY_AUTHORIZATION)
+                        .is_some_and(|value| value.as_bytes() == PROXY_AUTHORIZATION.as_bytes());
+                    _ = observations_tx.send(observation);
+
+                    if !authorized {
+                        return Ok::<_, Infallible>(
+                            Response::builder()
+                                .status(StatusCode::PROXY_AUTHENTICATION_REQUIRED)
+                                .body(Body::empty())
+                                .unwrap(),
+                        );
+                    }
+
+                    request.headers_mut().remove(header::PROXY_AUTHORIZATION);
+                    let response = Client::new().request(request).await.unwrap_or_else(|_| {
+                        Response::builder()
+                            .status(StatusCode::BAD_GATEWAY)
+                            .body(Body::empty())
+                            .unwrap()
+                    });
+                    Ok(response)
+                }
+            }))
+        }
+    });
+
+    let task = tokio::spawn(async move {
+        if let Err(error) = server.serve(make_service).await {
+            error!(message = "Test HTTP proxy error.", ?error);
+        }
+    });
+
+    AuthenticatedHttpProxy {
+        url: format!("http://proxy-user:proxy-pass@{address}"),
+        observations,
+        task,
+    }
 }


### PR DESCRIPTION
## Summary

Adds component-level coverage for routing HTTP traffic through a configured forward
proxy, complementing the transport contract tests in `src/http/transport_tests.rs`
from #26066. Both the `http_client` source and the `http` sink now have a
compliance test that runs a full request/response cycle through an authenticated
plaintext HTTP proxy, asserting:

- the component honors `SourceContext.proxy` / `SinkContext.proxy` wiring
- proxy credentials are presented to the proxy and never forwarded to the origin
- the origin receives the intact payload
- required component compliance telemetry is emitted

A reusable test fixture (`spawn_authenticated_http_proxy`) was added to
`src/test_util/http.rs`; TLS-proxy, CONNECT, `no_proxy`, and disabled-proxy
scenarios remain covered by the transport tests.

### References

Related: #26066

## Vector configuration

NA.

## How did you test this PR?

- `cargo test --no-default-features --features "sinks-http" --lib sinks::http::` — 37 passed.
- `cargo test --no-default-features --features "sources-http_client vrl-functions-crypto" --lib sources::http_client::` — 16 passed.
- `cargo test --no-default-features --features "sources-http_client sinks-http" --lib http::transport_tests` — 26 passed.
- `cargo fmt --all -- --check` — clean.
- `cargo clippy --no-default-features --features "sources-http_client sinks-http" --lib --tests` — no warnings.

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.