### PR TITLE
fix(prometheus): escape newlines in exporter output

### DIFF
--- a/changelog.d/prometheus_exporter_newline_escaping.fix.md
+++ b/changelog.d/prometheus_exporter_newline_escaping.fix.md
@@ -1,3 +1,5 @@
-Ensure the `prometheus_exporter` sink emits valid text exposition for metrics containing newlines.
+Ensure the `prometheus_exporter` sink emits valid text exposition by escaping newlines in label
+values and rejecting metrics whose metric names, namespaces, or label names contain carriage returns
+or newlines.
 
 authors: pront

--- a/changelog.d/prometheus_exporter_newline_escaping.fix.md
+++ b/changelog.d/prometheus_exporter_newline_escaping.fix.md
@@ -1,0 +1,3 @@
+Ensure the `prometheus_exporter` sink emits valid text exposition for metrics containing newlines.
+
+authors: pront

--- a/src/internal_events/prometheus.rs
+++ b/src/internal_events/prometheus.rs
@@ -89,3 +89,24 @@ impl InternalEvent for PrometheusNormalizationError {
         });
     }
 }
+
+#[derive(Debug, NamedInternalEvent)]
+pub struct PrometheusInvalidMetricError;
+
+impl InternalEvent for PrometheusInvalidMetricError {
+    fn emit(self) {
+        let reason = "Prometheus metric contains a line break in an identifier.";
+        error!(
+            message = reason,
+            error_type = error_type::ENCODER_FAILED,
+            stage = error_stage::PROCESSING,
+        );
+        counter!(
+            CounterName::ComponentErrorsTotal,
+            "error_type" => error_type::ENCODER_FAILED,
+            "stage" => error_stage::PROCESSING,
+        )
+        .increment(1);
+        emit!(ComponentEventsDropped::<UNINTENTIONAL> { count: 1, reason });
+    }
+}

--- a/src/sinks/prometheus/collector.rs
+++ b/src/sinks/prometheus/collector.rs
@@ -310,25 +310,17 @@ impl StringCollector {
         }
     }
 
