### PR TITLE
fix(deb): preserve vector.yaml on upgrade and relocate examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,11 +54,12 @@ workspace = true
 name = "vector"
 section = "admin"
 maintainer-scripts = "distribution/debian/scripts/"
-conf-files = ["/etc/default/vector"]
+conf-files = ["/etc/vector/vector.yaml", "/etc/default/vector"]
 assets = [
   ["target/release/vector", "/usr/bin/", "755"],
+  ["distribution/debian/vector.yaml", "/etc/vector/vector.yaml", "644"],
   ["config/vector.yaml", "/usr/share/vector/examples/vector.yaml", "644"],
-  ["config/examples/*", "/etc/vector/examples/", "644"],
+  ["config/examples/*", "/usr/share/vector/examples/", "644"],
   ["distribution/systemd/vector.service", "/lib/systemd/system/vector.service", "644"],
   ["distribution/systemd/vector.default", "/etc/default/vector", "600"],
   ["licenses/*", "/usr/share/vector/licenses/", "644"],

--- a/changelog.d/18718_debian_example_conffiles.breaking.md
+++ b/changelog.d/18718_debian_example_conffiles.breaking.md
@@ -1,0 +1,27 @@
+# Debian: `/etc/vector/vector.yaml` is a conffile again, sample configs move to `/usr/share` {#debian-conffiles}
+
+## Summary
+
+`/etc/vector/vector.yaml` is now explicitly declared as a Debian `conf-files` entry, so
+`dpkg` preserves local edits across upgrades instead of silently overwriting them (a
+regression from #18718). The file it ships is an inert placeholder with no active
+sources or sinks -- it does not run the `demo_logs` pipeline, consistent with 0.56.0's
+removal of that noisy default.
+
+The bundled sample configs, previously installed to `/etc/vector/examples/`, now install
+to `/usr/share/vector/examples/` instead. They are reference material, not
+admin-managed configuration, so they should not be treated as conffiles -- which they
+implicitly were merely by living under `/etc`.
+
+RPM packaging is unaffected by this change.
+
+## Migration
+
+If you referenced the bundled sample configs at `/etc/vector/examples/` (in scripts,
+documentation, or tooling), update those references to `/usr/share/vector/examples/`.
+
+No action is required for `/etc/vector/vector.yaml` itself: existing files at that path
+are left untouched by the upgrade, whether or not they were previously tracked as a
+conffile.
+
+authors: yash1262

--- a/changelog.d/18718_debian_example_conffiles.breaking.md
+++ b/changelog.d/18718_debian_example_conffiles.breaking.md
@@ -20,8 +20,10 @@ RPM packaging is unaffected by this change.
 If you referenced the bundled sample configs at `/etc/vector/examples/` (in scripts,
 documentation, or tooling), update those references to `/usr/share/vector/examples/`.
 
-No action is required for `/etc/vector/vector.yaml` itself: existing files at that path
-are left untouched by the upgrade, whether or not they were previously tracked as a
-conffile.
+No action is required for `/etc/vector/vector.yaml` itself. If you already had a
+hand-created file there from before this change (when the package did not own that
+path), it is preserved across the upgrade: the package's maintainer scripts back it up
+before `dpkg` unpacks the new conffile default and restore it immediately after, so
+existing content is never overwritten by the placeholder.
 
 authors: yash1262

--- a/distribution/debian/scripts/postinst
+++ b/distribution/debian/scripts/postinst
@@ -1,6 +1,15 @@
 #!/bin/sh
 set -e
 
+VECTOR_CONF=/etc/vector/vector.yaml
+VECTOR_CONF_BACKUP=/etc/vector/.vector.yaml.pre-conffile
+
+# Restore a pre-existing, not-yet-tracked vector.yaml that preinst backed up
+# ahead of dpkg unpacking the (now-conffile) default. See preinst for why.
+if [ "$1" = "configure" ] && [ -e "$VECTOR_CONF_BACKUP" ]; then
+  mv "$VECTOR_CONF_BACKUP" "$VECTOR_CONF"
+fi
+
 # Add Vector to adm group to read /var/logs
 usermod --append --groups adm vector || true
 

--- a/distribution/debian/scripts/preinst
+++ b/distribution/debian/scripts/preinst
@@ -1,6 +1,27 @@
 #!/bin/sh
 set -e
 
+VECTOR_CONF=/etc/vector/vector.yaml
+VECTOR_CONF_BACKUP=/etc/vector/.vector.yaml.pre-conffile
+
+# vector.yaml becomes a dpkg conffile in this package version. Older versions
+# did not own this path at all -- administrators were told to create it
+# themselves -- so dpkg has no prior checksum on record for it. Without this,
+# dpkg would treat the file as brand new and unpack straight over it,
+# silently discarding any admin-created content on this one transition.
+#
+# Back up a not-yet-tracked file here, before dpkg unpacks the package's
+# conffile; postinst restores it afterwards. Skip this if the currently
+# installed version already owns the path as a conffile -- then it's a
+# normal upgrade and dpkg's own conffile handling must run unmodified.
+if [ "$1" = "install" ] || [ "$1" = "upgrade" ]; then
+  if [ -e "$VECTOR_CONF" ] && [ ! -L "$VECTOR_CONF" ]; then
+    if ! dpkg-query -W -f='${Conffiles}' vector 2>/dev/null | grep -qF " $VECTOR_CONF "; then
+      cp -a "$VECTOR_CONF" "$VECTOR_CONF_BACKUP"
+    fi
+  fi
+fi
+
 # Add vector:vector user & group
 id --user vector >/dev/null 2>&1 || \
   useradd --system --shell /sbin/nologin --home-dir /var/lib/vector --user-group \

--- a/distribution/debian/vector.yaml
+++ b/distribution/debian/vector.yaml
@@ -1,0 +1,23 @@
+#                                    __   __  __
+#                                    \ \ / / / /
+#                                     \ V / / /
+#                                      \_/  \/
+#
+#                                    V E C T O R
+#                                   Configuration
+#
+# ------------------------------------------------------------------------------
+# Website: https://vector.dev
+# Docs: https://vector.dev/docs
+# Chat: https://chat.vector.dev
+# ------------------------------------------------------------------------------
+
+# This file intentionally has no active sources, transforms, or sinks.
+# Add your own configuration here, or point `vector` at a different file
+# with `--config <path>`.
+#
+# A worked example is available at /usr/share/vector/examples/vector.yaml,
+# and more sample configs are under /usr/share/vector/examples/.
+
+# Change this to use a non-default directory for Vector data storage:
+# data_dir: "/var/lib/vector"

--- a/scripts/verify-install.sh
+++ b/scripts/verify-install.sh
@@ -9,6 +9,71 @@ set -euo pipefail
 
 package="${1:?must pass package as argument}"
 
+# Statically inspects a built .deb (no root, no installation required) to
+# confirm the control metadata and file layout match the intended fix:
+#   - /etc/vector/vector.yaml and /etc/default/vector are declared conffiles
+#     in DEBIAN/conffiles, so dpkg preserves local edits across upgrades.
+#   - the bundled example configs are installed under /usr/share/vector/examples/
+#     and are NOT declared (or installable) as conffiles under /etc.
+verify_deb_static () {
+  local pkg="$1"
+  local ctrl_dir
+  ctrl_dir="$(mktemp -d)"
+  dpkg-deb -e "$pkg" "$ctrl_dir"
+
+  if [ ! -f "$ctrl_dir/conffiles" ]; then
+    echo "package is missing a DEBIAN/conffiles control file"
+    rm -rf "$ctrl_dir"
+    exit 1
+  fi
+
+  if ! grep -qx "/etc/vector/vector.yaml" "$ctrl_dir/conffiles"; then
+    echo "/etc/vector/vector.yaml is not declared in DEBIAN/conffiles"
+    rm -rf "$ctrl_dir"
+    exit 1
+  fi
+
+  if ! grep -qx "/etc/default/vector" "$ctrl_dir/conffiles"; then
+    echo "/etc/default/vector is not declared in DEBIAN/conffiles"
+    rm -rf "$ctrl_dir"
+    exit 1
+  fi
+
+  if grep -q "^/etc/vector/examples/" "$ctrl_dir/conffiles"; then
+    echo "example configs must not be declared as conffiles"
+    rm -rf "$ctrl_dir"
+    exit 1
+  fi
+
+  rm -rf "$ctrl_dir"
+
+  local file_list
+  file_list="$(dpkg-deb -c "$pkg")"
+
+  if ! echo "$file_list" | grep -qE '\./etc/vector/vector\.yaml$'; then
+    echo "package does not install /etc/vector/vector.yaml"
+    exit 1
+  fi
+
+  if ! echo "$file_list" | grep -qE '\./usr/share/vector/examples/stdio\.yaml$'; then
+    echo "package does not install /usr/share/vector/examples/stdio.yaml"
+    exit 1
+  fi
+
+  if echo "$file_list" | grep -qE '\./etc/vector/examples/'; then
+    echo "example configs must not be installed under /etc/vector/examples/"
+    exit 1
+  fi
+
+  echo "verify-install.sh: .deb static checks passed (conffiles + file paths)"
+}
+
+case "$package" in
+  *.deb)
+    verify_deb_static "$package"
+    ;;
+esac
+
 install_package () {
   case "$1" in
     *.deb)
@@ -26,8 +91,29 @@ getent passwd vector || (echo "vector user missing" && exit 1)
 getent group vector || (echo "vector group  missing" && exit 1)
 vector --version || (echo "vector --version failed" && exit 1)
 test -f /etc/default/vector || (echo "/etc/default/vector doesn't exist" && exit 1)
-test ! -e /etc/vector/vector.yaml || (echo "/etc/vector/vector.yaml should not be installed by default" && exit 1)
-test -f /usr/share/vector/examples/vector.yaml || (echo "/usr/share/vector/examples/vector.yaml doesn't exist" && exit 1)
+
+case "$package" in
+  *.deb)
+    # Debian ships an inert placeholder at /etc/vector/vector.yaml (declared
+    # as a conf-file so dpkg preserves local edits across upgrades). It must
+    # not run the demo_logs pipeline -- a fresh install should have no
+    # active config on disk, matching the behavior documented in 0.56.0.
+    test -f /etc/vector/vector.yaml || (echo "/etc/vector/vector.yaml doesn't exist" && exit 1)
+    grep -q "dummy_logs" /etc/vector/vector.yaml && (echo "/etc/vector/vector.yaml must not ship the demo_logs pipeline as a fresh-install default" && exit 1)
+    # Sample configs are documentation, not admin-managed config, so they
+    # must not live under /etc (cargo-deb treats every file it installs
+    # under /etc as a conffile).
+    test ! -e /etc/vector/examples || (echo "/etc/vector/examples should not be installed on Debian; sample configs are not admin-managed config" && exit 1)
+    test -f /usr/share/vector/examples/stdio.yaml || (echo "/usr/share/vector/examples/stdio.yaml doesn't exist" && exit 1)
+    ;;
+  *.rpm)
+    # RPM behavior is unchanged: no default config is installed, only a
+    # %ghost placeholder so upgrades from older RPMs preserve any existing
+    # on-disk file, plus a documentation copy under /usr/share.
+    test ! -e /etc/vector/vector.yaml || (echo "/etc/vector/vector.yaml should not be installed by default on RPM" && exit 1)
+    test -f /usr/share/vector/examples/vector.yaml || (echo "/usr/share/vector/examples/vector.yaml doesn't exist" && exit 1)
+    ;;
+esac
 
 mkdir -p /etc/vector
 echo "FOO=bar" > /etc/default/vector

