### PR TITLE
chore(rust): enforce redundant clone lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,6 +144,7 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tokio_unstable)', 'cfg(dds
 string_slice = "warn"
 await_holding_lock = "warn"
 let_underscore_must_use = "warn"
+redundant_clone = "warn"
 uninlined_format_args = "warn"
 borrow_as_ptr = "warn"
 checked_conversions = "warn"

--- a/benches/transform/dedupe.rs
+++ b/benches/transform/dedupe.rs
@@ -107,7 +107,7 @@ fn dedupe(c: &mut Criterion) {
         // event.
         Param {
             slug: "field_match_done",
-            input: fixed_stream.clone(),
+            input: fixed_stream,
             dedupe_config: DedupeConfig {
                 cache,
                 fields: Some(FieldMatchConfig::MatchFields(vec![

--- a/benches/transform/reduce.rs
+++ b/benches/transform/reduce.rs
@@ -36,7 +36,7 @@ fn reduce(c: &mut Criterion) {
     {
         let param = &Param {
             slug: "proof_of_concept",
-            input: fixed_stream.clone(),
+            input: fixed_stream,
             reduce_config: ReduceConfig {
                 expire_after_ms: Duration::from_secs(30),
                 end_every_period_ms: None,

--- a/benches/transform/route.rs
+++ b/benches/transform/route.rs
@@ -98,7 +98,7 @@ fn route(c: &mut Criterion) {
         // into named filters. A mixture of match and not match happens.
         Param {
             slug: "vrl_field_match_many",
-            input: event.clone(),
+            input: event,
             route_config: toml::from_str::<RouteConfig>(
                 r#"
             route.a.type = "vrl"
@@ -148,7 +148,7 @@ fn route(c: &mut Criterion) {
         "#,
             )
             .unwrap(),
-            output_buffer: output_buffer.clone(),
+            output_buffer,
         },
     ] {
         group.throughput(Throughput::Elements(param.input.len() as u64));

--- a/lib/codecs/src/decoding/format/json.rs
+++ b/lib/codecs/src/decoding/format/json.rs
@@ -192,7 +192,7 @@ mod tests {
         let deserializer = JsonDeserializer::default();
 
         let namespace = LogNamespace::Vector;
-        let events = deserializer.parse(input.clone(), namespace).unwrap();
+        let events = deserializer.parse(input, namespace).unwrap();
         let mut events = events.into_iter();
 
         let event = events.next().unwrap();

--- a/lib/codecs/src/encoding/format/arrow.rs
+++ b/lib/codecs/src/encoding/format/arrow.rs
@@ -389,7 +389,7 @@ mod tests {
         events: Vec<Event>,
         schema: SchemaRef,
     ) -> Result<RecordBatch, Box<dyn std::error::Error>> {
-        let bytes = encode_events_to_arrow_ipc_stream(&events, schema.clone())?;
+        let bytes = encode_events_to_arrow_ipc_stream(&events, schema)?;
         let cursor = Cursor::new(bytes);
         let mut reader = StreamReader::try_new(cursor, None)?;
         Ok(reader.next().unwrap()?)

--- a/lib/codecs/src/encoding/format/csv.rs
+++ b/lib/codecs/src/encoding/format/csv.rs
@@ -462,13 +462,13 @@ mod tests {
         .unwrap();
 
         CsvSerializerConfig::new(CsvSerializerOptions {
-            fields: fields.clone(),
+            fields,
             quote_style: QuoteStyle::NonNumeric,
             ..Default::default()
         })
         .build()
         .unwrap()
-        .encode(event.clone(), &mut non_numeric_bytes)
+        .encode(event, &mut non_numeric_bytes)
         .unwrap();
 
         assert_eq!(

--- a/lib/codecs/src/encoding/format/syslog.rs
+++ b/lib/codecs/src/encoding/format/syslog.rs
@@ -321,7 +321,7 @@ impl SyslogMessage {
     fn encode(&self, rfc: &SyslogRFC) -> String {
         let mut result = String::with_capacity(256);
 
-        result.push_str(&self.pri.encode().to_string());
+        result.push_str(&self.pri.encode());
 
         if *rfc == SyslogRFC::Rfc5424 {
             result.push_str(SYSLOG_V1);
@@ -821,7 +821,7 @@ mod tests {
         let mut log = create_simple_log();
         log.insert(event_path!("long_app_name"), long_string.clone());
         log.insert(event_path!("long_proc_id"), long_string.clone());
-        log.insert(event_path!("long_msg_id"), long_string.clone());
+        log.insert(event_path!("long_msg_id"), long_string);
 
         let config = toml::from_str::<SyslogSerializerConfig>(
             r#"

--- a/lib/codecs/tests/avro.rs
+++ b/lib/codecs/tests/avro.rs
@@ -38,7 +38,7 @@ fn roundtrip_avro(data_path: PathBuf, schema_path: PathBuf, reserialize: bool) {
     let deserializer = AvroDeserializerConfig::new(schema.clone(), false)
         .build()
         .unwrap();
-    let mut serializer = AvroSerializerConfig::new(schema.clone()).build().unwrap();
+    let mut serializer = AvroSerializerConfig::new(schema).build().unwrap();
 
     let (buf, event) = load_deserialize(&data_path, &deserializer);
 
@@ -57,7 +57,7 @@ fn roundtrip_avro(data_path: PathBuf, schema_path: PathBuf, reserialize: bool) {
     } else {
         // Ensure that the parsed event is serialized to the same bytes
         let mut new_buf = BytesMut::new();
-        serializer.encode(event.clone(), &mut new_buf).unwrap();
+        serializer.encode(event, &mut new_buf).unwrap();
         assert_eq!(buf, new_buf);
     }
 }

--- a/lib/vector-buffers/src/topology/channel/limited_queue.rs
+++ b/lib/vector-buffers/src/topology/channel/limited_queue.rs
@@ -191,7 +191,7 @@ impl Metrics {
             legacy_max_gauge.set(max_value);
             Self {
                 histogram: histogram!(histogram_name, "output" => label_value.clone()),
-                gauge: gauge!(level_name, "output" => label_value.clone()),
+                gauge: gauge!(level_name, "output" => label_value),
                 mean_gauge: TimeEwmaGauge::new(mean_gauge_handle, ewma_half_life_seconds),
                 max_gauge,
                 legacy_max_gauge,
@@ -639,7 +639,7 @@ mod tests {
 
         // Attempting to produce one more then the max capacity should block
         let mut send_final = spawn({
-            let msg_clone = msg.clone();
+            let msg_clone = msg;
             async { tx.send(msg_clone).await }
         });
         assert_pending!(send_final.poll());

--- a/lib/vector-core/src/event/lua/metric.rs
+++ b/lib/vector-core/src/event/lua/metric.rs
@@ -88,7 +88,7 @@ impl FromLua for TagValueSet {
                 }
                 Ok(Self::from(string_values))
             }
-            LuaValue::String(x) => Ok(Self::from([x.to_string_lossy().clone()])),
+            LuaValue::String(x) => Ok(Self::from([x.to_string_lossy()])),
             _ => Err(mlua::Error::FromLuaConversionError {
                 from: value.type_name(),
                 to: String::from("metric tag value"),

--- a/lib/vector-core/src/event/metadata.rs
+++ b/lib/vector-core/src/event/metadata.rs
@@ -602,7 +602,7 @@ mod test {
 
         {
             let mut merged = m2.clone();
-            merged.merge(m1.clone());
+            merged.merge(m1);
             assert_eq!(merged.source_event_id(), m2.source_event_id());
         }
     }

--- a/lib/vector-top/src/metrics.rs
+++ b/lib/vector-top/src/metrics.rs
@@ -91,7 +91,7 @@ fn component_to_row(component: &Component) -> state::ComponentRow {
     let metrics = component.metrics.as_ref();
 
     state::ComponentRow {
-        key: key.clone(),
+        key,
         kind: match component.component_type() {
             ComponentType::Unspecified => "unknown",
             ComponentType::Source => "source",

--- a/lib/vector-vrl/dnstap-parser/src/parser.rs
+++ b/lib/vector-vrl/dnstap-parser/src/parser.rs
@@ -106,7 +106,7 @@ impl DnstapParser {
                 event,
                 &root,
                 &DNSTAP_VALUE_PATHS.server_identity,
-                String::from_utf8(server_id.clone()).unwrap_or_default(),
+                String::from_utf8(server_id).unwrap_or_default(),
             );
         }
 
@@ -253,7 +253,7 @@ impl DnstapParser {
 
         DnstapParser::parse_dnstap_message_type(
             event,
-            prefix.clone(),
+            prefix,
             dnstap_message_type_id,
             dnstap_message,
             parsing_options,
@@ -518,7 +518,7 @@ impl DnstapParser {
         if let Some(response_port) = dnstap_message.response_port {
             DnstapParser::insert(
                 event,
-                prefix.clone(),
+                prefix,
                 &DNSTAP_VALUE_PATHS.response_port,
                 response_port,
             );
@@ -535,7 +535,7 @@ impl DnstapParser {
         DnstapParser::insert(event, prefix.clone(), &DNSTAP_VALUE_PATHS.time, time);
         DnstapParser::insert(
             event,
-            prefix.clone(),
+            prefix,
             &DNSTAP_VALUE_PATHS.time_precision,
             time_precision.to_string(),
         );
@@ -548,7 +548,7 @@ impl DnstapParser {
     ) {
         DnstapParser::insert(
             event,
-            prefix.clone(),
+            prefix,
             &DNSTAP_VALUE_PATHS.raw_data,
             BASE64_STANDARD.encode(raw_dns_message),
         );
@@ -661,7 +661,7 @@ impl DnstapParser {
         );
         DnstapParser::insert(
             event,
-            prefix.clone(),
+            prefix,
             &DNSTAP_VALUE_PATHS.ar_count,
             header.additional_count,
         );
@@ -705,7 +705,7 @@ impl DnstapParser {
         );
         DnstapParser::insert(
             event,
-            prefix.clone(),
+            prefix,
             &DNSTAP_VALUE_PATHS.class,
             question.class.clone(),
         );
@@ -813,7 +813,7 @@ impl DnstapParser {
 
         DnstapParser::insert(
             event,
-            prefix.clone(),
+            prefix,
             &DNSTAP_VALUE_PATHS.ad_count,
             header.additional_count,
         );
@@ -846,7 +846,7 @@ impl DnstapParser {
         );
         DnstapParser::insert(
             event,
-            prefix.clone(),
+            prefix,
             &DNSTAP_VALUE_PATHS.zone_class,
             zone.class.clone(),
         );
@@ -909,12 +909,7 @@ impl DnstapParser {
             DnstapParser::insert(event, prefix.clone(), &DNSTAP_VALUE_PATHS.purpose, purpose);
         }
         if let Some(extra_text) = entry.extra_text() {
-            DnstapParser::insert(
-                event,
-                prefix.clone(),
-                &DNSTAP_VALUE_PATHS.extra_text,
-                extra_text,
-            );
+            DnstapParser::insert(event, prefix, &DNSTAP_VALUE_PATHS.extra_text, extra_text);
         }
     }
 
@@ -944,7 +939,7 @@ impl DnstapParser {
         );
         DnstapParser::insert(
             event,
-            prefix.clone(),
+            prefix,
             &DNSTAP_VALUE_PATHS.opt_data,
             opt.opt_data.clone(),
         );
@@ -1000,7 +995,7 @@ impl DnstapParser {
         if let Some(rdata_bytes) = &record.rdata_bytes {
             DnstapParser::insert(
                 event,
-                prefix.clone(),
+                prefix,
                 &DNSTAP_VALUE_PATHS.rdata_bytes,
                 BASE64_STANDARD.encode(rdata_bytes),
             );

--- a/lib/vector-vrl/metrics/src/common.rs
+++ b/lib/vector-vrl/metrics/src/common.rs
@@ -226,7 +226,7 @@ mod tests {
         let state = TypeState::default();
 
         let mut config = CompileConfig::default();
-        config.set_custom(storage.clone());
+        config.set_custom(storage);
         config.set_read_only();
 
         compile_vrl(vrl_source, &functions, &state, config)

--- a/lib/vector-vrl/web-playground/build.rs
+++ b/lib/vector-vrl/web-playground/build.rs
@@ -20,7 +20,6 @@ fn get_vector_lock_path() -> PathBuf {
     parent_path
         .expect("Failed to find vector repo root")
         .join("Cargo.lock")
-        .to_path_buf()
 }
 
 fn get_git_hash() -> String {

--- a/src/api/grpc/service.rs
+++ b/src/api/grpc/service.rs
@@ -412,7 +412,7 @@ impl observability::Service for ObservabilityService {
         &self,
         _request: Request<GetMetaRequest>,
     ) -> Result<Response<GetMetaResponse>, Status> {
-        let version = crate::get_version().to_string();
+        let version = crate::get_version();
         let hostname = hostname::get()
             .ok()
             .and_then(|h| h.into_string().ok())

--- a/src/components/validation/resources/mod.rs
+++ b/src/components/validation/resources/mod.rs
@@ -259,7 +259,7 @@ fn encoder_framing_to_decoding_framer(framing: encoding::FramingConfig) -> decod
         }
         encoding::FramingConfig::LengthDelimited(config) => {
             decoding::FramingConfig::LengthDelimited(decoding::LengthDelimitedDecoderConfig {
-                length_delimited: config.length_delimited.clone(),
+                length_delimited: config.length_delimited,
             })
         }
         encoding::FramingConfig::NewlineDelimited => {

--- a/src/config/unit_test/mod.rs
+++ b/src/config/unit_test/mod.rs
@@ -651,7 +651,7 @@ fn build_input_event(input: &TestInput) -> Result<Event, String> {
         "vrl" => {
             if let Some(source) = &input.source {
                 let result = vrl::compiler::compile(source, &vector_vrl_functions::all())
-                    .map_err(|e| Formatter::new(source, e.clone()).to_string())?;
+                    .map_err(|e| Formatter::new(source, e).to_string())?;
 
                 let mut target = TargetValue {
                     value: value!({}),

--- a/src/config/watcher.rs
+++ b/src/config/watcher.rs
@@ -79,7 +79,7 @@ pub fn spawn_thread<'a>(
     let mut component_config_paths: Vec<_> = component_configs
         .clone()
         .into_iter()
-        .flat_map(|p| p.config_paths.clone())
+        .flat_map(|p| p.config_paths)
         .collect();
 
     config_paths.append(&mut component_config_paths);

--- a/src/convert_config.rs
+++ b/src/convert_config.rs
@@ -133,8 +133,7 @@ fn convert_config(
     let file_contents = fs::read_to_string(input_path).map_err(|e| vec![e.to_string()])?;
     let builder: ConfigBuilder = format::deserialize(&file_contents, input_format)?;
     let config = builder.build()?;
-    let output_string =
-        format::serialize(&config, output_format).map_err(|e| vec![e.to_string()])?;
+    let output_string = format::serialize(&config, output_format).map_err(|e| vec![e])?;
     fs::write(output_path, output_string).map_err(|e| vec![e.to_string()])?;
 
     #[allow(clippy::print_stdout)]

--- a/src/enrichment_tables/memory/cuckoo_table.rs
+++ b/src/enrichment_tables/memory/cuckoo_table.rs
@@ -316,7 +316,7 @@ impl CuckooMemoryTable {
                     .into());
             }
             let built_config = Self::build_config(&config, &cuckoo_config)?;
-            let built_ttl = built_config.ttl_config().clone();
+            let built_ttl = built_config.ttl_config();
             if built_config.compatible_layout(&prev_memory.filter.get_configuration())
                 && let Ok(mut old_filter) =
                     prev_memory.filter.exporter().snapshot().map(VecDeque::from)

--- a/src/internal_events/websocket_server.rs
+++ b/src/internal_events/websocket_server.rs
@@ -39,7 +39,7 @@ impl InternalEvent for WebSocketListenerConnectionFailedError {
             error_type = error_type::CONNECTION_FAILED,
             stage = error_stage::SENDING,
         );
-        let mut all_tags = self.extra_tags.clone();
+        let mut all_tags = self.extra_tags;
         all_tags.extend([
             ("error_code".to_string(), "ws_connection_failed".to_string()),
             (

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -231,7 +231,7 @@ pub mod built_info {
 /// The hostname can be overridden by setting the VECTOR_HOSTNAME environment variable.
 pub fn get_hostname() -> std::io::Result<String> {
     Ok(if let Ok(hostname) = std::env::var("VECTOR_HOSTNAME") {
-        hostname.to_string()
+        hostname
     } else {
         hostname::get()?.to_string_lossy().into_owned()
     })

--- a/src/sinks/aws_cloudwatch_logs/config.rs
+++ b/src/sinks/aws_cloudwatch_logs/config.rs
@@ -72,7 +72,7 @@ where
     if ALLOWED_VALUES.contains(&days) {
         Ok(days)
     } else {
-        let msg = format!("one of allowed values: {ALLOWED_VALUES:?}").to_owned();
+        let msg = format!("one of allowed values: {ALLOWED_VALUES:?}");
         let expected: &str = msg.as_str();
         Err(de::Error::invalid_value(
             de::Unexpected::Signed(days.into()),

--- a/src/sinks/aws_cloudwatch_logs/service.rs
+++ b/src/sinks/aws_cloudwatch_logs/service.rs
@@ -225,7 +225,7 @@ impl CloudwatchLogsSvc {
         let retention = config.retention.clone();
 
         let kms_key = config.kms_key.clone();
-        let tags = config.tags.clone();
+        let tags = config.tags;
 
         CloudwatchLogsSvc {
             headers,

--- a/src/sinks/aws_s_s/config.rs
+++ b/src/sinks/aws_s_s/config.rs
@@ -82,7 +82,6 @@ pub(super) fn message_deduplication_id(
     message_deduplication_id: Option<String>,
 ) -> crate::Result<Option<UnconfinedTemplate>> {
     Ok(message_deduplication_id
-        .clone()
         .map(UnconfinedTemplate::try_from)
         .transpose()?)
 }

--- a/src/sinks/aws_s_s/sns/config.rs
+++ b/src/sinks/aws_s_s/sns/config.rs
@@ -116,7 +116,7 @@ impl ValidatedSink for SnsSinkConfig {
     ) -> crate::Result<(crate::sinks::VectorSink, crate::sinks::Healthcheck)> {
         let client = self.create_client(&cx.proxy).await?;
         let publisher = SnsMessagePublisher::new(client.clone(), self.topic_arn.clone());
-        let healthcheck = Box::pin(healthcheck(client.clone(), self.topic_arn.clone()));
+        let healthcheck = Box::pin(healthcheck(client, self.topic_arn.clone()));
 
         let request_builder = SSRequestBuilder::new(
             validated.message_group_id.clone(),

--- a/src/sinks/aws_s_s/sqs/config.rs
+++ b/src/sinks/aws_s_s/sqs/config.rs
@@ -116,7 +116,7 @@ impl ValidatedSink for SqsSinkConfig {
     ) -> crate::Result<(crate::sinks::VectorSink, crate::sinks::Healthcheck)> {
         let client = self.create_client(&cx.proxy).await?;
         let publisher = SqsMessagePublisher::new(client.clone(), self.queue_url.clone());
-        let healthcheck = Box::pin(healthcheck(client.clone(), self.queue_url.clone()));
+        let healthcheck = Box::pin(healthcheck(client, self.queue_url.clone()));
 
         let request_builder = SSRequestBuilder::new(
             validated.message_group_id.clone(),

--- a/src/sinks/azure_common/config.rs
+++ b/src/sinks/azure_common/config.rs
@@ -417,8 +417,7 @@ impl TokenCredential for MockTokenCredential {
             BASE64_STANDARD
                 .encode(serde_json::to_string(&jwt).unwrap())
                 .trim_end_matches("=")
-        )
-        .to_string();
+        );
 
         warn!(
             "Using mock token credential, JWT: {}, base64: {jwt_base64}",

--- a/src/sinks/console/config.rs
+++ b/src/sinks/console/config.rs
@@ -104,12 +104,12 @@ impl ValidatedSink for ConsoleSinkConfig {
         let sink: VectorSink = match self.target {
             Target::Stdout => VectorSink::from_event_streamsink(WriterSink {
                 output: io::stdout(),
-                transformer: transformer.clone(),
+                transformer,
                 encoder,
             }),
             Target::Stderr => VectorSink::from_event_streamsink(WriterSink {
                 output: io::stderr(),
-                transformer: transformer.clone(),
+                transformer,
                 encoder,
             }),
         };

--- a/src/sinks/doris/integration_test.rs
+++ b/src/sinks/doris/integration_test.rs
@@ -138,8 +138,8 @@ async fn insert_events() {
         headers: default_headers(),
         batch,
         auth: Some(crate::http::Auth::Basic {
-            user: config_auth().user.clone(),
-            password: SensitiveString::from(config_auth().password.clone()),
+            user: config_auth().user,
+            password: SensitiveString::from(config_auth().password),
         }),
         request: Default::default(),
         ..Default::default()

--- a/src/sinks/http/config.rs
+++ b/src/sinks/http/config.rs
@@ -500,7 +500,7 @@ impl HttpSinkConfig {
                     AwsAuthentication::Role { region, .. } => region.clone(),
                     AwsAuthentication::Default { region, .. } => region.clone(),
                 })
-                .map_or(default_region, |r| Some(Region::new(r.to_string())))
+                .map_or(default_region, |r| Some(Region::new(r)))
                 .expect("Region must be specified");
 
                 HttpService::new_with_sig_v4(

--- a/src/sinks/kafka/config.rs
+++ b/src/sinks/kafka/config.rs
@@ -358,7 +358,7 @@ impl ValidatedSink for KafkaSinkConfig {
     ) -> crate::Result<(VectorSink, Healthcheck)> {
         let ValidatedKafkaSink { topic } = validated;
         let sink = KafkaSink::new(self.clone(), topic.clone())?;
-        let hc = healthcheck(self.clone(), topic.clone(), cx.healthcheck.clone()).boxed();
+        let hc = healthcheck(self.clone(), topic.clone(), cx.healthcheck).boxed();
         Ok((VectorSink::from_event_streamsink(sink), hc))
     }
 }

--- a/src/sinks/postgres/config.rs
+++ b/src/sinks/postgres/config.rs
@@ -198,7 +198,7 @@ impl ValidatedSink for PostgresConfig {
         let healthcheck = healthcheck(connection_pool.clone()).boxed();
 
         // The endpoint label must not carry credentials or query parameters.
-        let endpoint = protocol_endpoint(endpoint_uri.uri.clone()).1;
+        let endpoint = protocol_endpoint(endpoint_uri.uri).1;
         let service = PostgresService::new(connection_pool, self.table.clone(), endpoint);
         let service = ServiceBuilder::new()
             .settings(request_settings, PostgresRetryLogic)

--- a/src/sinks/prometheus/exporter.rs
+++ b/src/sinks/prometheus/exporter.rs
@@ -457,7 +457,7 @@ impl PrometheusExporter {
             });
 
             let service = ServiceBuilder::new()
-                .layer(build_http_trace_layer(span.clone()))
+                .layer(build_http_trace_layer(span))
                 .layer(CompressionLayer::new())
                 .service(inner);
 

--- a/src/sinks/splunk_hec/logs/tests.rs
+++ b/src/sinks/splunk_hec/logs/tests.rs
@@ -340,7 +340,7 @@ fn splunk_encode_log_event_json_timestamps() {
     // timestamp_key is provided and timestamp is valid, but auto_extract_timestamp is set
     hec_data = get_hec_data_for_timestamp_test(
         Some(Value::Timestamp(Utc::now())),
-        timestamp_key.clone(),
+        timestamp_key,
         do_auto_extract,
     );
     assert_eq!(hec_data.time, None);

--- a/src/sinks/util/encoding.rs
+++ b/src/sinks/util/encoding.rs
@@ -523,7 +523,7 @@ mod tests {
     #[test]
     fn test_encode_batch_protobuf_multiple() {
         let message_raw = std::fs::read(test_data_dir().join("test_proto.pb")).unwrap();
-        let messages = vec![message_raw.clone(), message_raw.clone()];
+        let messages = vec![message_raw.clone(), message_raw];
         let total_input_proto_size: usize = messages.iter().map(|m| m.len()).sum();
 
         let mut buf = BytesMut::with_capacity(128);

--- a/src/sources/datadog_agent/mod.rs
+++ b/src/sources/datadog_agent/mod.rs
@@ -520,7 +520,7 @@ impl DatadogAgentSource {
         }
 
         if !config.disable_llmobs {
-            let llmobs_filter = llmobs::build_warp_filter(handler.clone(), self.clone());
+            let llmobs_filter = llmobs::build_warp_filter(handler, self.clone());
             filters = filters
                 .map(|f| f.or(llmobs_filter.clone()).unify().boxed())
                 .or(Some(llmobs_filter));

--- a/src/sources/kafka.rs
+++ b/src/sources/kafka.rs
@@ -408,7 +408,7 @@ impl SourceConfig for KafkaSourceConfig {
             )
             .with_source_metadata(
                 Self::NAME,
-                keys.key_field.clone().map(LegacyKey::Overwrite),
+                keys.key_field.map(LegacyKey::Overwrite),
                 &owned_value_path!("message_key"),
                 Kind::bytes(),
                 None,

--- a/src/sources/mqtt/config.rs
+++ b/src/sources/mqtt/config.rs
@@ -80,7 +80,7 @@ impl SourceConfig for MqttSourceConfig {
             DecodingConfig::new(self.framing.clone(), self.decoding.clone(), log_namespace)
                 .build()?;
 
-        let sink = MqttSource::new(connector.clone(), decoder, log_namespace, self.clone())?;
+        let sink = MqttSource::new(connector, decoder, log_namespace, self.clone())?;
         Ok(Box::pin(sink.run(cx.out, cx.shutdown)))
     }
 

--- a/src/sources/opentelemetry/http.rs
+++ b/src/sources/opentelemetry/http.rs
@@ -122,10 +122,10 @@ pub(crate) fn build_warp_filter(
     );
     let trace_filters = build_warp_trace_filter(
         acknowledgements,
-        out.clone(),
+        out,
         bytes_received,
         events_received,
-        headers.clone(),
+        headers,
         traces_deserializer,
     );
     log_filters

--- a/src/sources/splunk_hec/mod.rs
+++ b/src/sources/splunk_hec/mod.rs
@@ -1812,7 +1812,7 @@ fn raw_event(
             Utc::now(),
         );
 
-        if let Some(batch) = batch.clone() {
+        if let Some(batch) = batch {
             log = log.with_batch_notifier(&batch);
         }
         (vec![Event::from(log)], false)

--- a/src/sources/static_metrics.rs
+++ b/src/sources/static_metrics.rs
@@ -164,7 +164,7 @@ impl StaticMetrics {
                                 interval_ms: NonZeroU32::new(self.interval.as_millis() as u32),
                             },
                             kind,
-                            value: value.clone(),
+                            value,
                         },
                         EventMetadata::default(),
                     )

--- a/src/sources/util/framestream.rs
+++ b/src/sources/util/framestream.rs
@@ -410,8 +410,6 @@ pub fn build_framestream_tcp_source(
 ) -> crate::Result<Source> {
     let addr = frame_handler.address();
     let tls = frame_handler.tls();
-    let shutdown = shutdown;
-    let out = out;
 
     Ok(Box::pin(async move {
         let listenfd = ListenFd::from_env();

--- a/src/sources/util/framestream.rs
+++ b/src/sources/util/framestream.rs
@@ -410,8 +410,8 @@ pub fn build_framestream_tcp_source(
 ) -> crate::Result<Source> {
     let addr = frame_handler.address();
     let tls = frame_handler.tls();
-    let shutdown = shutdown.clone();
-    let out = out.clone();
+    let shutdown = shutdown;
+    let out = out;
 
     Ok(Box::pin(async move {
         let listenfd = ListenFd::from_env();
@@ -835,7 +835,7 @@ fn build_framestream_source<T: Send + 'static>(
     error_mapper: impl FnMut(std::io::Error) + Send + 'static,
 ) {
     let content_type = frame_handler.content_type();
-    let mut event_sink = out.clone();
+    let mut event_sink = out;
     let (sock_sink, sock_stream) = Framed::new(
         socket,
         length_delimited::Builder::new()

--- a/src/tap/cmd.rs
+++ b/src/tap/cmd.rs
@@ -52,7 +52,7 @@ async fn tap_internal(
     let tap_runner = TapRunner::new(
         &url,
         opts.inputs_of.clone(),
-        opts.outputs_patterns().clone(),
+        opts.outputs_patterns(),
         &output_channel,
     );
 

--- a/src/topology/running.rs
+++ b/src/topology/running.rs
@@ -111,7 +111,7 @@ impl RunningTopology {
     /// initializes the pending reload set.
     pub fn extend_reload_set(&mut self, new_set: HashSet<ComponentKey>) {
         match &mut self.pending_reload {
-            None => self.pending_reload = Some(new_set.clone()),
+            None => self.pending_reload = Some(new_set),
             Some(existing) => existing.extend(new_set),
         }
     }

--- a/src/transforms/aggregate/tests.rs
+++ b/src/transforms/aggregate/tests.rs
@@ -436,7 +436,7 @@ fn count_agg() {
 
     // Two absolutes with the same series, counter should be 2
     agg.record(gauge_a_1.clone());
-    agg.record(gauge_a_2.clone());
+    agg.record(gauge_a_2);
     out.clear();
     agg.flush_into(&mut out);
     assert_eq!(1, out.len());
@@ -495,7 +495,7 @@ fn absolute_max() {
 
     // Two absolutes, result should be higher of the 2
     agg.record(gauge_a_1.clone());
-    agg.record(gauge_a_2.clone());
+    agg.record(gauge_a_2);
     out.clear();
     agg.flush_into(&mut out);
     assert_eq!(1, out.len());
@@ -537,7 +537,7 @@ fn absolute_min() {
 
     // Two absolutes, result should be lower of the 2
     agg.record(gauge_a_1.clone());
-    agg.record(gauge_a_2.clone());
+    agg.record(gauge_a_2);
     out.clear();
     agg.flush_into(&mut out);
     assert_eq!(1, out.len());
@@ -589,7 +589,7 @@ fn absolute_diff() {
     assert_eq!(1, out.len());
     assert_eq!(&gauge_a_1, &out[0]);
 
-    agg.record(gauge_a_2.clone());
+    agg.record(gauge_a_2);
     out.clear();
     agg.flush_into(&mut out);
     assert_eq!(1, out.len());
@@ -671,9 +671,9 @@ fn absolute_mean() {
     assert_eq!(0, out.len());
 
     // Three absolutes, result should be mean
-    agg.record(gauge_a_1.clone());
-    agg.record(gauge_a_2.clone());
-    agg.record(gauge_a_3.clone());
+    agg.record(gauge_a_1);
+    agg.record(gauge_a_2);
+    agg.record(gauge_a_3);
     out.clear();
     agg.flush_into(&mut out);
     assert_eq!(1, out.len());

--- a/src/transforms/log_to_metric.rs
+++ b/src/transforms/log_to_metric.rs
@@ -495,9 +495,7 @@ fn bytes_to_str(value: &Value) -> Option<String> {
 fn try_get_string_from_log(log: &LogEvent, path: &str) -> Result<Option<String>, TransformError> {
     // TODO: update returned errors after `TransformError` is refactored.
     let maybe_value = log.parse_path_and_get_value(path).map_err(|e| match e {
-        PathParseError::InvalidPathSyntax { path } => PathNotFound {
-            path: path.to_string(),
-        },
+        PathParseError::InvalidPathSyntax { path } => PathNotFound { path },
     })?;
     match maybe_value {
         None => Err(PathNotFound {

--- a/src/transforms/route.rs
+++ b/src/transforms/route.rs
@@ -397,7 +397,7 @@ mod test {
             1,
         );
 
-        transform.transform(event.clone(), &mut outputs);
+        transform.transform(event, &mut outputs);
         for output_name in output_names {
             let events: Vec<_> = outputs.drain_named(output_name).collect();
             assert_eq!(events.len(), 0);

--- a/src/transforms/sample/transform.rs
+++ b/src/transforms/sample/transform.rs
@@ -364,7 +364,7 @@ impl FunctionTransform for Sample {
                             event,
                             Some(LegacyKey::Overwrite(path)),
                             path,
-                            sample_rate.clone(),
+                            sample_rate,
                         );
                     }
                     Event::Trace(ref mut event) => {

--- a/tests/integration/shutdown.rs
+++ b/tests/integration/shutdown.rs
@@ -254,7 +254,7 @@ fn log_schema_multiple_config_files() {
         .arg("--dangerously-allow-env-var-interpolation")
         .env("VECTOR_CONFIG_DIR", config_dir)
         .env("VECTOR_DATA_DIR", create_directory())
-        .env("VECTOR_TEST_INPUT_FILE", input_file.clone());
+        .env("VECTOR_TEST_INPUT_FILE", input_file);
 
     // Run vector
     let vector = cmd.stdout(std::process::Stdio::piped()).spawn().unwrap();

--- a/vdev/src/commands/build/component_docs/runner.rs
+++ b/vdev/src/commands/build/component_docs/runner.rs
@@ -844,9 +844,9 @@ mod tests {
             names_by_value,
         };
         let mut generated = json!({
-            "first": {"type": shared.clone()},
+            "first": {"type": shared},
             "second": {"type": shared},
-            "only": {"type": unique.clone()},
+            "only": {"type": unique},
         });
 
         definitions.count_references(&generated);
@@ -898,7 +898,7 @@ mod tests {
             )]),
         };
         let mut generated = json!({
-            "first": {"type": shared.clone()},
+            "first": {"type": shared},
             "second": {"type": shared},
         });
 
@@ -928,7 +928,7 @@ mod tests {
         let outer = json!({
             "object": {
                 "options": {
-                    "inner": {"required": true, "type": inner.clone()},
+                    "inner": {"required": true, "type": inner},
                 },
             },
         });

--- a/vdev/src/commands/build/component_docs/schema_core.rs
+++ b/vdev/src/commands/build/component_docs/schema_core.rs
@@ -71,15 +71,14 @@ impl SchemaContext {
                 debug!("Expanding top-level schema ref of '{r}'...");
                 let unexpanded = self.get_schema_by_name(&r)?;
                 let expanded = self.expand_schema_references(&unexpanded)?;
-                self.expanded_schema_cache
-                    .insert(r.clone(), expanded.clone());
+                self.expanded_schema_cache.insert(r, expanded.clone());
                 expanded
             };
 
             let obj = schema.as_object_mut().unwrap();
             obj.shift_remove("$ref");
 
-            let mut new_schema = expanded_ref.clone();
+            let mut new_schema = expanded_ref;
             nested_merge(&mut new_schema, &Value::Object(obj.clone()));
             schema = new_schema;
         }

--- a/vdev/src/commands/check/events.rs
+++ b/vdev/src/commands/check/events.rs
@@ -767,12 +767,12 @@ impl<'ast> Visit<'ast> for Scanner<'_> {
             match name.as_str() {
                 "trace" | "debug" | "info" | "warn" | "error" => {
                     let parsed = parse_log_args(&node.tokens.to_string());
-                    let event = self.events.entry(ctx.event_name.clone()).or_default();
+                    let event = self.events.entry(ctx.event_name).or_default();
                     event.add_log(&name, &parsed.message, parsed.parameters);
                 }
                 "counter" | "gauge" | "histogram" => {
                     if let Some(metric) = parse_metric_args(&name, &node.tokens) {
-                        let event = self.events.entry(ctx.event_name.clone()).or_default();
+                        let event = self.events.entry(ctx.event_name).or_default();
                         event.add_metric(&metric.ty, &metric.name, metric.tags);
                     }
                 }
@@ -1136,7 +1136,7 @@ fn scan_file(path: &PathBuf, events: &mut HashMap<String, Event>) -> Result<usiz
 
     let mut scanner = Scanner {
         events,
-        path_str: path_str.clone(),
+        path_str,
         in_internal_events_dir: in_internal_events,
         skip_dropped_for_file: skip_dropped,
         text: &text,

--- a/vdev/src/testing/config.rs
+++ b/vdev/src/testing/config.rs
@@ -228,7 +228,7 @@ impl ComposeTestConfig {
         let config_dir = if use_config_subdir {
             test_dir.join(CONFIG_SUBDIR)
         } else {
-            test_dir.clone()
+            test_dir
         };
         let config = Self::parse_file(&config_dir.join(FILE_NAME))?;
         Ok((config_dir, config))


### PR DESCRIPTION
## Summary

### Motivation

Redundant clones add unnecessary work and can obscure ownership.

### Changes

- Enable `clippy::redundant_clone` for the workspace.
- Remove the existing redundant clones.

### References

N/A

## Vector configuration

N/A

## How did you test this PR?

- `make check-clippy`
- `cargo fmt --all -- --check`

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.
