### PR TITLE
fix(sample transform): cap per-group sampling state (max_groups) and stop always retaining first group events

### DIFF
--- a/changelog.d/sample_max_groups.security.md
+++ b/changelog.d/sample_max_groups.security.md
@@ -1,0 +1,3 @@
+Bound the `sample` transform's per-group state with the new `max_groups` option, which defaults to 5,000 and evicts the least recently used group to prevent unbounded memory growth from high-cardinality `group_by` values.
+
+authors: thomasqueirozb

--- a/src/transforms/sample/config.rs
+++ b/src/transforms/sample/config.rs
@@ -1,3 +1,5 @@
+use std::num::NonZeroUsize;
+
 use snafu::Snafu;
 use vector_lib::{
     config::LegacyKey,
@@ -122,9 +124,18 @@ pub struct SampleConfig {
         docs::examples = "{{ hostname }}-{{ service }}"
     ))]
     pub group_by: Option<UnconfinedTemplate>,
+    /// The maximum number of distinct group values whose sampling state is retained.
+    ///
+    /// When this limit is reached, the least recently used group's state is evicted. If
+    /// `group_by` is not configured, only one group is retained.
+    #[serde(default = "default_max_groups")]
+    pub max_groups: NonZeroUsize,
 
     /// A logical condition used to exclude events from sampling.
     pub exclude: Option<AnyCondition>,
+}
+pub const fn default_max_groups() -> NonZeroUsize {
+    NonZeroUsize::new(5000).expect("static non-zero number")
 }
 
 impl SampleConfig {
@@ -171,6 +182,7 @@ impl GenerateConfig for SampleConfig {
             rate_field: None,
             key_field: None,
             group_by: None,
+            max_groups: default_max_groups(),
             exclude: None::<AnyCondition>,
             sample_rate_key: default_sample_rate_key(),
         })
@@ -198,6 +210,7 @@ impl TransformConfig for SampleConfig {
                     rate_field: self.rate_field.clone(),
                 },
                 self.group_by.clone(),
+                self.max_groups,
                 exclude,
                 self.sample_rate_key.clone(),
             )
@@ -207,6 +220,7 @@ impl TransformConfig for SampleConfig {
                 sample_mode,
                 self.key_field.clone(),
                 self.group_by.clone(),
+                self.max_groups,
                 exclude,
                 self.sample_rate_key.clone(),
             )