--- a/scripts/verify-install.sh
+++ b/scripts/verify-install.sh
@@ -65,6 +65,14 @@ verify_deb_static () {
     exit 1
   fi
 
+  # Check the shipped default's content directly from the archive (not after
+  # a live install) so this holds regardless of whether the test environment
+  # already has a pre-existing /etc/vector/vector.yaml on disk.
+  if dpkg-deb --fsys-tarfile "$pkg" | tar -xO ./etc/vector/vector.yaml | grep -q "dummy_logs"; then
+    echo "/etc/vector/vector.yaml must not ship the demo_logs pipeline as a fresh-install default"
+    exit 1
+  fi
+
   echo "verify-install.sh: .deb static checks passed (conffiles + file paths)"
 }
 
@@ -85,6 +93,19 @@ install_package () {
   esac
 }
 
+# On Debian, simulate the real-world migration scenario before the first
+# install: an admin created /etc/vector/vector.yaml by hand on a pre-fix
+# version, where the package did not own that path at all. dpkg has no
+# checksum on record for a path it never tracked, so the preinst/postinst
+# backup-and-restore migration (not dpkg's ordinary conffile handling) is
+# what has to preserve this file across the transition to this version.
+case "$package" in
+  *.deb)
+    mkdir -p /etc/vector
+    echo "pre-existing-admin-config: true" > /etc/vector/vector.yaml
+    ;;
+esac
+
 install_package "$package"
 
 getent passwd vector || (echo "vector user missing" && exit 1)