-    fn escape_help(mut help: &str) -> String {
+    fn escape_help(help: &str) -> String {
         let mut result = String::with_capacity(help.len());
-        while let Some(i) = help.find(['\\', '\n']) {
-            #[expect(
-                clippy::string_slice,
-                reason = "i comes from find() on ASCII chars, i and i+1 are char boundaries"
-            )]
-            {
-                result.push_str(&help[..i]);
-                result.push('\\');
-                result.push(if help.as_bytes()[i] == b'\n' {
-                    'n'
-                } else {
-                    '\\'
-                });
-                help = &help[i + 1..];
+
+        for character in help.chars() {
+            match character {
+                '\\' => result.push_str("\\\\"),
+                '\n' => result.push_str("\\n"),
+                character => result.push(character),
             }
         }
-        result.push_str(help);
+
         result
     }
 

--- a/src/sinks/prometheus/collector.rs
+++ b/src/sinks/prometheus/collector.rs
@@ -15,6 +15,23 @@ use crate::{
     sinks::util::{encode_namespace, statistic::DistributionStatistic},
 };
 
+pub(super) fn metric_identifiers_have_no_line_breaks(
+    metric: &Metric,
+    default_namespace: Option<&str>,
+) -> bool {
+    let name = encode_namespace(metric.namespace().or(default_namespace), '_', metric.name());
+    identifiers_have_no_line_breaks(&name, metric.tags())
+}
+
+fn identifiers_have_no_line_breaks(name: &str, tags: Option<&MetricTags>) -> bool {
+    !contains_line_break(name)
+        && tags.is_none_or(|tags| tags.iter_single().all(|(key, _)| !contains_line_break(key)))
+}
+
+fn contains_line_break(value: &str) -> bool {
+    value.contains(['\r', '\n'])
+}
+
 pub(super) trait MetricCollector {
     type Output;
 
@@ -246,11 +263,7 @@ impl MetricCollector for StringCollector {
     }
 
     fn should_encode_metric(&self, name: &str, tags: Option<&MetricTags>) -> bool {
-        !Self::contains_line_break(name)
-            && tags.is_none_or(|tags| {
-                tags.iter_single()
-                    .all(|(key, _)| !Self::contains_line_break(key))
-            })
+        identifiers_have_no_line_breaks(name, tags)
     }
 
     fn emit_metadata(&mut self, name: &str, fullname: &str, value: &MetricValue) {
@@ -314,10 +327,6 @@ impl StringCollector {
         let r#type = prometheus_metric_type(value).as_str();
         let help = Self::escape_help(name);
         format!("# HELP {fullname} {help}\n# TYPE {fullname} {type}\n")
-    }
-
-    fn contains_line_break(value: &str) -> bool {
-        value.contains(['\r', '\n'])
     }
 
     fn escape_help(help: &str) -> String {

--- a/src/sinks/prometheus/collector.rs
+++ b/src/sinks/prometheus/collector.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeMap, fmt::Write as _};
+use std::{borrow::Cow, collections::BTreeMap, fmt::Write as _};
 
 use chrono::Utc;
 use indexmap::map::IndexMap;
@@ -234,9 +234,10 @@ impl MetricCollector for StringCollector {
     }
 
     fn emit_metadata(&mut self, name: &str, fullname: &str, value: &MetricValue) {
-        if !self.processed.contains_key(fullname) {
-            let header = Self::encode_header(name, fullname, value);
-            self.processed.insert(fullname.into(), header);
+        let fullname = Self::sanitize_metric_name_newlines(fullname).into_owned();
+        if let std::collections::btree_map::Entry::Vacant(entry) = self.processed.entry(fullname) {
+            let header = Self::encode_header(name, entry.key(), value);
+            entry.insert(header);
         }
     }
 
@@ -249,12 +250,13 @@ impl MetricCollector for StringCollector {
         tags: Option<&MetricTags>,
         extra: Option<(&str, String)>,
     ) {
+        let name = Self::sanitize_metric_name_newlines(name);
         let result = self
             .processed
-            .get_mut(name)
+            .get_mut(name.as_ref())
             .expect("metric metadata not encoded");
 
-        result.push_str(name);
+        result.push_str(name.as_ref());
         result.push_str(suffix);
         Self::encode_tags(result, tags, extra);
         _ = match timestamp_millis {
@@ -292,7 +294,38 @@ impl StringCollector {
 
     fn encode_header(name: &str, fullname: &str, value: &MetricValue) -> String {
         let r#type = prometheus_metric_type(value).as_str();
-        format!("# HELP {fullname} {name}\n# TYPE {fullname} {type}\n")
+        let help = Self::escape_help(name);
+        format!("# HELP {fullname} {help}\n# TYPE {fullname} {type}\n")
+    }
+
+    fn sanitize_metric_name_newlines(name: &str) -> Cow<'_, str> {
+        if name.contains('\n') {
+            Cow::Owned(name.replace('\n', "_"))
+        } else {
+            Cow::Borrowed(name)
+        }
+    }
+
+    fn escape_help(mut help: &str) -> String {
+        let mut result = String::with_capacity(help.len());
+        while let Some(i) = help.find(['\\', '\n']) {
+            #[expect(
+                clippy::string_slice,
+                reason = "i comes from find() on ASCII chars, i and i+1 are char boundaries"
+            )]
+            {
+                result.push_str(&help[..i]);
+                result.push('\\');
+                result.push(if help.as_bytes()[i] == b'\n' {
+                    'n'
+                } else {
+                    '\\'
+                });
+                help = &help[i + 1..];
+            }
+        }
+        result.push_str(help);
+        result
     }
 
     fn format_tag(key: &str, mut value: &str) -> String {
@@ -300,7 +333,7 @@ impl StringCollector {
         let mut result = String::with_capacity(key.len() + value.len() + 3);
         result.push_str(key);
         result.push_str("=\"");
-        while let Some(i) = value.find(['\\', '"']) {
+        while let Some(i) = value.find(['\\', '"', '\n']) {
             #[expect(
                 clippy::string_slice,
                 reason = "i comes from find() on ASCII chars, i and i+1 are char boundaries"
@@ -308,8 +341,11 @@ impl StringCollector {
             {
                 result.push_str(&value[..i]);
                 result.push('\\');
-                // Ugly but works because we know the character at `i` is ASCII
-                result.push(value.as_bytes()[i] as char);
+                result.push(if value.as_bytes()[i] == b'\n' {
+                    'n'
+                } else {
+                    value.as_bytes()[i] as char
+                });
                 value = &value[i + 1..];
             }
         }
@@ -927,6 +963,7 @@ mod tests {
     fn escapes_tags_text() {
         let tags = metric_tags!(
             "code" => "200",
+            "line" => "first\nsecond",
             "quoted" => r#"host"1""#,
             "path" => r"c:\Windows",
         );
@@ -942,8 +979,36 @@ mod tests {
             indoc! {r#"
                 # HELP something something
                 # TYPE something counter
-                something{code="200",path="c:\\Windows",quoted="host\"1\""} 1
+                something{code="200",line="first\nsecond",path="c:\\Windows",quoted="host\"1\""} 1
             "#}
+        );
+        vector_lib::prometheus::parser::parse_text(&encoded).unwrap();
+    }
+
+    #[test]
+    fn sanitizes_metric_name_newlines_text() {
+        let metric = Metric::new(
+            "invalid_metric\nname".to_owned(),
+            MetricKind::Absolute,
+            MetricValue::Counter { value: 1.0 },
+        );
+        let encoded = encode_one::<StringCollector>(None, &[], &[], &metric);
+        assert_eq!(
+            encoded,
+            indoc! {r#"
+                # HELP invalid_metric_name invalid_metric\nname
+                # TYPE invalid_metric_name counter
+                invalid_metric_name 1
+            "#}
+        );
+        vector_lib::prometheus::parser::parse_text(&encoded).unwrap();
+    }
+
+    #[test]
+    fn escapes_help_text() {
+        assert_eq!(
+            StringCollector::escape_help("line\npath\\name"),
+            r"line\npath\\name"
         );
     }
 

--- a/src/sinks/prometheus/collector.rs
+++ b/src/sinks/prometheus/collector.rs
@@ -1,5 +1,4 @@
 use std::{
-    borrow::Cow,
     collections::{BTreeMap, btree_map::Entry},
     fmt::Write as _,
 };
@@ -35,6 +34,10 @@ pub(super) trait MetricCollector {
 
     fn finish(self) -> Self::Output;
 
+    fn should_encode_metric(&self, _name: &str, _tags: Option<&MetricTags>) -> bool {
+        true
+    }
+
     fn encode_metric(
         &mut self,
         default_namespace: Option<&str>,
@@ -44,10 +47,15 @@ pub(super) trait MetricCollector {
     ) {
         let name = encode_namespace(metric.namespace().or(default_namespace), '_', metric.name());
         let name = &name;
+        let tags = metric.tags();
+
+        if !self.should_encode_metric(name, tags) {
+            return;
+        }
+
         let timestamp = metric.timestamp().map(|t| t.timestamp_millis());
 
         if metric.kind() == MetricKind::Absolute {
-            let tags = metric.tags();
             self.emit_metadata(metric.name(), name, metric.value());
 
             match metric.value() {
@@ -237,9 +245,16 @@ impl MetricCollector for StringCollector {
         Self { processed }
     }
 
+    fn should_encode_metric(&self, name: &str, tags: Option<&MetricTags>) -> bool {
+        !Self::contains_line_break(name)
+            && tags.is_none_or(|tags| {
+                tags.iter_single()
+                    .all(|(key, _)| !Self::contains_line_break(key))
+            })
+    }
+
     fn emit_metadata(&mut self, name: &str, fullname: &str, value: &MetricValue) {
-        let fullname = Self::sanitize_metric_name_newlines(fullname).into_owned();
-        if let Entry::Vacant(entry) = self.processed.entry(fullname) {
+        if let Entry::Vacant(entry) = self.processed.entry(fullname.into()) {
             let header = Self::encode_header(name, entry.key(), value);
             entry.insert(header);
         }
@@ -254,13 +269,12 @@ impl MetricCollector for StringCollector {
         tags: Option<&MetricTags>,
         extra: Option<(&str, String)>,
     ) {
-        let name = Self::sanitize_metric_name_newlines(name);
         let result = self
             .processed
-            .get_mut(name.as_ref())
+            .get_mut(name)
             .expect("metric metadata not encoded");
 
-        result.push_str(name.as_ref());
+        result.push_str(name);
         result.push_str(suffix);
         Self::encode_tags(result, tags, extra);
         _ = match timestamp_millis {
@@ -302,12 +316,8 @@ impl StringCollector {
         format!("# HELP {fullname} {help}\n# TYPE {fullname} {type}\n")
     }
 
-    fn sanitize_metric_name_newlines(name: &str) -> Cow<'_, str> {
-        if name.contains('\n') {
-            Cow::Owned(name.replace('\n', "_"))
-        } else {
-            Cow::Borrowed(name)
-        }
+    fn contains_line_break(value: &str) -> bool {
+        value.contains(['\r', '\n'])
     }
 
     fn escape_help(help: &str) -> String {
@@ -975,19 +985,63 @@ mod tests {
     }
 
     #[test]
-    fn sanitizes_metric_name_newlines_text() {
-        let metric = Metric::new(
-            "invalid_metric\nname".to_owned(),
+    fn rejects_metric_name_and_namespace_line_breaks_text() {
+        for (default_namespace, name) in [
+            (None, "invalid_metric\nname"),
+            (None, "invalid_metric\rname"),
+            (Some("invalid\nnamespace"), "valid_metric"),
+            (Some("invalid\rnamespace"), "valid_metric"),
+        ] {
+            let metric = Metric::new(
+                name.to_owned(),
+                MetricKind::Absolute,
+                MetricValue::Counter { value: 1.0 },
+            );
+            let encoded = encode_one::<StringCollector>(default_namespace, &[], &[], &metric);
+            assert_eq!(encoded, "");
+            parse_text(&encoded).unwrap();
+        }
+    }
+
+    #[test]
+    fn rejects_tag_name_line_breaks_text() {
+        for key in ["invalid_tag\nname", "invalid_tag\rname"] {
+            let mut tags = MetricTags::default();
+            tags.replace(key.to_owned(), "value".to_owned());
+            let metric = Metric::new(
+                "valid_metric".to_owned(),
+                MetricKind::Absolute,
+                MetricValue::Counter { value: 1.0 },
+            )
+            .with_tags(Some(tags));
+            let encoded = encode_one::<StringCollector>(None, &[], &[], &metric);
+            assert_eq!(encoded, "");
+            parse_text(&encoded).unwrap();
+        }
+    }
+
+    #[test]
+    fn rejected_metric_name_does_not_collide_text() {
+        let invalid = Metric::new(
+            "requests\ncount".to_owned(),
             MetricKind::Absolute,
             MetricValue::Counter { value: 1.0 },
         );
-        let encoded = encode_one::<StringCollector>(None, &[], &[], &metric);
+        let valid = Metric::new(
+            "requests_count".to_owned(),
+            MetricKind::Absolute,
+            MetricValue::Gauge { value: 2.0 },
+        );
+        let mut collector = StringCollector::new();
+        collector.encode_metric(None, &[], &[], &invalid);
+        collector.encode_metric(None, &[], &[], &valid);
+        let encoded = collector.finish();
         assert_eq!(
             encoded,
             indoc! {r#"
-                # HELP invalid_metric_name invalid_metric\nname
-                # TYPE invalid_metric_name counter
-                invalid_metric_name 1
+                # HELP requests_count requests_count
+                # TYPE requests_count gauge
+                requests_count 2
             "#}
         );
         parse_text(&encoded).unwrap();

--- a/src/sinks/prometheus/collector.rs
+++ b/src/sinks/prometheus/collector.rs
@@ -325,8 +325,8 @@ impl StringCollector {
 
         for character in help.chars() {
             match character {
-                '\\' => result.push_str("\\\\"),
-                '\n' => result.push_str("\\n"),
+                '\\' => result.push_str(r"\\"),
+                '\n' => result.push_str(r"\n"),
                 character => result.push(character),
             }
         }
@@ -342,9 +342,9 @@ impl StringCollector {
 
         for character in value.chars() {
             match character {
-                '\\' => result.push_str("\\\\"),
-                '"' => result.push_str("\\\""),
-                '\n' => result.push_str("\\n"),
+                '\\' => result.push_str(r"\\"),
+                '"' => result.push_str(r#"\""#),
+                '\n' => result.push_str(r"\n"),
                 character => result.push(character),
             }
         }

--- a/src/sinks/prometheus/collector.rs
+++ b/src/sinks/prometheus/collector.rs
@@ -1,4 +1,8 @@
-use std::{borrow::Cow, collections::BTreeMap, fmt::Write as _};
+use std::{
+    borrow::Cow,
+    collections::{BTreeMap, btree_map::Entry},
+    fmt::Write as _,
+};
 
 use chrono::Utc;
 use indexmap::map::IndexMap;
@@ -235,7 +239,7 @@ impl MetricCollector for StringCollector {
 
     fn emit_metadata(&mut self, name: &str, fullname: &str, value: &MetricValue) {
         let fullname = Self::sanitize_metric_name_newlines(fullname).into_owned();
-        if let std::collections::btree_map::Entry::Vacant(entry) = self.processed.entry(fullname) {
+        if let Entry::Vacant(entry) = self.processed.entry(fullname) {
             let header = Self::encode_header(name, entry.key(), value);
             entry.insert(header);
         }
@@ -481,7 +485,7 @@ mod tests {
     use chrono::{DateTime, TimeZone, Timelike};
     use indoc::indoc;
     use similar_asserts::assert_eq;
-    use vector_lib::metric_tags;
+    use vector_lib::{metric_tags, prometheus::parser::parse_text};
 
     use super::{super::default_summary_quantiles, *};
     use crate::{
@@ -982,7 +986,7 @@ mod tests {
                 something{code="200",line="first\nsecond",path="c:\\Windows",quoted="host\"1\""} 1
             "#}
         );
-        vector_lib::prometheus::parser::parse_text(&encoded).unwrap();
+        parse_text(&encoded).unwrap();
     }
 
     #[test]
@@ -1001,7 +1005,7 @@ mod tests {
                 invalid_metric_name 1
             "#}
         );
-        vector_lib::prometheus::parser::parse_text(&encoded).unwrap();
+        parse_text(&encoded).unwrap();
     }
 
     #[test]

--- a/src/sinks/prometheus/collector.rs
+++ b/src/sinks/prometheus/collector.rs
@@ -324,28 +324,21 @@ impl StringCollector {
         result
     }
 
-    fn format_tag(key: &str, mut value: &str) -> String {
+    fn format_tag(key: &str, value: &str) -> String {
         // For most tags, this is just `{KEY}="{VALUE}"` so allocate optimistically
         let mut result = String::with_capacity(key.len() + value.len() + 3);
         result.push_str(key);
         result.push_str("=\"");
-        while let Some(i) = value.find(['\\', '"', '\n']) {
-            #[expect(
-                clippy::string_slice,
-                reason = "i comes from find() on ASCII chars, i and i+1 are char boundaries"
-            )]
-            {
-                result.push_str(&value[..i]);
-                result.push('\\');
-                result.push(if value.as_bytes()[i] == b'\n' {
-                    'n'
-                } else {
-                    value.as_bytes()[i] as char
-                });
-                value = &value[i + 1..];
+
+        for character in value.chars() {
+            match character {
+                '\\' => result.push_str("\\\\"),
+                '"' => result.push_str("\\\""),
+                '\n' => result.push_str("\\n"),
+                character => result.push(character),
             }
         }
-        result.push_str(value);
+
         result.push('"');
         result
     }

--- a/src/sinks/prometheus/exporter.rs
+++ b/src/sinks/prometheus/exporter.rs
@@ -31,7 +31,7 @@ use vector_lib::{
     },
 };
 
-use super::collector::{MetricCollector, StringCollector};
+use super::collector::{MetricCollector, StringCollector, metric_identifiers_have_no_line_breaks};
 use crate::{
     config::{
         AcknowledgementsConfig, GenerateConfig, Input, Resource, SinkConfig, SinkContext,
@@ -42,7 +42,7 @@ use crate::{
         metric::{Metric, MetricData, MetricKind, MetricSeries, MetricValue},
     },
     http::{Auth, build_http_trace_layer},
-    internal_events::PrometheusNormalizationError,
+    internal_events::{PrometheusInvalidMetricError, PrometheusNormalizationError},
     sinks::{
         Healthcheck, VectorSink,
         util::{StreamSink, statistic::validate_quantiles},
@@ -571,6 +571,15 @@ impl StreamSink<Event> for PrometheusExporter {
             // Now process the metric we got.
             let mut metric = event.into_metric();
             let finalizers = metric.take_finalizers();
+
+            if !metric_identifiers_have_no_line_breaks(
+                &metric,
+                self.config.default_namespace.as_deref(),
+            ) {
+                emit!(PrometheusInvalidMetricError {});
+                finalizers.update_status(EventStatus::Rejected);
+                continue;
+            }
 
             match self.normalize(metric) {
                 Some(normalized) => {
@@ -1131,6 +1140,63 @@ mod tests {
             .with_tags(tags)
             .into();
         (name, event)
+    }
+
+    #[tokio::test]
+    async fn rejects_invalid_identifiers_before_caching() {
+        let (_guard, address) = next_addr();
+        let config = PrometheusExporterConfig {
+            address,
+            tls: None,
+            ..Default::default()
+        };
+
+        let mut invalid_tags = MetricTags::default();
+        invalid_tags.replace("invalid\nlabel".to_owned(), "value".to_owned());
+        let invalid_metrics = [
+            Metric::new(
+                "invalid\nname",
+                MetricKind::Absolute,
+                MetricValue::Gauge { value: 1.0 },
+            ),
+            Metric::new(
+                "valid_name",
+                MetricKind::Absolute,
+                MetricValue::Gauge { value: 1.0 },
+            )
+            .with_namespace(Some("invalid\rnamespace")),
+            Metric::new(
+                "valid_name",
+                MetricKind::Absolute,
+                MetricValue::Gauge { value: 1.0 },
+            )
+            .with_tags(Some(invalid_tags)),
+        ];
+        let mut events = invalid_metrics
+            .into_iter()
+            .map(Event::Metric)
+            .collect::<Vec<_>>();
+        let mut receiver = BatchNotifier::apply_to(&mut events[..]);
+
+        let valid = Metric::new(
+            "valid_name",
+            MetricKind::Absolute,
+            MetricValue::Gauge { value: 2.0 },
+        );
+        events.push(Event::Metric(valid.clone()));
+
+        let sink = PrometheusExporter::new(config);
+        let metrics_handle = Arc::clone(&sink.metrics);
+        let sink = VectorSink::from_event_streamsink(sink);
+        sink.run(stream::iter(events).map(Into::into))
+            .await
+            .unwrap();
+
+        assert_eq!(receiver.try_recv(), Ok(BatchStatus::Rejected));
+
+        let metrics = metrics_handle.read().unwrap();
+        assert_eq!(metrics.len(), 1);
+        assert!(metrics.contains_key(&MetricRef::from_metric(&valid)));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Escape newlines when encoding Prometheus exporter text output.

## How did you test this PR?

- Ran the affected exporter and collector tests.
- Built Vector with `cargo build --bin vector` and exercised an HTTP source through `log_to_metric` into `prometheus_exporter` with acknowledgements enabled. Valid input returned `200`; a metric name containing a newline returned `400`, was not cached, and did not affect the valid series.
- Validated the resulting scrape with `prom/prometheus:v3.6.0` `promtool` in Docker.
- Ran Clippy, event validation, formatting, and diff checks.

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.