@@ -278,6 +292,11 @@ mod tests {
     fn generate_config() {
         crate::test_util::test_generate_config::<SampleConfig>();
     }
+    #[test]
+    fn defaults_max_groups_to_finite_capacity() {
+        let config: SampleConfig = serde_yaml::from_str("ratio: 0.5").unwrap();
+        assert_eq!(config.max_groups, super::default_max_groups());
+    }
 
     #[test]
     fn rejects_dynamic_ratio_only_configuration() {
@@ -287,6 +306,7 @@ mod tests {
             ratio_field: Some("sample_rate".to_string()),
             rate_field: None,
             key_field: None,
+            max_groups: super::default_max_groups(),
             sample_rate_key: super::default_sample_rate_key(),
             group_by: None,
             exclude: None,
@@ -304,6 +324,7 @@ mod tests {
             ratio_field: None,
             rate_field: Some("sample_rate_n".to_string()),
             key_field: None,
+            max_groups: super::default_max_groups(),
             sample_rate_key: super::default_sample_rate_key(),
             group_by: None,
             exclude: None,
@@ -321,6 +342,7 @@ mod tests {
             ratio_field: None,
             rate_field: Some("sample_rate_n".to_string()),
             key_field: None,
+            max_groups: super::default_max_groups(),
             sample_rate_key: super::default_sample_rate_key(),
             group_by: None,
             exclude: None,
@@ -337,6 +359,7 @@ mod tests {
             ratio_field: Some("sample_rate".to_string()),
             rate_field: Some("sample_rate_n".to_string()),
             key_field: None,
+            max_groups: super::default_max_groups(),
             sample_rate_key: super::default_sample_rate_key(),
             group_by: None,
             exclude: None,
@@ -353,6 +376,7 @@ mod tests {
             ratio: None,
             ratio_field: Some("sample_ratio".to_string()),
             rate_field: None,
+            max_groups: super::default_max_groups(),
             key_field: Some("trace_id".to_string()),
             sample_rate_key: super::default_sample_rate_key(),
             group_by: None,

--- a/src/transforms/sample/config.rs
+++ b/src/transforms/sample/config.rs
@@ -121,7 +121,12 @@ pub struct SampleConfig {
     /// independently per rendered group value.
     #[configurable(metadata(
         docs::examples = "{{ service }}",
-        docs::examples = "{{ hostname }}-{{ service }}"
+        docs::examples = "{{ hostname }}-{{ service }}",
+        docs::warnings = "Prefer grouping by fields with a small, stable set of values, such as \
+        `service` or `host`. When the template interpolates event content (for example \
+        `{{ message }}` or `{{ request_id }}`), every distinct rendered value creates a new \
+        group: exceeding `max_groups` then evicts the least recently used groups' sampling \
+        state, and the retained group values consume memory in proportion to their size."
     ))]
     pub group_by: Option<UnconfinedTemplate>,
     /// The maximum number of distinct group values whose sampling state is retained.

--- a/src/transforms/sample/tests.rs
+++ b/src/transforms/sample/tests.rs
@@ -14,7 +14,7 @@ use crate::{
     transforms::{
         FunctionTransform, OutputBuffer,
         sample::{
-            config::{SampleConfig, default_sample_rate_key},
+            config::{SampleConfig, default_max_groups, default_sample_rate_key},
             transform::{DynamicSampleFields, Sample, SampleMode},
         },
         test::{create_topology, transform_one},
@@ -31,6 +31,7 @@ async fn emits_internal_events() {
             rate_field: None,
             key_field: None,
             group_by: None,
+            max_groups: default_max_groups(),
             exclude: None,
             sample_rate_key: default_sample_rate_key(),
         };
@@ -59,6 +60,7 @@ fn hash_samples_at_roughly_the_configured_rate() {
         SampleMode::new_rate(2),
         log_schema().message_key().map(ToString::to_string),
         None,
+        default_max_groups(),
         Some(condition_contains(
             log_schema().message_key().unwrap().to_string().as_str(),
             "na",
@@ -82,6 +84,7 @@ fn hash_samples_at_roughly_the_configured_rate() {
         SampleMode::new_ratio(0.04),
         log_schema().message_key().map(ToString::to_string),
         None,
+        default_max_groups(),
         Some(condition_contains(
             log_schema().message_key().unwrap().to_string().as_str(),
             "na",
@@ -108,6 +111,7 @@ fn hash_consistently_samples_the_same_events() {
         SampleMode::new_rate(2),
         log_schema().message_key().map(ToString::to_string),
         None,
+        default_max_groups(),
         Some(condition_contains(
             log_schema().message_key().unwrap().to_string().as_str(),
             "na",
@@ -145,6 +149,7 @@ fn always_passes_events_matching_pass_list() {
             SampleMode::new_rate(0),
             key_field.clone(),
             None,
+            default_max_groups(),
             Some(condition_contains(
                 log_schema().message_key().unwrap().to_string().as_str(),
                 "important",
@@ -175,6 +180,7 @@ fn handles_group_by() {
             SampleMode::new_rate(0),
             log_schema().message_key().map(ToString::to_string),
             group_by.clone(),
+            default_max_groups(),
             Some(condition_contains(
                 log_schema().message_key().unwrap().to_string().as_str(),
                 "na",
@@ -202,6 +208,7 @@ fn handles_key_field() {
             SampleMode::new_ratio(0.0),
             key_field.clone(),
             None,
+            default_max_groups(),
             Some(condition_contains("other_field", "foo")),
             default_sample_rate_key(),
         );
@@ -225,6 +232,7 @@ fn sampler_adds_sampling_rate_to_event() {
             SampleMode::new_ratio(0.1),
             key_field.clone(),
             None,
+            default_max_groups(),
             Some(condition_contains(&message_key, "na")),
             default_sample_rate_key(),
         );
@@ -241,6 +249,7 @@ fn sampler_adds_sampling_rate_to_event() {
             SampleMode::new_rate(25),
             key_field.clone(),
             None,
+            default_max_groups(),
             Some(condition_contains(&message_key, "na")),
             OptionalValuePath::from(owned_value_path!("custom_sample_rate")),
         );
@@ -258,6 +267,7 @@ fn sampler_adds_sampling_rate_to_event() {
             SampleMode::new_rate(2),
             key_field.clone(),
             None,
+            default_max_groups(),
             Some(condition_contains(&message_key, "na")),
             OptionalValuePath::from(owned_value_path!("")),
         );
@@ -274,6 +284,7 @@ fn sampler_adds_sampling_rate_to_event() {
             SampleMode::new_ratio(0.04),
             key_field.clone(),
             None,
+            default_max_groups(),
             Some(condition_contains(&message_key, "na")),
             default_sample_rate_key(),
         );
@@ -293,6 +304,7 @@ fn handles_trace_event() {
         SampleMode::new_rate(2),
         None,
         None,
+        default_max_groups(),
         None,
         default_sample_rate_key(),
     );
@@ -311,6 +323,7 @@ fn group_by_uses_independent_ratio_samplers() {
         SampleMode::new_ratio(0.5),
         None,
         Some(UnconfinedTemplate::try_from("{{ service }}").unwrap()),
+        default_max_groups(),
         None,
         default_sample_rate_key(),
     );
@@ -321,7 +334,130 @@ fn group_by_uses_independent_ratio_samplers() {
         transform_one(&mut sampler, event.into()).is_some()
     });
 
-    assert_eq!(sampled, [true, true, false, false]);
+    assert_eq!(sampled, [true, false, false, true]);
+}
+
+#[test]
+fn group_state_evicts_least_recently_used_group() {
+    let mut sampler = Sample::new(
+        "sample".to_string(),
+        SampleMode::new_rate(2),
+        None,
+        Some(UnconfinedTemplate::try_from("{{ service }}").unwrap()),
+        std::num::NonZeroUsize::new(2).unwrap(),
+        None,
+        default_sample_rate_key(),
+    );
+
+    let sampled = [
+        "service-a",
+        "service-b",
+        "service-a",
+        "service-c",
+        "service-a",
+        "service-b",
+    ]
+    .map(|service| {
+        let mut event = LogEvent::from("event");
+        event.insert(event_path!("service"), service);
+        transform_one(&mut sampler, event.into()).is_some()
+    });
+
+    assert_eq!(sampled, [true, false, false, true, true, false]);
+}
+
+#[test]
+fn capacity_thrashing_does_not_bypass_static_sampling() {
+    for (name, mode) in [
+        ("rate", SampleMode::new_rate(2)),
+        ("ratio", SampleMode::new_ratio(0.5)),
+    ] {
+        let mut sampler = Sample::new(
+            "sample".to_string(),
+            mode,
+            None,
+            Some(UnconfinedTemplate::try_from("{{ service }}").unwrap()),
+            std::num::NonZeroUsize::new(2).unwrap(),
+            None,
+            default_sample_rate_key(),
+        );
+
+        let sampled = (0..6).map(|index| {
+            let mut event = LogEvent::from("event");
+            event.insert(event_path!("service"), format!("service-{}", index % 3));
+            transform_one(&mut sampler, event.into()).is_some()
+        });
+
+        assert_eq!(
+            sampled.collect::<Vec<_>>(),
+            [true, false, true, false, true, false],
+            "{name} sampling was bypassed",
+        );
+    }
+}
+
+#[test]
+fn capacity_thrashing_does_not_bypass_dynamic_sampling() {
+    for (name, fields) in [
+        (
+            "rate",
+            DynamicSampleFields {
+                ratio_field: None,
+                rate_field: Some("dynamic_rate".to_string()),
+            },
+        ),
+        (
+            "ratio",
+            DynamicSampleFields {
+                ratio_field: Some("dynamic_ratio".to_string()),
+                rate_field: None,
+            },
+        ),
+    ] {
+        let make_sampler = |max_groups| {
+            Sample::new_with_dynamic(
+                "sample".to_string(),
+                SampleMode::new_ratio(0.0),
+                fields.clone(),
+                Some(UnconfinedTemplate::try_from("{{ service }}").unwrap()),
+                max_groups,
+                None,
+                default_sample_rate_key(),
+            )
+        };
+        let make_event = |service: &str| {
+            let mut event = LogEvent::from("event");
+            event.insert(event_path!("service"), service);
+            if fields.rate_field.is_some() {
+                event.insert(event_path!("dynamic_rate"), 2);
+            } else {
+                event.insert(event_path!("dynamic_ratio"), 0.5);
+            }
+            event.into()
+        };
+
+        let passing_groups = (0..100)
+            .filter_map(|index| {
+                let service = format!("service-{index}");
+                let mut sampler = make_sampler(default_max_groups());
+                transform_one(&mut sampler, make_event(&service))
+                    .is_some()
+                    .then_some(service)
+            })
+            .take(3)
+            .collect::<Vec<_>>();
+        assert_eq!(passing_groups.len(), 3);
+
+        let mut sampler = make_sampler(std::num::NonZeroUsize::new(2).unwrap());
+        let retained = (0..30)
+            .filter(|index| {
+                let service = &passing_groups[index % passing_groups.len()];
+                transform_one(&mut sampler, make_event(service)).is_some()
+            })
+            .count();
+
+        assert!(retained < 30, "{name} sampling was bypassed");
+    }
 }
 
 #[test]
@@ -335,6 +471,7 @@ fn sample_at_rates_higher_then_half() {
             SampleMode::new_ratio(ratio),
             None,
             None,
+            default_max_groups(),
             None,
             default_sample_rate_key(),
         );
@@ -360,6 +497,7 @@ fn dynamic_ratio_field_overrides_static_ratio() {
             rate_field: None,
         },
         None,
+        default_max_groups(),
         None,
         default_sample_rate_key(),
     );
@@ -382,6 +520,7 @@ fn dynamic_ratio_field_falls_back_to_static_ratio_when_missing() {
             rate_field: None,
         },
         None,
+        default_max_groups(),
         None,
         default_sample_rate_key(),
     );
@@ -401,6 +540,7 @@ fn dynamic_rate_field_overrides_static_ratio() {
             rate_field: Some("dynamic_rate".to_string()),
         },
         None,
+        default_max_groups(),
         None,
         default_sample_rate_key(),
     );
@@ -423,6 +563,7 @@ fn dynamic_rate_field_falls_back_to_static_ratio_when_missing() {
             rate_field: Some("dynamic_rate".to_string()),
         },
         None,
+        default_max_groups(),
         None,
         default_sample_rate_key(),
     );
@@ -442,6 +583,7 @@ fn dynamic_rate_field_rejects_float_and_falls_back_to_static_ratio() {
             rate_field: Some("dynamic_rate".to_string()),
         },
         None,
+        default_max_groups(),
         None,
         default_sample_rate_key(),
     );
@@ -466,6 +608,7 @@ fn dynamic_ratio_honors_group_by_key() {
             rate_field: None,
         },
         Some(UnconfinedTemplate::try_from("{{ service }}").unwrap()),
+        default_max_groups(),
         None,
         default_sample_rate_key(),
     );
@@ -511,6 +654,7 @@ fn dynamic_rate_honors_group_by_key() {
             rate_field: Some("dynamic_rate".to_string()),
         },
         Some(UnconfinedTemplate::try_from("{{ service }}").unwrap()),
+        default_max_groups(),
         None,
         default_sample_rate_key(),
     );
@@ -555,6 +699,7 @@ fn dynamic_ratio_group_by_samples_mixed_ratios_at_expected_rates() {
             rate_field: None,
         },
         Some(UnconfinedTemplate::try_from("{{ service }}").unwrap()),
+        default_max_groups(),
         None,
         default_sample_rate_key(),
     );
@@ -603,6 +748,7 @@ fn dynamic_rate_group_by_samples_mixed_rates_at_expected_rates() {
             rate_field: Some("dynamic_rate".to_string()),
         },
         Some(UnconfinedTemplate::try_from("{{ service }}").unwrap()),
+        default_max_groups(),
         None,
         default_sample_rate_key(),
     );

--- a/src/transforms/sample/transform.rs
+++ b/src/transforms/sample/transform.rs
@@ -1,10 +1,10 @@
 use std::{
-    collections::HashMap,
     fmt,
     hash::{Hash, Hasher},
-    num::NonZeroU64,
+    num::{NonZeroU64, NonZeroUsize},
 };
 
+use lru::LruCache;
 use vector_lib::{
     config::LegacyKey,
     lookup::{OwnedTargetPath, lookup_v2::OptionalValuePath},
@@ -27,27 +27,21 @@ use crate::{
 pub enum SampleMode {
     Rate {
         rate: u64,
-        counters: HashMap<Option<String>, u64>,
     },
     Ratio {
         ratio: f64,
-        samplers: HashMap<Option<String>, RatioSampler>,
         hash_ratio_threshold: u64,
     },
 }
 
 impl SampleMode {
-    pub fn new_rate(rate: u64) -> Self {
-        Self::Rate {
-            rate,
-            counters: HashMap::default(),
-        }
+    pub const fn new_rate(rate: u64) -> Self {
+        Self::Rate { rate }
     }
 
     pub fn new_ratio(ratio: f64) -> Self {
         Self::Ratio {
             ratio,
-            samplers: HashMap::default(),
             // Supports the 'key_field' option, assuming an equal distribution of values for a given
             // field, hashing its contents this component should output events according to the
             // configured ratio.
@@ -59,20 +53,24 @@ impl SampleMode {
         }
     }
 
-    fn increment(&mut self, group_by_key: Option<String>, value: Option<&Value>) -> bool {
-        let threshold_exceeded = match self {
-            Self::Rate { rate, counters } => {
-                let counter_value = counters.entry(group_by_key).or_default();
-                let old_counter_value = *counter_value;
-                *counter_value += 1;
+    fn new_state(&self) -> StaticSampleState {
+        match self {
+            Self::Rate { .. } => StaticSampleState::Rate { counter: 0 },
+            Self::Ratio { ratio, .. } => StaticSampleState::Ratio {
+                sampler: RatioSampler::new(*ratio),
+            },
+        }
+    }
+
+    fn increment(&self, state: &mut StaticSampleState, value: Option<&Value>) -> bool {
+        let threshold_exceeded = match (self, state) {
+            (Self::Rate { rate }, StaticSampleState::Rate { counter }) => {
+                let old_counter_value = *counter;
+                *counter += 1;
                 old_counter_value % *rate == 0
             }
-            Self::Ratio {
-                ratio, samplers, ..
-            } => samplers
-                .entry(group_by_key)
-                .or_insert_with(|| RatioSampler::new(*ratio))
-                .sample(),
+            (Self::Ratio { .. }, StaticSampleState::Ratio { sampler }) => sampler.sample(),
+            _ => unreachable!("sample mode state must match its configured mode"),
         };
         if let Some(value) = value {
             self.hash_within_ratio(value.to_string_lossy().as_bytes())
@@ -84,11 +82,32 @@ impl SampleMode {
     fn hash_within_ratio(&self, value: &[u8]) -> bool {
         let hash = seahash::hash(value);
         match self {
-            Self::Rate { rate, .. } => hash.is_multiple_of(*rate),
+            Self::Rate { rate } => hash.is_multiple_of(*rate),
             Self::Ratio {
                 hash_ratio_threshold,
                 ..
             } => hash <= *hash_ratio_threshold,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+enum StaticSampleState {
+    Rate { counter: u64 },
+    Ratio { sampler: RatioSampler },
+}
+
+#[derive(Clone, Debug)]
+struct GroupState {
+    static_state: StaticSampleState,
+    dynamic_event_counter: u64,
+}
+
+impl GroupState {
+    const fn new(static_state: StaticSampleState, dynamic_event_counter: u64) -> Self {
+        Self {
+            static_state,
+            dynamic_event_counter,
         }
     }
 }
@@ -141,7 +160,9 @@ pub struct Sample {
     name: String,
     static_mode: SampleMode,
     key_source: SampleKeySource,
-    dynamic_event_counters: HashMap<Option<String>, u64>,
+    next_group_static_state: StaticSampleState,
+    next_group_dynamic_event_counter: u64,
+    group_states: LruCache<Option<String>, GroupState>,
     exclude: Option<Condition>,
     sample_rate_key: OptionalValuePath,
 }
@@ -155,6 +176,7 @@ impl Sample {
         static_mode: SampleMode,
         key_field: Option<String>,
         group_by: Option<UnconfinedTemplate>,
+        max_groups: NonZeroUsize,
         exclude: Option<Condition>,
         sample_rate_key: OptionalValuePath,
     ) -> Self {
@@ -165,6 +187,7 @@ impl Sample {
                 key_field,
                 group_by,
             },
+            max_groups,
             exclude,
             sample_rate_key,
         )
@@ -175,6 +198,7 @@ impl Sample {
         static_mode: SampleMode,
         fields: DynamicSampleFields,
         group_by: Option<UnconfinedTemplate>,
+        max_groups: NonZeroUsize,
         exclude: Option<Condition>,
         sample_rate_key: OptionalValuePath,
     ) -> Self {
@@ -182,6 +206,7 @@ impl Sample {
             name,
             static_mode,
             SampleKeySource::Dynamic { fields, group_by },
+            max_groups,
             exclude,
             sample_rate_key,
         )
@@ -191,14 +216,18 @@ impl Sample {
         name: String,
         static_mode: SampleMode,
         key_source: SampleKeySource,
+        max_groups: NonZeroUsize,
         exclude: Option<Condition>,
         sample_rate_key: OptionalValuePath,
     ) -> Self {
+        let next_group_static_state = static_mode.new_state();
         Self {
             name,
             static_mode,
             key_source,
-            dynamic_event_counters: HashMap::default(),
+            next_group_static_state,
+            next_group_dynamic_event_counter: 0,
+            group_states: LruCache::new(max_groups),
             exclude,
             sample_rate_key,
         }
@@ -219,15 +248,15 @@ impl Sample {
         hasher.finish()
     }
 
-    fn sample_with_dynamic_ratio(&mut self, ratio: f64, group_by_key: Option<String>) -> bool {
-        let counter_value = self
-            .dynamic_event_counters
-            .entry(group_by_key.clone())
-            .or_default();
-        let old_counter_value = *counter_value;
-        *counter_value += 1;
+    fn sample_with_dynamic_ratio(
+        ratio: f64,
+        group_by_key: Option<&str>,
+        counter: &mut u64,
+    ) -> bool {
+        let old_counter_value = *counter;
+        *counter += 1;
 
-        let hash = Self::dynamic_sample_hash(group_by_key.as_deref(), old_counter_value);
+        let hash = Self::dynamic_sample_hash(group_by_key, old_counter_value);
         let hash_ratio_threshold = (ratio * (u64::MAX as u128) as f64) as u64;
         hash <= hash_ratio_threshold
     }
@@ -279,14 +308,14 @@ impl Sample {
             .or_else(|| self.event_rate(event).map(EventSampleMode::Rate))
     }
 
-    fn sample_with_dynamic_rate(&mut self, rate: NonZeroU64, group_by_key: Option<String>) -> bool {
-        let counter_value = self
-            .dynamic_event_counters
-            .entry(group_by_key.clone())
-            .or_default();
-        let old_counter_value = *counter_value;
-        *counter_value += 1;
-        let hash = Self::dynamic_sample_hash(group_by_key.as_deref(), old_counter_value);
+    fn sample_with_dynamic_rate(
+        rate: NonZeroU64,
+        group_by_key: Option<&str>,
+        counter: &mut u64,
+    ) -> bool {
+        let old_counter_value = *counter;
+        *counter += 1;
+        let hash = Self::dynamic_sample_hash(group_by_key, old_counter_value);
 
         hash.is_multiple_of(rate.get())
     }
@@ -347,12 +376,28 @@ impl FunctionTransform for Sample {
             .map(EventSampleMode::sample_rate_label)
             .unwrap_or_else(|| self.static_mode.to_string());
 
+        let static_mode = &self.static_mode;
+        let next_group_static_state = &mut self.next_group_static_state;
+        let next_group_dynamic_event_counter = &mut self.next_group_dynamic_event_counter;
+        let group_state = self.group_states.get_or_insert_mut_ref(&group_by_key, || {
+            let static_state = next_group_static_state.clone();
+            static_mode.increment(next_group_static_state, None);
+            let dynamic_event_counter = *next_group_dynamic_event_counter;
+            *next_group_dynamic_event_counter += 1;
+            GroupState::new(static_state, dynamic_event_counter)
+        });
         let should_sample = match event_sample_mode {
-            Some(EventSampleMode::Ratio(ratio)) => {
-                self.sample_with_dynamic_ratio(ratio, group_by_key)
-            }
-            Some(EventSampleMode::Rate(rate)) => self.sample_with_dynamic_rate(rate, group_by_key),
-            None => self.static_mode.increment(group_by_key, value),
+            Some(EventSampleMode::Ratio(ratio)) => Self::sample_with_dynamic_ratio(
+                ratio,
+                group_by_key.as_deref(),
+                &mut group_state.dynamic_event_counter,
+            ),
+            Some(EventSampleMode::Rate(rate)) => Self::sample_with_dynamic_rate(
+                rate,
+                group_by_key.as_deref(),
+                &mut group_state.dynamic_event_counter,
+            ),
+            None => static_mode.increment(&mut group_state.static_state, value),
         };
 
         if should_sample {

--- a/website/cue/reference/components/transforms/generated/sample.cue
+++ b/website/cue/reference/components/transforms/generated/sample.cue
@@ -21,6 +21,7 @@ generated: components: transforms: sample: configuration: {
 			examples: ["{{ service }}", "{{ hostname }}-{{ service }}"]
 			syntax: "template"
 		}
+		warnings: ["Prefer grouping by fields with a small, stable set of values, such as `service` or `host`. When the template interpolates event content (for example `{{ message }}` or `{{ request_id }}`), every distinct rendered value creates a new group: exceeding `max_groups` then evicts the least recently used groups' sampling state, and the retained group values consume memory in proportion to their size."]
 	}
 	key_field: {
 		description: """

--- a/website/cue/reference/components/transforms/generated/sample.cue
+++ b/website/cue/reference/components/transforms/generated/sample.cue
@@ -41,6 +41,16 @@ generated: components: transforms: sample: configuration: {
 		required: false
 		type: string: examples: ["message"]
 	}
+	max_groups: {
+		description: """
+			The maximum number of distinct group values whose sampling state is retained.
+
+			When this limit is reached, the least recently used group's state is evicted. If
+			`group_by` is not configured, only one group is retained.
+			"""
+		required: false
+		type: uint: default: 5000
+	}
 	rate: {
 		description: """
 			The rate at which events are forwarded, expressed as `1/N`.

--- a/website/generated/example-configs/transforms/sample/advanced.yaml
+++ b/website/generated/example-configs/transforms/sample/advanced.yaml
@@ -5,6 +5,7 @@ transforms:
       - my-source-or-transform-id
     group_by: "{{ service }}"
     key_field: message
+    max_groups: 5000
     measure_cpu_usage: false
     ratio: 0.13
     sample_rate_key: sample_rate


### PR DESCRIPTION
## Summary

Bound the sample transform's per-group sampling state with a new `max_groups` option (default 5000) using LRU eviction, and seed recreated groups from successive global sampling phases so eviction cannot bypass the configured sampling rate.

## How the ratio sampler works (the "clock hand")

For each group, `RatioSampler` tracks a single `value` in [0, 1). Each event advances the hand by `ratio`; the event is kept only when the hand crosses 1.0. This retains *exactly* the configured fraction over time — deterministic, no randomness.

```rust
increment = value + ratio;     // advance the clock hand
value = if increment >= 1.0 {  // hand reached or passed the top...
    increment - 1.0            // ...wrap it around, and KEEP the event
} else {
    increment                  // otherwise just store the new position
};
return increment >= 1.0;        // keep the event only if the hand wrapped
```

The constructor seeds `value = 1.0 - ratio`, so a *fresh* sampler's first decision is always a keep — that's the "first event of a new group passes" behavior the old code relied on, and the exact lever the capacity-thrashing bypass pulled.

### Old behavior: every new group gets a fresh hand

On a map miss, `or_insert_with(|| RatioSampler::new(ratio))` restarts at `value = 0.5` (ratio 0.5), so each group's first event is always kept:

| Event | Cache | New sampler's `value` before decision | `increment = value + 0.5` | Keep? | `value` after |
|---|---|---|---|---|---|
| `a` (new group) | miss | 0.5 (fresh) | 1.0 | ✅ | 0.0 |
| `b` (new group) | miss | 0.5 (fresh) | 1.0 | ✅ | 0.0 |
| `a` | hit | 0.0 | 0.5 | ❌ | 0.5 |
| `b` | hit | 0.0 | 0.5 | ❌ | 0.5 |

Every group's first event passes regardless of the configured ratio — so under group churn (or LRU eviction), retention is 100%.

### New behavior: groups inherit from one shared admission hand

On a cache miss, the new group clones the *current* position of a single shared hand (`next_group_static_state`), and the shared hand advances one step. Admission decisions are therefore dispensed at the configured ratio:

| Event | Cache | Admission (miss only) | Shared hand after admission | Group's `value` before decision | `increment = value + 0.5` | Keep? | Group's `value` after |
|---|---|---|---|---|---|---|---|
| `a` (new group) | miss | clone 0.5; shared hand advances | 0.0 | 0.5 | 1.0 | ✅ | 0.0 |
| `b` (new group) | miss | clone 0.0; shared hand advances | 0.5 | 0.0 | 0.5 | ❌ | 0.5 |
| `a` | hit | — | 0.5 | 0.0 | 0.5 | ❌ | 0.5 |
| `b` | hit | — | 0.5 | 0.5 | 1.0 | ✅ | 0.0 |

Aggregate retention is unchanged (2 of 4 at ratio 0.5), but "first event of a group always passes" is gone: an attacker churning `max_groups + 1` keys now gets ~ratio retention instead of 100%. The dynamic (`rate_field`/`ratio_field`) path received the same fix via a shared admission counter, so evicted groups no longer all restart at counter 0, where the counter-0 hash decision is attacker-selectable.

### References

NA

## Vector configuration

```yaml
sources:
  input:
    type: stdin
    decoding:
      codec: json

transforms:
  sample:
    type: sample
    inputs: [input]
    rate: 2
    group_by: "{{ service }}"
    max_groups: 2

sinks:
  output:
    type: console
    inputs: [sample]
    encoding:
      codec: json
```

## How did you test this PR?

Focused sample transform tests (30 tests) and Clippy with `FEATURES=transforms-sample` pass. Smoke-tested live Vector with `max_groups: 2` and a rotating three-group stream, confirming LRU eviction and that sampling is not bypassed under capacity thrashing.

## Does this PR include user facing changes?

- [x] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [ ] No. A maintainer will apply the `no-changelog` label to this PR.