### PR TITLE
chore(rust): remove unused async functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,6 +144,7 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tokio_unstable)', 'cfg(dds
 string_slice = "warn"
 await_holding_lock = "warn"
 let_underscore_must_use = "warn"
+unused_async = "warn"
 uninlined_format_args = "warn"
 borrow_as_ptr = "warn"
 checked_conversions = "warn"

--- a/benches/lua.rs
+++ b/benches/lua.rs
@@ -151,7 +151,7 @@ fn bench_field_filter(c: &mut Criterion) {
                     futures::executor::block_on(tx.send_all(&mut stream::iter(events).map(Ok)))
                         .unwrap();
 
-                    let output = futures::executor::block_on(collect_ready(&mut rx));
+                    let output = collect_ready(&mut rx);
 
                     let num = output.len();
 

--- a/lib/vector-top/src/state.rs
+++ b/lib/vector-top/src/state.rs
@@ -424,11 +424,7 @@ impl ComponentRow {
 /// represents the single destination for handling subscriptions and returning 'immutable' state
 /// for re-rendering the dashboard. This approach uses channels vs. mutexes.
 /// UI and other events are handled separately, to ensure one doesn't block the other.
-pub async fn updater(
-    mut event_rx: EventRx,
-    mut ui_event_rx: UiEventRx,
-    mut state: State,
-) -> StateRx {
+pub fn updater(mut event_rx: EventRx, mut ui_event_rx: UiEventRx, mut state: State) -> StateRx {
     let (tx, rx) = watch::channel(state.clone());
 
     tokio::spawn(async move {

--- a/src/aws/auth.rs
+++ b/src/aws/auth.rs
@@ -213,7 +213,7 @@ fn default_profile() -> String {
 
 impl AwsAuthentication {
     /// Creates the identity cache to store credentials based on the authentication mechanism chosen.
-    pub(super) async fn credentials_cache(&self) -> crate::Result<SharedIdentityCache> {
+    pub(super) fn credentials_cache(&self) -> crate::Result<SharedIdentityCache> {
         match self {
             AwsAuthentication::Role {
                 load_timeout_secs, ..

--- a/src/aws/mod.rs
+++ b/src/aws/mod.rs
@@ -223,7 +223,7 @@ where
     let mut config_builder = SdkConfig::builder()
         .http_client(connector)
         .sleep_impl(Arc::new(TokioSleep::new()))
-        .identity_cache(auth.credentials_cache().await?)
+        .identity_cache(auth.credentials_cache()?)
         .credentials_provider(
             auth.credentials_provider(region.clone(), proxy, tls_options)
                 .await?,

--- a/src/common/mqtt.rs
+++ b/src/common/mqtt.rs
@@ -121,7 +121,7 @@ impl MqttConnector {
     }
 
     /// TODO: Right now there is no way to implement the healthcheck properly: <https://github.com/bytebeamio/rumqtt/issues/562>
-    pub async fn healthcheck(&self) -> crate::Result<()> {
+    pub fn healthcheck(&self) -> crate::Result<()> {
         Ok(())
     }
 }

--- a/src/sinks/amqp/config.rs
+++ b/src/sinks/amqp/config.rs
@@ -194,7 +194,7 @@ impl ValidatedSink for AmqpSinkConfig {
             exchange,
             routing_key,
         } = validated.clone();
-        let sink = AmqpSink::new(self.clone(), exchange, routing_key).await?;
+        let sink = AmqpSink::new(self.clone(), exchange, routing_key)?;
         let hc = healthcheck(sink.channels.clone()).boxed();
         Ok((VectorSink::from_event_streamsink(sink), hc))
     }

--- a/src/sinks/amqp/sink.rs
+++ b/src/sinks/amqp/sink.rs
@@ -36,7 +36,7 @@ pub(super) struct AmqpSink {
 }
 
 impl AmqpSink {
-    pub(super) async fn new(
+    pub(super) fn new(
         config: AmqpSinkConfig,
         exchange: ConfinedTemplate,
         routing_key: Option<ConfinedTemplate>,

--- a/src/sinks/azure_blob/config.rs
+++ b/src/sinks/azure_blob/config.rs
@@ -521,8 +521,7 @@ impl ValidatedSink for AzureBlobSinkConfig {
             validated.container_url.clone(),
             cx.proxy(),
             self.tls.clone(),
-        )
-        .await?;
+        )?;
 
         let healthcheck = build_healthcheck(self.container_name.clone(), Arc::clone(&client))?;
         let sink = self.build_processor(client, validated)?;
@@ -1067,7 +1066,7 @@ fn validate_auth_conflict(
     }
 }
 
-pub async fn build_client(
+pub fn build_client(
     auth: Option<AzureAuthentication>,
     parsed: ParsedConnectionString,
     url: Url,
@@ -1117,7 +1116,7 @@ pub async fn build_client(
         (Auth::None, Some(AzureAuthentication::Specific(..))) => {
             info!("Using Azure Authentication method.");
             let credential_result: Arc<dyn TokenCredential> =
-                auth.unwrap().credential().await.map_err(|e| {
+                auth.unwrap().credential().map_err(|e| {
                     Error::with_message(
                         ErrorKind::Credential,
                         format!("Failed to configure Azure Authentication: {e}"),
@@ -1134,7 +1133,7 @@ pub async fn build_client(
         #[cfg(test)]
         (Auth::None, Some(AzureAuthentication::MockCredential)) => {
             warn!("Using mock token credential authentication.");
-            credential = Some(auth.unwrap().credential().await.unwrap());
+            credential = Some(auth.unwrap().credential().unwrap());
         }
         #[cfg(test)]
         (_, Some(AzureAuthentication::MockCredential)) => {

--- a/src/sinks/azure_blob/integration_tests.rs
+++ b/src/sinks/azure_blob/integration_tests.rs
@@ -36,7 +36,7 @@ use crate::{
 #[tokio::test]
 async fn azure_blob_uploads_one_shot_with_shared_key() {
     let config = AzureBlobSinkConfig::new_emulator().await;
-    let client = config.build_test_client().await;
+    let client = config.build_test_client();
     let blob_name = format!("one-shot/{}.blob", random_string(10));
     let payload = vec![b'x'; 3 * 1024 * 1024];
 
@@ -50,7 +50,7 @@ async fn azure_blob_uploads_one_shot_with_shared_key() {
 #[tokio::test]
 async fn azure_blob_uploads_multipart_with_shared_key() {
     let config = AzureBlobSinkConfig::new_emulator().await;
-    let client = config.build_test_client().await;
+    let client = config.build_test_client();
     let blob_name = format!("multipart/{}.blob", random_string(10));
     let payload = vec![b'x'; 5 * 1024 * 1024];
 
@@ -64,7 +64,7 @@ async fn azure_blob_uploads_multipart_with_shared_key() {
 #[tokio::test]
 async fn azure_blob_healthcheck_passed() {
     let config = AzureBlobSinkConfig::new_emulator().await;
-    let client = config.build_test_client().await;
+    let client = config.build_test_client();
 
     azure_blob::config::build_healthcheck(config.container_name, client)
         .expect("Failed to build healthcheck")
@@ -75,7 +75,7 @@ async fn azure_blob_healthcheck_passed() {
 #[tokio::test]
 async fn azure_blob_healthcheck_passed_with_oauth() {
     let config = AzureBlobSinkConfig::new_emulator_with_oauth().await;
-    let client = config.build_test_client().await;
+    let client = config.build_test_client();
 
     azure_blob::config::build_healthcheck(config.container_name, client)
         .expect("Failed to build healthcheck")
@@ -90,7 +90,7 @@ async fn azure_blob_healthcheck_unknown_container() {
         container_name: String::from("other-container-name"),
         ..config
     };
-    let client = config.build_test_client().await;
+    let client = config.build_test_client();
 
     assert_eq!(
         azure_blob::config::build_healthcheck(config.container_name, client)
@@ -677,7 +677,7 @@ impl AzureBlobSinkConfig {
         config
     }
 
-    async fn build_test_client(&self) -> Arc<BlobContainerClient> {
+    fn build_test_client(&self) -> Arc<BlobContainerClient> {
         let connection_string = self
             .connection_string
             .clone()
@@ -699,12 +699,11 @@ impl AzureBlobSinkConfig {
             &crate::config::ProxyConfig::default(),
             self.tls.clone(),
         )
-        .await
         .expect("Failed to create client")
     }
 
-    async fn to_sink(&self) -> VectorSink {
-        let client = self.build_test_client().await;
+    fn to_sink(&self) -> VectorSink {
+        let client = self.build_test_client();
         let validated = self.validate().expect("Failed to validate config");
         self.build_processor(client, &validated)
             .expect("Failed to create sink")
@@ -712,16 +711,13 @@ impl AzureBlobSinkConfig {
 
     async fn run_assert(&self, input: impl Stream<Item = EventArray> + Send) {
         // `to_sink` needs to be inside the assertion check
-        assert_sink_compliance(
-            &SINK_TAGS,
-            async move { self.to_sink().await.run(input).await },
-        )
-        .await
-        .expect("Running sink failed");
+        assert_sink_compliance(&SINK_TAGS, async move { self.to_sink().run(input).await })
+            .await
+            .expect("Running sink failed");
     }
 
     pub async fn list_blobs(&self, prefix: String) -> Vec<String> {
-        let client = self.build_test_client().await;
+        let client = self.build_test_client();
 
         // Iterate pager results and collect blob names. Filter by prefix server-side.
         let mut pager = client
@@ -741,7 +737,7 @@ impl AzureBlobSinkConfig {
     }
 
     pub async fn get_blob(&self, blob: String) -> (Option<String>, Option<String>, Vec<String>) {
-        let client = self.build_test_client().await;
+        let client = self.build_test_client();
 
         let blob_client = client.blob_client(&blob);
 
@@ -784,7 +780,7 @@ impl AzureBlobSinkConfig {
     }
 
     pub async fn get_blob_metadata(&self, blob: String) -> HashMap<String, String> {
-        let client = self.build_test_client().await;
+        let client = self.build_test_client();
         let blob_client = client.blob_client(&blob);
         let props_resp = blob_client
             .get_properties(None)
@@ -809,7 +805,7 @@ impl AzureBlobSinkConfig {
     }
 
     pub async fn get_blob_tags(&self, blob: String) -> HashMap<String, String> {
-        let client = self.build_test_client().await;
+        let client = self.build_test_client();
         let blob_client = client.blob_client(&blob);
         let resp = blob_client
             .get_tags(None)
@@ -833,7 +829,7 @@ impl AzureBlobSinkConfig {
     }
 
     async fn ensure_container(&self) {
-        let client = self.build_test_client().await;
+        let client = self.build_test_client();
         let result = client.create(None).await;
 
         let response = match result {

--- a/src/sinks/azure_common/config.rs
+++ b/src/sinks/azure_common/config.rs
@@ -222,9 +222,9 @@ impl ClientAssertion for ManagedIdentityClientAssertion {
 
 impl AzureAuthentication {
     /// Returns the provider for the credentials based on the authentication mechanism chosen.
-    pub async fn credential(&self) -> azure_core::Result<Arc<dyn TokenCredential>> {
+    pub fn credential(&self) -> azure_core::Result<Arc<dyn TokenCredential>> {
         match self {
-            Self::Specific(specific) => specific.credential().await,
+            Self::Specific(specific) => specific.credential(),
 
             #[cfg(test)]
             Self::MockCredential => Ok(Arc::new(MockTokenCredential) as Arc<dyn TokenCredential>),
@@ -234,7 +234,7 @@ impl AzureAuthentication {
 
 impl SpecificAzureCredential {
     /// Returns the provider for the credentials based on the specific credential type.
-    pub async fn credential(&self) -> azure_core::Result<Arc<dyn TokenCredential>> {
+    pub fn credential(&self) -> azure_core::Result<Arc<dyn TokenCredential>> {
         let credential: Arc<dyn TokenCredential> = match self {
             #[cfg(not(target_arch = "wasm32"))]
             Self::AzureCli {} => AzureCliCredential::new(None)?,

--- a/src/sinks/azure_logs_ingestion/config.rs
+++ b/src/sinks/azure_logs_ingestion/config.rs
@@ -128,7 +128,7 @@ impl Default for AzureLogsIngestionConfig {
 
 impl AzureLogsIngestionConfig {
     #[allow(clippy::too_many_arguments)]
-    pub(super) async fn build_inner(
+    pub(super) fn build_inner(
         &self,
         cx: SinkContext,
         validated: &ValidatedAzureLogsIngestion,
@@ -220,7 +220,7 @@ impl ValidatedSink for AzureLogsIngestionConfig {
         validated: &ValidatedAzureLogsIngestion,
         cx: SinkContext,
     ) -> crate::Result<(VectorSink, Healthcheck)> {
-        let credential: Arc<dyn TokenCredential> = self.auth.credential().await?;
+        let credential: Arc<dyn TokenCredential> = self.auth.credential()?;
 
         self.build_inner(
             cx,
@@ -230,6 +230,5 @@ impl ValidatedSink for AzureLogsIngestionConfig {
             self.token_scope.clone(),
             self.timestamp_field.clone(),
         )
-        .await
     }
 }

--- a/src/sinks/azure_logs_ingestion/tests.rs
+++ b/src/sinks/azure_logs_ingestion/tests.rs
@@ -257,7 +257,6 @@ async fn correct_request() {
             config.token_scope.clone(),
             config.timestamp_field.clone(),
         )
-        .await
         .unwrap();
 
     run_and_assert_sink_compliance(sink, stream::iter(vec![log1, log2]), &SINK_TAGS).await;
@@ -369,7 +368,6 @@ async fn mock_healthcheck_with_400_response() {
             config.token_scope.clone(),
             config.timestamp_field.clone(),
         )
-        .await
         .unwrap();
 
     let hc_err = healthcheck.await.unwrap_err();
@@ -434,7 +432,6 @@ async fn mock_healthcheck_with_403_response() {
             config.token_scope.clone(),
             config.timestamp_field.clone(),
         )
-        .await
         .unwrap();
 
     let hc_err = healthcheck.await.unwrap_err();

--- a/src/sinks/databend/service.rs
+++ b/src/sinks/databend/service.rs
@@ -118,7 +118,7 @@ impl DatabendService {
         })
     }
 
-    async fn new_stage_location(&self) -> String {
+    fn new_stage_location(&self) -> String {
         let now = Utc::now().timestamp();
         let database = self
             .client
@@ -133,7 +133,7 @@ impl DatabendService {
     }
 
     pub(crate) async fn insert_with_stage(&self, data: Bytes) -> Result<(), DatabendError> {
-        let stage = self.new_stage_location().await;
+        let stage = self.new_stage_location();
         let size = data.len() as u64;
         let reader = Box::new(Cursor::new(data));
         self.client.upload_to_stage(&stage, reader, size).await?;

--- a/src/sinks/databricks_zerobus/config.rs
+++ b/src/sinks/databricks_zerobus/config.rs
@@ -255,7 +255,7 @@ impl ValidatedSink for ZerobusSinkConfig {
         validated: &ValidatedZerobus,
         cx: SinkContext,
     ) -> crate::Result<(VectorSink, Healthcheck)> {
-        let service = ZerobusService::new(self.clone(), cx.proxy()).await?;
+        let service = ZerobusService::new(self.clone(), cx.proxy())?;
         let healthcheck_service = service.clone();
 
         let sink = ZerobusSink::new(

--- a/src/sinks/databricks_zerobus/service.rs
+++ b/src/sinks/databricks_zerobus/service.rs
@@ -313,10 +313,7 @@ pub struct ZerobusService {
 }
 
 impl ZerobusService {
-    pub async fn new(
-        config: ZerobusSinkConfig,
-        proxy: &ProxyConfig,
-    ) -> Result<Self, ZerobusSinkError> {
+    pub fn new(config: ZerobusSinkConfig, proxy: &ProxyConfig) -> Result<Self, ZerobusSinkError> {
         let mut builder = ZerobusSdk::builder()
             .endpoint(config.ingestion_endpoint.to_string())
             .unity_catalog_url(
@@ -585,7 +582,7 @@ pub struct ZerobusRetryLogic;
 #[cfg(test)]
 impl ZerobusService {
     /// Create a service with a mock stream already installed for testing.
-    pub async fn new_with_mock(
+    pub fn new_with_mock(
         config: ZerobusSinkConfig,
         mock: MockStream,
     ) -> Result<Self, ZerobusSinkError> {
@@ -747,9 +744,8 @@ mod tests {
 
     #[tokio::test]
     async fn ingest_succeeds_with_mock_stream() {
-        let service = ZerobusService::new_with_mock(test_config(), MockStream::succeeding())
-            .await
-            .unwrap();
+        let service =
+            ZerobusService::new_with_mock(test_config(), MockStream::succeeding()).unwrap();
 
         let stream = current_stream(&service).await;
         let result = service
@@ -765,9 +761,7 @@ mod tests {
         let mock = MockStream::failing(ZerobusError::ChannelCreationError(
             "connection reset".to_string(),
         ));
-        let service = ZerobusService::new_with_mock(test_config(), mock)
-            .await
-            .unwrap();
+        let service = ZerobusService::new_with_mock(test_config(), mock).unwrap();
 
         assert!(service.has_active_stream().await);
 
@@ -786,9 +780,7 @@ mod tests {
     #[tokio::test]
     async fn non_retryable_error_keeps_stream() {
         let mock = MockStream::failing(ZerobusError::InvalidArgument("bad field".to_string()));
-        let service = ZerobusService::new_with_mock(test_config(), mock)
-            .await
-            .unwrap();
+        let service = ZerobusService::new_with_mock(test_config(), mock).unwrap();
 
         assert!(service.has_active_stream().await);
 
@@ -808,9 +800,7 @@ mod tests {
     async fn stream_recovers_after_retryable_failure() {
         // Simulate: success → retryable failure → success again.
         let mock = MockStream::succeeding();
-        let service = ZerobusService::new_with_mock(test_config(), mock)
-            .await
-            .unwrap();
+        let service = ZerobusService::new_with_mock(test_config(), mock).unwrap();
 
         // First ingest succeeds.
         let stream = current_stream(&service).await;
@@ -861,9 +851,7 @@ mod tests {
         let mock = MockStream::succeeding();
         let closed = mock.closed_flag();
 
-        let service = ZerobusService::new_with_mock(test_config(), mock)
-            .await
-            .unwrap();
+        let service = ZerobusService::new_with_mock(test_config(), mock).unwrap();
 
         assert!(service.has_active_stream().await);
         assert!(!closed.load(std::sync::atomic::Ordering::Relaxed));
@@ -888,9 +876,7 @@ mod tests {
         .with_gate();
         let closed = mock.closed_flag();
 
-        let service = ZerobusService::new_with_mock(test_config(), mock)
-            .await
-            .unwrap();
+        let service = ZerobusService::new_with_mock(test_config(), mock).unwrap();
 
         // Spawn two concurrent ingests. Each clones the same stream `Arc`,
         // then blocks in the gate.

--- a/src/sinks/doris/client.rs
+++ b/src/sinks/doris/client.rs
@@ -64,7 +64,7 @@ pub struct DorisSinkClient {
 }
 
 impl DorisSinkClient {
-    pub async fn new(
+    pub fn new(
         http_client: HttpClient,
         base_url: Uri,
         auth: Option<Auth>,
@@ -118,7 +118,7 @@ impl DorisSinkClient {
     }
 
     /// Build a request for the Doris stream load
-    async fn build_request(
+    fn build_request(
         &self,
         database: &str,
         table: &str,
@@ -229,9 +229,7 @@ impl DorisSinkClient {
         let payload_ref = &payload;
 
         // Build and send initial request
-        let request = self
-            .build_request(&database, &table, payload_ref, None)
-            .await?;
+        let request = self.build_request(&database, &table, payload_ref, None)?;
         let endpoint = request.uri().to_string();
         let byte_size = payload.len();
 
@@ -267,9 +265,8 @@ impl DorisSinkClient {
                     }
 
                     // Build and send redirect request
-                    let redirect_req = self
-                        .build_request(&database, &table, payload_ref, Some(location_str))
-                        .await?;
+                    let redirect_req =
+                        self.build_request(&database, &table, payload_ref, Some(location_str))?;
 
                     response = self.http_client.send(redirect_req).await?;
                     status = response.status();

--- a/src/sinks/doris/config.rs
+++ b/src/sinks/doris/config.rs
@@ -257,8 +257,7 @@ impl ValidatedSink for DorisConfig {
                         compression,
                         label_prefix,
                         headers,
-                    )
-                    .await;
+                    );
 
                     let doris_client_safe = doris_client.into_thread_safe();
 
@@ -306,8 +305,7 @@ impl ValidatedSink for DorisConfig {
                 self.compression,
                 self.label_prefix.clone(),
                 self.headers.clone(),
-            )
-            .await;
+            );
             doris_client.into_thread_safe()
         };
 

--- a/src/sinks/doris/integration_test.rs
+++ b/src/sinks/doris/integration_test.rs
@@ -109,7 +109,7 @@ async fn insert_events() {
     let database = format!("test_db_{}_point", random_string(5).to_lowercase());
     let table = format!("test_table_{}", random_string(5).to_lowercase());
 
-    let client = DorisTestClient::new(doris_mysql_address_port()).await;
+    let client = DorisTestClient::new(doris_mysql_address_port());
     info!(
         message = "DorisTestClient created successfully, creating database...",
         internal_log_rate_limit = true
@@ -192,7 +192,7 @@ struct DorisTestClient {
 }
 
 impl DorisTestClient {
-    async fn new(query_address_port: (String, u16)) -> Self {
+    fn new(query_address_port: (String, u16)) -> Self {
         let auth = config_auth();
         let (host, port) = query_address_port;
 

--- a/src/sinks/doris/service.rs
+++ b/src/sinks/doris/service.rs
@@ -33,7 +33,7 @@ impl DorisService {
             log_request,
         }
     }
-    pub(crate) async fn reporter_run(&self, response: DorisStreamLoadResponse) {
+    pub(crate) fn reporter_run(&self, response: DorisStreamLoadResponse) {
         let stream_load_status = response.stream_load_status;
         let http_status_code = response.http_status_code;
         let response_json = response.response_json;
@@ -123,7 +123,7 @@ impl Service<HttpRequest<DorisPartitionKey>> for DorisService {
                 .send_stream_load(database, table, request.take_payload())
                 .await?;
             let report_response = doris_response.clone();
-            service.reporter_run(report_response).await;
+            service.reporter_run(report_response);
 
             let event_status = if doris_response.stream_load_status == StreamLoadStatus::Successful
             {

--- a/src/sinks/gcp/stackdriver/metrics/config.rs
+++ b/src/sinks/gcp/stackdriver/metrics/config.rs
@@ -133,7 +133,7 @@ impl ValidatedSink for StackdriverConfig {
 
         let auth = self.auth.build(Scope::MonitoringWrite).await?;
 
-        let healthcheck = healthcheck().boxed();
+        let healthcheck = async { healthcheck() }.boxed();
         let started = chrono::Utc::now();
         let tls_settings = TlsSettings::from_options(self.tls.as_ref())?;
         let client = HttpClient::new(tls_settings.into(), cx.proxy())?;
@@ -227,6 +227,6 @@ impl HttpServiceRequestBuilder<()> for StackdriverMetricsServiceRequestBuilder {
     }
 }
 
-async fn healthcheck() -> crate::Result<()> {
+fn healthcheck() -> crate::Result<()> {
     Ok(())
 }

--- a/src/sinks/mqtt/config.rs
+++ b/src/sinks/mqtt/config.rs
@@ -168,7 +168,7 @@ impl ValidatedSink for MqttSinkConfig {
         let sink = MqttSink::new(self, topic, connector.clone())?;
         Ok((
             VectorSink::from_event_streamsink(sink),
-            Box::pin(async move { connector.healthcheck().await }),
+            Box::pin(async move { connector.healthcheck() }),
         ))
     }
 }

--- a/src/sources/apache_metrics/mod.rs
+++ b/src/sources/apache_metrics/mod.rs
@@ -431,7 +431,6 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
         sleep(Duration::from_secs(1)).await;
 
         let metrics = collect_ready(rx)
-            .await
             .into_iter()
             .map(|e| e.into_metric())
             .collect::<Vec<_>>();
@@ -465,7 +464,6 @@ Scoreboard: ____S_____I______R____I_______KK___D__C__G_L____________W___________
         sleep(Duration::from_secs(1)).await;
 
         let metrics = collect_ready(rx)
-            .await
             .into_iter()
             .map(|e| e.into_metric())
             .collect::<Vec<_>>();

--- a/src/sources/aws_kinesis_firehose/mod.rs
+++ b/src/sources/aws_kinesis_firehose/mod.rs
@@ -473,7 +473,7 @@ mod tests {
         builder.send().await
     }
 
-    async fn spawn_send(
+    fn spawn_send(
         address: SocketAddr,
         timestamp: DateTime<Utc>,
         records: Vec<&'static [u8]>,
@@ -596,8 +596,7 @@ mod tests {
                 false,
                 record_compression,
                 None,
-            )
-            .await;
+            );
 
             if success {
                 let events = collect_n(rx, 1).await;
@@ -706,8 +705,7 @@ mod tests {
                 false,
                 record_compression,
                 None,
-            )
-            .await;
+            );
 
             if success {
                 let events = collect_n(rx, 1).await;
@@ -785,8 +783,7 @@ mod tests {
                 true,
                 Compression::None,
                 None,
-            )
-            .await;
+            );
 
             let events = collect_n(rx, 1).await;
             let res = res.await.unwrap().unwrap();
@@ -833,8 +830,7 @@ mod tests {
                 true,
                 Compression::None,
                 Some(COMMON_ATTRIBUTES),
-            )
-            .await;
+            );
 
             let events = collect_n(rx, 1).await;
             let res = res.await.unwrap().unwrap();
@@ -882,8 +878,7 @@ mod tests {
                 true,
                 Compression::None,
                 Some(COMMON_ATTRIBUTES),
-            )
-            .await;
+            );
 
             let mut events = collect_n(rx, 1).await;
             let res = res.await.unwrap().unwrap();
@@ -971,8 +966,7 @@ mod tests {
                 true,
                 Compression::None,
                 Some(COMMON_ATTRIBUTES),
-            )
-            .await;
+            );
 
             let events = collect_n(rx, 1).await;
             let res = res.await.unwrap().unwrap();
@@ -1027,8 +1021,7 @@ mod tests {
                 true,
                 Compression::None,
                 Some(COMMON_ATTRIBUTES),
-            )
-            .await;
+            );
 
             let mut events = collect_n(rx, 1).await;
             let res = res.await.unwrap().unwrap();
@@ -1104,8 +1097,7 @@ mod tests {
                 true,
                 Compression::None,
                 Some("malformed-common-attributes"),
-            )
-            .await;
+            );
 
             let mut events = collect_n(rx, 1).await;
             let res = res.await.unwrap().unwrap();
@@ -1307,8 +1299,7 @@ mod tests {
             false,
             Compression::None,
             None,
-        )
-        .await;
+        );
 
         let events = collect_n(rx, 1).await;
 
@@ -1353,8 +1344,7 @@ mod tests {
             false,
             Compression::None,
             None,
-        )
-        .await;
+        );
 
         let events = collect_n(rx, 1).await;
         let access_key = events[0]
@@ -1380,8 +1370,7 @@ mod tests {
             false,
             Compression::None,
             None,
-        )
-        .await;
+        );
 
         let events = collect_n(rx, 1).await;
 

--- a/src/sources/aws_s3/mod.rs
+++ b/src/sources/aws_s3/mod.rs
@@ -311,8 +311,7 @@ impl AwsS3Config {
                     },
                     multiline,
                     decoder,
-                )
-                .await?;
+                )?;
 
                 Ok(ingestor)
             }

--- a/src/sources/aws_s3/sqs.rs
+++ b/src/sources/aws_s3/sqs.rs
@@ -301,7 +301,7 @@ pub(super) struct Ingestor {
 }
 
 impl Ingestor {
-    pub(super) async fn new(
+    pub(super) fn new(
         region: Region,
         sqs_client: SqsClient,
         s3_client: S3Client,

--- a/src/sources/docker_logs/tests.rs
+++ b/src/sources/docker_logs/tests.rs
@@ -571,7 +571,7 @@ mod integration_tests {
             let id1 = container_log_n(1, &included0, None, included0_message, &docker).await;
             let id2 = container_log_n(1, &included1, None, included1_message, &docker).await;
             tokio::time::sleep(Duration::from_secs(1)).await;
-            let events = collect_ready(out).await;
+            let events = collect_ready(out);
             container_remove(&id0, &docker).await;
             container_remove(&id1, &docker).await;
             container_remove(&id2, &docker).await;

--- a/src/sources/exec/mod.rs
+++ b/src/sources/exec/mod.rs
@@ -497,7 +497,7 @@ async fn run_command(
     'outer: loop {
         tokio::select! {
             _ = &mut shutdown => {
-                if !shutdown_child(&mut child, &command).await {
+                if !shutdown_child(&mut child, &command) {
                         break 'outer; // couldn't signal, exit early
                 }
             }
@@ -560,10 +560,7 @@ fn handle_exit_status(config: &ExecConfig, exit_status: Option<i32>, exec_durati
 }
 
 #[cfg(unix)]
-async fn shutdown_child(
-    child: &mut tokio::process::Child,
-    command: &tokio::process::Command,
-) -> bool {
+fn shutdown_child(child: &mut tokio::process::Child, command: &tokio::process::Command) -> bool {
     match child.id().map(i32::try_from) {
         Some(Ok(pid)) => {
             // shutting down, send a SIGTERM to the child

--- a/src/sources/exec/mod.rs
+++ b/src/sources/exec/mod.rs
@@ -497,8 +497,13 @@ async fn run_command(
     'outer: loop {
         tokio::select! {
             _ = &mut shutdown => {
-                if !shutdown_child(&mut child, &command) {
-                        break 'outer; // couldn't signal, exit early
+                #[cfg(unix)]
+                let shutdown_succeeded = shutdown_child(&mut child, &command);
+                #[cfg(windows)]
+                let shutdown_succeeded = shutdown_child(&mut child, &command).await;
+
+                if !shutdown_succeeded {
+                    break 'outer; // couldn't signal, exit early
                 }
             }
             v = receiver.recv() => {

--- a/src/sources/fluent/mod.rs
+++ b/src/sources/fluent/mod.rs
@@ -1428,7 +1428,7 @@ mod integration_tests {
                         .unwrap();
                     sleep(Duration::from_secs(2)).await;
 
-                    collect_ready(out).await
+                    collect_ready(out)
                 })
                 .await;
 
@@ -1508,7 +1508,7 @@ mod integration_tests {
                         .await
                         .unwrap();
                     sleep(Duration::from_secs(2)).await;
-                    collect_ready(out).await
+                    collect_ready(out)
                 })
                 .await;
 

--- a/src/sources/gcp_pubsub.rs
+++ b/src/sources/gcp_pubsub.rs
@@ -618,7 +618,7 @@ impl PubsubSource {
         self.bytes_received.emit(ByteSize(response.size_of()));
 
         let (batch, notifier) = BatchNotifier::maybe_new_with_receiver(self.acknowledgements);
-        let (events, ids) = self.parse_messages(response.received_messages, batch).await;
+        let (events, ids) = self.parse_messages(response.received_messages, batch);
 
         let count = events.len();
         match self.out.send_batch(events).await {
@@ -639,7 +639,7 @@ impl PubsubSource {
         }
     }
 
-    async fn parse_messages(
+    fn parse_messages(
         &self,
         response: Vec<proto::ReceivedMessage>,
         batch: Option<BatchNotifier>,

--- a/src/sources/host_metrics/mod.rs
+++ b/src/sources/host_metrics/mod.rs
@@ -401,7 +401,7 @@ impl HostMetrics {
             self.cpu_metrics(&mut buffer).await;
         }
         if self.config.has_collector(Collector::Process) {
-            self.process_metrics(&mut buffer).await;
+            self.process_metrics(&mut buffer);
         }
         if self.config.has_collector(Collector::Disk) {
             self.disk_metrics(&mut buffer).await;
@@ -427,7 +427,7 @@ impl HostMetrics {
             self.tcp_metrics(&mut buffer).await;
         }
         if self.config.has_collector(Collector::Temperature) {
-            self.temperature_metrics(&mut buffer).await;
+            self.temperature_metrics(&mut buffer);
         }
 
         let metrics = buffer.metrics;

--- a/src/sources/host_metrics/process.rs
+++ b/src/sources/host_metrics/process.rs
@@ -23,7 +23,7 @@ const MEMORY_USAGE: &str = "process_memory_usage";
 const MEMORY_VIRTUAL_USAGE: &str = "process_memory_virtual_usage";
 
 impl HostMetrics {
-    pub async fn process_metrics(&mut self, output: &mut super::MetricsBuffer) {
+    pub fn process_metrics(&mut self, output: &mut super::MetricsBuffer) {
         self.system.refresh_processes_specifics(
             ProcessesToUpdate::All,
             true,
@@ -66,9 +66,7 @@ mod tests {
     #[tokio::test]
     async fn generates_process_metrics() {
         let mut buffer = MetricsBuffer::new(None);
-        HostMetrics::new(HostMetricsConfig::default())
-            .process_metrics(&mut buffer)
-            .await;
+        HostMetrics::new(HostMetricsConfig::default()).process_metrics(&mut buffer);
         let metrics = buffer.metrics;
         assert!(!metrics.is_empty());
 

--- a/src/sources/host_metrics/temperature.rs
+++ b/src/sources/host_metrics/temperature.rs
@@ -8,7 +8,7 @@ const TEMPERATURE_MAX_CELSIUS: &str = "temperature_max_celsius";
 const TEMPERATURE_CRITICAL_CELSIUS: &str = "temperature_critical_celsius";
 
 impl HostMetrics {
-    pub async fn temperature_metrics(&mut self, output: &mut super::MetricsBuffer) {
+    pub fn temperature_metrics(&mut self, output: &mut super::MetricsBuffer) {
         output.name = "temperature";
         // Refresh the long-lived component list in place. `Component::max()` is
         // derived by sysinfo from successive refreshes when the sensor does not
@@ -57,9 +57,7 @@ mod tests {
     #[tokio::test]
     async fn generates_temperature_metrics() {
         let mut buffer = MetricsBuffer::new(None);
-        HostMetrics::new(HostMetricsConfig::default())
-            .temperature_metrics(&mut buffer)
-            .await;
+        HostMetrics::new(HostMetricsConfig::default()).temperature_metrics(&mut buffer);
         let metrics = buffer.metrics;
 
         // Temperature sensors are not exposed in many environments (containers,

--- a/src/sources/http_server.rs
+++ b/src/sources/http_server.rs
@@ -686,13 +686,13 @@ mod tests {
                 SimpleHttpConfig::NAME.into()
             );
             assert_eq!(log["http_path"], "/".into());
-            assert_event_metadata(log).await;
+            assert_event_metadata(log);
         }
         {
             let event = events.remove(0);
             let log = event.as_log();
             assert_eq!(*log.get_message().unwrap(), "test body 2".into());
-            assert_event_metadata(log).await;
+            assert_event_metadata(log);
         }
     }
 
@@ -727,13 +727,13 @@ mod tests {
             let event = events.remove(0);
             let log = event.as_log();
             assert_eq!(*log.get_message().unwrap(), "test body".into());
-            assert_event_metadata(log).await;
+            assert_event_metadata(log);
         }
         {
             let event = events.remove(0);
             let log = event.as_log();
             assert_eq!(*log.get_message().unwrap(), "test body 2".into());
-            assert_event_metadata(log).await;
+            assert_event_metadata(log);
         }
     }
 
@@ -769,7 +769,7 @@ mod tests {
             let event = events.remove(0);
             let log = event.as_log();
             assert_eq!(*log.get_message().unwrap(), "foo\nbar".into());
-            assert_event_metadata(log).await;
+            assert_event_metadata(log);
         }
     }
 
@@ -848,13 +848,13 @@ mod tests {
             let event = events.remove(0);
             let log = event.as_log();
             assert_eq!(log["key"], "value".into());
-            assert_event_metadata(log).await;
+            assert_event_metadata(log);
         }
         {
             let event = events.remove(0);
             let log = event.as_log();
             assert_eq!(log["key2"], "value2".into());
-            assert_event_metadata(log).await;
+            assert_event_metadata(log);
         }
     }
 
@@ -953,29 +953,29 @@ mod tests {
             let event = events.remove(0);
             let log = event.as_log();
             assert_eq!(log["key1"], "value1".into());
-            assert_event_metadata(log).await;
+            assert_event_metadata(log);
         }
         {
             let event = events.remove(0);
             let log = event.as_log();
             assert_eq!(log["key2"], "value2".into());
-            assert_event_metadata(log).await;
+            assert_event_metadata(log);
         }
         {
             let event = events.remove(0);
             let log = event.as_log();
             assert_eq!(log["key1"], "value1".into());
-            assert_event_metadata(log).await;
+            assert_event_metadata(log);
         }
         {
             let event = events.remove(0);
             let log = event.as_log();
             assert_eq!(log["key2"], "value2".into());
-            assert_event_metadata(log).await;
+            assert_event_metadata(log);
         }
     }
 
-    async fn assert_event_metadata(log: &LogEvent) {
+    fn assert_event_metadata(log: &LogEvent) {
         assert!(log.get_timestamp().is_some());
 
         let source_type_key_value = log
@@ -1034,7 +1034,7 @@ mod tests {
             assert_eq!(log["\"Upgrade-Insecure-Requests\""], "false".into());
             assert_eq!(log["\"x-test-header\""], "true".into());
             assert_eq!(log["AbsentHeader"], Value::Null);
-            assert_event_metadata(log).await;
+            assert_event_metadata(log);
         }
     }
 
@@ -1079,7 +1079,7 @@ mod tests {
             assert_eq!(log["key1"], "value1".into());
             assert_eq!(log["\"user-agent\""], "test_client".into());
             assert_eq!(log["\"x-case-sensitive-value\""], "CaseSensitive".into());
-            assert_event_metadata(log).await;
+            assert_event_metadata(log);
         }
     }
 
@@ -1123,7 +1123,7 @@ mod tests {
             assert_eq!(log["source"], "staging".into());
             assert_eq!(log["region"], "gb".into());
             assert_eq!(log["absent"], Value::Null);
-            assert_event_metadata(log).await;
+            assert_event_metadata(log);
         }
     }
 
@@ -1167,7 +1167,7 @@ mod tests {
             assert_eq!(log["key2"], "value2".into());
             assert_eq!(log["source"], "staging".into());
             assert_eq!(log["region"], "gb".into());
-            assert_event_metadata(log).await;
+            assert_event_metadata(log);
         }
     }
 
@@ -1212,7 +1212,7 @@ mod tests {
             let event = events.remove(0);
             let log = event.as_log();
             assert_eq!(*log.get_message().unwrap(), "test body".into());
-            assert_event_metadata(log).await;
+            assert_event_metadata(log);
         }
     }
 

--- a/src/sources/internal_logs.rs
+++ b/src/sources/internal_logs.rs
@@ -288,7 +288,7 @@ mod tests {
         drop(enter);
 
         sleep(Duration::from_millis(1)).await;
-        let mut events = collect_ready(rx).await;
+        let mut events = collect_ready(rx);
         let test_id = Value::from(test_id.to_string());
         events.retain(|event| event.as_log().get(event_path!("test_id")) == Some(&test_id));
 
@@ -382,7 +382,7 @@ mod tests {
         }
 
         sleep(Duration::from_millis(1)).await;
-        let mut events = collect_ready(rx).await;
+        let mut events = collect_ready(rx);
         let test_id_value = Value::from(test_id.to_string());
         events.retain(|event| event.as_log().get(event_path!("test_id")) == Some(&test_id_value));
 
@@ -412,7 +412,7 @@ mod tests {
         }
 
         sleep(Duration::from_millis(50)).await;
-        let events = collect_ready(rx).await;
+        let events = collect_ready(rx);
 
         // Filter to only our test messages
         let test_events: Vec<_> = events

--- a/src/sources/mqtt/integration_tests.rs
+++ b/src/sources/mqtt/integration_tests.rs
@@ -40,7 +40,7 @@ async fn send_test_events(client: &AsyncClient, topic: &str, messages: &Vec<Stri
     }
 }
 
-async fn get_mqtt_client() -> AsyncClient {
+fn get_mqtt_client() -> AsyncClient {
     let mut mqtt_options = MqttOptions::new(
         "integration-test-producer",
         mqtt_broker_address(),
@@ -94,7 +94,7 @@ async fn mqtt_one_topic_happy() {
 
         tokio::time::sleep(Duration::from_millis(100)).await;
 
-        let client = get_mqtt_client().await;
+        let client = get_mqtt_client();
         send_test_events(&client, topic, &input).await;
 
         let mut expected_messages: HashSet<_> = input.into_iter().collect();
@@ -158,7 +158,7 @@ async fn mqtt_many_topics_happy() {
 
         tokio::time::sleep(Duration::from_millis(100)).await;
 
-        let client = get_mqtt_client().await;
+        let client = get_mqtt_client();
         send_test_events(&client, &format!("{topic_prefix_1}/test"), &input_1).await;
         send_test_events(&client, &format!("{topic_prefix_2}/test"), &input_2).await;
 

--- a/src/sources/opentelemetry/config.rs
+++ b/src/sources/opentelemetry/config.rs
@@ -264,7 +264,7 @@ impl OpentelemetryConfig {
 
 impl OpentelemetryConfig {
     /// Build the source serving runtime-swappable TLS acceptors for the gRPC and/or HTTP listeners.
-    pub async fn build_with_tls_reloaders(
+    pub fn build_with_tls_reloaders(
         &self,
         cx: SourceContext,
         grpc_tls_reloader: Option<TlsAcceptorReloader>,
@@ -376,7 +376,7 @@ impl OpentelemetryConfig {
 #[typetag::serde(name = "opentelemetry")]
 impl SourceConfig for OpentelemetryConfig {
     async fn build(&self, cx: SourceContext) -> crate::Result<Source> {
-        self.build_with_tls_reloaders(cx, None, None).await
+        self.build_with_tls_reloaders(cx, None, None)
     }
 
     // TODO: appropriately handle "severity" meaning across both "severity_text" and "severity_number",

--- a/src/sources/opentelemetry/tests.rs
+++ b/src/sources/opentelemetry/tests.rs
@@ -246,7 +246,7 @@ async fn receive_grpc_logs_vector_namespace() {
             .unwrap();
         let req = create_test_logs_request();
         _ = client.export(req).await;
-        let mut output = test_util::collect_ready(env.output).await;
+        let mut output = test_util::collect_ready(env.output);
         // we just send one, so only one output
         assert_eq!(output.len(), 1);
         let event = output.pop().unwrap();
@@ -349,7 +349,7 @@ async fn receive_grpc_logs_legacy_namespace() {
             .unwrap();
         let req = create_test_logs_request();
         _ = client.export(req).await;
-        let mut output = test_util::collect_ready(env.output).await;
+        let mut output = test_util::collect_ready(env.output);
         // we just send one, so only one output
         assert_eq!(output.len(), 1);
         let actual_event = output.pop().unwrap();
@@ -460,7 +460,7 @@ async fn receive_sum_metric() {
             }],
         });
         _ = client.export(req).await;
-        let mut output = test_util::collect_ready(env.output).await;
+        let mut output = test_util::collect_ready(env.output);
         assert_eq!(output.len(), 1);
         let actual_event = output.pop().unwrap();
 
@@ -552,7 +552,7 @@ async fn receive_sum_non_monotonic_metric() {
             }],
         });
         _ = client.export(req).await;
-        let mut output = test_util::collect_ready(env.output).await;
+        let mut output = test_util::collect_ready(env.output);
         assert_eq!(output.len(), 1);
         let actual_event = output.pop().unwrap();
 
@@ -641,7 +641,7 @@ async fn receive_gauge_metric() {
             }],
         });
         _ = client.export(req).await;
-        let mut output = test_util::collect_ready(env.output).await;
+        let mut output = test_util::collect_ready(env.output);
         assert_eq!(output.len(), 1);
         let actual_event = output.pop().unwrap();
 
@@ -739,7 +739,7 @@ async fn receive_histogram_metric() {
             }],
         });
         _ = client.export(req).await;
-        let mut output = test_util::collect_ready(env.output).await;
+        let mut output = test_util::collect_ready(env.output);
         assert_eq!(output.len(), 1);
         let actual_event = output.pop().unwrap();
 
@@ -866,7 +866,7 @@ async fn receive_histogram_delta_metric() {
             }],
         });
         _ = client.export(req).await;
-        let mut output = test_util::collect_ready(env.output).await;
+        let mut output = test_util::collect_ready(env.output);
         assert_eq!(output.len(), 1);
         let actual_event = output.pop().unwrap();
 
@@ -1002,7 +1002,7 @@ async fn receive_exponential_histogram_metric() {
             }],
         });
         _ = client.export(req).await;
-        let mut output = test_util::collect_ready(env.output).await;
+        let mut output = test_util::collect_ready(env.output);
         assert_eq!(output.len(), 1);
         let actual_event = output.pop().unwrap();
 
@@ -1141,7 +1141,7 @@ async fn receive_summary_metric() {
             }],
         });
         _ = client.export(req).await;
-        let mut output = test_util::collect_ready(env.output).await;
+        let mut output = test_util::collect_ready(env.output);
         assert_eq!(output.len(), 1);
         let actual_event = output.pop().unwrap();
 
@@ -1248,7 +1248,7 @@ async fn send_and_collect_otel_event(
         .await
         .expect("Failed to send request to OpenTelemetry source.");
 
-    let mut events = test_util::collect_ready(output).await;
+    let mut events = test_util::collect_ready(output);
     assert_eq!(events.len(), 1);
     events.pop().unwrap()
 }
@@ -1308,7 +1308,7 @@ async fn http_headers_logs_use_otlp_decoding_false() {
             .await
             .expect("Failed to send log to Opentelemetry Collector.");
 
-        let mut output = test_util::collect_ready(logs_output).await;
+        let mut output = test_util::collect_ready(logs_output);
         assert_eq!(output.len(), 1);
         let actual_event = output.pop().unwrap();
         schema_definitions
@@ -1389,7 +1389,7 @@ async fn http_headers_logs_use_otlp_decoding_true() {
             .await
             .expect("Failed to send log to Opentelemetry Collector.");
 
-        let mut output = test_util::collect_ready(logs_output).await;
+        let mut output = test_util::collect_ready(logs_output);
         assert_eq!(output.len(), 1);
         let actual_event = output.pop().unwrap();
         let log = actual_event.as_log();
@@ -1672,7 +1672,7 @@ async fn http_logs_use_otlp_decoding_emits_metric() {
         .await
         .expect("Failed to send log to Opentelemetry Collector.");
 
-    let mut output = test_util::collect_ready(logs_output).await;
+    let mut output = test_util::collect_ready(logs_output);
     assert_eq!(output.len(), 1);
     output.pop().unwrap();
 

--- a/src/sources/postgresql_metrics.rs
+++ b/src/sources/postgresql_metrics.rs
@@ -203,15 +203,18 @@ impl SourceConfig for PostgresqlMetricsConfig {
         );
         let namespace = Some(self.namespace.clone()).filter(|namespace| !namespace.is_empty());
 
-        let mut sources = try_join_all(self.endpoints.iter().map(|endpoint| {
-            PostgresqlMetrics::new(
-                endpoint.clone(),
-                datname_filter.clone(),
-                namespace.clone(),
-                self.tls.clone(),
-            )
-        }))
-        .await?;
+        let mut sources = self
+            .endpoints
+            .iter()
+            .map(|endpoint| {
+                PostgresqlMetrics::new(
+                    endpoint.clone(),
+                    datname_filter.clone(),
+                    namespace.clone(),
+                    self.tls.clone(),
+                )
+            })
+            .collect::<Result<Vec<_>, _>>()?;
 
         let duration = self.scrape_interval_secs;
         let shutdown = cx.shutdown;
@@ -495,7 +498,7 @@ struct PostgresqlMetrics {
 }
 
 impl PostgresqlMetrics {
-    async fn new(
+    fn new(
         endpoint: String,
         datname_filter: DatnameFilter,
         namespace: Option<String>,

--- a/src/sources/prometheus/remote_write.rs
+++ b/src/sources/prometheus/remote_write.rs
@@ -571,7 +571,7 @@ mod test {
         send_request_and_assert(address.port(), request_body).await;
 
         // Verify we only received the valid metric (NaN metric should be filtered)
-        let output = test_util::collect_ready(rx).await;
+        let output = test_util::collect_ready(rx);
         assert_eq!(output.len(), 1);
 
         let metric = output[0].as_metric();
@@ -642,7 +642,7 @@ mod test {
         send_request_and_assert(address.port(), request_body).await;
 
         // Verify we received both metrics (including NaN metric)
-        let mut output = test_util::collect_ready(rx).await;
+        let mut output = test_util::collect_ready(rx);
         assert_eq!(output.len(), 2);
 
         // Sort by name for predictable testing
@@ -783,7 +783,7 @@ mod test {
         send_request_and_assert(address.port(), request_body).await;
 
         // Verify we received the metric data
-        let output = test_util::collect_ready(rx).await;
+        let output = test_util::collect_ready(rx);
         assert_eq!(output.len(), 1);
 
         let metric = output[0].as_metric();
@@ -864,7 +864,7 @@ mod test {
         );
 
         // Verify we received the metric data
-        let output = test_util::collect_ready(rx).await;
+        let output = test_util::collect_ready(rx);
         assert_eq!(output.len(), 1);
 
         let metric = output[0].as_metric();

--- a/src/sources/socket/mod.rs
+++ b/src/sources/socket/mod.rs
@@ -970,7 +970,7 @@ mod test {
     }
 
     //////// UDP TESTS ////////
-    async fn send_lines_udp(to: SocketAddr, lines: impl IntoIterator<Item = String>) -> UdpSocket {
+    fn send_lines_udp(to: SocketAddr, lines: impl IntoIterator<Item = String>) -> UdpSocket {
         send_lines_udp_from(bind_unused_udp(), to, lines)
     }
 
@@ -982,10 +982,7 @@ mod test {
         send_packets_udp_from(from, to, lines.into_iter().map(|line| line.into()))
     }
 
-    async fn send_packets_udp(
-        to: SocketAddr,
-        packets: impl IntoIterator<Item = Bytes>,
-    ) -> UdpSocket {
+    fn send_packets_udp(to: SocketAddr, packets: impl IntoIterator<Item = Bytes>) -> UdpSocket {
         send_packets_udp_from(bind_unused_udp(), to, packets)
     }
 
@@ -1109,7 +1106,7 @@ mod test {
             let (tx, rx) = SourceSender::new_test();
             let address = init_udp(tx, false).await;
 
-            send_lines_udp(address, vec!["test".to_string()]).await;
+            send_lines_udp(address, vec!["test".to_string()]);
             let events = collect_n(rx, 1).await;
 
             assert_eq!(
@@ -1126,7 +1123,7 @@ mod test {
             let (tx, rx) = SourceSender::new_test();
             let address = init_udp(tx, false).await;
 
-            send_lines_udp(address, vec!["foo\nbar".to_string()]).await;
+            send_lines_udp(address, vec!["foo\nbar".to_string()]);
             let events = collect_n(rx, 1).await;
 
             assert_eq!(
@@ -1143,7 +1140,7 @@ mod test {
             let (tx, rx) = SourceSender::new_test();
             let address = init_udp(tx, false).await;
 
-            send_lines_udp(address, vec!["test".to_string(), "test2".to_string()]).await;
+            send_lines_udp(address, vec!["test".to_string(), "test2".to_string()]);
             let events = collect_n(rx, 2).await;
 
             assert_eq!(
@@ -1174,8 +1171,7 @@ mod test {
                     "test with a long line".to_string(),
                     "a short un".to_string(),
                 ],
-            )
-            .await;
+            );
 
             let events = collect_n(rx, 2).await;
             assert_eq!(
@@ -1213,8 +1209,7 @@ mod test {
             send_lines_udp(
                 address,
                 vec!["test with, long line".to_string(), "short one".to_string()],
-            )
-            .await;
+            );
 
             let events = collect_n(rx, 2).await;
             assert_eq!(
@@ -1248,7 +1243,7 @@ mod test {
             chunks.append(&mut another_chunks);
             chunks.shuffle(&mut rng);
 
-            send_packets_udp(address, chunks).await;
+            send_packets_udp(address, chunks);
 
             let events = collect_n(rx, 2).await;
             assert_eq!(
@@ -1269,7 +1264,7 @@ mod test {
             let (tx, rx) = SourceSender::new_test();
             let address = init_udp(tx, false).await;
 
-            let from = send_lines_udp(address, vec!["test".to_string()]).await;
+            let from = send_lines_udp(address, vec!["test".to_string()]);
             let events = collect_n(rx, 1).await;
 
             assert_eq!(
@@ -1290,7 +1285,7 @@ mod test {
             let (tx, rx) = SourceSender::new_test();
             let address = init_udp(tx, true).await;
 
-            let from = send_lines_udp(address, vec!["test".to_string()]).await;
+            let from = send_lines_udp(address, vec!["test".to_string()]);
             let events = collect_n(rx, 1).await;
             let log = events[0].as_log();
             let event_meta = log.metadata().value();
@@ -1318,7 +1313,7 @@ mod test {
             let (tx, rx) = SourceSender::new_test();
             let address = init_udp(tx, false).await;
 
-            _ = send_lines_udp(address, vec!["test".to_string()]).await;
+            _ = send_lines_udp(address, vec!["test".to_string()]);
             let events = collect_n(rx, 1).await;
 
             assert_eq!(
@@ -1339,7 +1334,7 @@ mod test {
             let (address, source_handle) =
                 init_udp_with_shutdown(tx, &source_id, &mut shutdown).await;
 
-            send_lines_udp(address, vec!["test".to_string()]).await;
+            send_lines_udp(address, vec!["test".to_string()]);
             let events = collect_n(rx, 1).await;
 
             assert_eq!(
@@ -1373,12 +1368,11 @@ mod test {
             let run_pump_atomic_sender = Arc::new(AtomicBool::new(true));
             let run_pump_atomic_receiver = Arc::clone(&run_pump_atomic_sender);
             let pump_handle = tokio::task::spawn_blocking(move || {
-                let handle = tokio::runtime::Handle::current();
-                handle.block_on(send_lines_udp(
+                send_lines_udp(
                     address,
                     std::iter::repeat("test".to_string())
                         .take_while(move |_| run_pump_atomic_receiver.load(Ordering::Relaxed)),
-                ));
+                );
             });
 
             // Important that 'rx' doesn't get dropped until the pump has finished sending items to it.

--- a/src/sources/vector/mod.rs
+++ b/src/sources/vector/mod.rs
@@ -425,7 +425,7 @@ mod tests {
             );
         }
 
-        let output = test_util::collect_ready(rx).await;
+        let output = test_util::collect_ready(rx);
         assert_event_data_eq!(events, output);
     }
 

--- a/src/test_util/mod.rs
+++ b/src/test_util/mod.rs
@@ -434,7 +434,7 @@ pub async fn collect_n_stream<T, S: Stream<Item = T> + Unpin>(stream: &mut S, n:
     events
 }
 
-pub async fn collect_ready<S>(mut rx: S) -> Vec<S::Item>
+pub fn collect_ready<S>(mut rx: S) -> Vec<S::Item>
 where
     S: Stream + Unpin,
 {
@@ -781,7 +781,7 @@ where
 {
     let sender = tokio::spawn(future);
     tokio::time::sleep(Duration::from_secs(sleep)).await;
-    let events = collect_ready(stream).await;
+    let events = collect_ready(stream);
     sender.await.expect("Failed to send data");
     events
 }
@@ -796,7 +796,7 @@ mod tests {
     use super::retry_until;
 
     // helper which errors the first 3x, and succeeds on the 4th
-    async fn retry_until_helper(count: Arc<RwLock<i32>>) -> Result<(), ()> {
+    fn retry_until_helper(count: Arc<RwLock<i32>>) -> Result<(), ()> {
         if *count.read().unwrap() < 3 {
             let mut c = count.write().unwrap();
             *c += 1;
@@ -810,7 +810,7 @@ mod tests {
         let count = Arc::new(RwLock::new(0));
         let func = || {
             let count = Arc::clone(&count);
-            retry_until_helper(count)
+            async move { retry_until_helper(count) }
         };
 
         retry_until(func, Duration::from_millis(10), Duration::from_secs(1)).await;

--- a/src/top/cmd.rs
+++ b/src/top/cmd.rs
@@ -66,7 +66,7 @@ pub async fn top(opts: &super::Opts, uri: Uri, dashboard_title: &str) -> exitcod
         .as_deref()
         .map(Regex::new)
         .and_then(Result::ok);
-    let state_rx = state::updater(rx, ui_rx, starting_state).await;
+    let state_rx = state::updater(rx, ui_rx, starting_state);
     // Channel for shutdown signal
     let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
 

--- a/src/topology/running.rs
+++ b/src/topology/running.rs
@@ -343,7 +343,7 @@ impl RunningTopology {
                 .run_healthchecks(&diff, &mut new_pieces, new_config.healthchecks)
                 .await
             {
-                self.connect_diff(&diff, &mut new_pieces).await;
+                self.connect_diff(&diff, &mut new_pieces);
                 self.spawn_diff(&diff, new_pieces);
                 self.config = new_config;
                 self.refresh_confinement_gauges();
@@ -370,7 +370,7 @@ impl RunningTopology {
                 .run_healthchecks(&diff, &mut new_pieces, self.config.healthchecks)
                 .await
         {
-            self.connect_diff(&diff, &mut new_pieces).await;
+            self.connect_diff(&diff, &mut new_pieces);
             self.spawn_diff(&diff, new_pieces);
             // `self.config` still holds the old config on the rollback path, so
             // this restores the gauges for the re-spawned old sinks.
@@ -502,7 +502,7 @@ impl RunningTopology {
             let previous = self.tasks.remove(key).unwrap();
             drop(previous); // detach and forget
 
-            self.remove_inputs(key, diff, new_config).await;
+            self.remove_inputs(key, diff, new_config);
             self.remove_outputs(key);
 
             if let Some(registry) = self.utilization_registry.as_ref() {
@@ -513,7 +513,7 @@ impl RunningTopology {
         for key in &diff.transforms.to_change {
             debug!(component_id = %key, "Changing transform.");
 
-            self.remove_inputs(key, diff, new_config).await;
+            self.remove_inputs(key, diff, new_config);
             self.remove_outputs(key);
         }
 
@@ -646,7 +646,7 @@ impl RunningTopology {
             .collect::<Vec<_>>();
         for key in &removed_sinks {
             debug!(component_id = %key, "Removing sink.");
-            self.remove_inputs(key, diff, new_config).await;
+            self.remove_inputs(key, diff, new_config);
 
             if let Some(registry) = self.utilization_registry.as_ref() {
                 registry.remove_component(key);
@@ -687,7 +687,7 @@ impl RunningTopology {
                     buffer_tx.insert((*key).clone(), self.inputs.get(key).unwrap().clone());
                 }
             }
-            self.remove_inputs(key, diff, new_config).await;
+            self.remove_inputs(key, diff, new_config);
         }
 
         // Now that we've disconnected or temporarily detached the inputs to all changed/removed
@@ -736,11 +736,7 @@ impl RunningTopology {
     }
 
     /// Connects all changed/added components in the given configuration diff.
-    pub(crate) async fn connect_diff(
-        &mut self,
-        diff: &ConfigDiff,
-        new_pieces: &mut TopologyPieces,
-    ) {
+    pub(crate) fn connect_diff(&mut self, diff: &ConfigDiff, new_pieces: &mut TopologyPieces) {
         debug!("Connecting changed/added component(s).");
 
         // Update tap metadata
@@ -827,7 +823,7 @@ impl RunningTopology {
         // transforms and sinks that come afterwards.
         for key in diff.sources.changed_and_added() {
             debug!(component_id = %key, "Configuring outputs for source.");
-            self.setup_outputs(key, new_pieces).await;
+            self.setup_outputs(key, new_pieces);
         }
 
         let added_changed_table_sources: Vec<ComponentKey> = diff
@@ -838,27 +834,27 @@ impl RunningTopology {
             .collect();
         for key in &added_changed_table_sources {
             debug!(component_id = %key, "Connecting outputs for enrichment table source.");
-            self.setup_outputs(key, new_pieces).await;
+            self.setup_outputs(key, new_pieces);
         }
 
         // We configure the outputs of any changed/added transforms next, for the same reason: we
         // need them to be available to any transforms and sinks that come afterwards.
         for key in diff.transforms.changed_and_added() {
             debug!(component_id = %key, "Configuring outputs for transform.");
-            self.setup_outputs(key, new_pieces).await;
+            self.setup_outputs(key, new_pieces);
         }
 
         // Now that all possible outputs are configured, we can start wiring up inputs, starting
         // with transforms.
         for key in diff.transforms.changed_and_added() {
             debug!(component_id = %key, "Connecting inputs for transform.");
-            self.setup_inputs(key, diff, new_pieces).await;
+            self.setup_inputs(key, diff, new_pieces);
         }
 
         // Now that all sources and transforms are fully configured, we can wire up sinks.
         for key in diff.sinks.changed_and_added() {
             debug!(component_id = %key, "Connecting inputs for sink.");
-            self.setup_inputs(key, diff, new_pieces).await;
+            self.setup_inputs(key, diff, new_pieces);
         }
         let added_changed_tables: Vec<ComponentKey> = diff
             .enrichment_tables
@@ -868,7 +864,7 @@ impl RunningTopology {
             .collect();
         for key in &added_changed_tables {
             debug!(component_id = %key, "Connecting inputs for enrichment table sink.");
-            self.setup_inputs(key, diff, new_pieces).await;
+            self.setup_inputs(key, diff, new_pieces);
         }
 
         // We do a final pass here to reconnect unchanged components.
@@ -941,11 +937,7 @@ impl RunningTopology {
         }
     }
 
-    async fn setup_outputs(
-        &mut self,
-        key: &ComponentKey,
-        new_pieces: &mut builder::TopologyPieces,
-    ) {
+    fn setup_outputs(&mut self, key: &ComponentKey, new_pieces: &mut builder::TopologyPieces) {
         let outputs = new_pieces.outputs.remove(key).unwrap();
         for (port, output) in outputs {
             debug!(component_id = %key, output_id = ?port, "Configuring output for component.");
@@ -959,7 +951,7 @@ impl RunningTopology {
         }
     }
 
-    async fn setup_inputs(
+    fn setup_inputs(
         &mut self,
         key: &ComponentKey,
         diff: &ConfigDiff,
@@ -1010,7 +1002,7 @@ impl RunningTopology {
         self.outputs.retain(|id, _output| &id.component != key);
     }
 
-    async fn remove_inputs(&mut self, key: &ComponentKey, diff: &ConfigDiff, new_config: &Config) {
+    fn remove_inputs(&mut self, key: &ComponentKey, diff: &ConfigDiff, new_config: &Config) {
         self.inputs.remove(key);
         self.detach_triggers.remove(key);
 
@@ -1439,7 +1431,7 @@ impl RunningTopology {
         {
             return None;
         }
-        running_topology.connect_diff(&diff, &mut pieces).await;
+        running_topology.connect_diff(&diff, &mut pieces);
         running_topology.spawn_diff(&diff, pieces);
         // `running_topology.config` was set from the initial config in `new()`.
         running_topology.refresh_confinement_gauges();

--- a/src/transforms/metric_to_log.rs
+++ b/src/transforms/metric_to_log.rs
@@ -350,7 +350,6 @@ mod tests {
     use std::sync::Arc;
 
     use chrono::{DateTime, Timelike, Utc, offset::TimeZone};
-    use futures::executor::block_on;
     use proptest::prelude::*;
     use similar_asserts::assert_eq;
     use tokio::sync::mpsc;
@@ -676,12 +675,12 @@ mod tests {
         #[test]
         fn transform_tag_single_encoding(values: TagValueSet) {
             let name = random_string(16);
-            let tags = block_on(transform_tags(
+            let tags = transform_tags(
                 MetricTagValues::Single,
                 values.iter()
                     .map(|value| (name.clone(), TagValue::from(value.map(String::from))))
                     .collect(),
-            ));
+            );
             // The resulting tag must be either a single string value or not present.
             let value = values.into_single().map(|value| Value::Bytes(value.into()));
             assert_eq!(tags.get(vrl::path!(&*name)), value.as_ref());
@@ -690,12 +689,12 @@ mod tests {
         #[test]
         fn transform_tag_full_encoding(values: TagValueSet) {
             let name = random_string(16);
-            let tags = block_on(transform_tags(
+            let tags = transform_tags(
                 MetricTagValues::Full,
                 values.iter()
                     .map(|value| (name.clone(), TagValue::from(value.map(String::from))))
                     .collect(),
-            ));
+            );
             let tag = tags.get(vrl::path!(&*name));
             match values.len() {
                 // Empty tag set => missing tag
@@ -712,7 +711,7 @@ mod tests {
         tag.into_option().into()
     }
 
-    async fn transform_tags(metric_tag_values: MetricTagValues, tags: MetricTags) -> Value {
+    fn transform_tags(metric_tag_values: MetricTagValues, tags: MetricTags) -> Value {
         let counter = Metric::new(
             "counter",
             MetricKind::Absolute,

--- a/src/transforms/window/transform.rs
+++ b/src/transforms/window/transform.rs
@@ -123,7 +123,7 @@ mod test {
                 create_topology(ReceiverStream::new(rx), transform_config).await;
 
             send_event(&tx, "flush").await;
-            assert_event("flush", out.recv().await).await;
+            assert_event("flush", out.recv().await);
 
             drop(tx);
             topology.stop().await;
@@ -145,7 +145,7 @@ mod test {
                 create_topology(ReceiverStream::new(rx), transform_config).await;
 
             send_event(&tx, "forward").await;
-            assert_event("forward", out.recv().await).await;
+            assert_event("forward", out.recv().await);
 
             drop(tx);
             topology.stop().await;
@@ -392,7 +392,7 @@ mod test {
         tx.send(Event::from(LogEvent::from(message))).await.unwrap();
     }
 
-    async fn assert_event(message: &str, event: Option<Event>) {
+    fn assert_event(message: &str, event: Option<Event>) {
         assert_eq!(
             &Value::from(message),
             event.unwrap().as_log().get(event_path!("message")).unwrap()
@@ -401,7 +401,7 @@ mod test {
 
     async fn assert_events(messages: &mut [&str], out: &mut Receiver<Event>) {
         for message in messages {
-            assert_event(message, out.recv().await).await;
+            assert_event(message, out.recv().await);
         }
     }
 }

--- a/src/validate.rs
+++ b/src/validate.rs
@@ -181,7 +181,7 @@ pub async fn validate(
         None => return exitcode::CONFIG,
     };
 
-    validated &= validate_transforms(&config, &mut fmt).await;
+    validated &= validate_transforms(&config, &mut fmt);
     validated &= validate_sinks_with_context(&config, &mut fmt);
 
     if !opts.no_environment {
@@ -285,7 +285,7 @@ fn stub_enrichment_tables(config: &Config) -> TableRegistry {
     enrichment_tables
 }
 
-async fn validate_transforms(config: &Config, fmt: &mut Formatter) -> bool {
+fn validate_transforms(config: &Config, fmt: &mut Formatter) -> bool {
     let enrichment_tables = stub_enrichment_tables(config);
     let mut definition_cache = HashMap::new();
     let mut errors = Vec::new();


### PR DESCRIPTION
## Summary

### Motivation

Functions that never await anything should not expose an asynchronous API.

### Changes

- Enable `clippy::unused_async` for the workspace.
- Make the existing unused async functions synchronous and update their callers.

### References

N/A

## Vector configuration

N/A

## How did you test this PR?

- `make check-clippy`
- `cargo fmt --all -- --check`
- `cargo test -p vector-top --all-features`

## Is this a breaking change?

- [ ] Yes
- [x] No

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.
