### PR TITLE
chore(deps): migrate vector-buffers from temp-dir to tempfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11888,12 +11888,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "temp-dir"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "016ef9739649996fcc983b9c588fe3d557cf216d4d98503ce1b057ab5a66d689"
-
-[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13522,7 +13516,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "snafu 0.9.0",
- "temp-dir",
+ "tempfile",
  "tokio",
  "tokio-test",
  "tokio-util",

--- a/lib/vector-buffers/Cargo.toml
+++ b/lib/vector-buffers/Cargo.toml
@@ -50,7 +50,7 @@ quickcheck.workspace = true
 rand.workspace = true
 serde_json.workspace = true
 serde_yaml.workspace = true
-temp-dir = "0.2.0"
+tempfile.workspace = true
 tokio-test.workspace = true
 tracing-fluent-assertions = { version = "0.3" }
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt", "registry", "std", "ansi"] }

--- a/lib/vector-buffers/src/test/helpers.rs
+++ b/lib/vector-buffers/src/test/helpers.rs
@@ -1,6 +1,6 @@
 use std::{future::Future, path::Path, str::FromStr, sync::LazyLock};
 
-use temp_dir::TempDir;
+use tempfile::tempdir;
 use tracing_fluent_assertions::{AssertionRegistry, AssertionsLayer};
 use tracing_subscriber::{Layer, Registry, filter::LevelFilter, layer::SubscriberExt};
 use vector_common::finalization::{EventStatus, Finalizable};
@@ -49,8 +49,7 @@ where
     F: FnOnce(&Path) -> Fut,
     Fut: Future<Output = V>,
 {
-    let buf_dir = TempDir::with_prefix("vector-buffers")
-        .expect("cannot recover from failure to create temp dir");
+    let buf_dir = tempdir().expect("cannot recover from failure to create temp dir");
     f(buf_dir.path()).await
 }
 

--- a/lib/vector-buffers/src/variants/disk_v2/tests/model/mod.rs
+++ b/lib/vector-buffers/src/variants/disk_v2/tests/model/mod.rs
@@ -10,7 +10,7 @@ use std::{
 
 use crossbeam_queue::SegQueue;
 use proptest::{prop_assert, prop_assert_eq, proptest};
-use temp_dir::TempDir;
+use tempfile::tempdir;
 use tokio::runtime::Builder;
 
 use crate::{
@@ -798,7 +798,7 @@ proptest! {
         // configuration. This allows us to use a utility that will generate a random directory each
         // time -- parallel runs of this test can't clobber each other anymore -- but also ensure
         // that the directory is cleaned up when the test run is over.
-        let buf_dir = TempDir::with_prefix("vector-buffers-disk-v2-model").expect("creating temp dir should never fail");
+        let buf_dir = tempdir().expect("creating temp dir should never fail");
         config.data_dir = buf_dir.path().to_path_buf();
 
         rt.block_on(async move {


### PR DESCRIPTION
## Summary

Migrates the `vector-buffers` crate from the `temp-dir` crate to `tempfile`, removing `temp-dir` from the workspace dependency tree entirely.

### References

- Closes: #25020

## Vector configuration

NA

## How did you test this PR?

- `cargo test -p vector-buffers`: 112 passed, 0 failed, 2 ignored (pre-existing)
- `cargo clippy -p vector-buffers --all-targets`: clean

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## Contributor Guidelines

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Before pushing, follow our [pre-push guidance](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#pre-push).
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