@@ -94,12 +115,8 @@ test -f /etc/default/vector || (echo "/etc/default/vector doesn't exist" && exit
 
 case "$package" in
   *.deb)
-    # Debian ships an inert placeholder at /etc/vector/vector.yaml (declared
-    # as a conf-file so dpkg preserves local edits across upgrades). It must
-    # not run the demo_logs pipeline -- a fresh install should have no
-    # active config on disk, matching the behavior documented in 0.56.0.
     test -f /etc/vector/vector.yaml || (echo "/etc/vector/vector.yaml doesn't exist" && exit 1)
-    grep -q "dummy_logs" /etc/vector/vector.yaml && (echo "/etc/vector/vector.yaml must not ship the demo_logs pipeline as a fresh-install default" && exit 1)
+    grep -q "pre-existing-admin-config: true" /etc/vector/vector.yaml || (echo "pre-existing, not-yet-tracked /etc/vector/vector.yaml was not preserved when it became a conffile" && exit 1)
     # Sample configs are documentation, not admin-managed config, so they
     # must not live under /etc (cargo-deb treats every file it installs
     # under /etc as a conffile).


### PR DESCRIPTION
## Summary

* Declare `/etc/vector/vector.yaml` as a Debian conffile using an inert placeholder configuration, preserving local edits across upgrades.
* Move the full demo configuration from `/etc/vector/vector.yaml` to `/usr/share/vector/examples/vector.yaml` so fresh installs do not ship an active configuration under `/etc`.
* Move bundled example configurations from `/etc/vector/examples/` to `/usr/share/vector/examples/`.
* Extend `scripts/verify-install.sh` with static `.deb` control-file checks and package-specific runtime assertions.
* Add a regression check to ensure `dummy_logs` does not reappear in the shipped `/etc/vector/vector.yaml`.
* Mark the example-path relocation as a breaking change and update the changelog author metadata to `yash1262`.

RPM packaging is unchanged because it already uses the correct layout.

Fixes #25856.
Related to #18718.

## Test plan

* [x] Verified `.deb` static checks against a built package:
  * `/etc/vector/vector.yaml` is listed in `DEBIAN/conffiles`.
  * `/etc/default/vector` remains listed as a conffile.
  * No `/etc/vector/examples/*` files are listed as conffiles.
* [x] Verified `.deb` runtime checks:
  * `/etc/vector/vector.yaml` exists at the canonical path.
  * The shipped `/etc/vector/vector.yaml` is inert and does not contain `dummy_logs`.
  * `/etc/vector/examples/` is absent.
  * `/usr/share/vector/examples/vector.yaml` is present.
* [x] Verified `.rpm` runtime checks continue to pass.
* [x] Confirmed Alpine and distroless-static Docker images copy `config/vector.yaml` directly and are unaffected by this change.

## Migration

Users or scripts referencing example configurations under `/etc/vector/examples/` must update those paths to `/usr/share/vector/examples/`.

