### PR TITLE
chore(dev): bump Rust toolchain to 1.96.1

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.95"
+channel = "1.96.1"
 profile = "default"


### PR DESCRIPTION
## Summary

### Motivation

Rust 1.96.1 includes security fixes for the bundled libssh2 used by Cargo.

### Changes

- Bump the pinned Rust toolchain from 1.95 to 1.96.1.
- Keep the project MSRV at Rust 1.95.

### References

## Vector configuration

Not applicable.

## How did you test this PR?

- `make check-clippy`
- `make test` (3,843 tests passed)
- `git diff --check`

`make fmt` completed Rust formatting, but its Prettier phase was unavailable in the local environment.

## Does this PR include user facing changes?

- [ ] Yes. Please add a changelog fragment based on our [guidelines](https://github.com/vectordotdev/vector/blob/master/changelog.d/README.md).
- [x] No. A maintainer will apply the `no-changelog` label to this PR.

## Contributor Guidelines

- Please read our [Vector contributor resources](https://github.com/vectordotdev/vector/tree/master/docs#getting-started).
- Do not hesitate to use `@vectordotdev/vector` to reach out to us regarding this PR.
- Before pushing, follow our [pre-push guidance](https://github.com/vectordotdev/vector/blob/master/CONTRIBUTING.md#pre-push).
- After a review is requested, please avoid force pushes to help us review incrementally.
  - Feel free to push as many commits as you want. They will be squashed into one before merging.
  - For example, you can run `git merge origin master` and `git push`.
