### PR TITLE
refactor(concurrency): replace arc-swap with standard locks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4240,7 +4240,6 @@ checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 name = "enrichment"
 version = "0.1.0"
 dependencies = [
- "arc-swap",
  "chrono",
  "const-str",
  "dyn-clone",
@@ -13258,7 +13257,6 @@ version = "0.59.0"
 dependencies = [
  "antithesis-instrumentation",
  "approx",
- "arc-swap",
  "arr_macro",
  "arrow 59.2.0",
  "assert_cmd",
@@ -13627,7 +13625,6 @@ dependencies = [
 name = "vector-core"
 version = "0.1.0"
 dependencies = [
- "arc-swap",
  "async-trait",
  "base64 0.23.0",
  "bitmask-enum",
@@ -13845,7 +13842,6 @@ dependencies = [
 name = "vector-vrl-metrics"
 version = "0.1.0"
 dependencies = [
- "arc-swap",
  "const-str",
  "tokio",
  "tokio-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,7 +155,6 @@ todo = "warn"
 antithesis-instrumentation = { version = "0.1", default-features = false, features = [] }
 antithesis_sdk = { version = "0.2", default-features = false, features = [] }
 anyhow = { version = "1.0.102", default-features = false, features = ["std"] }
-arc-swap = { version = "1.8.2", default-features = false }
 async-compression = { version = "0.4.42", default-features = false, features = ["tokio", "gzip"] }
 async-stream = { version = "0.3.6", default-features = false }
 async-trait = { version = "0.1.89", default-features = false }
@@ -382,7 +381,6 @@ hex = { version = "0.4.3", default-features = false, optional = true }
 greptimedb-ingester = { version = "0.17.0", default-features = false, optional = true }
 
 # External libs
-arc-swap = { workspace = true, default-features = false, optional = true }
 async-compression = { workspace = true, features = ["zstd"], optional = true }
 arrow = { version = "59.2.0", default-features = false, features = ["ipc"], optional = true }
 parquet = { version = "59.2.0", default-features = false, features = [
@@ -852,7 +850,7 @@ transforms-metrics = [
 ]
 
 transforms-aggregate = []
-transforms-aws_ec2_metadata = ["dep:arc-swap"]
+transforms-aws_ec2_metadata = []
 transforms-dedupe = ["transforms-impl-dedupe"]
 transforms-delay = []
 transforms-filter = []

--- a/STYLE.md
+++ b/STYLE.md
@@ -285,13 +285,10 @@ we prefer `std::sync::OnceLock` over **[`once_cell`](https://docs.rs/once_cell)*
 [`lazy_static`](https://docs.rs/lazy-static). It is slightly faster and provides a richer API than
 `lazy_static`, and has equivalent features to the `once_cell` version.
 
-If you're working with data that _changes over time_, but has a very high read-to-write ratio, such
-as _many readers_, but _one writer_ and infrequent writes, we prefer
-**[`arc-swap`](https://docs.rs/arc-swap)**.  The main feature of this crate is allowing a piece of
-data to be atomically updated while being shared concurrently. It does this by wrapping all data in
-`Arc<T>` to provide the safe, concurrent access, while adding the ability to atomically swap the
-`Arc<T>` itself. As it cannot be constructed in a const fashion, `arc-swap` pairs well with
-`once_cell` for actually storing it in a global static variable.
+If you're working with data that _changes over time_, prefer the synchronization primitives in the
+standard library unless measurements show they are insufficient. For data with many readers and
+infrequent writes, wrapping an `Arc<T>` inside a `Mutex` lets readers cheaply clone a consistent
+snapshot and release the lock before doing more expensive work.
 
 #### Concurrent data structures
 

--- a/lib/vector-core/Cargo.toml
+++ b/lib/vector-core/Cargo.toml
@@ -9,7 +9,6 @@ publish = false
 workspace = true
 
 [dependencies]
-arc-swap = { workspace = true }
 async-trait.workspace = true
 bitmask-enum = { version = "2.2.5", default-features = false }
 bytes = { workspace = true, features = ["serde"] }

--- a/lib/vector-core/src/tls/incoming.rs
+++ b/lib/vector-core/src/tls/incoming.rs
@@ -3,11 +3,10 @@ use std::{
     future::Future,
     net::SocketAddr,
     pin::Pin,
-    sync::Arc,
+    sync::{Arc, Mutex, PoisonError},
     task::{Context, Poll},
 };
 
-use arc_swap::ArcSwap;
 use futures::{FutureExt, Stream, future::BoxFuture, stream};
 use ipnet::IpNet;
 use openssl::{
@@ -72,7 +71,7 @@ impl MaybeTlsSettings {
         let acceptor = match (self, reloader) {
             (Self::Raw(()), _) => None,
             (Self::Tls(_), Some(reloader)) => Some(reloader.shared()),
-            (Self::Tls(tls), None) => Some(Arc::new(ArcSwap::from_pointee(tls.acceptor()?))),
+            (Self::Tls(tls), None) => Some(Arc::new(Mutex::new(Arc::new(tls.acceptor()?)))),
         };
 
         Ok(MaybeTlsListener {
@@ -86,7 +85,7 @@ impl MaybeTlsSettings {
 
 pub struct MaybeTlsListener {
     listener: TcpListener,
-    acceptor: Option<Arc<ArcSwap<SslAcceptor>>>,
+    acceptor: Option<Arc<Mutex<Arc<SslAcceptor>>>>,
     origin_filter: Option<Vec<IpNet>>,
     keepalive: Option<TcpKeepaliveConfig>,
 }
@@ -112,9 +111,13 @@ impl MaybeTlsListener {
         let listener = MaybeTlsIncomingStream::new(
             stream,
             peer_addr,
-            self.acceptor
-                .as_ref()
-                .map(|accptr| accptr.load().as_ref().clone()),
+            self.acceptor.as_ref().map(|acceptor| {
+                acceptor
+                    .lock()
+                    .unwrap_or_else(PoisonError::into_inner)
+                    .as_ref()
+                    .clone()
+            }),
         );
 
         if let Some(origin_filter) = &self.origin_filter {

--- a/lib/vector-core/src/tls/reload.rs
+++ b/lib/vector-core/src/tls/reload.rs
@@ -7,9 +7,8 @@
 //! connection then handshakes with the latest acceptor while in-flight connections keep what they
 //! negotiated.
 
-use std::sync::{Arc, Weak};
+use std::sync::{Arc, Mutex, PoisonError, Weak};
 
-use arc_swap::ArcSwap;
 use openssl::ssl::SslAcceptor;
 
 use super::{MaybeTlsSettings, TlsSettings};
@@ -20,26 +19,27 @@ use super::{MaybeTlsSettings, TlsSettings};
 /// established keep whatever they negotiated at handshake time.
 #[derive(Clone)]
 pub struct TlsAcceptorReloader {
-    acceptor: Arc<ArcSwap<SslAcceptor>>,
+    acceptor: Arc<Mutex<Arc<SslAcceptor>>>,
 }
 
 impl TlsAcceptorReloader {
     /// Wrap an initial acceptor in a swappable cell.
     pub(super) fn new(acceptor: SslAcceptor) -> Self {
         Self {
-            acceptor: Arc::new(ArcSwap::from_pointee(acceptor)),
+            acceptor: Arc::new(Mutex::new(Arc::new(acceptor))),
         }
     }
 
     /// The shared cell the bound listener reads from on each accept.
-    pub(super) fn shared(&self) -> Arc<ArcSwap<SslAcceptor>> {
+    pub(super) fn shared(&self) -> Arc<Mutex<Arc<SslAcceptor>>> {
         Arc::clone(&self.acceptor)
     }
 
     /// Swap in a freshly built acceptor from `settings`. New connections pick it up
     /// immediately; the previous acceptor is dropped once its last in-flight handshake completes.
     pub fn reload(&self, settings: &TlsSettings) -> crate::tls::Result<()> {
-        self.acceptor.store(Arc::new(settings.acceptor()?));
+        let acceptor = Arc::new(settings.acceptor()?);
+        *self.acceptor.lock().unwrap_or_else(PoisonError::into_inner) = acceptor;
         Ok(())
     }
 
@@ -54,7 +54,7 @@ impl TlsAcceptorReloader {
 /// A non-owning handle to a served TLS acceptor, obtained from [`TlsAcceptorReloader::downgrade`].
 #[derive(Clone)]
 pub struct WeakTlsAcceptorReloader {
-    acceptor: Weak<ArcSwap<SslAcceptor>>,
+    acceptor: Weak<Mutex<Arc<SslAcceptor>>>,
 }
 
 impl WeakTlsAcceptorReloader {

--- a/lib/vector-vrl/enrichment/Cargo.toml
+++ b/lib/vector-vrl/enrichment/Cargo.toml
@@ -9,7 +9,6 @@ publish = false
 workspace = true
 
 [dependencies]
-arc-swap.workspace = true
 chrono.workspace = true
 const-str.workspace = true
 dyn-clone = { version = "1.0.20", default-features = false }

--- a/lib/vector-vrl/enrichment/src/tables.rs
+++ b/lib/vector-vrl/enrichment/src/tables.rs
@@ -18,12 +18,11 @@
 //!
 //! Once all the data has been loaded we can move to the next stage. This is
 //! signified by calling the `finish_load` method. At this point all the data is
-//! swapped into the `ArcSwap` of the `tables` field. `ArcSwap` provides
-//! lock-free read-only access to the data. From this point on we have fast,
-//! efficient read-only access and can no longer add indexes or otherwise mutate
-//! the data.
+//! published as a shared snapshot in the `tables` field. From this point on we
+//! have read-only access and can no longer add indexes or otherwise mutate the
+//! data.
 //!
-//! This data within the `ArcSwap` is accessed through the `TableSearch`
+//! This snapshot is accessed through the `TableSearch`
 //! struct. Any transform that needs access to this can call
 //! `TableRegistry::as_readonly`. This returns a cheaply cloneable struct that
 //! implements `vrl:EnrichmentTableSearch` through with the enrichment tables
@@ -31,10 +30,9 @@
 
 use std::{
     collections::HashMap,
-    sync::{Arc, Mutex},
+    sync::{Arc, Mutex, PoisonError},
 };
 
-use arc_swap::ArcSwap;
 use vrl::value::{ObjectMap, Value};
 
 use super::{Condition, Error, IndexHandle, InternalError, Table};
@@ -46,15 +44,15 @@ type TableMap = HashMap<String, Box<dyn Table + Send + Sync>>;
 #[derive(Clone, Default)]
 pub struct TableRegistry {
     loading: Arc<Mutex<Option<TableMap>>>,
-    tables: Arc<ArcSwap<Option<TableMap>>>,
+    tables: Arc<Mutex<Arc<Option<TableMap>>>>,
 }
 
 /// Pessimistic Eq implementation for caching purposes
 impl PartialEq for TableRegistry {
     fn eq(&self, other: &Self) -> bool {
         Arc::ptr_eq(&self.tables, &other.tables) && Arc::ptr_eq(&self.loading, &other.loading)
-            || self.tables.load().is_none()
-                && other.tables.load().is_none()
+            || self.table_snapshot().is_none()
+                && other.table_snapshot().is_none()
                 && self.loading.lock().expect("lock poison").is_none()
                 && other.loading.lock().expect("lock poison").is_none()
     }
@@ -71,12 +69,11 @@ impl TableRegistry {
     ///
     /// If there are tables that have already been loaded things get a bit more
     /// complicated. This can occur when the config is reloaded. Vector will be
-    /// currently running and transforming events, thus the tables loaded into
-    /// the `tables` field could be in active use. Since there is no lock
-    /// against these tables, we cannot mutate this list. We do need to have a
-    /// full list of tables in the `loading` field since there may be some
-    /// transforms that will need to add indexes to these tables during the
-    /// reload.
+    /// currently running and transforming events, thus the snapshot in the
+    /// `tables` field could be in active use. We cannot mutate that snapshot.
+    /// We do need to have a full list of tables in the `loading` field since
+    /// there may be some transforms that will need to add indexes to these
+    /// tables during the reload.
     ///
     /// Our only option is to clone the data that is in `tables` and move it
     /// into the `loading` field so it can be mutated. This could be a
@@ -92,8 +89,8 @@ impl TableRegistry {
     /// Panics if the Mutex is poisoned.
     pub fn load(&self, mut tables: TableMap) {
         let mut loading = self.loading.lock().unwrap();
-        let existing = self.tables.load();
-        if let Some(existing) = &**existing {
+        let existing = Arc::clone(&self.tables.lock().unwrap_or_else(PoisonError::into_inner));
+        if let Some(existing) = &*existing {
             // We already have some tables
             let extend = existing
                 .iter()
@@ -109,7 +106,7 @@ impl TableRegistry {
         }
     }
 
-    /// Swap the data out of the `HashTable` into the `ArcSwap`.
+    /// Publish the data from the `HashTable` as the current shared snapshot.
     ///
     /// From this point we can no longer add indexes to the tables, but are now
     /// allowed to read the data.
@@ -120,7 +117,7 @@ impl TableRegistry {
     pub fn finish_load(&self) {
         let mut tables_lock = self.loading.lock().unwrap();
         let tables = tables_lock.take();
-        self.tables.swap(Arc::new(tables));
+        *self.tables.lock().unwrap_or_else(PoisonError::into_inner) = Arc::new(tables);
     }
 
     /// Return a list of the available tables that we can write to.
@@ -167,8 +164,7 @@ impl TableRegistry {
         }
     }
 
-    /// Returns a cheaply cloneable struct through that provides lock free read
-    /// access to the enrichment tables.
+    /// Returns a cheaply cloneable struct that provides read access to the enrichment tables.
     pub fn as_readonly(&self) -> TableSearch {
         TableSearch(self.tables.clone())
     }
@@ -176,7 +172,7 @@ impl TableRegistry {
     /// Returns the indexes that have been applied to the given table.
     /// If the table is reloaded we need these to reapply them to the new reloaded tables.
     pub fn index_fields(&self, table: &str) -> Vec<(Case, Vec<String>)> {
-        match &**self.tables.load() {
+        match &*self.table_snapshot() {
             Some(tables) => tables
                 .get(table)
                 .map(|table| table.index_fields())
@@ -188,7 +184,7 @@ impl TableRegistry {
     /// Checks if the table needs reloading.
     /// If in doubt (the table isn't in our list) we return true.
     pub fn needs_reload(&self, table: &str) -> bool {
-        match &**self.tables.load() {
+        match &*self.table_snapshot() {
             Some(tables) => tables
                 .get(table)
                 .map(|table| table.needs_reload())
@@ -199,10 +195,14 @@ impl TableRegistry {
 
     /// Extracts state from the table if available.
     pub fn extract_state(&self, table: &str) -> Option<Box<dyn std::any::Any + Send + Sync>> {
-        match &**self.tables.load() {
+        match &*self.table_snapshot() {
             Some(tables) => tables.get(table).and_then(|t| t.extract_state()),
             None => None,
         }
+    }
+
+    fn table_snapshot(&self) -> Arc<Option<TableMap>> {
+        Arc::clone(&self.tables.lock().unwrap_or_else(PoisonError::into_inner))
     }
 }
 
@@ -216,7 +216,7 @@ impl std::fmt::Debug for TableRegistry {
 /// `vrl::EnrichmentTableSearch` trait. Cloning this object is designed to be
 /// cheap. The underlying data will be shared by all clones.
 #[derive(Clone, Default)]
-pub struct TableSearch(Arc<ArcSwap<Option<TableMap>>>);
+pub struct TableSearch(Arc<Mutex<Arc<Option<TableMap>>>>);
 
 impl TableSearch {
     /// Search the given table to find the data.
@@ -231,8 +231,8 @@ impl TableSearch {
         wildcard: Option<&Value>,
         index: Option<IndexHandle>,
     ) -> Result<ObjectMap, Error> {
-        let tables = self.0.load();
-        if let Some(ref tables) = **tables {
+        let tables = table_snapshot(&self.0);
+        if let Some(ref tables) = *tables {
             match tables.get(table) {
                 None => Err(Error::TableNotLoaded {
                     table: table.to_string(),
@@ -258,8 +258,8 @@ impl TableSearch {
         wildcard: Option<&Value>,
         index: Option<IndexHandle>,
     ) -> Result<Vec<ObjectMap>, Error> {
-        let tables = self.0.load();
-        if let Some(ref tables) = **tables {
+        let tables = table_snapshot(&self.0);
+        if let Some(ref tables) = *tables {
             match tables.get(table) {
                 None => Err(Error::TableNotLoaded {
                     table: table.to_string(),
@@ -284,10 +284,10 @@ impl std::fmt::Debug for TableSearch {
 fn fmt_enrichment_table(
     f: &mut std::fmt::Formatter<'_>,
     name: &'static str,
-    tables: &Arc<ArcSwap<Option<TableMap>>>,
+    tables: &Arc<Mutex<Arc<Option<TableMap>>>>,
 ) -> std::fmt::Result {
-    let tables = tables.load();
-    match **tables {
+    let tables = table_snapshot(tables);
+    match *tables {
         Some(ref tables) => {
             let mut tables = tables.iter().fold(String::from("("), |mut s, (key, _)| {
                 s.push_str(key);
@@ -302,6 +302,10 @@ fn fmt_enrichment_table(
         }
         None => write!(f, "{name} loading"),
     }
+}
+
+fn table_snapshot(tables: &Arc<Mutex<Arc<Option<TableMap>>>>) -> Arc<Option<TableMap>> {
+    Arc::clone(&tables.lock().unwrap_or_else(PoisonError::into_inner))
 }
 
 #[cfg(test)]

--- a/lib/vector-vrl/enrichment/src/tables.rs
+++ b/lib/vector-vrl/enrichment/src/tables.rs
@@ -115,9 +115,16 @@ impl TableRegistry {
     ///
     /// Panics if the Mutex is poisoned.
     pub fn finish_load(&self) {
-        let mut tables_lock = self.loading.lock().unwrap();
-        let tables = tables_lock.take();
-        *self.tables.lock().unwrap_or_else(PoisonError::into_inner) = Arc::new(tables);
+        let tables = {
+            let mut loading = self.loading.lock().unwrap();
+            loading.take()
+        };
+        let tables = Arc::new(tables);
+        let previous = {
+            let mut current = self.tables.lock().unwrap_or_else(PoisonError::into_inner);
+            std::mem::replace(&mut *current, tables)
+        };
+        drop(previous);
     }
 
     /// Return a list of the available tables that we can write to.
@@ -310,10 +317,73 @@ fn table_snapshot(tables: &Arc<Mutex<Arc<Option<TableMap>>>>) -> Arc<Option<Tabl
 
 #[cfg(test)]
 mod tests {
+    use std::sync::{
+        Weak,
+        atomic::{AtomicBool, Ordering},
+    };
+
     use vrl::value::Value;
 
     use super::*;
     use crate::test_util::DummyEnrichmentTable;
+
+    #[derive(Clone)]
+    struct DropCheckTable {
+        inner: DummyEnrichmentTable,
+        tables: Weak<Mutex<Arc<Option<TableMap>>>>,
+        dropped: Arc<AtomicBool>,
+        dropped_after_unlock: Arc<AtomicBool>,
+    }
+
+    impl Drop for DropCheckTable {
+        fn drop(&mut self) {
+            let dropped_after_unlock = self
+                .tables
+                .upgrade()
+                .is_none_or(|tables| tables.try_lock().is_ok());
+            self.dropped_after_unlock
+                .store(dropped_after_unlock, Ordering::SeqCst);
+            self.dropped.store(true, Ordering::SeqCst);
+        }
+    }
+
+    impl Table for DropCheckTable {
+        fn find_table_row<'a>(
+            &self,
+            case: Case,
+            condition: &'a [Condition<'a>],
+            select: Option<&[String]>,
+            wildcard: Option<&Value>,
+            index: Option<IndexHandle>,
+        ) -> Result<ObjectMap, Error> {
+            self.inner
+                .find_table_row(case, condition, select, wildcard, index)
+        }
+
+        fn find_table_rows<'a>(
+            &self,
+            case: Case,
+            condition: &'a [Condition<'a>],
+            select: Option<&[String]>,
+            wildcard: Option<&Value>,
+            index: Option<IndexHandle>,
+        ) -> Result<Vec<ObjectMap>, Error> {
+            self.inner
+                .find_table_rows(case, condition, select, wildcard, index)
+        }
+
+        fn add_index(&mut self, case: Case, fields: &[&str]) -> Result<IndexHandle, Error> {
+            self.inner.add_index(case, fields)
+        }
+
+        fn index_fields(&self) -> Vec<(Case, Vec<String>)> {
+            self.inner.index_fields()
+        }
+
+        fn needs_reload(&self) -> bool {
+            self.inner.needs_reload()
+        }
+    }
 
     #[test]
     fn tables_loaded() {
@@ -440,6 +510,33 @@ mod tests {
         table_ids.sort();
 
         assert_eq!(vec!["dummy1".to_string(), "dummy2".to_string()], table_ids,);
+    }
+
+    #[test]
+    fn drops_replaced_snapshot_after_unlocking() {
+        let registry = TableRegistry::default();
+        let dropped = Arc::new(AtomicBool::new(false));
+        let dropped_after_unlock = Arc::new(AtomicBool::new(false));
+        let mut tables: TableMap = HashMap::new();
+        tables.insert(
+            "dummy".to_string(),
+            Box::new(DropCheckTable {
+                inner: DummyEnrichmentTable::new(),
+                tables: Arc::downgrade(&registry.tables),
+                dropped: Arc::clone(&dropped),
+                dropped_after_unlock: Arc::clone(&dropped_after_unlock),
+            }),
+        );
+        registry.load(tables);
+        registry.finish_load();
+
+        let mut replacement: TableMap = HashMap::new();
+        replacement.insert("dummy".to_string(), Box::new(DummyEnrichmentTable::new()));
+        registry.load(replacement);
+        registry.finish_load();
+
+        assert!(dropped.load(Ordering::SeqCst));
+        assert!(dropped_after_unlock.load(Ordering::SeqCst));
     }
 
     #[test]

--- a/lib/vector-vrl/metrics/Cargo.toml
+++ b/lib/vector-vrl/metrics/Cargo.toml
@@ -10,7 +10,6 @@ license = "MPL-2.0"
 workspace = true
 
 [dependencies]
-arc-swap.workspace = true
 const-str.workspace = true
 vrl.workspace = true
 vector-core = { path = "../../vector-core", default-features = false }

--- a/lib/vector-vrl/metrics/src/common.rs
+++ b/lib/vector-vrl/metrics/src/common.rs
@@ -1,4 +1,8 @@
-use std::{collections::BTreeMap, sync::Arc, time::Duration};
+use std::{
+    collections::BTreeMap,
+    sync::{Arc, Mutex, PoisonError},
+    time::Duration,
+};
 use tokio::time::interval;
 use tokio_stream::{wrappers::IntervalStream, StreamExt};
 use vector_common::shutdown::ShutdownSignal;
@@ -8,7 +12,6 @@ use vrl::{
     value,
 };
 
-use arc_swap::ArcSwap;
 use vector_core::{event::Metric, metrics::Controller};
 
 #[derive(Debug)]
@@ -45,9 +48,7 @@ impl DiagnosticMessage for Error {
 
 #[derive(Debug, Default, Clone)]
 pub struct MetricsStorage {
-    // Made pub only for vrl-test module
-    #[doc(hidden)]
-    pub cache: Arc<ArcSwap<Vec<Metric>>>,
+    cache: Arc<Mutex<Arc<[Metric]>>>,
 }
 
 impl MetricsStorage {
@@ -56,16 +57,14 @@ impl MetricsStorage {
         metric: &str,
         tags: BTreeMap<String, String>,
     ) -> Option<Metric> {
-        self.cache
-            .load()
+        self.metrics()
             .iter()
             .find(|m| m.name() == metric && tags.iter().all(|tag| tag_matches(m, tag)))
             .cloned()
     }
 
     pub(crate) fn find_metrics(&self, metric: &str, tags: BTreeMap<String, String>) -> Vec<Metric> {
-        self.cache
-            .load()
+        self.metrics()
             .iter()
             .filter(|m| m.name() == metric && tags.iter().all(|tag| tag_matches(m, tag)))
             .cloned()
@@ -76,7 +75,17 @@ impl MetricsStorage {
         let new_metrics = Controller::get()
             .expect("metrics not initialized")
             .capture_metrics();
-        self.cache.store(new_metrics.into());
+        self.set_metrics(new_metrics.into());
+    }
+
+    /// Replace the cached metrics. Exposed for the VRL test crate.
+    #[doc(hidden)]
+    pub fn set_metrics(&self, metrics: Arc<[Metric]>) {
+        *self.cache.lock().unwrap_or_else(PoisonError::into_inner) = metrics;
+    }
+
+    fn metrics(&self) -> Arc<[Metric]> {
+        Arc::clone(&self.cache.lock().unwrap_or_else(PoisonError::into_inner))
     }
 
     pub async fn run_periodic_refresh(
@@ -280,7 +289,7 @@ mod tests {
     #[test]
     fn test_get_vector_metric() {
         let storage = MetricsStorage::default();
-        storage.cache.store(
+        storage.set_metrics(
             vec![Metric::new(
                 "test",
                 MetricKind::Absolute,
@@ -304,7 +313,7 @@ mod tests {
     #[test]
     fn test_find_vector_metrics() {
         let storage = MetricsStorage::default();
-        storage.cache.store(
+        storage.set_metrics(
             vec![
                 Metric::new(
                     "test",
@@ -354,7 +363,7 @@ mod tests {
     #[test]
     fn test_get_vector_metric_by_tag() {
         let storage = MetricsStorage::default();
-        storage.cache.store(
+        storage.set_metrics(
             vec![
                 Metric::new(
                     "test",
@@ -393,7 +402,7 @@ mod tests {
     #[test]
     fn test_find_vector_metrics_wildcard() {
         let storage = MetricsStorage::default();
-        storage.cache.store(
+        storage.set_metrics(
             vec![
                 Metric::new(
                     "test",
@@ -450,7 +459,7 @@ mod tests {
     #[test]
     fn test_find_vector_metrics_wildcard_start() {
         let storage = MetricsStorage::default();
-        storage.cache.store(
+        storage.set_metrics(
             vec![
                 Metric::new(
                     "test",
@@ -510,7 +519,7 @@ mod tests {
     #[test]
     fn test_find_vector_metrics_wildcard_end() {
         let storage = MetricsStorage::default();
-        storage.cache.store(
+        storage.set_metrics(
             vec![
                 Metric::new(
                     "test",
@@ -570,7 +579,7 @@ mod tests {
     #[test]
     fn test_find_vector_metrics_wildcard_middle() {
         let storage = MetricsStorage::default();
-        storage.cache.store(
+        storage.set_metrics(
             vec![
                 Metric::new(
                     "test",
@@ -630,7 +639,7 @@ mod tests {
     #[test]
     fn test_aggregate_vector_metrics_sum() {
         let storage = MetricsStorage::default();
-        storage.cache.store(
+        storage.set_metrics(
             vec![
                 Metric::new(
                     "test",
@@ -678,7 +687,7 @@ mod tests {
     #[test]
     fn test_aggregate_vector_metrics_avg() {
         let storage = MetricsStorage::default();
-        storage.cache.store(
+        storage.set_metrics(
             vec![
                 Metric::new(
                     "test",
@@ -726,7 +735,7 @@ mod tests {
     #[test]
     fn test_aggregate_vector_metrics_max() {
         let storage = MetricsStorage::default();
-        storage.cache.store(
+        storage.set_metrics(
             vec![
                 Metric::new(
                     "test",
@@ -774,7 +783,7 @@ mod tests {
     #[test]
     fn test_aggregate_vector_metrics_min() {
         let storage = MetricsStorage::default();
-        storage.cache.store(
+        storage.set_metrics(
             vec![
                 Metric::new(
                     "test",

--- a/lib/vector-vrl/tests/src/test_vrl_metrics.rs
+++ b/lib/vector-vrl/tests/src/test_vrl_metrics.rs
@@ -3,7 +3,7 @@ use vector_vrl_metrics::MetricsStorage;
 
 pub(crate) fn test_vrl_metrics_storage() -> MetricsStorage {
     let storage = MetricsStorage::default();
-    storage.cache.store(
+    storage.set_metrics(
         vec![
             Metric::new(
                 "utilization",

--- a/src/transforms/aws_ec2_metadata.rs
+++ b/src/transforms/aws_ec2_metadata.rs
@@ -3,10 +3,9 @@ use std::{
     error, fmt,
     future::ready,
     pin::Pin,
-    sync::{Arc, LazyLock},
+    sync::{Arc, LazyLock, Mutex, PoisonError},
 };
 
-use arc_swap::ArcSwap;
 use bytes::Bytes;
 use futures::{Stream, StreamExt};
 use http::{Request, StatusCode, Uri, uri::PathAndQuery};
@@ -171,7 +170,7 @@ const fn default_required() -> bool {
 
 #[derive(Clone, Debug)]
 pub struct Ec2MetadataTransform {
-    state: Arc<ArcSwap<Vec<(MetadataKey, Bytes)>>>,
+    state: Arc<Mutex<Arc<[(MetadataKey, Bytes)]>>>,
 }
 
 #[derive(Debug, Clone)]
@@ -204,7 +203,7 @@ impl_generate_config_from_default!(Ec2Metadata);
 #[typetag::serde(name = "aws_ec2_metadata")]
 impl TransformConfig for Ec2Metadata {
     async fn build(&self, context: &TransformContext) -> crate::Result<Transform> {
-        let state = Arc::new(ArcSwap::new(Arc::new(vec![])));
+        let state = Arc::new(Mutex::new(Arc::from([])));
 
         let keys = Keys::new(self.namespace.clone());
         let host = Uri::from_maybe_shared(self.endpoint.clone()).unwrap();
@@ -322,7 +321,7 @@ impl TaskTransform<Event> for Ec2MetadataTransform {
 
 impl Ec2MetadataTransform {
     fn transform_one(&mut self, mut event: Event) -> Event {
-        let state = self.state.load();
+        let state = Arc::clone(&self.state.lock().unwrap_or_else(PoisonError::into_inner));
         match event {
             Event::Log(ref mut log) => {
                 state.iter().for_each(|(k, v)| {
@@ -346,7 +345,7 @@ struct MetadataClient {
     host: Uri,
     token: Option<(Bytes, Instant)>,
     keys: Keys,
-    state: Arc<ArcSwap<Vec<(MetadataKey, Bytes)>>>,
+    state: Arc<Mutex<Arc<[(MetadataKey, Bytes)]>>>,
     refresh_interval: Duration,
     refresh_timeout: Duration,
     fields: HashSet<String>,
@@ -373,7 +372,7 @@ impl MetadataClient {
         client: HttpClient<Body>,
         host: Uri,
         keys: Keys,
-        state: Arc<ArcSwap<Vec<(MetadataKey, Bytes)>>>,
+        state: Arc<Mutex<Arc<[(MetadataKey, Bytes)]>>>,
         refresh_interval: Duration,
         refresh_timeout: Duration,
         fields: Vec<String>,
@@ -586,7 +585,7 @@ impl MetadataClient {
                 }
             }
 
-            self.state.store(Arc::new(new_state));
+            *self.state.lock().unwrap_or_else(PoisonError::into_inner) = Arc::from(new_state);
         }
 
         Ok(())

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -280,7 +280,7 @@ fn stub_enrichment_tables(config: &Config) -> TableRegistry {
         enrichment_tables.load(stubs);
         // Do not call finish_load(): table_ids() and add_index() (used during
         // VRL compilation) both operate on the loading stage. finish_load()
-        // would move tables to the ArcSwap and make table_ids() return nothing.
+        // would publish the tables snapshot and make table_ids() return nothing.
     }
     enrichment_tables
 }


### PR DESCRIPTION
## Summary

### Motivation

Vector uses `arc-swap` for several read-heavy snapshots, but there is no evidence that a standard lock is insufficient for these paths. Keeping the specialized synchronization primitive as a direct dependency adds complexity before it is justified by measurements.

### Changes

- Replace the TLS acceptor, enrichment table, VRL metrics, and EC2 metadata snapshots with `Mutex<Arc<T>>`.
- Hold each lock only long enough to clone or replace the shared snapshot.
- Remove Vector's direct `arc-swap` declarations and update the concurrency guidance.

### References

<!-- Closes: <#issue/#PR or full link> -->
<!-- Related: <#issue/#PR or full link> -->

## Vector configuration

N/A

## How did you test this PR?

Ran the focused TLS certificate rotation, enrichment reload, VRL metrics, and EC2 metadata tests. CI covers the remaining validation.

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## Contributor Guidelines

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Before pushing, follow our [pre-push guidance](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#pre-push).
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
