### PR TITLE
chore(sinks): migrate HttpService sinks to the native Hyper 1 client

### DIFF
--- a/src/gcp.rs
+++ b/src/gcp.rs
@@ -12,6 +12,7 @@ use goauth::{
     credentials::Credentials,
 };
 use http::{Uri, uri::PathAndQuery};
+use http_1::{Uri as UriV1, header::AUTHORIZATION as AUTHORIZATION_V1};
 use http_body::{Body as _, Collected};
 use hyper::header::AUTHORIZATION;
 use smpl_jwt::Jwt;
@@ -171,6 +172,16 @@ impl GcpAuthenticator {
         self.apply_uri(request.uri_mut());
     }
 
+    /// Applies authentication to a native `http 1` request, mirroring [`Self::apply`].
+    pub fn apply_v1<T>(&self, request: &mut http_1::Request<T>) {
+        if let Some(token) = self.make_token() {
+            request
+                .headers_mut()
+                .insert(AUTHORIZATION_V1, token.parse().unwrap());
+        }
+        self.apply_uri_v1(request.uri_mut());
+    }
+
     pub fn apply_uri(&self, uri: &mut Uri) {
         match self {
             Self::Credentials(_) | Self::None => (),
@@ -188,6 +199,27 @@ impl GcpAuthenticator {
                 parts.path_and_query =
                     Some(paq.parse().expect("Could not re-parse path and query"));
                 *uri = Uri::from_parts(parts).expect("Could not re-parse URL");
+            }
+        }
+    }
+
+    fn apply_uri_v1(&self, uri: &mut UriV1) {
+        match self {
+            Self::Credentials(_) | Self::None => (),
+            Self::ApiKey(api_key) => {
+                let mut parts = uri.clone().into_parts();
+                let path = parts
+                    .path_and_query
+                    .as_ref()
+                    .map_or("/", http_1::uri::PathAndQuery::path);
+                let paq = format!("{path}?key={api_key}");
+                // The API key is verified above to only contain
+                // URL-safe characters. That key is added to a path
+                // that came from a successfully parsed URI. As such,
+                // re-parsing the string cannot fail.
+                parts.path_and_query =
+                    Some(paq.parse().expect("Could not re-parse path and query"));
+                *uri = UriV1::from_parts(parts).expect("Could not re-parse URL");
             }
         }
     }

