### PR TITLE
chore(deps): upgrade syn to 3, darling to 0.24, serde_derive_internals to 0.30

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2224,7 +2224,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "proc-macro2 1.0.106",
  "quote 1.0.45",
  "regex",
@@ -3542,6 +3542,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed17f5901b6630b993ca003def43f2f8ef4014fc13b047b57aad617ff32bc2ec"
+dependencies = [
+ "darling_core 0.24.1",
+ "darling_macro 0.24.1",
+]
+
+[[package]]
 name = "darling_core"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3569,6 +3579,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6837e2cf7485aaae18f86181d2f0e9a7ed297a025e220aeabf63fdebd3a2ddff"
+dependencies = [
+ "ident_case",
+ "proc-macro2 1.0.106",
+ "quote 1.0.45",
+ "strsim",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3588,6 +3611,17 @@ dependencies = [
  "darling_core 0.23.0",
  "quote 1.0.45",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ac7135c3ef02b2f7833bbeb1be5ba7f966dcde8a87c6b87f65a778d71a02785"
+dependencies = [
+ "darling_core 0.24.1",
+ "quote 1.0.45",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -9053,7 +9087,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -9073,7 +9107,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -9107,7 +9141,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2 1.0.106",
  "quote 1.0.45",
  "syn 2.0.119",
@@ -9120,7 +9154,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2 1.0.106",
  "quote 1.0.45",
  "syn 2.0.119",
@@ -10760,13 +10794,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive_internals"
-version = "0.29.1"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
 dependencies = [
  "proc-macro2 1.0.106",
  "quote 1.0.45",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -13604,12 +13638,12 @@ name = "vector-config-common"
 version = "0.1.0"
 dependencies = [
  "convert_case 0.10.0",
- "darling 0.23.0",
+ "darling 0.24.1",
  "proc-macro2 1.0.106",
  "quote 1.0.45",
  "serde",
  "serde_json",
- "syn 2.0.119",
+ "syn 3.0.3",
  "tracing 0.1.44",
 ]
 
@@ -13617,12 +13651,12 @@ dependencies = [
 name = "vector-config-macros"
 version = "0.1.0"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.24.1",
  "proc-macro2 1.0.106",
  "quote 1.0.45",
  "serde",
  "serde_derive_internals",
- "syn 2.0.119",
+ "syn 3.0.3",
  "vector-config",
  "vector-config-common",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,7 +168,7 @@ convert_case = { version = "0.10", default-features = false }
 criterion = "0.8"
 crossbeam-utils = { version = "0.8.21", default-features = false }
 cuckoo-clock = { version = "0.2.7" , default-features = false }
-darling = { version = "0.23.0", default-features = false, features = ["suggestions"] }
+darling = { version = "0.24.1", default-features = false, features = ["suggestions"] }
 dashmap = { version = "6.1.0", default-features = false }
 derivative = { version = "2.2.0", default-features = false }
 derive_more = { version = "2.1.1", default-features = false, features = ["display", "debug"] }
@@ -219,7 +219,7 @@ tokio-test = "0.4.5"
 tokio-tungstenite = { version = "0.20.1", default-features = false }
 proc-macro2 = { version = "1", default-features = false }
 quote = { version = "1", default-features = false }
-syn = { version = "3", default-features = false }
+syn = { version = "3", default-features = false, features = ["full", "visit", "extra-traits"] }
 toml = { version = "0.9.8", default-features = false, features = ["serde", "display", "parse"] }
 tonic = { version = "0.11", default-features = false, features = ["transport", "codegen", "prost", "tls", "tls-roots", "gzip", "zstd"] }
 tonic-build = { version = "0.11", default-features = false, features = ["transport", "prost"] }

--- a/lib/vector-common-macros/Cargo.toml
+++ b/lib/vector-common-macros/Cargo.toml
@@ -13,4 +13,4 @@ proc-macro = true
 [dependencies]
 proc-macro2 = { version = "1.0", default-features = false }
 quote = { version = "1.0", default-features = false }
-syn = { version = "3.0", default-features = false, features = ["derive", "full", "extra-traits", "parsing", "printing", "proc-macro", "visit-mut", "visit"] }
+syn = { workspace = true, features = ["derive", "parsing", "printing", "proc-macro", "visit-mut"] }

--- a/lib/vector-config-common/Cargo.toml
+++ b/lib/vector-config-common/Cargo.toml
@@ -13,6 +13,6 @@ darling.workspace = true
 proc-macro2 = { version = "1.0", default-features = false }
 serde.workspace = true
 serde_json.workspace = true
-syn = { version = "2.0", features = ["full", "extra-traits", "visit-mut", "visit"] }
+syn = { workspace = true, features = ["visit-mut"] }
 tracing.workspace = true
 quote = { version = "1.0", default-features = false }

--- a/lib/vector-config-macros/Cargo.toml
+++ b/lib/vector-config-macros/Cargo.toml
@@ -14,8 +14,8 @@ proc-macro = true
 darling.workspace = true
 proc-macro2 = { version = "1.0", default-features = false }
 quote = { version = "1.0", default-features = false }
-serde_derive_internals = "0.29"
-syn = { version = "2.0", default-features = false, features = ["full", "extra-traits", "visit-mut", "visit"] }
+serde_derive_internals = "0.30"
+syn = { workspace = true, features = ["visit-mut"] }
 vector-config-common = { path = "../vector-config-common" }
 
 [dev-dependencies]

--- a/lib/vector-config-macros/src/ast/container.rs
+++ b/lib/vector-config-macros/src/ast/container.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
 
 use darling::{FromAttributes, error::Accumulator, util::Flag};
+use proc_macro2::Span;
 use serde_derive_internals::{Ctxt, Derive, ast as serde_ast};
 use syn::{
     DeriveInput, ExprPath, GenericArgument, Generics, Ident, PathArguments, PathSegment, Type,
@@ -41,7 +42,12 @@ impl<'a> Container<'a> {
         // We can't do anything unless `serde` can also handle this container. We specifically only care about
         // deserialization here, because the schema tells us what we can _give_ to Vector.
         let context = Ctxt::new();
-        let serde = match serde_ast::Container::from_ast(&context, input, Derive::Deserialize) {
+        let serde = match serde_ast::Container::from_ast(
+            &context,
+            input,
+            Derive::Deserialize,
+            &Ident::new("__private", Span::call_site()),
+        ) {
             Some(serde) => {
                 // This `serde_derive_internals` helper will panic if `check` isn't _always_ called, so we also have to
                 // call it on the success path.

--- a/lib/vector-config-macros/src/ast/mod.rs
+++ b/lib/vector-config-macros/src/ast/mod.rs
@@ -242,6 +242,10 @@ impl FromMeta for Metadata {
                     errors.push(darling::Error::unexpected_type("literal").with_span(nmeta));
                     None
                 }
+                NestedMeta::NameValueInvalidExpr(invalid) => {
+                    errors.push(invalid.error.clone().with_span(nmeta));
+                    None
+                }
             })
             .collect::<Vec<_>>();
 

--- a/lib/vector-config-macros/src/configurable_component.rs
+++ b/lib/vector-config-macros/src/configurable_component.rs
@@ -238,6 +238,9 @@ impl FromMeta for Options {
                 }
 
                 NestedMeta::Lit(lit) => errors.push(Error::unexpected_lit_type(lit)),
+                NestedMeta::NameValueInvalidExpr(invalid) => {
+                    errors.push(invalid.error.clone().with_span(nm));
+                }
             }
         }
 

--- a/vdev/Cargo.toml
+++ b/vdev/Cargo.toml
@@ -52,7 +52,7 @@ cfg-if.workspace = true
 convert_case.workspace = true
 # Used by check-events to walk Rust source via syn's AST. The extra features
 # are vdev-local; they do not propagate into the `vector` package's build.
-syn = { workspace = true, features = ["full", "visit", "extra-traits", "printing", "parsing"] }
+syn = { workspace = true, features = ["printing", "parsing"] }
 proc-macro2 = { workspace = true, features = ["span-locations"] }
 quote.workspace = true
 


### PR DESCRIPTION
## Summary

Upgrades the proc-macro dependency stack for Vector's config-schema macros and vdev:
syn 2 to 3, darling 0.23 to 0.24, serde_derive_internals 0.29 to 0.30.

### References

NA

## Vector configuration

NA

## How did you test this PR?

- `cargo check -p vector --no-default-features` and full workspace build clean
- `vdev check events`: 0 errors
- Macro crate tests pass (vector-config-macros, vector-config-common, vector-common-macros)
- `make generate-docs`: no diff
- `vector generate-schema` output byte-identical (canonicalized) before and after the upgrade
- Clippy and fmt clean

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## Contributor Guidelines

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Before pushing, follow our [pre-push guidance](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#pre-push).
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.