--- a/src/http.rs
+++ b/src/http.rs
@@ -9,13 +9,13 @@ use std::{
 
 use futures::future::BoxFuture;
 use headers::{Authorization, HeaderMapExt};
-#[cfg(any(feature = "sinks-clickhouse", test))]
+#[cfg(any(feature = "sinks-clickhouse", feature = "sinks-greptimedb_logs", test))]
 use headers_1::{Authorization as AuthorizationV1, HeaderMapExt as HeaderMapExtV1};
 use http::{
     HeaderMap, Request, Response, Uri, Version, header::HeaderValue, request::Builder,
     uri::InvalidUri,
 };
-#[cfg(any(feature = "sinks-clickhouse", test))]
+#[cfg(any(feature = "sinks-clickhouse", feature = "sinks-greptimedb_logs", test))]
 use http_1::Request as RequestV1;
 use hyper::{
     body::{Body, HttpBody},
@@ -466,7 +466,7 @@ impl Auth {
         builder
     }
 
-    #[cfg(any(feature = "sinks-clickhouse", test))]
+    #[cfg(any(feature = "sinks-clickhouse", feature = "sinks-greptimedb_logs", test))]
     pub(crate) fn apply_v1<B>(&self, request: &mut RequestV1<B>) {
         self.apply_headers_map_v1(request.headers_mut())
     }
@@ -498,7 +498,7 @@ impl Auth {
         }
     }
 
-    #[cfg(any(feature = "sinks-clickhouse", test))]
+    #[cfg(any(feature = "sinks-clickhouse", feature = "sinks-greptimedb_logs", test))]
     fn apply_headers_map_v1(&self, map: &mut http_1::HeaderMap) {
         match &self {
             Auth::Basic { user, password } => {

--- a/src/sinks/gcp/stackdriver/logs/config.rs
+++ b/src/sinks/gcp/stackdriver/logs/config.rs
@@ -2,8 +2,8 @@
 
 use std::collections::HashMap;
 
-use http::{Request, Uri};
-use hyper::Body;
+use http::StatusCode;
+use http_1::Request;
 use snafu::Snafu;
 use vector_lib::lookup::lookup_v2::ConfigValuePath;
 use vrl::value::Kind;
@@ -20,14 +20,15 @@ use super::{
 use crate::{
     config::ValidatedSink,
     gcp::{GcpAuthConfig, GcpAuthenticator, Scope},
-    http::HttpClient,
+    http::client_v1::{HttpClient, full_body},
     schema,
     sinks::{
-        gcs_common::config::healthcheck_response,
+        gcs_common::config::healthcheck_status,
         prelude::*,
         util::{
             BoxedRawValue, HttpEndpoint, RealtimeSizeBasedDefaultBatchSettings,
-            http::{HttpService, RetryStrategy, http_response_retry_logic},
+            http::RetryStrategy,
+            http_v1::{HttpService, http_response_retry_logic},
             service::TowerRequestConfigDefaults,
         },
     },
@@ -324,10 +325,10 @@ impl ValidatedSink for StackdriverConfig {
         let request_limits = self.request.into_settings();
 
         let tls_settings = TlsSettings::from_options(self.tls.as_ref())?;
-        let client = HttpClient::new(tls_settings, cx.proxy())?;
+        let client = HttpClient::new(tls_settings.into(), cx.proxy())?;
 
         let stackdriver_logs_service_request_builder = StackdriverLogsServiceRequestBuilder {
-            uri: self.endpoint.as_uri().clone(),
+            endpoint: self.endpoint.clone(),
             auth: auth.clone(),
         };
 
@@ -342,7 +343,7 @@ impl ValidatedSink for StackdriverConfig {
 
         let sink = StackdriverLogsSink::new(service, *batch_settings, request_builder);
 
-        let healthcheck = healthcheck(client, auth.clone(), self.endpoint.as_uri().clone()).boxed();
+        let healthcheck = healthcheck(client, auth.clone(), self.endpoint.clone()).boxed();
 
         auth.spawn_regenerate_token();
         Ok((VectorSink::from_event_streamsink(sink), healthcheck))
@@ -355,24 +356,28 @@ pub struct ValidatedStackdriverLogs {
     batch_settings: BatcherSettings,
 }
 
-async fn healthcheck(client: HttpClient, auth: GcpAuthenticator, uri: Uri) -> crate::Result<()> {
+async fn healthcheck(
+    client: HttpClient,
+    auth: GcpAuthenticator,
+    endpoint: HttpEndpoint,
+) -> crate::Result<()> {
     let entries: Vec<BoxedRawValue> = Vec::new();
     let events = serde_json::json!({ "entries": entries });
 
     let body = crate::serde::json::to_bytes(&events).unwrap().freeze();
-
-    let mut request = Request::post(uri)
+    let mut request = Request::post(endpoint.into_v1())
         .header("Content-Type", "application/json")
         .body(body)
         .unwrap();
 
-    auth.apply(&mut request);
-
-    let request = request.map(Body::from);
+    auth.apply_v1(&mut request);
+    let request = request.map(full_body);
 
     let response = client.send(request).await?;
 
-    healthcheck_response(response, HealthcheckError::NotFound.into())
+    let status = StatusCode::from_u16(response.status().as_u16())
+        .expect("HTTP status codes are valid u16 values");
+    healthcheck_status(status, HealthcheckError::NotFound.into())
 }
 
 #[cfg(test)]

--- a/src/sinks/gcp/stackdriver/logs/service.rs
+++ b/src/sinks/gcp/stackdriver/logs/service.rs
@@ -1,33 +1,34 @@
 //! Service implementation for the `gcp_stackdriver_logs` sink.
 
 use bytes::Bytes;
-use http::{Request, Uri, header::CONTENT_TYPE};
+use http_1::{Request, header::CONTENT_TYPE};
 use snafu::ResultExt;
 
 use crate::{
     gcp::GcpAuthenticator,
     sinks::{
-        HTTPRequestBuilderSnafu,
-        util::http::{HttpRequest, HttpServiceRequestBuilder},
+        HTTPV1RequestBuilderSnafu,
+        util::{HttpEndpoint, http::HttpRequest, http_v1::HttpServiceRequestBuilder},
     },
 };
 
 #[derive(Debug, Clone)]
 pub(super) struct StackdriverLogsServiceRequestBuilder {
-    pub(super) uri: Uri,
+    pub(super) endpoint: HttpEndpoint,
     pub(super) auth: GcpAuthenticator,
 }
 
 impl HttpServiceRequestBuilder<()> for StackdriverLogsServiceRequestBuilder {
     fn build(&self, mut request: HttpRequest<()>) -> Result<Request<Bytes>, crate::Error> {
-        let builder = Request::post(self.uri.clone()).header(CONTENT_TYPE, "application/json");
+        let builder =
+            Request::post(self.endpoint.clone().into_v1()).header(CONTENT_TYPE, "application/json");
 
         let mut request = builder
             .body(request.take_payload())
-            .context(HTTPRequestBuilderSnafu)
-            .map_err(Into::<crate::Error>::into)?;
+            .context(HTTPV1RequestBuilderSnafu)
+            .map_err(crate::Error::from)?;
 
-        self.auth.apply(&mut request);
+        self.auth.apply_v1(&mut request);
 
         Ok(request)
     }

--- a/src/sinks/gcp/stackdriver/logs/tests.rs
+++ b/src/sinks/gcp/stackdriver/logs/tests.rs
@@ -5,7 +5,6 @@ use std::collections::HashMap;
 use bytes::Bytes;
 use chrono::{TimeZone, Utc};
 use futures::{future::ready, stream};
-use http::Uri;
 use indoc::indoc;
 use vector_lib::lookup::lookup_v2::ConfigValuePath;
 use vrl::{event_path, value};
@@ -28,9 +27,8 @@ use crate::{
         },
         prelude::*,
         util::{
-            HttpEndpoint,
-            encoding::Encoder as _,
-            http::{HttpRequest, HttpServiceRequestBuilder},
+            HttpEndpoint, encoding::Encoder as _, http::HttpRequest,
+            http_v1::HttpServiceRequestBuilder,
         },
     },
     template::{ConfinementConfig, Template, UnconfinedTemplate},
@@ -222,8 +220,6 @@ fn severity_remaps_strings() {
 
 #[tokio::test]
 async fn correct_request() {
-    let uri: Uri = default_endpoint().into_uri();
-
     let transformer = Transformer::default();
     let encoder = StackdriverLogsEncoder::new(
         transformer,
@@ -251,7 +247,7 @@ async fn correct_request() {
     let body = Bytes::copy_from_slice(&writer);
 
     let stackdriver_logs_service_request_builder = StackdriverLogsServiceRequestBuilder {
-        uri: uri.clone(),
+        endpoint: default_endpoint(),
         auth: GcpAuthenticator::None,
     };
 

--- a/src/sinks/gcp/stackdriver/metrics/config.rs
+++ b/src/sinks/gcp/stackdriver/metrics/config.rs
@@ -1,6 +1,6 @@
 use bytes::Bytes;
 use goauth::scopes::Scope;
-use http::{Request, Uri, header::CONTENT_TYPE};
+use http_1::{Request, header::CONTENT_TYPE};
 use snafu::ResultExt;
 
 use super::{
@@ -10,16 +10,14 @@ use super::{
 use crate::{
     config::ValidatedSink,
     gcp::{GcpAuthConfig, GcpAuthenticator},
-    http::HttpClient,
+    http::client_v1::HttpClient,
     sinks::{
-        HTTPRequestBuilderSnafu, gcp,
+        HTTPV1RequestBuilderSnafu, gcp,
         prelude::*,
         util::{
             HttpEndpoint,
-            http::{
-                HttpRequest, HttpService, HttpServiceRequestBuilder, RetryStrategy,
-                http_response_retry_logic,
-            },
+            http::{HttpRequest, RetryStrategy},
+            http_v1::{HttpService, HttpServiceRequestBuilder, http_response_retry_logic},
             service::TowerRequestConfigDefaults,
         },
     },
@@ -138,7 +136,7 @@ impl ValidatedSink for StackdriverConfig {
         let healthcheck = healthcheck().boxed();
         let started = chrono::Utc::now();
         let tls_settings = TlsSettings::from_options(self.tls.as_ref())?;
-        let client = HttpClient::new(tls_settings, cx.proxy())?;
+        let client = HttpClient::new(tls_settings.into(), cx.proxy())?;
 
         let request_builder = StackdriverMetricsRequestBuilder {
             encoder: StackdriverMetricsEncoder {
@@ -153,7 +151,7 @@ impl ValidatedSink for StackdriverConfig {
         auth.spawn_regenerate_token();
 
         let stackdriver_metrics_service_request_builder = StackdriverMetricsServiceRequestBuilder {
-            uri: uri.into_uri(),
+            endpoint: uri.clone(),
             auth,
         };
 
@@ -209,20 +207,21 @@ impl SinkBatchSettings for StackdriverMetricsDefaultBatchSettings {
 
 #[derive(Debug, Clone)]
 pub(super) struct StackdriverMetricsServiceRequestBuilder {
-    pub(super) uri: Uri,
+    pub(super) endpoint: HttpEndpoint,
     pub(super) auth: GcpAuthenticator,
 }
 
 impl HttpServiceRequestBuilder<()> for StackdriverMetricsServiceRequestBuilder {
     fn build(&self, mut request: HttpRequest<()>) -> Result<Request<Bytes>, crate::Error> {
-        let builder = Request::post(self.uri.clone()).header(CONTENT_TYPE, "application/json");
+        let builder =
+            Request::post(self.endpoint.clone().into_v1()).header(CONTENT_TYPE, "application/json");
 
         let mut request = builder
             .body(request.take_payload())
-            .context(HTTPRequestBuilderSnafu)
-            .map_err(Into::<crate::Error>::into)?;
+            .context(HTTPV1RequestBuilderSnafu)
+            .map_err(crate::Error::from)?;
 
-        self.auth.apply(&mut request);
+        self.auth.apply_v1(&mut request);
 
         Ok(request)
     }

--- a/src/sinks/gcs_common/config.rs
+++ b/src/sinks/gcs_common/config.rs
@@ -134,7 +134,16 @@ pub fn healthcheck_response(
     response: http::Response<hyper::Body>,
     not_found_error: crate::Error,
 ) -> crate::Result<()> {
-    match response.status() {
+    healthcheck_status(response.status(), not_found_error)
+}
+
+/// Classifies a GCP healthcheck response by status alone, shared by the legacy and native
+/// HTTP clients.
+pub fn healthcheck_status(
+    status: http::StatusCode,
+    not_found_error: crate::Error,
+) -> crate::Result<()> {
+    match status {
         StatusCode::OK => Ok(()),
         StatusCode::FORBIDDEN => Err(GcpError::HealthcheckForbidden.into()),
         StatusCode::NOT_FOUND => Err(not_found_error),

--- a/src/sinks/greptimedb/logs/config.rs
+++ b/src/sinks/greptimedb/logs/config.rs
@@ -8,20 +8,23 @@ use vector_lib::{
 
 use crate::{
     config::ValidatedSink,
-    http::{Auth, HttpClient},
+    http::{Auth, client_v1::HttpClient},
     sinks::{
         greptimedb::{
             GreptimeDBDefaultBatchSettings, default_dbname_template, default_pipeline_template,
             logs::{
                 http_request_builder::{
-                    GreptimeDBHttpRetryLogic, GreptimeDBLogsHttpRequestBuilder, PartitionKey,
-                    http_healthcheck,
+                    GreptimeDBLogsHttpRequestBuilder, PartitionKey, http_healthcheck,
                 },
                 sink::{GreptimeDBLogsHttpSink, LogsSinkSetting},
             },
         },
         prelude::*,
-        util::{HttpEndpoint, http::HttpService},
+        util::{
+            HttpEndpoint,
+            http::RetryStrategy,
+            http_v1::{HttpService, http_response_retry_logic},
+        },
     },
     template::ConfinementConfig,
 };
@@ -216,7 +219,7 @@ impl ValidatedSink for GreptimeDBLogsConfig {
         } = validated;
 
         let tls_settings = TlsSettings::from_options(self.tls.as_ref())?;
-        let client = HttpClient::new(tls_settings, &cx.proxy)?;
+        let client = HttpClient::new(tls_settings.into(), &cx.proxy)?;
 
         let request_builder = GreptimeDBLogsHttpRequestBuilder {
             endpoint: self.endpoint.clone(),
@@ -239,7 +242,10 @@ impl ValidatedSink for GreptimeDBLogsConfig {
         let request_limits = self.request.into_settings();
 
         let service = ServiceBuilder::new()
-            .settings(request_limits, GreptimeDBHttpRetryLogic::default())
+            .settings(
+                request_limits,
+                http_response_retry_logic(RetryStrategy::default()),
+            )
             .service(service);
 
         let logs_sink_setting = LogsSinkSetting {

--- a/src/sinks/greptimedb/logs/http_request_builder.rs
+++ b/src/sinks/greptimedb/logs/http_request_builder.rs
@@ -1,11 +1,11 @@
 use std::collections::HashMap;
 
 use bytes::Bytes;
-use http::{
-    Request, StatusCode,
+use http::StatusCode;
+use http_1::{
+    Request,
     header::{CONTENT_ENCODING, CONTENT_LENGTH, CONTENT_TYPE},
 };
-use hyper::Body;
 use snafu::ResultExt;
 use vector_lib::codecs::encoding::Framer;
 
@@ -13,14 +13,14 @@ use crate::{
     Error,
     codecs::{Encoder, Transformer},
     event::{Event, EventFinalizers, Finalizable},
-    http::{Auth, HttpClient, HttpError},
+    http::{
+        Auth,
+        client_v1::{HttpClient, empty_body},
+    },
     sinks::{
-        HTTPRequestBuilderSnafu, HealthcheckError,
+        HTTPV1RequestBuilderSnafu, HealthcheckError,
         prelude::*,
-        util::{
-            HttpEndpoint,
-            http::{HttpRequest, HttpResponse, HttpRetryLogic, HttpServiceRequestBuilder},
-        },
+        util::{HttpEndpoint, http::HttpRequest, http_v1::HttpServiceRequestBuilder},
     },
 };
 
@@ -182,14 +182,15 @@ impl HttpServiceRequestBuilder<PartitionKey> for GreptimeDBLogsHttpRequestBuilde
             builder = builder.header(CONTENT_ENCODING, ce);
         }
 
-        if let Some(auth) = self.auth.clone() {
-            builder = auth.apply_builder(builder);
+        let mut request = builder
+            .body(payload)
+            .context(HTTPV1RequestBuilderSnafu)
+            .map_err(crate::Error::from)?;
+        if let Some(auth) = &self.auth {
+            auth.apply_v1(&mut request);
         }
 
-        builder
-            .body(payload)
-            .context(HTTPRequestBuilderSnafu)
-            .map_err(Into::into)
+        Ok(request)
     }
 }
 
@@ -250,37 +251,19 @@ pub(super) async fn http_healthcheck(
         .append_path("/health")
         .expect("static health path should be a valid URL")
         .to_string();
-    let mut request = Request::get(uri).body(Body::empty())?;
+    let mut request = Request::get(uri).body(empty_body())?;
 
     if let Some(auth) = auth {
-        auth.apply(&mut request);
+        auth.apply_v1(&mut request);
     }
 
     let response = client.send(request).await?;
 
-    match response.status() {
+    let status = StatusCode::from_u16(response.status().as_u16())
+        .expect("HTTP status codes are valid u16 values");
+    match status {
         StatusCode::OK => Ok(()),
         status => Err(HealthcheckError::UnexpectedStatus { status }.into()),
-    }
-}
-
-/// GreptimeDB HTTP retry logic.
-#[derive(Clone, Default)]
-pub(super) struct GreptimeDBHttpRetryLogic {
-    inner: HttpRetryLogic<HttpRequest<PartitionKey>>,
-}
-
-impl RetryLogic for GreptimeDBHttpRetryLogic {
-    type Error = HttpError;
-    type Request = HttpRequest<PartitionKey>;
-    type Response = HttpResponse;
-
-    fn is_retriable_error(&self, error: &Self::Error) -> bool {
-        error.is_retriable()
-    }
-
-    fn should_retry_response(&self, response: &Self::Response) -> RetryAction<Self::Request> {
-        self.inner.should_retry_response(&response.http_response)
     }
 }
 

--- a/src/sinks/greptimedb/mod.rs
+++ b/src/sinks/greptimedb/mod.rs
@@ -1,10 +1,13 @@
 use crate::sinks::prelude::*;
 
 // sub level implementations
+#[cfg(feature = "sinks-greptimedb_logs")]
 mod logs;
+#[cfg(feature = "sinks-greptimedb_metrics")]
 mod metrics;
 
 /// Compression algorithm for gRPC requests to GreptimeDB.
+#[cfg(feature = "sinks-greptimedb_metrics")]
 #[configurable_component]
 #[derive(Clone, Copy, Debug, Default)]
 #[serde(rename_all = "lowercase")]
@@ -18,14 +21,20 @@ enum GrpcCompression {
     Zstd,
 }
 
+#[cfg(any(
+    feature = "sinks-greptimedb_logs",
+    feature = "sinks-greptimedb_metrics"
+))]
 fn default_dbname() -> String {
     greptimedb_ingester::DEFAULT_SCHEMA_NAME.to_string()
 }
 
+#[cfg(feature = "sinks-greptimedb_logs")]
 fn default_dbname_template() -> Template {
     Template::try_from(default_dbname()).unwrap()
 }
 
+#[cfg(feature = "sinks-greptimedb_logs")]
 fn default_pipeline_template() -> Template {
     Template::try_from("greptime_identity").unwrap()
 }

--- a/src/sinks/honeycomb/config.rs
+++ b/src/sinks/honeycomb/config.rs
@@ -1,6 +1,8 @@
 use bytes::Bytes;
 use futures::FutureExt;
-use http::{HeaderValue, Request, StatusCode};
+use http::StatusCode;
+use http_1::{HeaderValue, Request};
+use http_body_util::BodyExt;
 use vector_lib::{configurable::configurable_component, sensitive_string::SensitiveString};
 use vrl::value::Kind;
 
@@ -10,14 +12,16 @@ use super::{
 };
 use crate::{
     config::ValidatedSink,
-    http::HttpClient,
+    http::client_v1::{HttpClient, full_body},
     sinks::{
         prelude::*,
         util::{
             BatchConfig, BoxedRawValue, HttpEndpoint, TowerRequestSettings,
-            http::{HttpService, RetryStrategy, http_response_retry_logic},
+            http::RetryStrategy,
+            http_v1::{HttpService, http_response_retry_logic},
         },
     },
+    tls::MaybeTlsSettings,
 };
 
 pub(super) const HTTP_HEADER_HONEYCOMB: &str = "X-Honeycomb-Team";
@@ -122,7 +126,6 @@ pub struct ValidatedHoneycomb {
 #[async_trait::async_trait]
 impl ValidatedSink for HoneycombConfig {
     type Validated = ValidatedHoneycomb;
-
     fn validate(&self) -> crate::Result<ValidatedHoneycomb> {
         let batch_settings = self.batch.validate()?.into_batcher_settings()?;
         let uri = self.build_uri()?;
@@ -164,7 +167,7 @@ impl ValidatedSink for HoneycombConfig {
             compression: self.compression,
         };
 
-        let client = HttpClient::new(None, cx.proxy())?;
+        let client = HttpClient::new(MaybeTlsSettings::from_config(None, false)?, cx.proxy())?;
 
         let service = HttpService::new(client.clone(), honeycomb_service_request_builder);
 
@@ -190,23 +193,23 @@ impl HoneycombConfig {
             .append_path(&format!("1/batch/{}", self.dataset))?)
     }
 }
-
 async fn healthcheck(
     uri: HttpEndpoint,
     api_key: HeaderValue,
     client: HttpClient,
 ) -> crate::Result<()> {
-    let request = Request::post(uri.as_uri()).header(HTTP_HEADER_HONEYCOMB, api_key);
+    let request = Request::post(uri.clone().into_v1()).header(HTTP_HEADER_HONEYCOMB, api_key);
     let body = crate::serde::json::to_bytes(&Vec::<BoxedRawValue>::new())
         .unwrap()
         .freeze();
     let req: Request<Bytes> = request.body(body)?;
-    let req = req.map(hyper::Body::from);
+    let req = req.map(full_body);
 
     let res = client.send(req).await?;
 
-    let status = res.status();
-    let body = http_body::Body::collect(res.into_body()).await?.to_bytes();
+    let status = StatusCode::from_u16(res.status().as_u16())
+        .expect("HTTP status codes are valid u16 values");
+    let body = res.into_body().collect().await?.to_bytes();
 
     if status == StatusCode::BAD_REQUEST {
         Ok(())

--- a/src/sinks/honeycomb/service.rs
+++ b/src/sinks/honeycomb/service.rs
@@ -1,18 +1,16 @@
 //! Service implementation for the `honeycomb` sink.
 use bytes::Bytes;
-use http::{HeaderValue, Request};
+use http_1::{HeaderValue, Request};
 use snafu::ResultExt;
 
 use super::config::HTTP_HEADER_HONEYCOMB;
 use crate::sinks::{
-    HTTPRequestBuilderSnafu,
+    HTTPV1RequestBuilderSnafu,
     util::{
-        HttpEndpoint,
-        buffer::compression::Compression,
-        http::{HttpRequest, HttpServiceRequestBuilder},
+        HttpEndpoint, buffer::compression::Compression, http::HttpRequest,
+        http_v1::HttpServiceRequestBuilder,
     },
 };
-
 #[derive(Clone, derive_more::Debug)]
 pub(super) struct HoneycombSvcRequestBuilder {
     pub(super) uri: HttpEndpoint,
@@ -25,8 +23,8 @@ pub(super) struct HoneycombSvcRequestBuilder {
 
 impl HttpServiceRequestBuilder<()> for HoneycombSvcRequestBuilder {
     fn build(&self, mut request: HttpRequest<()>) -> Result<Request<Bytes>, crate::Error> {
-        let mut builder =
-            Request::post(self.uri.as_uri()).header(HTTP_HEADER_HONEYCOMB, self.api_key.clone());
+        let mut builder = Request::post(self.uri.clone().into_v1())
+            .header(HTTP_HEADER_HONEYCOMB, self.api_key.clone());
 
         if let Some(ce) = self.compression.content_encoding() {
             builder = builder.header("Content-Encoding".to_string(), ce.to_string());
@@ -34,8 +32,8 @@ impl HttpServiceRequestBuilder<()> for HoneycombSvcRequestBuilder {
 
         builder
             .body(request.take_payload())
-            .context(HTTPRequestBuilderSnafu)
-            .map_err(Into::into)
+            .context(HTTPV1RequestBuilderSnafu)
+            .map_err(crate::Error::from)
     }
 }
 

--- a/src/sinks/keep/config.rs
+++ b/src/sinks/keep/config.rs
@@ -2,7 +2,9 @@
 
 use bytes::Bytes;
 use futures::FutureExt;
-use http::{Request, StatusCode, Uri};
+use http::StatusCode;
+use http_1::Request;
+use http_body_util::BodyExt;
 use vector_lib::{configurable::configurable_component, sensitive_string::SensitiveString};
 use vrl::value::Kind;
 
@@ -12,14 +14,16 @@ use super::{
 };
 use crate::{
     config::ValidatedSink,
-    http::HttpClient,
+    http::client_v1::{HttpClient, full_body},
     sinks::{
         prelude::*,
         util::{
             BatchConfig, BoxedRawValue, HttpEndpoint, TowerRequestSettings,
-            http::{HttpService, RetryStrategy, http_response_retry_logic},
+            http::RetryStrategy,
+            http_v1::{HttpService, http_response_retry_logic},
         },
     },
+    tls::MaybeTlsSettings,
 };
 
 pub(super) const HTTP_HEADER_KEEP_API_KEY: &str = "x-api-key";
@@ -102,7 +106,7 @@ impl SinkConfig for KeepConfig {
 #[derive(Clone, Debug)]
 pub struct ValidatedKeep {
     batch_settings: BatcherSettings,
-    uri: Uri,
+    endpoint: HttpEndpoint,
     request_limits: TowerRequestSettings,
 }
 
@@ -112,12 +116,12 @@ impl ValidatedSink for KeepConfig {
 
     fn validate(&self) -> crate::Result<ValidatedKeep> {
         let batch_settings = self.batch.validate()?.into_batcher_settings()?;
-        let uri = self.endpoint.clone().into_uri();
+        let endpoint = self.endpoint.clone();
         let request_limits = self.request.into_settings();
 
         Ok(ValidatedKeep {
             batch_settings,
-            uri,
+            endpoint,
             request_limits,
         })
     }
@@ -129,7 +133,7 @@ impl ValidatedSink for KeepConfig {
     ) -> crate::Result<(VectorSink, Healthcheck)> {
         let ValidatedKeep {
             batch_settings,
-            uri,
+            endpoint,
             request_limits,
         } = validated;
 
@@ -142,11 +146,11 @@ impl ValidatedSink for KeepConfig {
         };
 
         let keep_service_request_builder = KeepSvcRequestBuilder {
-            uri: uri.clone(),
+            endpoint: endpoint.clone(),
             api_key: self.api_key.clone(),
         };
 
-        let client = HttpClient::new(None, cx.proxy())?;
+        let client = HttpClient::new(MaybeTlsSettings::from_config(None, false)?, cx.proxy())?;
 
         let service = HttpService::new(client.clone(), keep_service_request_builder);
 
@@ -159,24 +163,30 @@ impl ValidatedSink for KeepConfig {
 
         let sink = KeepSink::new(service, *batch_settings, request_builder);
 
-        let healthcheck = healthcheck(uri.clone(), self.api_key.clone(), client).boxed();
+        let healthcheck = healthcheck(endpoint.clone(), self.api_key.clone(), client).boxed();
 
         Ok((VectorSink::from_event_streamsink(sink), healthcheck))
     }
 }
-
-async fn healthcheck(uri: Uri, api_key: SensitiveString, client: HttpClient) -> crate::Result<()> {
-    let request = Request::post(uri).header(HTTP_HEADER_KEEP_API_KEY, api_key.inner());
+async fn healthcheck(
+    endpoint: HttpEndpoint,
+    api_key: SensitiveString,
+    client: HttpClient,
+) -> crate::Result<()> {
+    let request =
+        Request::post(endpoint.into_v1()).header(HTTP_HEADER_KEEP_API_KEY, api_key.inner());
     let body = crate::serde::json::to_bytes(&Vec::<BoxedRawValue>::new())
         .unwrap()
         .freeze();
+
     let req: Request<Bytes> = request.body(body)?;
-    let req = req.map(hyper::Body::from);
+    let req = req.map(full_body);
 
     let res = client.send(req).await?;
 
-    let status = res.status();
-    let body = http_body::Body::collect(res.into_body()).await?.to_bytes();
+    let status = StatusCode::from_u16(res.status().as_u16())
+        .expect("HTTP status codes are valid u16 values");
+    let body = res.into_body().collect().await?.to_bytes();
 
     match status {
         StatusCode::OK => Ok(()),          // Healthcheck passed
@@ -228,7 +238,7 @@ mod tests {
         .unwrap();
         let validated = config.validate().expect("validation should succeed");
         assert_eq!(
-            validated.uri.to_string(),
+            validated.endpoint.to_string(),
             "http://localhost:8080/alerts/event/vectordev?provider_id=test"
         );
         assert_eq!(validated.batch_settings.size_limit, 100_000);

--- a/src/sinks/keep/service.rs
+++ b/src/sinks/keep/service.rs
@@ -1,32 +1,32 @@
 //! Service implementation for the `keep` sink.
 
 use bytes::Bytes;
-use http::{Request, Uri};
+use http_1::Request;
 use snafu::ResultExt;
 use vector_lib::sensitive_string::SensitiveString;
 
 use super::config::HTTP_HEADER_KEEP_API_KEY;
 use crate::sinks::{
-    HTTPRequestBuilderSnafu,
-    util::http::{HttpRequest, HttpServiceRequestBuilder},
+    HTTPV1RequestBuilderSnafu,
+    util::{HttpEndpoint, http::HttpRequest, http_v1::HttpServiceRequestBuilder},
 };
 
 #[derive(Debug, Clone)]
 pub(super) struct KeepSvcRequestBuilder {
-    pub(super) uri: Uri,
+    pub(super) endpoint: HttpEndpoint,
     pub(super) api_key: SensitiveString,
 }
 
 impl HttpServiceRequestBuilder<()> for KeepSvcRequestBuilder {
     fn build(&self, mut request: HttpRequest<()>) -> Result<Request<Bytes>, crate::Error> {
-        let builder =
-            Request::post(&self.uri).header(HTTP_HEADER_KEEP_API_KEY, self.api_key.inner());
+        let builder = Request::post(self.endpoint.clone().into_v1())
+            .header(HTTP_HEADER_KEEP_API_KEY, self.api_key.inner());
 
         let builder = builder.header("Content-Type".to_string(), "application/json".to_string());
 
         builder
             .body(request.take_payload())
-            .context(HTTPRequestBuilderSnafu)
-            .map_err(Into::into)
+            .context(HTTPV1RequestBuilderSnafu)
+            .map_err(crate::Error::from)
     }
 }

--- a/src/sinks/mod.rs
+++ b/src/sinks/mod.rs
@@ -136,6 +136,8 @@ pub enum BuildError {
     UriParseError { source: ::http::uri::InvalidUri },
     #[snafu(display("HTTP request build error: {}", source))]
     HTTPRequestBuilderError { source: ::http::Error },
+    #[snafu(display("HTTP request build error: {}", source))]
+    HTTPV1RequestBuilderError { source: ::http_1::Error },
 }
 
 /// Common healthcheck errors

--- a/src/sinks/util/http.rs
+++ b/src/sinks/util/http.rs
@@ -10,7 +10,7 @@ use http_body::Body as _;
 use tracing::debug;
 
 /// Maximum number of response body bytes to include in a non-retriable error's reason.
-const MAX_ERROR_BODY_BYTES: usize = 1024;
+pub(crate) const MAX_ERROR_BODY_BYTES: usize = 1024;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct OrderedHeaderName(HeaderName);

--- a/src/sinks/util/http_v1.rs
+++ b/src/sinks/util/http_v1.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)] // This shared service is exercised as sinks migrate to the native client.
-
 use std::{
     marker::PhantomData,
     sync::Arc,

--- a/src/sinks/util/http_v1.rs
+++ b/src/sinks/util/http_v1.rs
@@ -9,6 +9,12 @@ use futures::future::BoxFuture;
 use http_1::{Request, Response, Uri};
 use http_body_util::BodyExt;
 use tower::Service;
+#[cfg(any(
+    feature = "sinks-gcp",
+    feature = "sinks-greptimedb_logs",
+    feature = "sinks-honeycomb",
+    feature = "sinks-keep",
+))]
 use tracing::debug;
 
 use vector_lib::{
@@ -138,6 +144,13 @@ where
     }
 }
 
+// Clickhouse implements its own retry logic, so this is only used by the sinks below.
+#[cfg(any(
+    feature = "sinks-gcp",
+    feature = "sinks-greptimedb_logs",
+    feature = "sinks-honeycomb",
+    feature = "sinks-keep",
+))]
 pub(crate) fn http_response_retry_logic<Request: Clone + Send + Sync + 'static>(
     retry_strategy: super::http::RetryStrategy,
 ) -> super::http::HttpStatusRetryLogic<

--- a/src/sinks/util/http_v1.rs
+++ b/src/sinks/util/http_v1.rs
@@ -167,7 +167,13 @@ pub(crate) fn http_response_retry_logic<Request: Clone + Send + Sync + 'static>(
                 debug!(
                     message = "HTTP response.",
                     %status,
-                    body = %String::from_utf8_lossy(response.http_response.body()),
+                    body = %String::from_utf8_lossy(
+                        &response.http_response.body()[..response
+                            .http_response
+                            .body()
+                            .len()
+                            .min(super::http::MAX_ERROR_BODY_BYTES)],
+                    ),
                 );
             }
             status

--- a/src/sinks/util/mod.rs
+++ b/src/sinks/util/mod.rs
@@ -9,6 +9,13 @@ pub mod compressor;
 pub mod datagram;
 pub mod encoding;
 pub mod http;
+#[cfg(any(
+    feature = "sinks-clickhouse",
+    feature = "sinks-gcp",
+    feature = "sinks-greptimedb_logs",
+    feature = "sinks-honeycomb",
+    feature = "sinks-keep",
+))]
 pub(crate) mod http_v1;
 pub mod metadata;
 pub mod normalizer;

--- a/src/sinks/util/uri.rs
+++ b/src/sinks/util/uri.rs
@@ -391,6 +391,20 @@ impl HttpEndpoint {
         self.0
     }
 
+    /// Consumes the endpoint, returning the underlying `Uri` as an `http 1` `Uri`.
+    ///
+    /// The two `http` crate versions share no conversion traits, so the bridge
+    /// is a string round-trip. `Display` of a validated absolute `http(s)` URL
+    /// is always parseable back by `http 1` (the `http 1` parser descends from
+    /// the `http 0.2` parser and accepts the same absolute forms), so this
+    /// cannot fail — the same invariant `protocol_endpoint` relies on.
+    pub fn into_v1(self) -> http_1::Uri {
+        self.0
+            .to_string()
+            .parse()
+            .expect("a validated HTTP endpoint is a valid `http 1` URI")
+    }
+
     /// Extracts basic-auth credentials embedded in the authority, returning a
     /// credential-free endpoint alongside the credentials.
     pub fn extract_basic_auth(self) -> crate::Result<(Self, Option<Auth>)> {


### PR DESCRIPTION
## Summary

Migrates the remaining standard `HttpService::new` consumers to the private native Hyper 1 client, following the ClickHouse migration in #26157:

- GreptimeDB logs
- Honeycomb
- Keep
- GCP Stackdriver logs
- GCP Stackdriver metrics

Endpoints remain `HttpEndpoint`-typed end to end; the v0-to-v1 URI bridge is centralized in `HttpEndpoint::into_v1`, and request-build failures keep Snafu context via the new `BuildError::HTTPV1RequestBuilderError`. GCP request signing gains native `GcpAuthenticator::apply_v1`, mirroring the legacy `apply` for unmigrated callers.

### References

- Related: #19179 (HTTP v1 migration plan)
- Follows: #26157 (ClickHouse sink migration)
- Builds on: #26087 (private Hyper 1 client)

## Vector configuration

NA — no configuration surface change.

## How did you test this PR?

- `cargo nextest run --no-default-features --features sinks-greptimedb_logs,sinks-honeycomb,sinks-keep,sinks-gcp -p vector http::transport_tests` (26 passed)
- Component unit tests for all five sinks (32 passed), including the Stackdriver `correct_request` wire-format assertion
- `cargo vdev int test gcp` (50 passed)
- `cargo vdev int test greptimedb` — logs sink integration tests pass against a live server; the `greptimedb_metrics` failures reproduce identically on clean master (gRPC ingester, untouched by this PR)
- Per-feature and combined Clippy, `cargo vdev fmt`/`check fmt`, all clean

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## Contributor Guidelines

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Before pushing, follow our [pre-push guidance](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#pre-push).
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
